### PR TITLE
feat(topics): completa o tópico de Notação Big O com artigo e visualizadores

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -23,7 +23,7 @@ export type Problem = {
   url: string;
 };
 
-export type Visualizer = "sliding-window-fixed" | "sliding-window-dynamic" | "two-pointers";
+export type Visualizer = "sliding-window-fixed" | "sliding-window-dynamic" | "two-pointers" | "big-o";
 
 // Vídeos extras de um tópico: aparecem como links clicáveis (não embed).
 export type VideoLink = { title: string; youtube?: string; url?: string; duration?: string };
@@ -70,7 +70,33 @@ export const GROUPS: Group[] = [
     name: "Introdução",
     intro: { name: "Introdução", href: "/introducao", description: "Como o guia funciona e por onde começar." },
     topics: [
-      { slug: "big-o", name: "Notação Big O", group: "Introdução", level: "Fácil", status: "soon", youtube: yt("MtLv9Rwb55Q"), description: "Como medir tempo e espaço de um algoritmo sem cronômetro." },
+      {
+        slug: "big-o",
+        name: "Notação Big O",
+        group: "Introdução",
+        level: "Fácil",
+        status: "ready",
+        viz: "big-o",
+        youtube: yt("MtLv9Rwb55Q"),
+        videoMinutes: "1:38:08",
+        readingTime: "10 min",
+        language: "Python",
+        description: "Como medir tempo e espaço de um algoritmo sem cronômetro.",
+        problems: [
+          { id: "lc-704", name: "Binary Search", number: "704", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/binary-search/" },
+          { id: "lc-217", name: "Contains Duplicate", number: "217", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/contains-duplicate/" },
+          { id: "lc-121", name: "Best Time to Buy and Sell Stock", number: "121", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/best-time-to-buy-and-sell-stock/" },
+          { id: "lc-1", name: "Two Sum", number: "1", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/two-sum/" },
+          { id: "lc-509", name: "Fibonacci Number", number: "509", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/fibonacci-number/" },
+          { id: "gfg-complexidade", name: "Practice Questions on Time Complexity Analysis", source: "GeeksforGeeks", level: "Guia", url: "https://www.geeksforgeeks.org/dsa/practice-questions-time-complexity-analysis/" },
+        ],
+        references: [
+          { title: "Big O Notation", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/analysis-algorithms-big-o-analysis/" },
+          { title: "Analysis of Algorithms: Asymptotic Analysis", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/analysis-of-algorithms-set-1-asymptotic-analysis/" },
+          { title: "Big-O Cheat Sheet: complexidade das estruturas de dados", source: "bigocheatsheet.com", url: "https://www.bigocheatsheet.com/" },
+          { title: "Time and Space Complexity: cartão do LeetCode Explore", source: "LeetCode", url: "https://leetcode.com/explore/learn/card/recursion-i/256/complexity-analysis/" },
+        ],
+      },
     ],
   },
   {

--- a/content/topics/big-o.mdx
+++ b/content/topics/big-o.mdx
@@ -1,0 +1,124 @@
+<Callout>
+Big O é o jeito de responder "esse algoritmo aguenta?" **sem rodar cronômetro**. Em vez de medir segundos, que dependem da sua máquina, ele mede **como o número de operações cresce quando a entrada cresce**. É a primeira ferramenta do roadmap porque, daqui para frente, todo tópico volta a ela.
+</Callout>
+
+## O que o Big O mede
+
+Todo algoritmo recebe uma entrada. Chamamos de **n** o tamanho dela: o número de posições de um array, a quantidade de nós de uma árvore, o número de linhas de uma tabela. A pergunta do Big O é sempre a mesma:
+
+**Se n dobrar, o que acontece com o trabalho que o algoritmo faz?**
+
+Repare no que ficou de fora. O Big O não diz quantos segundos algo leva, porque isso depende de processador, memória, linguagem e compilador. Ele **tira a máquina da equação** e classifica o algoritmo em uma **família de crescimento**. Dois algoritmos O(n) podem ter tempos bem diferentes na prática, mas os dois reagem do mesmo jeito quando a entrada aumenta.
+
+<Colunas>
+<Cartao titulo="Complexidade de tempo">
+Quantas **operações** o algoritmo executa em função de n. "Tempo" aqui é contagem de passos, não relógio de parede.
+</Cartao>
+<Cartao titulo="Complexidade de espaço">
+Quanta **memória extra** ele precisa além da entrada: arrays auxiliares, hashes, a pilha da recursão. Também se mede em Big O.
+</Cartao>
+</Colunas>
+
+Existem outras notações para a mesma família de perguntas (Ω para o limite inferior, Θ quando os dois limites coincidem), mas Big O virou o padrão porque é o **limite superior**: a promessa de que, a partir de um certo n, o algoritmo não passa disso.
+
+## As três regras
+
+Na prática você quase nunca precisa da definição formal. Três regras resolvem quase todo caso do dia a dia.
+
+**1. n é o tamanho da entrada.** Quando aparecem duas entradas independentes, elas ganham letras próprias: percorrer dois arrays diferentes é O(n + m), não O(2n).
+
+**2. Constantes somem.** Um algoritmo que faz `3n` operações e outro que faz `n` estão na mesma família: os dois são O(n). Multiplicar por 3, ou dividir por 2, desloca a curva mas não muda o formato dela. Processar o array pela metade continua sendo O(n).
+
+**3. Fica só o termo dominante.** Em uma **soma**, o termo de maior grau engole os outros:
+
+```python
+# 4n³ + 3n² + n + 1000  →  O(n³)
+```
+
+Cuidado com o outro lado da regra 3: ela vale para **soma**, não para multiplicação. Dois laços em sequência somam, e o resultado é O(n). Um laço dentro do outro multiplica, e vira O(n²).
+
+```python
+for x in nums:      # n operações
+    ...
+for x in nums:      # + n operações  →  O(n + n) = O(n)
+    ...
+
+for x in nums:          # n vezes...
+    for y in nums:      # ...n operações cada  →  O(n × n) = O(n²)
+        ...
+```
+
+<Callout tipo="aviso">
+Termos com **variáveis diferentes** não se cancelam. `n² + k²` continua `O(n² + k²)`, porque você não sabe qual dos dois é maior. Só simplifique quando souber que uma entrada domina a outra.
+</Callout>
+
+## As famílias, do O(1) ao O(n!)
+
+Esta é a tabela que vale colar na parede. Repare menos nos nomes e mais na coluna de n = 1.000: é ali que as famílias deixam de ser parecidas.
+
+<BigOFamilias />
+
+O gráfico abaixo é a mesma tabela em movimento. Ligue e desligue as famílias, arraste o marcador sobre a curva e, principalmente, **aumente a entrada máxima**: o que parecia dramático com n = 10 vira uma linha colada no chão quando n chega a 1.000. É esse efeito que faz a constante ser descartada.
+
+<BigOChartVisualizer />
+
+<Callout>
+Ligue O(2ⁿ) e O(n!) e veja o gráfico inteiro achatar: do lado dessas duas, todas as outras viram uma linha colada no chão. Aí troque para a escala **logarítmica** e diminua a entrada máxima para 25. Cada família vira uma inclinação diferente, e dá para comparar as oito de uma vez.
+</Callout>
+
+Dois detalhes que confundem no começo:
+
+- **O log do Big O é base 2**, não base 10. A busca binária corta o espaço de busca ao meio a cada passo, então a conta natural é log₂. Com 1.024 posições são 10 passos; com 1 milhão, 20.
+- **O(1) não quer dizer "uma operação"**. Atualizar três campos de um objeto são três operações, mas continuam sendo três com qualquer entrada. Constante é isso: **não reage ao tamanho de n**.
+
+## Contando operações no mesmo array
+
+Teoria bonita, mas o que convence mesmo é ver o contador. Abaixo, quatro algoritmos rodando sobre o **mesmo array de 8 posições**. Troque entre eles e compare o número final de operações, e também o campo "pior caso com n = 16".
+
+<BigOCounterVisualizer />
+
+O que você deveria ver ao rodar os quatro:
+
+| Algoritmo | Pior caso com n = 8 | Pior caso com n = 16 | Família |
+| --- | --- | --- | --- |
+| Acesso por índice | 1 | 1 | O(1) |
+| Busca binária | 4 | 5 | O(log n) |
+| Busca linear | 8 | 16 | O(n) |
+| Todos os pares | 28 | 120 | O(n²) |
+
+Dobrar a entrada não fez nada com o primeiro, somou 1 no segundo, dobrou o terceiro e **praticamente quadruplicou** o quarto. Essa é a diferença entre famílias, e é por isso que a discussão sobre performance começa aqui, não no micro-otimizador de linha de código.
+
+Repare também na busca binária procurando o 20: ela acerta em 3 passos, contra os 5 da busca linear. Com 1 milhão de posições seriam 20 passos contra 1 milhão. É o mesmo motivo pelo qual um índice de banco de dados transforma um full scan em algo instantâneo.
+
+## Melhor caso, caso médio e pior caso
+
+O mesmo algoritmo pode ter três respostas dependendo da entrada que chega.
+
+<Colunas>
+<Cartao titulo="Melhor caso">
+A busca linear acha o alvo na primeira posição: O(1). Um Bubble Sort otimizado recebe o array já ordenado e faz uma passada só: O(n). Bonito, e raro.
+</Cartao>
+<Cartao titulo="Pior caso">
+O alvo não existe e a busca linear percorre tudo: O(n). É o que se assume por padrão, inclusive em entrevista, quando ninguém especifica qual caso.
+</Cartao>
+</Colunas>
+
+O **caso médio** é o que costuma governar a decisão de arquitetura, mas é o mais difícil de calcular, porque depende da distribuição real dos dados. Por isso o pior caso ganha tanto espaço: ele é o contrato, a garantia de que pior do que aquilo não fica.
+
+Algumas estruturas existem justamente para eliminar essa distância. Uma **árvore AVL** se rebalanceia a cada inserção para que nenhum ramo fique muito mais alto que o outro, e com isso busca, inserção e remoção ficam em O(log n) **no pior caso**, não só na média. Uma BST comum, sem rebalanceamento, degenera para uma lista e cai para O(n) quando os dados chegam já ordenados.
+
+## As armadilhas que pegam todo mundo
+
+**Eficiente não é a mesma coisa que rápido.** Levar 500 TB de dados num caminhão de São Paulo ao Rio é O(1): o tempo não muda se você colocar mais um disco. Mandar pela internet é O(n): dobrou o volume, dobrou o tempo. Para 1 GB a internet ganha fácil; para 500 TB, o caminhão. Complexidade fala de **escala**, o custo absoluto de cada operação continua importando.
+
+**Ordenar para depois buscar quase sempre é pior.** A tentação é clássica: "busca binária é O(log n), muito melhor que O(n), então vou ordenar e buscar". Só que ordenar custa O(n log n), e `n log n + log n` continua sendo O(n log n), que é **pior** que a busca linear O(n). A conta só vira quando você ordena uma vez e busca muitas: aí o custo inicial se dilui, que é exatamente o raciocínio por trás de um índice de banco de dados.
+
+**Com entrada pequena, a família não decide nada.** Ordenar as 26 letras do alfabeto vai ser instantâneo com qualquer algoritmo. Se o problema garante que n é pequeno e limitado, escolha o código mais simples de ler e manter. O Big O só cobra a conta quando a escala aparece.
+
+**Complexidade não é legibilidade.** Um algoritmo O(n²) pode ser trivial de entender e um O(n) pode ser um quebra-cabeça. São eixos diferentes, e "complexo" no sentido do Big O não quer dizer "complicado de ler".
+
+<Callout tipo="aviso">
+Quando o problema é naturalmente O(2ⁿ) ou O(n!), como o caixeiro viajante ou montar todas as permutações, não existe truque de implementação que salve. O caminho passa a ser outro: heurísticas, aproximações, programação dinâmica ou podar o espaço de busca com [backtracking](/topico/backtracking). Uma boa solução rápida costuma valer mais que a ótima que nunca termina.
+</Callout>
+
+O próximo passo é aplicar isso em algo concreto: veja como [Two Pointers](/topico/two-pointers) transforma um O(n²) em O(n), e como a [Sliding Window](/topico/sliding-window-fixed) evita recalcular o que já foi calculado.

--- a/content/topics/index.ts
+++ b/content/topics/index.ts
@@ -1,4 +1,5 @@
 import type { ComponentType } from "react";
+import BigO from "./big-o.mdx";
 import TwoPointers from "./two-pointers.mdx";
 import SlidingWindowFixed from "./sliding-window-fixed.mdx";
 import SlidingWindowDynamic from "./sliding-window-dynamic.mdx";
@@ -12,6 +13,17 @@ export type Article = { Body: ComponentType; summary: string[] };
 // summary = SÓ os títulos (h2) do artigo, no texto exato. A página do tópico
 // acrescenta "Vídeo da aula" e "Problemas para praticar" quando existem.
 export const ARTICLES: Record<string, Article> = {
+  "big-o": {
+    Body: BigO,
+    summary: [
+      "O que o Big O mede",
+      "As três regras",
+      "As famílias, do O(1) ao O(n!)",
+      "Contando operações no mesmo array",
+      "Melhor caso, caso médio e pior caso",
+      "As armadilhas que pegam todo mundo",
+    ],
+  },
   "two-pointers": {
     Body: TwoPointers,
     summary: ["O padrão", "Two Sum num array ordenado", "Por que funciona"],

--- a/content/visualizers/BigOChartVisualizer.tsx
+++ b/content/visualizers/BigOChartVisualizer.tsx
@@ -287,6 +287,25 @@ export function BigOChartVisualizer() {
     setMarcadorPct(Math.min(1, Math.max(0.001, pct)));
   };
 
+  // O marcador também anda pelo teclado: o canvas é um slider ao longo do eixo
+  // n, então setas andam de pouco em pouco, PageUp/PageDown de muito em muito e
+  // Home/End vão para as pontas.
+  const aoTeclar = (e: React.KeyboardEvent<HTMLCanvasElement>) => {
+    const passos: Record<string, number> = {
+      ArrowLeft: -0.02, ArrowRight: 0.02, ArrowDown: -0.02, ArrowUp: 0.02,
+      PageDown: -0.1, PageUp: 0.1,
+    };
+    if (e.key === "Home" || e.key === "End") {
+      e.preventDefault();
+      setMarcadorPct(e.key === "Home" ? 0.001 : 1);
+      return;
+    }
+    const d = passos[e.key];
+    if (d === undefined) return;
+    e.preventDefault();
+    setMarcadorPct((p) => Math.min(1, Math.max(0.001, p + d)));
+  };
+
   // Capturar o ponteiro mantém o arrasto vivo mesmo com o cursor saindo do
   // canvas. É um extra: se o navegador recusar o id, o arrasto normal segue
   // funcionando, então a falha é engolida de propósito.
@@ -344,9 +363,18 @@ export function BigOChartVisualizer() {
             ref={canvasRef}
             className="bigo-canvas"
             style={{ height: altura }}
+            role="slider"
+            tabIndex={0}
+            aria-label="Marcador do gráfico de crescimento: escolhe o tamanho da entrada lido nas curvas"
+            aria-valuemin={1}
+            aria-valuemax={nMax}
+            aria-valuenow={nMarcador}
+            aria-valuetext={`n igual a ${num(nMarcador)}, ${leitura.map((l) => `${l.valor} operações em ${l.rotulo}`).join(", ")}`}
+            onKeyDown={aoTeclar}
             onPointerDown={(e) => { moverMarcador(e); capturar(e); }}
             onPointerMove={(e) => { if (e.buttons === 1) moverMarcador(e); }}
             onPointerUp={soltar}
+            onPointerCancel={soltar}
           />
         </div>
 
@@ -358,7 +386,7 @@ export function BigOChartVisualizer() {
               <strong style={{ color: l.cor }}>{l.valor}</strong> operações em {l.rotulo}
             </span>
           ))}
-          . Arraste sobre o gráfico para mover o marcador.
+          . Arraste sobre o gráfico, ou use as setas do teclado, para mover o marcador.
         </p>
 
         <div className="bigo-grid">

--- a/content/visualizers/BigOChartVisualizer.tsx
+++ b/content/visualizers/BigOChartVisualizer.tsx
@@ -275,6 +275,8 @@ export function BigOChartVisualizer() {
     ctx.strokeRect(padE + 0.5, padT + 0.5, gw - 1, gh - 1);
   }, [visiveis, nMax, nMarcador, logaritmica, largura, altura]);
 
+  // Só move com o ponteiro pressionado (o texto embaixo do gráfico pede para
+  // arrastar). Seguir o hover redesenharia o canvas a cada mousemove.
   const moverMarcador = (e: React.PointerEvent<HTMLCanvasElement>) => {
     const cv = canvasRef.current;
     if (!cv) return;
@@ -283,6 +285,16 @@ export function BigOChartVisualizer() {
     const gw = r.width - padE - padD;
     const pct = (e.clientX - r.left - padE) / Math.max(1, gw);
     setMarcadorPct(Math.min(1, Math.max(0.001, pct)));
+  };
+
+  // Capturar o ponteiro mantém o arrasto vivo mesmo com o cursor saindo do
+  // canvas. É um extra: se o navegador recusar o id, o arrasto normal segue
+  // funcionando, então a falha é engolida de propósito.
+  const capturar = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* segue sem captura */ }
+  };
+  const soltar = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* nada a soltar */ }
   };
 
   const leitura = visiveis.map((f) => ({
@@ -332,8 +344,9 @@ export function BigOChartVisualizer() {
             ref={canvasRef}
             className="bigo-canvas"
             style={{ height: altura }}
-            onPointerDown={moverMarcador}
-            onPointerMove={(e) => { if (e.buttons === 1 || e.pointerType === "mouse") moverMarcador(e); }}
+            onPointerDown={(e) => { moverMarcador(e); capturar(e); }}
+            onPointerMove={(e) => { if (e.buttons === 1) moverMarcador(e); }}
+            onPointerUp={soltar}
           />
         </div>
 

--- a/content/visualizers/BigOChartVisualizer.tsx
+++ b/content/visualizers/BigOChartVisualizer.tsx
@@ -1,0 +1,396 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// BigOChartVisualizer, as curvas de crescimento desenhadas num canvas.
+//
+// Foge um pouco do padrão "gerador puro de passos" dos outros visualizadores
+// porque aqui não existe um algoritmo rodando passo a passo: o que se aprende
+// é a FORMA de cada família quando a entrada cresce. A casca (viz-head,
+// viz-body, controles, Expandir) é a mesma dos demais.
+//
+// Toda família é definida em duas versões: `val` (o número de operações, que
+// estoura para Infinity em 2^n e n!) e `log10` (o mesmo valor em log, sempre
+// finito). Assim a escala logarítmica continua desenhando o que a linear não
+// consegue mais representar.
+// ---------------------------------------------------------------------------
+
+type Familia = {
+  key: string;
+  rotulo: string;
+  cor: string;
+  exemplo: string;
+  val: (n: number) => number;
+  log10: (n: number) => number;
+};
+
+const LN10 = Math.LN10;
+
+// log10(n!) por Stirling com o termo de correção 1/(12n). Contínua (a curva
+// sai lisa em vez de escadinha) e barata mesmo com n na casa do milhão, onde
+// somar log de cada termo seria inviável a cada ponto do gráfico.
+function log10Fatorial(n: number): number {
+  const x = Math.max(1, n);
+  return (x * Math.log(x) - x + 0.5 * Math.log(2 * Math.PI * x) + 1 / (12 * x)) / LN10;
+}
+
+function fatorial(n: number): number {
+  if (n > 170) return Infinity;
+  let f = 1;
+  for (let i = 2; i <= Math.floor(n); i++) f *= i;
+  return f;
+}
+
+const FAMILIAS: Familia[] = [
+  { key: "c", rotulo: "O(1)", cor: "#34d399", exemplo: "acesso por índice",
+    val: () => 1, log10: () => 0 },
+  { key: "log", rotulo: "O(log n)", cor: "#22d3ee", exemplo: "busca binária",
+    val: (n) => Math.max(1, Math.log2(n)), log10: (n) => Math.log10(Math.max(1, Math.log2(n))) },
+  { key: "n", rotulo: "O(n)", cor: "#60a5fa", exemplo: "busca linear",
+    val: (n) => n, log10: (n) => Math.log10(n) },
+  { key: "nlog", rotulo: "O(n log n)", cor: "#a78bfa", exemplo: "merge sort",
+    val: (n) => n * Math.max(1, Math.log2(n)), log10: (n) => Math.log10(n) + Math.log10(Math.max(1, Math.log2(n))) },
+  { key: "n2", rotulo: "O(n²)", cor: "#fbbf24", exemplo: "dois laços aninhados",
+    val: (n) => n * n, log10: (n) => 2 * Math.log10(n) },
+  { key: "n3", rotulo: "O(n³)", cor: "#fb923c", exemplo: "três laços aninhados",
+    val: (n) => n * n * n, log10: (n) => 3 * Math.log10(n) },
+  { key: "exp", rotulo: "O(2ⁿ)", cor: "#f87171", exemplo: "fibonacci recursivo",
+    val: (n) => (n > 1023 ? Infinity : Math.pow(2, n)), log10: (n) => n * Math.log10(2) },
+  { key: "fat", rotulo: "O(n!)", cor: "#f472b6", exemplo: "permutações, caixeiro viajante",
+    val: (n) => fatorial(n), log10: (n) => log10Fatorial(n) },
+];
+
+// Entradas em passos redondos, do "cabe na cabeça" ao "escala de produção".
+const ENTRADAS = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 100000, 1000000];
+
+const PADRAO = new Set(["c", "log", "n", "nlog", "n2"]);
+
+// Formatação determinística (nada de Intl, para o HTML do servidor e do
+// cliente baterem exatamente na hidratação).
+function num(v: number): string {
+  const r = Math.round(v * 10) / 10;
+  const txt = Number.isInteger(r) ? String(r) : r.toFixed(1).replace(".", ",");
+  return txt.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+}
+
+function fmt(v: number): string {
+  if (!isFinite(v)) return "grande demais";
+  if (v >= 1e15) return `10^${Math.round(Math.log10(v))}`;
+  if (v >= 1e12) return `${num(v / 1e12)} tri`;
+  if (v >= 1e9) return `${num(v / 1e9)} bi`;
+  if (v >= 1e6) return `${num(v / 1e6)} mi`;
+  return num(Math.round(v));
+}
+
+function fmtLog(log10v: number): string {
+  if (log10v < 15) return fmt(Math.pow(10, log10v));
+  return `10^${Math.round(log10v)}`;
+}
+
+// Rótulo do eixo Y em escala log: sempre uma potência de 10 redonda.
+function decada(exp: number): string {
+  if (exp === 0) return "1";
+  if (exp <= 6) return num(Math.pow(10, exp));
+  return `10^${exp}`;
+}
+
+export function BigOChartVisualizer() {
+  const [iEntrada, setIEntrada] = useState(3); // 100
+  const [logaritmica, setLogaritmica] = useState(false);
+  const [ativas, setAtivas] = useState<Set<string>>(new Set(PADRAO));
+  const [marcadorPct, setMarcadorPct] = useState(0.62);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [largura, setLargura] = useState(720);
+
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const nMax = ENTRADAS[iEntrada];
+  const nMarcador = Math.max(1, Math.round(nMax * marcadorPct));
+  const visiveis = useMemo(() => FAMILIAS.filter((f) => ativas.has(f.key)), [ativas]);
+
+  const alternar = useCallback((key: string) => {
+    setAtivas((s) => {
+      const novo = new Set(s);
+      if (novo.has(key)) novo.delete(key); else novo.add(key);
+      return novo.size ? novo : new Set([key]);
+    });
+  }, []);
+
+  // Largura real do canvas: o gráfico é redesenhado quando o container muda
+  // (troca de viewport, abrir/fechar o Expandir).
+  const medir = useCallback((el: HTMLDivElement | null) => {
+    wrapRef.current = el;
+    if (el) setLargura(el.clientWidth || 720);
+  }, []);
+
+  useEffect(() => {
+    const el = wrapRef.current;
+    if (!el || typeof ResizeObserver === "undefined") return;
+    const ro = new ResizeObserver(() => setLargura(el.clientWidth || 720));
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [expanded, mounted]);
+
+  const altura = expanded ? 400 : 300;
+
+  useEffect(() => {
+    const cv = canvasRef.current;
+    if (!cv) return;
+    const ctx = cv.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    const W = Math.max(280, largura);
+    const H = altura;
+    cv.width = Math.round(W * dpr);
+    cv.height = Math.round(H * dpr);
+    cv.style.height = `${H}px`;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, W, H);
+
+    const padE = 72, padD = 16, padT = 26, padB = 34;
+    const gw = W - padE - padD;
+    const gh = H - padT - padB;
+    const mono = '11px ui-monospace, SFMono-Regular, Menlo, monospace';
+
+    // Teto do eixo Y. Na linear, o maior valor visível; na log, a maior ordem
+    // de grandeza arredondada para um número redondo de décadas por linha,
+    // para os rótulos saírem sempre como potências inteiras de 10.
+    const topoLog = Math.max(1, ...visiveis.map((f) => f.log10(nMax)));
+    const passoLog = Math.max(1, Math.ceil(topoLog / 5));
+    const yMaxLog = passoLog * Math.ceil(topoLog / passoLog);
+    const brutos = visiveis.map((f) => f.val(nMax)).filter((v) => isFinite(v));
+    const yMax = brutos.length ? Math.max(10, Math.max(...brutos)) : 10;
+
+    const px = (n: number) => padE + ((n - 1) / Math.max(1, nMax - 1)) * gw;
+    const py = (f: Familia, n: number) => {
+      if (logaritmica) {
+        const v = Math.max(0, f.log10(n));
+        return padT + gh - (v / yMaxLog) * gh;
+      }
+      const v = f.val(n);
+      if (!isFinite(v)) return padT - 40;
+      return padT + gh - Math.min(1.2, v / yMax) * gh;
+    };
+
+    // Grade e eixo Y
+    ctx.strokeStyle = "rgba(255,255,255,0.06)";
+    ctx.fillStyle = "#61748c";
+    ctx.font = mono;
+    ctx.lineWidth = 1;
+    ctx.textAlign = "right";
+    ctx.textBaseline = "middle";
+    const linhas = logaritmica ? Math.round(yMaxLog / passoLog) : 5;
+    for (let i = 0; i <= linhas; i++) {
+      const y = padT + gh - (i / linhas) * gh;
+      ctx.beginPath();
+      ctx.moveTo(padE, Math.round(y) + 0.5);
+      ctx.lineTo(padE + gw, Math.round(y) + 0.5);
+      ctx.stroke();
+      const rotulo = logaritmica ? decada(i * passoLog) : fmt((i / linhas) * yMax);
+      ctx.fillText(rotulo, padE - 8, y);
+    }
+
+    // Eixo X
+    ctx.textAlign = "center";
+    ctx.textBaseline = "top";
+    const marcasX = 4;
+    for (let i = 0; i <= marcasX; i++) {
+      const n = 1 + ((nMax - 1) * i) / marcasX;
+      const x = px(n);
+      ctx.beginPath();
+      ctx.strokeStyle = "rgba(255,255,255,0.04)";
+      ctx.moveTo(Math.round(x) + 0.5, padT);
+      ctx.lineTo(Math.round(x) + 0.5, padT + gh);
+      ctx.stroke();
+      ctx.fillStyle = "#61748c";
+      ctx.fillText(fmt(Math.round(n)), x, padT + gh + 8);
+    }
+
+    ctx.textAlign = "left";
+    ctx.fillStyle = "#4c5f79";
+    ctx.fillText("n (tamanho da entrada) →", padE, padT + gh + 21);
+    ctx.fillText(logaritmica ? "↑ operações (escala logarítmica)" : "↑ operações", padE, 7);
+
+    // Curvas, recortadas na área do gráfico
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(padE, padT - 1, gw, gh + 2);
+    ctx.clip();
+    ctx.lineWidth = 2;
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    const amostras = Math.max(80, Math.round(gw));
+    for (const f of visiveis) {
+      ctx.strokeStyle = f.cor;
+      ctx.beginPath();
+      for (let i = 0; i <= amostras; i++) {
+        const n = 1 + ((nMax - 1) * i) / amostras;
+        const x = px(n);
+        const y = py(f, n);
+        if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
+      }
+      ctx.stroke();
+    }
+
+    // Marcador: linha vertical + bolinha em cada curva
+    const xm = px(nMarcador);
+    ctx.setLineDash([4, 4]);
+    ctx.strokeStyle = "rgba(255,255,255,0.28)";
+    ctx.lineWidth = 1;
+    ctx.beginPath();
+    ctx.moveTo(Math.round(xm) + 0.5, padT);
+    ctx.lineTo(Math.round(xm) + 0.5, padT + gh);
+    ctx.stroke();
+    ctx.setLineDash([]);
+    for (const f of visiveis) {
+      const y = py(f, nMarcador);
+      if (y < padT - 2 || y > padT + gh + 2) continue;
+      ctx.fillStyle = f.cor;
+      ctx.beginPath();
+      ctx.arc(xm, y, 3.5, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.strokeStyle = "#0d1420";
+      ctx.lineWidth = 1.5;
+      ctx.stroke();
+    }
+    ctx.restore();
+
+    // Moldura
+    ctx.strokeStyle = "rgba(255,255,255,0.08)";
+    ctx.lineWidth = 1;
+    ctx.strokeRect(padE + 0.5, padT + 0.5, gw - 1, gh - 1);
+  }, [visiveis, nMax, nMarcador, logaritmica, largura, altura]);
+
+  const moverMarcador = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const cv = canvasRef.current;
+    if (!cv) return;
+    const r = cv.getBoundingClientRect();
+    const padE = 72, padD = 16;
+    const gw = r.width - padE - padD;
+    const pct = (e.clientX - r.left - padE) / Math.max(1, gw);
+    setMarcadorPct(Math.min(1, Math.max(0.001, pct)));
+  };
+
+  const leitura = visiveis.map((f) => ({
+    key: f.key,
+    rotulo: f.rotulo,
+    cor: f.cor,
+    exemplo: f.exemplo,
+    valor: f.log10(nMarcador) >= 15 ? fmtLog(f.log10(nMarcador)) : fmt(f.val(nMarcador)),
+  }));
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · como cada família cresce</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">n = {num(nMarcador)}</span>
+          <button className="viz-expand" onClick={() => setExpanded((v) => !v)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {FAMILIAS.map((f) => {
+            const on = ativas.has(f.key);
+            return (
+              <button
+                key={f.key}
+                className={`bigo-chip${on ? " on" : ""}`}
+                style={on ? { borderColor: f.cor, color: f.cor } : undefined}
+                onClick={() => alternar(f.key)}
+                aria-pressed={on}
+              >
+                <span className="sw" style={{ background: on ? f.cor : "#3a4a60" }} />
+                {f.rotulo}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="bigo-canvas-wrap" ref={medir}>
+          <canvas
+            ref={canvasRef}
+            className="bigo-canvas"
+            style={{ height: altura }}
+            onPointerDown={moverMarcador}
+            onPointerMove={(e) => { if (e.buttons === 1 || e.pointerType === "mouse") moverMarcador(e); }}
+          />
+        </div>
+
+        <p className="viz-note">
+          Com <strong>n = {num(nMarcador)}</strong>, {leitura.length === 1 ? "a família marcada faz" : "as famílias marcadas fazem"}{" "}
+          {leitura.map((l, i) => (
+            <span key={l.key}>
+              {i > 0 ? (i === leitura.length - 1 ? " e " : ", ") : ""}
+              <strong style={{ color: l.cor }}>{l.valor}</strong> operações em {l.rotulo}
+            </span>
+          ))}
+          . Arraste sobre o gráfico para mover o marcador.
+        </p>
+
+        <div className="bigo-grid">
+          {leitura.map((l) => (
+            <div className="bigo-card" key={l.key} style={{ borderLeftColor: l.cor }}>
+              <div className="bigo-card-top">
+                <span className="bigo-card-nome" style={{ color: l.cor }}>{l.rotulo}</span>
+                <span className="bigo-card-val">{l.valor}</span>
+              </div>
+              <div className="bigo-card-ex">{l.exemplo}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="viz-controls">
+          <div className="viz-field grow">
+            <span>Entrada máxima: n até {num(nMax)}</span>
+            <input
+              type="range"
+              min={0}
+              max={ENTRADAS.length - 1}
+              step={1}
+              value={iEntrada}
+              onChange={(e) => setIEntrada(parseInt(e.target.value, 10))}
+              style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
+            />
+          </div>
+          <button className="viz-btn" onClick={() => setLogaritmica((v) => !v)}>
+            Escala: {logaritmica ? "logarítmica" : "linear"}
+          </button>
+          <button className="viz-btn" onClick={() => { setAtivas(new Set(PADRAO)); setIEntrada(3); setMarcadorPct(0.62); setLogaritmica(false); }}>
+            ↺ Reiniciar
+          </button>
+        </div>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/content/visualizers/BigOCounterVisualizer.tsx
+++ b/content/visualizers/BigOCounterVisualizer.tsx
@@ -1,0 +1,413 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// BigOCounterVisualizer, o contador de operações.
+//
+// Mesmo padrão dos outros visualizadores (gerador puro de passos + casca
+// compartilhada), com um detalhe a mais: cada passo carrega o contador de
+// operações. A ideia é o aluno ver o contador parar em 1, em log n, em n e em
+// n² sobre o MESMO array, e conferir a conta do pior caso ao lado.
+// ---------------------------------------------------------------------------
+
+type Passo = {
+  linha: number;
+  ops: number;
+  marcas: Record<number, string>;
+  ativos: number[];
+  fora: number[];
+  nota: string;
+  vars: { nome: string; valor: string; best?: boolean }[];
+  ok?: boolean;
+  fim?: boolean;
+};
+
+type Algoritmo = {
+  key: string;
+  nome: string;
+  familia: string;
+  cor: string;
+  usaAlvo: boolean;
+  codigo: string[];
+  arquivo: string;
+  piorCaso: (n: number) => number;
+  formula: string;
+  gerar: (nums: number[], alvo: number) => Passo[];
+};
+
+const CONSTANTE: string[] = [
+  "def pegar(nums, i):",
+  "    return nums[i]",
+];
+
+const BINARIA: string[] = [
+  "def busca_binaria(nums, alvo):",
+  "    esq, dir = 0, len(nums) - 1",
+  "    while esq <= dir:",
+  "        meio = (esq + dir) // 2",
+  "        if nums[meio] == alvo:",
+  "            return meio",
+  "        if nums[meio] < alvo:",
+  "            esq = meio + 1",
+  "        else:",
+  "            dir = meio - 1",
+  "    return -1",
+];
+
+const LINEAR: string[] = [
+  "def busca_linear(nums, alvo):",
+  "    for i in range(len(nums)):",
+  "        if nums[i] == alvo:",
+  "            return i",
+  "    return -1",
+];
+
+const PARES: string[] = [
+  "def tem_repetido(nums):",
+  "    for i in range(len(nums)):",
+  "        for j in range(i + 1, len(nums)):",
+  "            if nums[i] == nums[j]:",
+  "                return True",
+  "    return False",
+];
+
+function faixa(de: number, ate: number): number[] {
+  const out: number[] = [];
+  for (let i = de; i <= ate; i++) out.push(i);
+  return out;
+}
+
+const ALGORITMOS: Algoritmo[] = [
+  {
+    key: "const",
+    nome: "Acesso por índice",
+    familia: "O(1)",
+    cor: "#34d399",
+    usaAlvo: false,
+    codigo: CONSTANTE,
+    arquivo: "constante.py",
+    piorCaso: () => 1,
+    formula: "1 operação, sempre",
+    gerar: (nums) => {
+      const i = Math.min(3, nums.length - 1);
+      return [
+        { linha: 0, ops: 0, marcas: {}, ativos: [], fora: [], nota: `Quero o elemento na posição ${i}. O array tem ${nums.length} posições.`, vars: [{ nome: "i", valor: `${i}` }, { nome: "operações", valor: "0" }] },
+        { linha: 1, ops: 1, marcas: { [i]: "i" }, ativos: [i], fora: [], ok: true, fim: true, nota: `Peguei nums[${i}] = ${nums[i]} direto. Uma operação, e ela seria uma só com um array de 1 bilhão de posições.`, vars: [{ nome: "i", valor: `${i}` }, { nome: "operações", valor: "1", best: true }] },
+      ];
+    },
+  },
+  {
+    key: "bin",
+    nome: "Busca binária",
+    familia: "O(log n)",
+    cor: "#22d3ee",
+    usaAlvo: true,
+    codigo: BINARIA,
+    arquivo: "busca_binaria.py",
+    piorCaso: (n) => Math.ceil(Math.log2(n + 1)),
+    formula: "log₂(n) operações",
+    gerar: (nums, alvo) => {
+      const out: Passo[] = [];
+      let esq = 0, dir = nums.length - 1, ops = 0;
+      const vars = () => [
+        { nome: "esq", valor: `${esq}` },
+        { nome: "dir", valor: `${dir}` },
+        { nome: "operações", valor: `${ops}`, best: true },
+      ];
+      out.push({ linha: 1, ops, marcas: { [esq]: "E", [dir]: "D" }, ativos: faixa(esq, dir), fora: [], nota: `O array precisa estar ordenado. Procurando ${alvo} entre as posições ${esq} e ${dir}.`, vars: vars() });
+      let guarda = 0;
+      while (esq <= dir && guarda++ < 60) {
+        const meio = Math.floor((esq + dir) / 2);
+        ops++;
+        const marcas: Record<number, string> = { [meio]: "meio" };
+        const fora = [...faixa(0, esq - 1), ...faixa(dir + 1, nums.length - 1)];
+        out.push({ linha: 3, ops, marcas, ativos: faixa(esq, dir), fora, nota: `Operação ${ops}: olho o meio, posição ${meio}, valor ${nums[meio]}.`, vars: vars() });
+        if (nums[meio] === alvo) {
+          out.push({ linha: 5, ops, marcas, ativos: [meio], fora, ok: true, fim: true, nota: `Achei ${alvo} na posição ${meio} com ${ops} ${ops === 1 ? "operação" : "operações"}. A busca linear teria olhado ${meio + 1}.`, vars: vars() });
+          return out;
+        }
+        if (nums[meio] < alvo) {
+          esq = meio + 1;
+          out.push({ linha: 7, ops, marcas, ativos: faixa(esq, dir), fora: [...faixa(0, esq - 1), ...faixa(dir + 1, nums.length - 1)], nota: `${nums[meio]} < ${alvo}: descarto a metade da esquerda de uma vez só.`, vars: vars() });
+        } else {
+          dir = meio - 1;
+          out.push({ linha: 9, ops, marcas, ativos: faixa(esq, dir), fora: [...faixa(0, esq - 1), ...faixa(dir + 1, nums.length - 1)], nota: `${nums[meio]} > ${alvo}: descarto a metade da direita de uma vez só.`, vars: vars() });
+        }
+      }
+      out.push({ linha: 10, ops, marcas: {}, ativos: [], fora: faixa(0, nums.length - 1), fim: true, nota: `Sobrou nada para olhar: ${alvo} não está no array. Custou ${ops} ${ops === 1 ? "operação" : "operações"}.`, vars: vars() });
+      return out;
+    },
+  },
+  {
+    key: "lin",
+    nome: "Busca linear",
+    familia: "O(n)",
+    cor: "#60a5fa",
+    usaAlvo: true,
+    codigo: LINEAR,
+    arquivo: "busca_linear.py",
+    piorCaso: (n) => n,
+    formula: "n operações",
+    gerar: (nums, alvo) => {
+      const out: Passo[] = [];
+      let ops = 0;
+      out.push({ linha: 1, ops, marcas: {}, ativos: [], fora: [], nota: `Sem ordem garantida, só resta olhar posição por posição até achar ${alvo}.`, vars: [{ nome: "i", valor: "-" }, { nome: "operações", valor: "0", best: true }] });
+      for (let i = 0; i < nums.length; i++) {
+        ops++;
+        const vars = [{ nome: "i", valor: `${i}` }, { nome: "operações", valor: `${ops}`, best: true }];
+        if (nums[i] === alvo) {
+          out.push({ linha: 3, ops, marcas: { [i]: "i" }, ativos: [i], fora: faixa(0, i - 1), ok: true, fim: true, nota: `Achei ${alvo} na posição ${i}. Custou ${ops} ${ops === 1 ? "operação" : "operações"}.`, vars });
+          return out;
+        }
+        out.push({ linha: 2, ops, marcas: { [i]: "i" }, ativos: [i], fora: faixa(0, i - 1), nota: `Operação ${ops}: nums[${i}] = ${nums[i]}, não é ${alvo}. Sigo.`, vars });
+      }
+      out.push({ linha: 4, ops, marcas: {}, ativos: [], fora: faixa(0, nums.length - 1), fim: true, nota: `${alvo} não está no array. Este é o pior caso: ${ops} operações para n = ${nums.length}.`, vars: [{ nome: "i", valor: "-" }, { nome: "operações", valor: `${ops}`, best: true }] });
+      return out;
+    },
+  },
+  {
+    key: "quad",
+    nome: "Todos os pares",
+    familia: "O(n²)",
+    cor: "#fbbf24",
+    usaAlvo: false,
+    codigo: PARES,
+    arquivo: "tem_repetido.py",
+    piorCaso: (n) => (n * (n - 1)) / 2,
+    formula: "n(n-1)/2 comparações, que é O(n²)",
+    gerar: (nums) => {
+      const out: Passo[] = [];
+      let ops = 0;
+      out.push({ linha: 1, ops, marcas: {}, ativos: [], fora: [], nota: "Sem estrutura auxiliar, cada elemento é comparado com todos os outros.", vars: [{ nome: "i", valor: "-" }, { nome: "j", valor: "-" }, { nome: "comparações", valor: "0", best: true }] });
+      for (let i = 0; i < nums.length; i++) {
+        for (let j = i + 1; j < nums.length; j++) {
+          ops++;
+          const vars = [{ nome: "i", valor: `${i}` }, { nome: "j", valor: `${j}` }, { nome: "comparações", valor: `${ops}`, best: true }];
+          if (nums[i] === nums[j]) {
+            out.push({ linha: 4, ops, marcas: { [i]: "i", [j]: "j" }, ativos: [i, j], fora: [], ok: true, fim: true, nota: `nums[${i}] e nums[${j}] são iguais (${nums[i]}). Parei na comparação ${ops}.`, vars });
+            return out;
+          }
+          out.push({ linha: 3, ops, marcas: { [i]: "i", [j]: "j" }, ativos: [i, j], fora: [], nota: `Comparação ${ops}: nums[${i}] = ${nums[i]} contra nums[${j}] = ${nums[j]}. Diferentes.`, vars });
+        }
+      }
+      const n = nums.length;
+      out.push({ linha: 5, ops, marcas: {}, ativos: [], fora: faixa(0, n - 1), fim: true, nota: `Nenhum repetido. Foram ${ops} comparações para n = ${n}. Dobre o array e esse número quadruplica.`, vars: [{ nome: "i", valor: "-" }, { nome: "j", valor: "-" }, { nome: "comparações", valor: `${ops}`, best: true }] });
+      return out;
+    },
+  },
+];
+
+const VELOCIDADES = [0, 1200, 800, 520, 320, 170];
+const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
+// O array do vídeo, já ordenado (a busca binária exige ordem).
+const PADRAO = [2, 6, 10, 15, 20, 43, 60, 70];
+const ALVO_PADRAO = 20;
+
+function num(v: number): string {
+  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+}
+
+export function BigOCounterVisualizer() {
+  const [iAlg, setIAlg] = useState(1);
+  const [nums, setNums] = useState<number[]>(PADRAO);
+  const [entrada, setEntrada] = useState(PADRAO.join(", "));
+  const [alvo, setAlvo] = useState(ALVO_PADRAO);
+  const [passo, setPasso] = useState(0);
+  const [tocando, setTocando] = useState(false);
+  const [velocidade, setVelocidade] = useState(3);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  const alg = ALGORITMOS[iAlg];
+  const passos = useMemo(() => alg.gerar(nums.length ? nums : [1], alvo), [alg, nums, alvo]);
+  const total = passos.length;
+  const idx = Math.min(passo, total - 1);
+  const p = passos[idx];
+  const n = nums.length;
+
+  const parar = useCallback(() => {
+    if (timer.current) { clearInterval(timer.current); timer.current = null; }
+  }, []);
+  useEffect(() => () => parar(), [parar]);
+
+  useEffect(() => {
+    parar();
+    if (!tocando) return;
+    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
+    return parar;
+  }, [tocando, velocidade, total, parar]);
+
+  useEffect(() => {
+    if (tocando && idx >= total - 1) setTocando(false);
+  }, [tocando, idx, total]);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
+
+  const aoMudarEntrada = (v: string) => {
+    const arr = v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 14);
+    const ordenado = [...arr].sort((a, b) => a - b);
+    reiniciar();
+    setEntrada(v);
+    setNums(ordenado.length ? ordenado : [1]);
+  };
+
+  const trocarAlg = (i: number) => { reiniciar(); setIAlg(i); };
+
+  const cells = nums.map((v, i) => {
+    let cls = "viz-cell";
+    if (p.ativos.includes(i)) cls += " in";
+    if (p.fora.includes(i)) cls += " drop";
+    if (p.ok && p.ativos.includes(i)) cls += " entra";
+    return { i, v, cls, marca: p.marcas[i] ?? "" };
+  });
+
+  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
+  const pctPasso = Math.round(((idx + 1) / total) * 100);
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" style={{ background: alg.cor }} />
+          <span>Visualizador · contando operações no mesmo array</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">passo {idx + 1} de {total}</span>
+          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {ALGORITMOS.map((a, i) => {
+            const on = i === iAlg;
+            return (
+              <button
+                key={a.key}
+                className={`bigo-chip${on ? " on" : ""}`}
+                style={on ? { borderColor: a.cor, color: a.cor } : undefined}
+                onClick={() => trocarAlg(i)}
+                aria-pressed={on}
+              >
+                <span className="sw" style={{ background: on ? a.cor : "#3a4a60" }} />
+                {a.familia} · {a.nome}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="viz-inputs">
+          <label className="viz-field grow">
+            <span>Array (fica ordenado)</span>
+            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+          </label>
+          {alg.usaAlvo && (
+            <label className="viz-field">
+              <span>alvo</span>
+              <input
+                className="viz-input k"
+                type="number"
+                value={alvo}
+                onChange={(e) => { reiniciar(); setAlvo(parseInt(e.target.value, 10) || 0); }}
+              />
+            </label>
+          )}
+        </div>
+
+        <div className="viz-cells">
+          {cells.map((c) => (
+            <div className="viz-cell-wrap" key={c.i}>
+              <span className="viz-cell-idx">{c.i}</span>
+              <div className={c.cls}>{c.v}</div>
+              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+            </div>
+          ))}
+        </div>
+
+        <div className="bigo-stats">
+          <div className="bigo-stat">
+            <span>operações até aqui</span>
+            <strong style={{ color: alg.cor }}>{num(p.ops)}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>n (tamanho da entrada)</span>
+            <strong>{num(n)}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>pior caso com n = {num(n)}</span>
+            <strong>{num(alg.piorCaso(n))}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>pior caso com n = {num(n * 2)}</span>
+            <strong>{num(alg.piorCaso(n * 2))}</strong>
+          </div>
+        </div>
+
+        <p className={notaCls}>{p.nota}</p>
+
+        <div className="viz-split">
+          <div className="viz-code">
+            <div className="viz-code-head">{alg.arquivo} · {alg.formula}</div>
+            <div className="viz-code-body">
+              {alg.codigo.map((txt, i) => (
+                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                  <span className="ln">{i + 1}</span>
+                  {txt}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="viz-vars">
+            <div className="viz-vars-head">Variáveis</div>
+            {p.vars.map((v) => (
+              <div className="viz-var" key={v.nome}>
+                <span className="viz-var-name">{v.nome}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="viz-controls">
+          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
+          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
+          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
+            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+          </button>
+          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
+          <div className="viz-speed">
+            <span>Velocidade</span>
+            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
+            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+          </div>
+        </div>
+        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%`, background: alg.cor }} /></div>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/content/visualizers/BigOFamilias.tsx
+++ b/content/visualizers/BigOFamilias.tsx
@@ -2,9 +2,12 @@
 // BigOFamilias, a tabela de referência das famílias de complexidade.
 //
 // Componente estático (sem "use client"): é HTML puro no build, serve de
-// consulta rápida e continua legível sem JavaScript. A barra de cada linha é
-// proporcional ao log do número de operações com n = 1.000, para caber na
-// mesma escala visual desde O(1) até O(n!).
+// consulta rápida e continua legível sem JavaScript.
+//
+// O `peso` de cada linha (a largura da barra) é uma rampa escolhida à mão, não
+// um valor calculado: serve só para ordenar as famílias visualmente. Derivar a
+// barra do número real de operações não funcionaria nem em escala log, porque
+// log10(1000!) ≈ 2568 contra log10(1000²) = 6, e tudo abaixo de O(2ⁿ) sumiria.
 // ---------------------------------------------------------------------------
 
 type Linha = {
@@ -15,7 +18,7 @@ type Linha = {
   n100: string;
   n1000: string;
   veredito: "otimo" | "bom" | "atencao" | "ruim";
-  peso: number; // 0 a 1, largura da barra
+  peso: number; // 0 a 1, largura da barra (rampa visual, ver o comentário acima)
 };
 
 const LINHAS: Linha[] = [

--- a/content/visualizers/BigOFamilias.tsx
+++ b/content/visualizers/BigOFamilias.tsx
@@ -1,0 +1,83 @@
+// ---------------------------------------------------------------------------
+// BigOFamilias, a tabela de referência das famílias de complexidade.
+//
+// Componente estático (sem "use client"): é HTML puro no build, serve de
+// consulta rápida e continua legível sem JavaScript. A barra de cada linha é
+// proporcional ao log do número de operações com n = 1.000, para caber na
+// mesma escala visual desde O(1) até O(n!).
+// ---------------------------------------------------------------------------
+
+type Linha = {
+  notacao: string;
+  nome: string;
+  exemplo: string;
+  n10: string;
+  n100: string;
+  n1000: string;
+  veredito: "otimo" | "bom" | "atencao" | "ruim";
+  peso: number; // 0 a 1, largura da barra
+};
+
+const LINHAS: Linha[] = [
+  { notacao: "O(1)", nome: "constante", exemplo: "acessar nums[i], ler de um hash", n10: "1", n100: "1", n1000: "1", veredito: "otimo", peso: 0.02 },
+  { notacao: "O(log n)", nome: "logarítmica", exemplo: "busca binária, índice B-tree", n10: "4", n100: "7", n1000: "10", veredito: "otimo", peso: 0.06 },
+  { notacao: "O(n)", nome: "linear", exemplo: "percorrer o array uma vez", n10: "10", n100: "100", n1000: "1.000", veredito: "bom", peso: 0.18 },
+  { notacao: "O(n log n)", nome: "linearítmica", exemplo: "merge sort, quick sort, qualquer Order By", n10: "33", n100: "664", n1000: "9.966", veredito: "bom", peso: 0.28 },
+  { notacao: "O(n²)", nome: "quadrática", exemplo: "dois laços aninhados, comparar todos os pares", n10: "100", n100: "10 mil", n1000: "1 milhão", veredito: "atencao", peso: 0.42 },
+  { notacao: "O(n³)", nome: "cúbica", exemplo: "três laços aninhados, Floyd-Warshall", n10: "1.000", n100: "1 milhão", n1000: "1 bilhão", veredito: "atencao", peso: 0.56 },
+  { notacao: "O(2ⁿ)", nome: "exponencial", exemplo: "fibonacci recursivo sem memo, subconjuntos", n10: "1.024", n100: "10³⁰", n1000: "10³⁰¹", veredito: "ruim", peso: 0.8 },
+  { notacao: "O(n!)", nome: "fatorial", exemplo: "permutações, caixeiro viajante por força bruta", n10: "3,6 mi", n100: "10¹⁵⁸", n1000: "10²⁵⁶⁸", veredito: "ruim", peso: 1 },
+];
+
+const ROTULO: Record<Linha["veredito"], string> = {
+  otimo: "escala liso",
+  bom: "escala bem",
+  atencao: "cuidado",
+  ruim: "inviável",
+};
+
+export function BigOFamilias() {
+  return (
+    <figure className="bigo-fam">
+      <div className="bigo-fam-head">
+        <span className="dot" />
+        <span>Famílias de complexidade e o número de operações no pior caso</span>
+      </div>
+      <div className="bigo-fam-scroll">
+        <table className="bigo-fam-table">
+          <thead>
+            <tr>
+              <th>Família</th>
+              <th>Exemplo típico</th>
+              <th className="nums">n = 10</th>
+              <th className="nums">n = 100</th>
+              <th className="nums">n = 1.000</th>
+            </tr>
+          </thead>
+          <tbody>
+            {LINHAS.map((l) => (
+              <tr key={l.notacao} className={`v-${l.veredito}`}>
+                <td>
+                  <div className="bigo-fam-not">{l.notacao}</div>
+                  <div className="bigo-fam-nome">{l.nome}</div>
+                  <div className="bigo-fam-barra"><span style={{ width: `${l.peso * 100}%` }} /></div>
+                </td>
+                <td className="bigo-fam-ex">
+                  {l.exemplo}
+                  <span className="bigo-fam-tag">{ROTULO[l.veredito]}</span>
+                </td>
+                <td className="nums">{l.n10}</td>
+                <td className="nums">{l.n100}</td>
+                <td className="nums">{l.n1000}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <figcaption>
+        Cada linha é uma família, não um algoritmo. Dois algoritmos O(n) podem ter tempos de
+        execução bem diferentes: o que a família garante é o formato da curva quando n cresce.
+      </figcaption>
+    </figure>
+  );
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -2,6 +2,9 @@ import type { MDXComponents } from "mdx/types";
 import type { ReactNode } from "react";
 import { SlidingWindowVisualizer } from "@content/visualizers/SlidingWindowVisualizer";
 import { TwoPointersVisualizer } from "@content/visualizers/TwoPointersVisualizer";
+import { BigOChartVisualizer } from "@content/visualizers/BigOChartVisualizer";
+import { BigOCounterVisualizer } from "@content/visualizers/BigOCounterVisualizer";
+import { BigOFamilias } from "@content/visualizers/BigOFamilias";
 import { slugify, textOf } from "@/lib/slug";
 
 /**
@@ -59,6 +62,9 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     Cartao,
     SlidingWindowVisualizer,
     TwoPointersVisualizer,
+    BigOChartVisualizer,
+    BigOCounterVisualizer,
+    BigOFamilias,
     ...components,
   };
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -434,6 +434,50 @@ html { scroll-behavior: smooth; }
 .viz-overlay .viz-line { font-size: 14px; line-height: 1.9; }
 .viz-overlay .viz-cell { width: 58px; height: 58px; font-size: 19px; }
 
+/* ------ Big O: gráfico de crescimento, contador e tabela de famílias ------ */
+.bigo-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+.bigo-chip { display: inline-flex; align-items: center; gap: 7px; padding: 6px 11px; border: 1px solid var(--ccc-line); border-radius: 99px; background: transparent; color: var(--ccc-muted); font: inherit; font-family: var(--mono); font-size: 12.5px; cursor: pointer; }
+.bigo-chip:hover { background: rgba(255, 255, 255, 0.05); }
+.bigo-chip.on { background: rgba(255, 255, 255, 0.05); font-weight: 600; }
+.bigo-chip .sw { width: 10px; height: 10px; border-radius: 3px; flex: none; }
+.bigo-canvas-wrap { border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-panel); overflow: hidden; }
+.bigo-canvas { display: block; width: 100%; touch-action: pan-y; cursor: crosshair; }
+.bigo-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(158px, 1fr)); gap: 8px; margin-bottom: 4px; }
+.bigo-card { min-width: 0; padding: 10px 12px; border: 1px solid var(--ccc-line); border-left: 3px solid var(--ccc-line); border-radius: 9px; background: #0e1725; }
+.bigo-card-top { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.bigo-card-nome { font-family: var(--mono); font-size: 12.5px; font-weight: 600; }
+.bigo-card-val { font-family: var(--mono); font-size: 13.5px; font-weight: 600; color: #fff; }
+.bigo-card-ex { margin-top: 3px; font-size: 11.5px; color: var(--ccc-muted); }
+.bigo-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; margin-top: 14px; }
+.bigo-stat { min-width: 0; padding: 10px 12px; border: 1px solid var(--ccc-line); border-radius: 9px; background: #0e1725; }
+.bigo-stat span { display: block; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--ccc-muted); }
+.bigo-stat strong { display: block; margin-top: 3px; font-family: var(--mono); font-size: 19px; font-weight: 600; color: #fff; }
+
+.bigo-fam { margin: 0 0 30px; border: 1px solid var(--ccc-line); border-radius: 14px; background: var(--ccc-surface); overflow: hidden; }
+.bigo-fam-head { display: flex; align-items: center; gap: 9px; padding: 12px 16px; border-bottom: 1px solid var(--ccc-line); background: #0f1826; font-size: 13px; font-weight: 600; }
+.bigo-fam-head .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--ccc-accent); flex: none; }
+.bigo-fam-scroll { overflow-x: auto; }
+.bigo-fam-table { width: 100%; min-width: 560px; border-collapse: collapse; font-size: 13.5px; }
+.bigo-fam-table th { padding: 10px 14px; text-align: left; font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ccc-muted); border-bottom: 1px solid var(--ccc-line); }
+.bigo-fam-table td { padding: 11px 14px; border-bottom: 1px solid var(--ccc-line); vertical-align: top; color: #b9c9dd; }
+.bigo-fam-table tr:last-child td { border-bottom: none; }
+.bigo-fam-table .nums { text-align: right; font-family: var(--mono); font-size: 13px; white-space: nowrap; color: #cbd9ea; }
+.bigo-fam-not { font-family: var(--mono); font-size: 14px; font-weight: 600; color: #fff; }
+.bigo-fam-nome { font-size: 11.5px; color: var(--ccc-muted); }
+.bigo-fam-barra { margin-top: 6px; width: 92px; max-width: 100%; height: 4px; border-radius: 99px; background: rgba(255, 255, 255, 0.07); overflow: hidden; }
+.bigo-fam-barra span { display: block; height: 100%; border-radius: 99px; }
+.bigo-fam-ex { max-width: 34ch; }
+.bigo-fam-tag { display: block; margin-top: 5px; font-size: 10.5px; font-weight: 600; letter-spacing: 0.04em; text-transform: uppercase; }
+.bigo-fam .v-otimo .bigo-fam-barra span { background: #34d399; }
+.bigo-fam .v-otimo .bigo-fam-tag { color: var(--ccc-green); }
+.bigo-fam .v-bom .bigo-fam-barra span { background: #60a5fa; }
+.bigo-fam .v-bom .bigo-fam-tag { color: #93bbfd; }
+.bigo-fam .v-atencao .bigo-fam-barra span { background: #fbbf24; }
+.bigo-fam .v-atencao .bigo-fam-tag { color: #fbbf24; }
+.bigo-fam .v-ruim .bigo-fam-barra span { background: #f87171; }
+.bigo-fam .v-ruim .bigo-fam-tag { color: #f87171; }
+.bigo-fam figcaption { padding: 12px 16px; border-top: 1px solid var(--ccc-line); font-size: 12.5px; line-height: 1.55; color: var(--ccc-muted); }
+
 /* ------ apoie page ------ */
 .apoie-wrap { padding: 56px; max-width: 820px; }
 .apoie-wrap h1 { font-size: 40px; font-weight: 600; letter-spacing: -0.03em; margin: 12px 0 14px; }

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -59,6 +59,18 @@ test("Two Pointers é uma página completa com visualizador e problemas", async 
   await expect(page.getByRole("link", { name: /Two Sum II/ }).first()).toHaveAttribute("href", /leetcode\.com/);
 });
 
+test("Big O traz o gráfico de crescimento, o contador de operações e a tabela de famílias", async ({ page }) => {
+  await page.goto("/topico/big-o/");
+  // gráfico: o canvas existe e o marcador reage ao chip de uma família
+  await expect(page.locator("canvas.bigo-canvas")).toHaveCount(1);
+  await expect(page.getByRole("button", { name: "O(n!)" })).toBeVisible();
+  // contador: a casca padrão de visualizador, com passo a passo
+  await expect(page.getByRole("button", { name: /Rodar/ })).toBeVisible();
+  // tabela de famílias: estática, precisa estar no HTML mesmo sem JS
+  await expect(page.locator(".bigo-fam-table tbody tr")).toHaveCount(8);
+  await expect(page.getByRole("link", { name: /Big O Notation/ })).toHaveAttribute("href", /geeksforgeeks/);
+});
+
 test("marcar um tópico como concluído persiste na sessão", async ({ page }) => {
   await page.goto("/topico/sliding-window-fixed/");
   // Há dois botões de concluir (topo e fim da página); ambos alternam juntos.


### PR DESCRIPTION
## O que muda

Tira o **Notação Big O** do `soon` e entrega a página completa: artigo, três visualizadores novos, problemas e referências. O artigo nasce do encontro #001 da comunidade (o vídeo de 1h38 que já estava linkado no tópico), complementado com GeeksforGeeks e LeetCode.

### Visualizadores

| Componente | O que faz |
| --- | --- |
| `BigOChartVisualizer` | Canvas com as oito famílias desenhadas. Liga/desliga curvas, arrasta o marcador para ler o número de operações em cada n, muda a entrada máxima de 10 a 1 milhão e alterna entre escala linear e logarítmica. É onde dá para *ver* a constante virar irrelevante. |
| `BigOCounterVisualizer` | Casca padrão de visualizador (passo a passo, código sincronizado, variáveis). Roda quatro algoritmos sobre o **mesmo array**: acesso por índice, busca binária, busca linear e todos os pares. O contador de operações para em 1, log n, n e n², com o pior caso para n e para 2n ao lado. |
| `BigOFamilias` | Tabela estática de consulta, com as operações em n = 10, 100 e 1.000 e um veredito por família. Sem JS, renderiza no build. |

### Artigo

Seis seções: o que o Big O mede, as três regras (n é a entrada, constantes somem, fica o termo dominante), as famílias do O(1) ao O(n!), a contagem de operações na prática, os três casos e as armadilhas do dia a dia (eficiente não é rápido, ordenar antes de buscar, entrada pequena, complexidade não é legibilidade).

Também entram 6 problemas (LeetCode 704, 217, 121, 1, 509 e o guia de análise do GeeksforGeeks) e 4 referências.

## Tipo

- [x] `feat` novo conteúdo/tópico/visualizador
- [ ] `fix` correção
- [ ] `docs` documentação
- [ ] `refactor` / `style` / `perf`
- [ ] `ci` / `build` / `chore`

## Checklist

- [x] `npm run build` passa
- [x] `npm test` passa (12 testes, incluindo um novo para a página de Big O)
- [x] Segui o padrão de [Conventional Commits](https://conventionalcommits.org/)
- [x] Sem o caractere travessão (`—`) na copy do site
- [x] Li o [guia de contribuição](../CONTRIBUTING.md)

Conferido também com o `agent-browser` em 1280px e 390px: sem overflow horizontal (`document.body.scrollWidth === window.innerWidth`), sem erro de console nem aviso de hidratação, e a tabela de famílias rola dentro do próprio container no celular.

## Issue relacionada

<!-- Ex.: Closes #123 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PStn5fD4PMxqAeeGrY9Ki5