### PR TITLE
feat(nav): "em breve" só em tópico sem nenhum material

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,8 +47,12 @@ npm test         # Playwright (roda contra o ./out via python http.server). DEVE
   Greedy Algorithms) como grupos próprios.
 - **Nomes dos campos em inglês; valores exibidos em português.** Campos do tópico: `name`, `group`,
   `level`, `description`, `youtube` (id), `article` (link do blog), `extraVideos`, `references`,
-  `problems`, `viz`, `status: "ready" | "soon"`.
+  `problems`, `viz`, `noViz`, `status: "ready" | "soon"`.
 - Tópicos "ready" têm corpo em `content/topics/<slug>.mdx`, registrado em `content/topics/index.ts`.
+- **"Em breve" é só para tópico vazio.** `isEmptyTopic()` (em `content/roadmap.ts`) = `soon` sem
+  `youtube`, `article`, `viz` nem `extraVideos`. Só esses levam o selo "em breve" no menu lateral e
+  o `noindex`; quem já tem qualquer material aparece normal. Tópico que nunca vai ter visualizador
+  recebe `noViz: true` e deixa de mostrar o aviso de "visualização em construção".
 - Visualizadores ficam em `content/visualizers/` (ex.: `SlidingWindowVisualizer`,
   `TwoPointersVisualizer`), expostos em `mdx-components.tsx`. A lista de apoiadores fica em
   `src/app/apoie/apoiadores.ts` (página fixa, não é conteúdo de DSA).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ mdx-components.tsx          componentes globais disponíveis em todo .mdx
      description: "Maior soma contígua, o clássico." }
    ```
 
+   O selo **"em breve"** no menu lateral aparece só nos tópicos ainda sem nenhum material
+   (sem `youtube`, `article`, `viz` e `extraVideos`). Assim que o tópico ganha um vídeo, um
+   artigo ou um visualizador, o selo some sozinho. Se o tópico não vai ter visualizador,
+   marque `noViz: true` para a página não prometer um que não vem.
+
 2. **Escreva o artigo** (para virar `status: "ready"`): crie `content/topics/kadane.mdx`.
    Dentro do MDX você já pode usar, sem importar: `<Callout>`, `<Colunas>`, `<Cartao>` e
    qualquer visualizador exposto em `mdx-components.tsx`.

--- a/README.md
+++ b/README.md
@@ -66,10 +66,11 @@ mdx-components.tsx          componentes globais disponíveis em todo .mdx
      description: "Maior soma contígua, o clássico." }
    ```
 
-   O selo **"em breve"** no menu lateral aparece só nos tópicos ainda sem nenhum material
-   (sem `youtube`, `article`, `viz` e `extraVideos`). Assim que o tópico ganha um vídeo, um
-   artigo ou um visualizador, o selo some sozinho. Se o tópico não vai ter visualizador,
-   marque `noViz: true` para a página não prometer um que não vem.
+   O selo **"em breve"** no menu lateral aparece só nos tópicos ainda sem nenhum material:
+   `status: "soon"` **e** sem `youtube`, `article`, `viz` e `extraVideos` (é a regra do
+   `isEmptyTopic()`, em `content/roadmap.ts`). Assim que o tópico ganha um vídeo, um artigo ou
+   um visualizador, o selo some sozinho, e tópico `ready` nunca leva o selo. Se o tópico não
+   vai ter visualizador, marque `noViz: true` para a página não prometer um que não vem.
 
 2. **Escreva o artigo** (para virar `status: "ready"`): crie `content/topics/kadane.mdx`.
    Dentro do MDX você já pode usar, sem importar: `<Callout>`, `<Colunas>`, `<Cartao>` e

--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -43,6 +43,10 @@ export type Topic = {
   article?: string; // url do artigo/aula no blog
   repo?: string; // implementação de referência
   viz?: Visualizer;
+  // Alguns tópicos não pedem visualizador (são conceituais, ou o passo a passo
+  // não acrescenta nada). Marque `noViz: true` para não prometer um que não vem:
+  // a página deixa de exibir o aviso de "visualização em construção".
+  noViz?: boolean;
   problems?: Problem[];
   readingTime?: string;
   language?: string;
@@ -320,6 +324,13 @@ export function topicTags(t: Topic): Tag[] {
   if (t.youtube || (t.extraVideos && t.extraVideos.length)) tags.push({ kind: "video", label: "Vídeo" });
   if (t.problems && t.problems.length) tags.push({ kind: "exercises", label: "Exercícios" });
   return tags;
+}
+
+// Tópico realmente vazio: ainda não tem nenhum material (vídeo, artigo ou
+// visualização). Só esses recebem o rótulo "em breve" no menu e ficam fora do
+// índice do Google; quem já tem ao menos um material não é mais "em breve".
+export function isEmptyTopic(t: Topic): boolean {
+  return t.status === "soon" && !t.youtube && !t.article && !t.viz && !t.extraVideos?.length;
 }
 
 export function getNeighbors(slug: string): { previous?: Topic; next?: Topic } {

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -39,9 +39,16 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
   const { previous, next } = getNeighbors(slug);
 
   // Onde o tópico já pode ser estudado hoje (usado no aviso de quem não tem artigo).
-  const ondeEstudar = [t.youtube ? "no vídeo da aula" : null, t.article ? "no artigo do blog" : null]
-    .filter(Boolean)
-    .join(" e ");
+  // Cobre tudo que a página mostra, inclusive os vídeos extras.
+  const ondeEstudar = [
+    t.youtube ? "no vídeo da aula" : null,
+    t.extraVideos && t.extraVideos.length ? "nos vídeos extras" : null,
+    t.article ? "no artigo do blog" : null,
+  ].filter((x): x is string => x !== null);
+  const ondeEstudarTexto =
+    ondeEstudar.length > 1
+      ? `${ondeEstudar.slice(0, -1).join(", ")} e ${ondeEstudar[ondeEstudar.length - 1]}`
+      : ondeEstudar[0];
 
   // Índice "Nesta página": títulos do artigo + seções que a página acrescenta.
   const toc: string[] = [
@@ -77,10 +84,10 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
             <p className="prose-p" style={{ marginTop: 18 }}>{t.description}</p>
             <div className="soon-note">
               {t.noViz ? (
-                ondeEstudar ? (
+                ondeEstudarTexto ? (
                   <>
-                    Este tópico não tem visualizador interativo: o conteúdo vive {ondeEstudar}.
-                    Dúvidas e sugestões, no Discord da comunidade.
+                    Este tópico não tem visualizador interativo: o conteúdo vive{" "}
+                    {ondeEstudarTexto}. Dúvidas e sugestões, no Discord da comunidade.
                   </>
                 ) : (
                   <>

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { getTopic, getNeighbors, ALL_TOPICS } from "@content/roadmap";
+import { getTopic, getNeighbors, isEmptyTopic, ALL_TOPICS } from "@content/roadmap";
 import { getArticle } from "@content/topics";
 import { LINKS, ytEmbed, ytWatch } from "@/lib/links";
 import { levelClass } from "@/lib/ui";
@@ -21,7 +21,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   if (!t) return { title: "Tópico" };
   // Não indexa páginas realmente vazias (sem vídeo, artigo ou visualização) para
   // não criar conteúdo raso aos olhos do Google. Assim que ganham material, entram.
-  const emptyTopic = t.status === "soon" && !t.youtube && !t.article && !t.viz && !(t.extraVideos && t.extraVideos.length);
+  const emptyTopic = isEmptyTopic(t);
   return {
     title: t.name,
     description: t.description,
@@ -37,6 +37,11 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
   const article = getArticle(slug);
   const Body = article?.Body;
   const { previous, next } = getNeighbors(slug);
+
+  // Onde o tópico já pode ser estudado hoje (usado no aviso de quem não tem artigo).
+  const ondeEstudar = [t.youtube ? "no vídeo da aula" : null, t.article ? "no artigo do blog" : null]
+    .filter(Boolean)
+    .join(" e ");
 
   // Índice "Nesta página": títulos do artigo + seções que a página acrescenta.
   const toc: string[] = [
@@ -68,12 +73,28 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
           <Body />
         ) : (
           <>
-            <span className="soon-badge">🚧 Visualização em construção</span>
+            {!t.noViz && <span className="soon-badge">🚧 Visualização em construção</span>}
             <p className="prose-p" style={{ marginTop: 18 }}>{t.description}</p>
             <div className="soon-note">
-              O visualizador interativo deste tópico está a caminho. Por enquanto, assista à aula no
-              vídeo abaixo{t.article ? " e leia o artigo completo no blog" : ""}, e acompanhe o
-              cronograma de produção no Discord da comunidade.
+              {t.noViz ? (
+                ondeEstudar ? (
+                  <>
+                    Este tópico não tem visualizador interativo: o conteúdo vive {ondeEstudar}.
+                    Dúvidas e sugestões, no Discord da comunidade.
+                  </>
+                ) : (
+                  <>
+                    Este tópico não vai ter visualizador interativo, e o material ainda está sendo
+                    escrito. Acompanhe o cronograma de produção no Discord da comunidade.
+                  </>
+                )
+              ) : (
+                <>
+                  O visualizador interativo deste tópico está a caminho. Por enquanto, assista à
+                  aula no vídeo abaixo{t.article ? " e leia o artigo completo no blog" : ""}, e
+                  acompanhe o cronograma de produção no Discord da comunidade.
+                </>
+              )}
             </div>
             {t.article && (
               <a className="btn" href={t.article} target="_blank" rel="noopener noreferrer" style={{ marginBottom: 8 }}>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
-import { GROUPS, TOTAL_TOPICS } from "@content/roadmap";
+import { GROUPS, TOTAL_TOPICS, isEmptyTopic } from "@content/roadmap";
 import { LINKS } from "@/lib/links";
 import { useProgress } from "@/components/ProgressProvider";
 
@@ -158,8 +158,11 @@ export function Shell({ children }: { children: React.ReactNode }) {
                     {g.itens.map((t) => {
                       const feito = isTopico(t.slug);
                       const ativo = slugAtivo === t.slug;
+                      // "Em breve" é só para quem ainda não tem nada: se já existe vídeo,
+                      // artigo ou visualização, o tópico é navegável como qualquer outro.
+                      const vazio = isEmptyTopic(t);
                       return (
-                        <Link key={t.slug} href={`/topico/${t.slug}`} className={`side-item${ativo ? " on" : ""}${t.status === "soon" ? " soon" : ""}`}>
+                        <Link key={t.slug} href={`/topico/${t.slug}`} className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}>
                           <span
                             className={`side-check${feito ? " done" : ""}`}
                             role="checkbox"
@@ -173,7 +176,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
                           </span>
                           <span className="side-item-name">{t.name}</span>
                           {t.viz && <span className="badge-novo">NOVO</span>}
-                          {t.status === "soon" && !t.viz && <span className="badge-soon">em breve</span>}
+                          {vazio && <span className="badge-soon">em breve</span>}
                         </Link>
                       );
                     })}


### PR DESCRIPTION
O selo **"em breve"** no menu lateral marcava todo tópico com `status: "soon"` (44 dos 47), inclusive os que já têm vídeo ou artigo publicado. Isso fazia o guia parecer mais vazio do que é.

## O que muda

- **Menu lateral:** só os tópicos realmente sem material ficam com o selo "em breve" (e com o texto esmaecido). De 44 para 11: Intervalos, Trie, Floyd-Warshall, Grafos Avançados, Busca Binária no Espaço de Respostas, Counting/Radix/Bucket Sort, Greedy Algorithms, Operações Bitwise e Matemática.
- **Regra única:** `isEmptyTopic()` em `content/roadmap.ts` (`soon` sem `youtube`, `article`, `viz` nem `extraVideos`). A página de tópico passa a reusar a mesma função no `noindex`, que antes repetia a condição na mão.
- **Novo campo opcional `noViz`:** para tópico que não vai ganhar visualizador. Com `noViz: true` a página não mostra o selo "🚧 Visualização em construção" nem promete o visualizador; o aviso aponta o vídeo e o artigo (ou diz que o material ainda está sendo escrito, quando não há nenhum). Nenhum tópico usa o campo ainda, é só a porta para marcar caso a caso.
- Docs: CLAUDE.md e README explicam as duas regras.

## Verificação

- `npm run build` (47 páginas) e `npm test` (11 testes Playwright) passando.
- Conferido no build servido: 48 itens no menu, 11 com "em breve".
- `noViz` testado nos três casos (com vídeo + artigo, sem nada, e tópico normal sem o campo) em builds temporários; os flags de teste não ficaram no commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)