### PR TITLE
chore: prepara o repositório para virar público

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: 💬 Discord da comunidade
-    url: https://discord.gg/b5NnndAbFc
+    url: https://craftcodeclub.io/join
     about: Dúvidas, ideias e conversa com a comunidade Craft & Code Club.
   - name: ☕ Apoie a comunidade
     url: https://dsa.craftcodeclub.io/apoie

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,6 +8,10 @@ on:
 
 permissions:
   contents: read
+  # A action lista os commits do PR pela API. Sem esta permissão ela morre com
+  # "Resource not accessible by integration" e o job reprova qualquer PR, mesmo
+  # com as mensagens corretas.
+  pull-requests: read
 
 jobs:
   commitlint:

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,10 @@ pnpm-debug.log*
 .idea/
 .vscode/*
 !.vscode/extensions.json
+
+# === ferramentas de agente (config local da máquina) ===
+# Guarda caminhos e permissões da máquina de quem edita, não do projeto.
+# O CLAUDE.md (esse sim versionado) é a configuração compartilhada.
+.claude/settings.local.json
+.claude/scheduled_tasks.*
+.claude/worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,9 +58,12 @@ npm test         # Playwright (roda contra o ./out via python http.server). DEVE
 
 ## Navegação e links
 
-- **`src/lib/links.ts` é ponto único.** Todo link de Discord lê `LINKS.discord` (convite direto).
-  Comunidade = `LINKS.site` (craftcodeclub.io); repo = `LINKS.github`; apoio = `LINKS.apoiar`
-  (campanha na APOIA.se).
+- **`src/lib/links.ts` é ponto único.** Comunidade = `LINKS.site` (craftcodeclub.io); repo =
+  `LINKS.github` (`craft-code-club/roadmap-dsa`); apoio = `LINKS.apoiar` (campanha na APOIA.se).
+- **Discord tem duas portas, por design.** *Dentro do app*: `LINKS.discord`, convite direto, um
+  clique só. *Fora do app* (README, CONTRIBUTING, SECURITY, templates do `.github/`, qualquer
+  `.md`): `https://craftcodeclub.io/join`, que é o ponto de rotação da comunidade. Nunca cole
+  `discord.gg/<código>` cru em arquivo de documentação.
 - Barra: **esquerda** = Início, Roadmap; **direita** = YouTube, Discord, Apoiar + menu `⋯`.
   O menu `⋯` tem: Craft & Code Club, GitHub do projeto, Apoiadores e Parceiros (e, só no mobile,
   Início/Roadmap/YouTube que somem da barra).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,13 @@
 # Contribuindo
 
-Adoraríamos a sua ajuda para tornar o **Roadmap DSA** ainda melhor! Feito pela
-comunidade [Craft & Code Club](https://craftcodeclub.io), para a comunidade.
-Este guia explica como contribuir com o mínimo de atrito.
+Adoraríamos a sua ajuda para tornar o **Roadmap DSA** ainda melhor! É um projeto
+**gratuito e open source**, feito pela comunidade
+[Craft & Code Club](https://craftcodeclub.io), para a comunidade: o código e o
+conteúdo estão todos aqui, e qualquer pessoa pode ler, estudar, adaptar e
+propor mudança. Este guia explica como contribuir com o mínimo de atrito.
+
+Ficou com dúvida em qualquer ponto? Chama a gente no
+[Discord](https://craftcodeclub.io/join), é o jeito mais rápido de destravar.
 
 - [Código de Conduta](#codigo-de-conduta)
 - [Como rodar o projeto](#como-rodar)
@@ -40,23 +45,37 @@ progresso) são ilhas client; o resto é estático.
 
 ## <a name="adicionar-topico"></a> Adicionar ou completar um tópico
 
-1. **Índice** — em `src/content/roadmap.ts`, adicione (ou edite) o tópico no
-   grupo certo. Só isso já coloca o tópico no menu e no roadmap. Campos úteis:
-   `youtube` (vídeo), `artigo` (link do blog), `videosExtras` (mais vídeos),
-   `referencias` (artigos), `problemas` (LeetCode/GeeksforGeeks), `viz`.
+O conteúdo mora em `content/`, na raiz do projeto (irmão de `src/`, que guarda
+só o código de estrutura). Os **nomes dos campos são em inglês**; os valores
+exibidos ficam em português.
+
+1. **Índice** — em `content/roadmap.ts`, adicione (ou edite) o tópico no grupo
+   certo. Só isso já coloca o tópico no menu e no roadmap. Campos úteis:
+   `youtube` (id do vídeo), `article` (link do artigo no blog), `extraVideos`
+   (mais vídeos), `references` (leituras), `problems` (LeetCode/GeeksforGeeks)
+   e `viz` (visualizador).
 
    ```ts
-   { slug: "kadane", nome: "Kadane", grupo: "Arrays e Strings",
-     nivel: "Médio", status: "soon", youtube: "VIDEO_ID",
-     descricao: "Maior soma contígua, o clássico." }
+   { slug: "kadane", name: "Kadane", group: "Arrays e Strings",
+     level: "Médio", status: "soon", youtube: "VIDEO_ID",
+     description: "Maior soma contígua, o clássico." }
    ```
 
-2. **Artigo** — para virar `status: "ready"`, crie `src/content/topics/<slug>.mdx`.
+2. **Artigo** — para virar `status: "ready"`, crie `content/topics/<slug>.mdx`.
    Dentro do MDX já dá para usar, sem importar: `<Callout>`, `<Colunas>`,
    `<Cartao>` e os visualizadores (ver `mdx-components.tsx`).
 
-3. **Ligue o artigo** — registre em `src/content/topics/index.ts` e mude o
-   `status` para `"ready"` em `roadmap.ts`.
+3. **Ligue o artigo** — registre em `content/topics/index.ts` e mude o `status`
+   para `"ready"` em `content/roadmap.ts`. No registro vão o componente e o
+   `summary`, que alimenta o índice "Nesta página" e precisa repetir os títulos
+   `h2` do artigo **no texto exato**:
+
+   ```ts
+   "kadane": {
+     Body: Kadane,
+     summary: ["O problema", "A ideia, em uma frase", "Por que funciona"],
+   },
+   ```
 
 **Sem travessão:** na copy do site, use pontuação simples (vírgula, ponto, dois
 pontos), nunca o caractere `—`.
@@ -64,10 +83,10 @@ pontos), nunca o caractere `—`.
 
 ## <a name="adicionar-visualizador"></a> Adicionar um visualizador
 
-O padrão vive em `src/components/JanelaVisualizer.tsx` e
-`src/components/DoisPonteirosVisualizer.tsx`: um **gerador puro de passos** +
-a mesma casca de UI (células, código sincronizado, painel de variáveis,
-controles e o botão **Expandir**). Para uma técnica nova:
+Os visualizadores ficam em `content/visualizers/`. O padrão vive em
+`SlidingWindowVisualizer.tsx` e `TwoPointersVisualizer.tsx`: um **gerador puro
+de passos** + a mesma casca de UI (células, código sincronizado, painel de
+variáveis, controles e o botão **Expandir**). Para uma técnica nova:
 
 1. Copie o componente, troque `gerarPassos` e a constante `CODIGO`.
 2. Exponha-o em `mdx-components.tsx`.
@@ -176,4 +195,8 @@ liberar a execução.
 
 Ao contribuir, você concorda que a sua contribuição será licenciada sob a
 **[PolyForm Noncommercial License 1.0.0](./LICENSE)** — livre para qualquer uso
-**não comercial**. Uso comercial não é permitido.
+**não comercial** (estudo, ensino, comunidade, outros projetos livres). Uso
+comercial não é permitido.
+
+Na prática, é o que garante que o guia siga aberto e gratuito para quem quer
+aprender, sem virar produto de ninguém.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ página só: o **algoritmo rodando passo a passo**, o **artigo**, o **vídeo**, 
 **problemas** do LeetCode / GeeksforGeeks e **referências**, com o progresso salvo no navegador.
 
 🔗 **A Plataforma:** https://dsa.craftcodeclub.io \
-💬 **Comunidade:** [Discord](https://discord.gg/b5NnndAbFc) \
+💬 **Comunidade:** [Discord](https://craftcodeclub.io/join) \
 ▶️ [YouTube](https://www.youtube.com/@CraftCodeClub) \
 ☕ [Apoie](https://dsa.craftcodeclub.io/apoie)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,9 +4,18 @@
 
 Levamos a segurança dos nossos repositórios a sério, incluindo todos os projetos mantidos sob a nossa [organização Craft Code Club no GitHub](https://github.com/craft-code-club).
 
-Todos os nossos projetos usam GitHub Issues para acompanhar bugs e melhorias. Se você acredita ter encontrado uma vulnerabilidade de segurança em algum dos nossos repositórios, por favor abra uma issue no projeto correspondente para nos avisar.
+**Não abra uma issue pública para relatar uma vulnerabilidade.** Como os repositórios são públicos, uma issue expõe a falha para todo mundo antes de existir correção. Use um dos canais privados abaixo:
 
-Se você também tiver uma correção para a vulnerabilidade, fique à vontade para abrir um Pull Request com a sua sugestão de melhoria. Vamos revisar a sua contribuição com cuidado e, se ela resolver o problema de forma adequada, faremos o merge em uma versão futura do projeto.
+1. **GitHub Security Advisories (preferido)**: na aba **Security** do repositório, clique em **Report a vulnerability**. O relato fica visível só para você e para quem mantém o projeto, e é por lá que coordenamos a correção e o crédito.
+2. **E-mail**: se preferir, escreva para **craftcodeclub@gmail.com** com o assunto começando por `[security]`.
+
+No relato, ajuda muito incluir: o que está vulnerável, como reproduzir, qual o impacto esperado e, se souber, uma sugestão de correção.
+
+Confirmamos o recebimento e, a partir daí, mantemos você informado sobre o andamento. Pedimos que aguarde a correção ser publicada antes de divulgar a falha publicamente.
+
+Se você também tiver uma correção, ótimo, mas **não abra um Pull Request público** com ela: um PR de segurança denuncia a falha tanto quanto uma issue. Anexe o patch ao relato privado e combinamos a melhor forma de publicar.
+
+Bugs e melhorias que **não** são de segurança seguem normalmente por [issues](https://github.com/craft-code-club/roadmap-dsa/issues) e Pull Requests.
 
 Obrigado por colaborar conosco para tornar nossos projetos mais seguros.
 

--- a/scripts/smoke-screenshots.sh
+++ b/scripts/smoke-screenshots.sh
@@ -15,6 +15,14 @@ if ! command -v agent-browser >/dev/null 2>&1; then
   exit 1
 fi
 
+# Sem esta checagem, curl ausente deixaria a resposta vazia lá embaixo e o erro
+# sairia como "sem resposta", culpando o servidor ou o slug em vez da falta da
+# dependência.
+if ! command -v curl >/dev/null 2>&1; then
+  echo "✗ curl não encontrado no PATH. É usado para conferir cada rota antes do print."
+  exit 1
+fi
+
 echo "→ build (SSG)"
 npm run build >/dev/null
 

--- a/scripts/smoke-screenshots.sh
+++ b/scripts/smoke-screenshots.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # Regenera as capturas do app (screenshots/) a partir do build estático.
-# Requer: Node (build) + Python3 (servidor) + `agent-browser` no PATH
+# Requer: Node (build) + Python3 (servidor) + curl + `agent-browser` no PATH
 # (Vercel Labs: https://github.com/vercel-labs/agent-browser).
 #
 #   npm run screenshots
@@ -26,6 +26,16 @@ sleep 1
 mkdir -p "$OUT"
 
 shot() { # <rota> <arquivo>
+  # Confere a rota antes de capturar: sem isso, um slug renomeado gera um print
+  # da página 404 e o script termina "verde", escondendo o erro.
+  local code
+  # `|| true`: sem isso, o `set -e` mataria o script sem mensagem se o servidor
+  # não subisse (curl sai 7), e o motivo real ficaria invisível.
+  code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:$PORT$1" || true)
+  if [ "$code" != "200" ]; then
+    echo "✗ $1 respondeu ${code:-sem resposta} (slug renomeado ou servidor fora do ar?)"
+    exit 1
+  fi
   agent-browser open "http://localhost:$PORT$1" >/dev/null 2>&1
   agent-browser wait 900 >/dev/null 2>&1
   agent-browser screenshot "$OUT/$2" --full >/dev/null 2>&1
@@ -33,10 +43,12 @@ shot() { # <rota> <arquivo>
 }
 
 echo "→ capturando"
-shot "/"                                  01-home.png
-shot "/roadmap/"                          02-roadmap.png
-shot "/topico/dois-ponteiros/"            03-dois-ponteiros.png
-shot "/topico/janela-deslizante-fixa/"    04-janela-fixa.png
-shot "/topico/janela-deslizante-dinamica/" 05-janela-dinamica.png
+shot "/"                                   01-home.png
+shot "/introducao/"                        02-introducao.png
+shot "/roadmap/"                           03-roadmap.png
+shot "/topico/two-pointers/"               04-two-pointers.png
+shot "/topico/sliding-window-fixed/"       05-sliding-window-fixed.png
+shot "/topico/sliding-window-dynamic/"     06-sliding-window-dynamic.png
+shot "/apoie/"                             07-apoie.png
 
 echo "✓ pronto → $OUT/"

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -2,16 +2,22 @@
 export const SITE_URL = "https://dsa.craftcodeclub.io";
 
 // Links da comunidade, ponto único. Trocar aqui muda o site inteiro.
-// TODO o app lê `LINKS.discord`, então o convite fica numa constante só: para
-// trocar/rotacionar o convite, mude apenas aqui.
+//
+// Discord, duas portas de entrada:
+//   - Dentro do app (esta constante): convite direto, um clique só, sem pulo
+//     intermediário. Todo o app lê `LINKS.discord`, então rotacionar o convite
+//     é mudar só esta linha.
+//   - Fora do app (README, CONTRIBUTING, templates do GitHub, qualquer .md):
+//     use https://craftcodeclub.io/join. Esses arquivos não importam constante,
+//     e o /join é o ponto de rotação da comunidade: convite revogado lá não
+//     deixa link morto espalhado pelo repositório.
 export const LINKS = {
   discord: "https://discord.gg/b5NnndAbFc",
   // Destino do apoio: a campanha da comunidade na APOIA.se. A lista de
   // apoiadores em /apoie é puxada dessa mesma campanha no build.
   apoiar: "https://apoia.se/craftcodeclub",
-  // Org pública da comunidade. Aponta para a org (e não para o repo) porque o
-  // repositório ainda é privado; quando ficar público, dá para trocar pelo repo.
-  github: "https://github.com/craft-code-club",
+  // Repositório do projeto: é para onde vão os "Contribua no GitHub" do site.
+  github: "https://github.com/craft-code-club/roadmap-dsa",
   site: "https://craftcodeclub.io",
   blog: "https://craftcodeclub.io/blog",
   clubeDoLivro: "https://craftcodeclub.io/book-clubs/designing-data-intensive-applications",

--- a/src/lib/links.ts
+++ b/src/lib/links.ts
@@ -8,9 +8,9 @@ export const SITE_URL = "https://dsa.craftcodeclub.io";
 //     intermediário. Todo o app lê `LINKS.discord`, então rotacionar o convite
 //     é mudar só esta linha.
 //   - Fora do app (README, CONTRIBUTING, templates do GitHub, qualquer .md):
-//     use https://craftcodeclub.io/join. Esses arquivos não importam constante,
-//     e o /join é o ponto de rotação da comunidade: convite revogado lá não
-//     deixa link morto espalhado pelo repositório.
+//     use https://craftcodeclub.io/join. Esses arquivos não têm como importar
+//     a constante, e o /join é o ponto de rotação da comunidade: convite
+//     revogado lá não deixa link morto espalhado pelo repositório.
 export const LINKS = {
   discord: "https://discord.gg/b5NnndAbFc",
   // Destino do apoio: a campanha da comunidade na APOIA.se. A lista de


### PR DESCRIPTION
## O que muda

Auditoria do repositório antes de torná-lo público, e a correção do que ela encontrou.

**Segredos: nada a fazer.** Varri a árvore de trabalho, os 54 arquivos versionados e os 230 objetos do histórico procurando API keys, bearer tokens, chaves privadas, credenciais de nuvem, PATs e JWTs. Zero ocorrências: só aparecem os *nomes* das variáveis, sempre como `${{ secrets.X }}` ou placeholder vazio. O `APOIASE_TOKEN` é lido apenas em build server-side e não deixa traço no `out/`. Os autores do histórico usam e-mail noreply do GitHub.

O que precisou de correção:

1. **`SECURITY.md` mandava abrir issue pública para vulnerabilidade.** Inofensivo enquanto privado; público, expõe a falha para todo mundo antes de existir correção. Agora aponta para o GitHub Security Advisories e para o e-mail da comunidade, e avisa que um PR público com o fix denuncia a falha do mesmo jeito.

2. **`CONTRIBUTING.md` estava desatualizado.** Ainda descrevia a estrutura anterior ao refactor `73c70e9` (`src/content/`, `JanelaVisualizer.tsx`, campos em português). O README foi atualizado em `eb43598`, este não, e é o primeiro arquivo que alguém de fora abre. Documenta também o `summary` de `content/topics/index.ts`, que não estava em lugar nenhum.

3. **`LINKS.github` apontava para a org**, não para o repositório, porque ele era privado. Corrige os cinco "Contribua no GitHub" do site.

4. **Discord passa a ter duas portas, de propósito.** Dentro do app segue o convite direto (`LINKS.discord`), um clique só. Em docs e templates do `.github/` passa a ser `craftcodeclub.io/join`, que é o ponto de rotação da comunidade: convite revogado lá não deixa link morto espalhado num repositório público. A regra está registrada no `links.ts` e no `CLAUDE.md`.

5. **`scripts/smoke-screenshots.sh` estava quebrado**, com os slugs antigos. Como mandava tudo para `/dev/null`, capturava a 404 e terminava verde. Agora valida o HTTP status antes de cada print e falha alto.

6. **`.claude/settings.local.json` só era ignorado pelo gitignore global da máquina.** Passa a ser ignorado pelo repositório.

## Decisão registrada

O `wrangler.toml` removido em `aebaf2e` deixou os nomes do projeto Cloudflare visíveis no histórico. Não são credencial (o deploy segue exigindo o API token) e reescrever histórico custa mais do que resolve, então ficam como estão.

## Verificação

- `npm run build` passa (57 páginas)
- `npm test` passa (11/11)
- `commitlint --from main --to HEAD` passa
- As 7 rotas do smoke respondem 200, e a nova guarda foi testada com um slug morto (falha com `✗ ... respondeu 404`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017sbvXuNEcwzG24MXUvQqnz