### PR TITLE
feat(topics): novo tópico sobre subarray, subsequence e subset

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ código sincronizado, painel de variáveis, controles e o botão **Expandir**). 
 2. Exponha-o em `mdx-components.tsx`.
 3. Use no `.mdx` do tópico: `<MeuVisualizador />`.
 
+Nem todo tópico tem algoritmo rodando. Quando o que se aprende é uma **classificação** (e não
+uma execução passo a passo), o visualizador troca a linha do tempo por manipulação direta:
+veja `SubTypesVisualizer.tsx`, onde o leitor monta um pedaço clicando nos elementos e o painel
+responde o que aquele pedaço é. A casca (cabeçalho, **Expandir**, células) continua a mesma.
+
 ## Progresso do usuário
 
 `ProgressProvider` guarda dois mapas no `localStorage`: `ccc-dsa-progresso` (tópicos concluídos)

--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -107,7 +107,7 @@ export const GROUPS: Group[] = [
       { slug: "strings", name: "Strings", group: "Arrays e Strings", level: "Fácil", status: "soon", youtube: yt("B9CCEwjoXBk"), description: "Manipulação e processamento de texto e caracteres.", extraVideos: [{ title: "LeetCode 1704: Determine if String Halves Are Alike", youtube: "qtPcJclLlmI" }] },
       {
         slug: "subarray-substring-subsequence-subset",
-        name: 'Os 4 "sub"',
+        name: "Os 4 \"sub\"",
         group: "Arrays e Strings",
         level: "Fácil",
         status: "ready",

--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -23,7 +23,7 @@ export type Problem = {
   url: string;
 };
 
-export type Visualizer = "sliding-window-fixed" | "sliding-window-dynamic" | "two-pointers" | "big-o";
+export type Visualizer = "sliding-window-fixed" | "sliding-window-dynamic" | "two-pointers" | "big-o" | "sub-types";
 
 // Vídeos extras de um tópico: aparecem como links clicáveis (não embed).
 export type VideoLink = { title: string; youtube?: string; url?: string; duration?: string };
@@ -105,6 +105,34 @@ export const GROUPS: Group[] = [
     topics: [
       { slug: "arrays", name: "Arrays e Listas", group: "Arrays e Strings", level: "Fácil", status: "soon", youtube: yt("c95xvXCU34A"), description: "A estrutura sequencial base: acesso por índice em O(1)." },
       { slug: "strings", name: "Strings", group: "Arrays e Strings", level: "Fácil", status: "soon", youtube: yt("B9CCEwjoXBk"), description: "Manipulação e processamento de texto e caracteres.", extraVideos: [{ title: "LeetCode 1704: Determine if String Halves Are Alike", youtube: "qtPcJclLlmI" }] },
+      {
+        slug: "subarray-substring-subsequence-subset",
+        name: "Subarray x Substring x Subsequence x Subset",
+        group: "Arrays e Strings",
+        level: "Fácil",
+        status: "ready",
+        viz: "sub-types",
+        readingTime: "9 min",
+        language: "Python",
+        description: "Quatro palavras parecidas que levam a quatro algoritmos diferentes. Duas perguntas separam todas: os elementos precisam ser contíguos? A ordem importa?",
+        problems: [
+          { id: "lc-53", name: "Maximum Subarray", number: "53", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/maximum-subarray/" },
+          { id: "lc-560", name: "Subarray Sum Equals K", number: "560", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/subarray-sum-equals-k/" },
+          { id: "lc-3", name: "Longest Substring Without Repeating Characters", number: "3", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/longest-substring-without-repeating-characters/" },
+          { id: "lc-5", name: "Longest Palindromic Substring", number: "5", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/longest-palindromic-substring/" },
+          { id: "lc-300", name: "Longest Increasing Subsequence", number: "300", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/longest-increasing-subsequence/" },
+          { id: "lc-1143", name: "Longest Common Subsequence", number: "1143", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/longest-common-subsequence/" },
+          { id: "lc-78", name: "Subsets (Power Set)", number: "78", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/subsets/" },
+          { id: "lc-416", name: "Partition Equal Subset Sum", number: "416", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/partition-equal-subset-sum/" },
+          { id: "gfg-sub-vs", name: "Subarray/Substring vs Subsequence", source: "GeeksforGeeks", level: "Guia", url: "https://www.geeksforgeeks.org/dsa/subarraysubstring-vs-subsequence-and-programs-to-generate-them/" },
+        ],
+        references: [
+          { title: "Subarray/Substring vs Subsequence e como gerar cada um", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/subarraysubstring-vs-subsequence-and-programs-to-generate-them/" },
+          { title: "Power Set: os 2ⁿ subconjuntos", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/power-set/" },
+          { title: "Longest Common Substring (DP): o grid que zera na quebra", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/longest-common-substring-dp-29/" },
+          { title: "Longest Common Subsequence (DP): o mesmo grid, outro else", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/longest-common-subsequence-dp-4/" },
+        ],
+      },
       {
         slug: "two-pointers",
         name: "Two Pointers",

--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -107,14 +107,16 @@ export const GROUPS: Group[] = [
       { slug: "strings", name: "Strings", group: "Arrays e Strings", level: "Fácil", status: "soon", youtube: yt("B9CCEwjoXBk"), description: "Manipulação e processamento de texto e caracteres.", extraVideos: [{ title: "LeetCode 1704: Determine if String Halves Are Alike", youtube: "qtPcJclLlmI" }] },
       {
         slug: "subarray-substring-subsequence-subset",
-        name: "Subarray x Substring x Subsequence x Subset",
+        name: 'Os 4 "sub"',
         group: "Arrays e Strings",
         level: "Fácil",
         status: "ready",
         viz: "sub-types",
         readingTime: "9 min",
         language: "Python",
-        description: "Quatro palavras parecidas que levam a quatro algoritmos diferentes. Duas perguntas separam todas: os elementos precisam ser contíguos? A ordem importa?",
+        // O nome é curto de propósito (cabe em uma linha no menu), então os quatro
+        // termos vivem aqui: é esta descrição que vira a meta description da página.
+        description: "Subarray, substring, subsequence e subset: quatro palavras parecidas que levam a algoritmos diferentes. Duas perguntas separam todas: os elementos precisam ser contíguos? A ordem importa?",
         problems: [
           { id: "lc-53", name: "Maximum Subarray", number: "53", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/maximum-subarray/" },
           { id: "lc-560", name: "Subarray Sum Equals K", number: "560", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/subarray-sum-equals-k/" },

--- a/content/topics/index.ts
+++ b/content/topics/index.ts
@@ -3,6 +3,7 @@ import BigO from "./big-o.mdx";
 import TwoPointers from "./two-pointers.mdx";
 import SlidingWindowFixed from "./sliding-window-fixed.mdx";
 import SlidingWindowDynamic from "./sliding-window-dynamic.mdx";
+import SubTypes from "./subarray-substring-subsequence-subset.mdx";
 
 // Registro dos artigos em MDX. Para adicionar um tópico "ready":
 //   1. crie content/topics/<slug>.mdx (use <SlidingWindowVisualizer /> etc.)
@@ -22,6 +23,18 @@ export const ARTICLES: Record<string, Article> = {
       "Contando operações no mesmo array",
       "Melhor caso, caso médio e pior caso",
       "As armadilhas que pegam todo mundo",
+    ],
+  },
+  "subarray-substring-subsequence-subset": {
+    Body: SubTypes,
+    summary: [
+      "As duas perguntas",
+      "Subarray e substring: a fatia",
+      "Subsequence: apaga, mas não reordena",
+      "Subset: o saco de elementos",
+      "A pegadinha: subsequence x subset",
+      "O mesmo grid resolve substring e subsequence",
+      "Lendo o enunciado em 5 segundos",
     ],
   },
   "two-pointers": {

--- a/content/topics/subarray-substring-subsequence-subset.mdx
+++ b/content/topics/subarray-substring-subsequence-subset.mdx
@@ -1,0 +1,142 @@
+<Callout>
+Quatro palavras parecidas, quatro algoritmos diferentes. Ler "subsequence" e resolver como se fosse "subarray" é o tipo de erro que derruba a questão inteira antes da primeira linha de código. A boa notícia: você não precisa decorar quatro definições, **duas perguntas** separam todas.
+</Callout>
+
+## As duas perguntas
+
+Sempre que um enunciado fala de "um pedaço" de um array ou de uma string, ele está dizendo quais liberdades você tem para montar esse pedaço. São só duas:
+
+1. **Os elementos precisam ser contíguos?** Colados, sem pular nada.
+2. **A ordem importa?** O pedaço continua sendo uma sequência, ou virou um saco de elementos?
+
+Cruzando as duas respostas, cada termo cai em um canto:
+
+<Colunas>
+<Cartao titulo="Contíguo · ordem importa">
+**Subarray** (em array) e **substring** (em string). Uma fatia: você escolhe início e fim e leva tudo que está no meio.
+</Cartao>
+
+<Cartao titulo="Não contíguo · ordem importa">
+**Subsequence**. Apaga zero ou mais elementos, mas nunca reordena os que sobraram.
+</Cartao>
+
+<Cartao titulo="Não contíguo · ordem não importa">
+**Subset**. É conjunto, não sequência: `{1, 3}` e `{3, 1}` são exatamente a mesma coisa.
+</Cartao>
+
+<Cartao titulo="Contíguo · ordem não importa">
+Esse canto é vazio, e isso não é acidente: se os elementos são colados no original, a posição deles já define a ordem. Contiguidade implica ordem.
+</Cartao>
+</Colunas>
+
+Antes de ler as definições formais, brinque com elas. No visualizador abaixo você monta um pedaço clicando nos elementos, e **a ordem em que você clica conta**. Clique `1` e depois `2` e veja três "é". Clique na ordem invertida e veja duas viradas para "não é". Use o botão **String** para conferir que substring é a mesma coisa que subarray, só que em texto.
+
+<SubTypesVisualizer />
+
+## Subarray e substring: a fatia
+
+Um **subarray** é um pedaço contíguo de um array. Na prática você escolhe dois índices, `i` e `j`, e leva tudo de `i` até `j`. Em `[1, 2, 3, 4]`, `[2, 3]` é subarray; `[2, 4]` não é, porque pulou o `3`.
+
+**Substring** é exatamente a mesma ideia aplicada a uma string: caracteres contíguos. Em `"code"`, `"od"` é substring e `"ce"` não é. Os dois termos são gêmeos, muda só o tipo do que está embaixo.
+
+Quantos existem? Escolher uma fatia é escolher um par (início, fim) com início ≤ fim, o que dá:
+
+```
+n(n+1)/2 fatias não-vazias
+```
+
+Para `n = 4`, são 10. Esse número triangular é o teto de qualquer solução que testa todas as fatias, e é exatamente por isso que os padrões de janela deslizante existem: eles trocam esse `O(n²)` por uma passada só.
+
+O problema âncora aqui é o **Maximum Subarray** (LeetCode 53), resolvido pelo algoritmo de Kadane. Repare que a contiguidade é o que faz o truque funcionar: como o pedaço não pode ter buraco, dá para decidir localmente entre "estender a soma atual" e "recomeçar daqui", sem nunca olhar para trás.
+
+## Subsequence: apaga, mas não reordena
+
+Uma **subsequence** sai do original apagando zero ou mais elementos e mantendo a ordem relativa dos que sobraram. Não precisa ser contígua, mas a ordem é sagrada.
+
+Em `[1, 2, 3, 4]`:
+
+- `[1, 3]` é subsequence: pulou o `2`, mas o `1` continua antes do `3`.
+- `[3, 1]` não é: no original o `3` vem depois do `1`.
+
+Quantos existem? Cada elemento tem duas opções, entra ou não entra:
+
+```
+2ⁿ subsequências (2ⁿ − 1 se você descartar a vazia)
+```
+
+Esse salto de `n(n+1)/2` para `2ⁿ` é a razão de subsequence quase sempre pedir programação dinâmica: enumerar tudo é exponencial, então a solução precisa reaproveitar respostas de prefixos. Os clássicos são **Longest Increasing Subsequence** (LeetCode 300) e **Longest Common Subsequence** (LeetCode 1143).
+
+## Subset: o saco de elementos
+
+Um **subset** é qualquer combinação de elementos do conjunto original, e aqui a ordem simplesmente não existe. `{1, 3}` e `{3, 1}` são o mesmo subconjunto, escrito de dois jeitos.
+
+A contagem é a mesma da subsequence, e pela mesma razão: cada elemento entra ou não entra, `2ⁿ`. O jeito mais direto de enxergar isso é o truque de bits do **Power Set** (problema 8.4 do *Cracking the Coding Interview*, equivalente ao LeetCode 78): conte de `0` até `2ⁿ − 1` e leia cada número em binário. Cada bit ligado é um elemento dentro do subconjunto.
+
+```
+n = 3, elementos {a, b, c}
+
+000 -> {}        100 -> {c}
+001 -> {a}       101 -> {a, c}
+010 -> {b}       110 -> {b, c}
+011 -> {a, b}    111 -> {a, b, c}
+```
+
+Oito linhas, `2³`. O conjunto vazio e o conjunto inteiro contam como subconjuntos; quando um enunciado quer excluir o próprio conjunto, ele fala em *proper subset*.
+
+## A pegadinha: subsequence x subset
+
+Aqui mora a confusão que mais custa caro, porque os dois **contam a mesma coisa**, `2ⁿ`. A quantidade é igual, o significado não. A diferença é a ordem, e ela só aparece quando o array não está ordenado.
+
+Pegue `[3, 1, 2]`:
+
+- Como **subconjunto**, `{1, 3}` existe. É o mesmo que `{3, 1}`, e os dois são válidos.
+- Como **subsequência**, só `[3, 1]` vale. `[1, 3]` não existe aqui, porque no original o `3` vem antes do `1`.
+
+<Callout tipo="aviso">
+Quando o array já está ordenado, subsequence e subset parecem a mesma coisa, e é aí que a confusão se instala sem ninguém perceber. Teste seu raciocínio sempre em um array desordenado: é o único cenário em que os dois se separam.
+</Callout>
+
+## O mesmo grid resolve substring e subsequence
+
+O melhor argumento de que esses termos não são sinônimos está no capítulo 9 do *Grokking Algorithms*: **Longest Common Substring** e **Longest Common Subsequence** usam o mesmo grid de programação dinâmica, a mesma recorrência no caso de match, e diferem em **uma única linha**.
+
+<Colunas>
+<Cartao titulo="Substring (contíguo)">
+Quebrou a sequência, zera. É a contiguidade sendo cobrada.
+
+```python
+if a[i] == b[j]:
+    dp[i][j] = dp[i-1][j-1] + 1
+else:
+    dp[i][j] = 0
+```
+</Cartao>
+
+<Cartao titulo="Subsequence (pode pular)">
+Não bateu, herda o melhor vizinho e segue. O buraco é permitido.
+
+```python
+if a[i] == b[j]:
+    dp[i][j] = dp[i-1][j-1] + 1
+else:
+    dp[i][j] = max(dp[i-1][j], dp[i][j-1])
+```
+</Cartao>
+</Colunas>
+
+A diferença inteira entre os dois conceitos está no `else`. Em substring, uma falha destrói o progresso acumulado, então a resposta é a maior célula do grid. Em subsequence, a falha só não acrescenta nada, o progresso continua atravessando a tabela, e a resposta é o canto final.
+
+## Lendo o enunciado em 5 segundos
+
+Na hora da prova, você não vai reconstruir a teoria: vai caçar palavra-chave. Vale memorizar este mapa:
+
+| Se o enunciado diz | Você está em | Padrão que costuma resolver |
+| --- | --- | --- |
+| *contiguous*, *consecutive*, *subarray*, *substring* | fatia contígua | janela deslizante, dois ponteiros, prefix sum |
+| *maintaining the relative order*, *by deleting some elements* | subsequence | programação dinâmica em grid |
+| *any combination*, *order does not matter*, *subsets* | subset | backtracking, bitmask, DP de mochila |
+
+E o resumo que cabe em duas perguntas:
+
+1. **É contíguo?** Sim, é subarray (ou substring, se for texto).
+2. Não? Então: **a ordem importa?** Sim, é subsequence. Não, é subset.

--- a/content/topics/subarray-substring-subsequence-subset.mdx
+++ b/content/topics/subarray-substring-subsequence-subset.mdx
@@ -1,5 +1,5 @@
 <Callout>
-Quatro palavras parecidas, quatro algoritmos diferentes. Ler "subsequence" e resolver como se fosse "subarray" é o tipo de erro que derruba a questão inteira antes da primeira linha de código. A boa notícia: você não precisa decorar quatro definições, **duas perguntas** separam todas.
+**Subarray, substring, subsequence e subset.** Quatro palavras parecidas, quatro algoritmos diferentes. Ler "subsequence" e resolver como se fosse "subarray" é o tipo de erro que derruba a questão inteira antes da primeira linha de código. A boa notícia: você não precisa decorar quatro definições, **duas perguntas** separam todas.
 </Callout>
 
 ## As duas perguntas

--- a/content/visualizers/SubTypesVisualizer.tsx
+++ b/content/visualizers/SubTypesVisualizer.tsx
@@ -9,7 +9,7 @@ import { createPortal } from "react-dom";
 // Foge de propósito do padrão "gerador de passos" dos outros visualizadores:
 // aqui não há algoritmo rodando, o que se aprende é uma CLASSIFICAÇÃO. Você
 // monta um pedaço clicando nos elementos (a ORDEM DO CLIQUE conta) e o painel
-// responde as duas perguntas que separam os quatro termos: é contíguo? a ordem
+// responde às duas perguntas que separam os quatro termos: é contíguo? a ordem
 // do original foi mantida?
 //
 // O botão Array/String existe para provar que substring é subarray em uma

--- a/content/visualizers/SubTypesVisualizer.tsx
+++ b/content/visualizers/SubTypesVisualizer.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// SubTypesVisualizer, subarray / substring / subsequence / subset.
+//
+// Foge de propósito do padrão "gerador de passos" dos outros visualizadores:
+// aqui não há algoritmo rodando, o que se aprende é uma CLASSIFICAÇÃO. Você
+// monta um pedaço clicando nos elementos (a ORDEM DO CLIQUE conta) e o painel
+// responde as duas perguntas que separam os quatro termos: é contíguo? a ordem
+// do original foi mantida?
+//
+// O botão Array/String existe para provar que substring é subarray em uma
+// string: a lógica de classificação é literalmente a mesma, só muda o rótulo.
+// ---------------------------------------------------------------------------
+
+type Modo = "array" | "string";
+
+const BASE_ARRAY = "3, 1, 2, 4";
+const BASE_STRING = "code";
+const MAX = 8;
+
+function tokens(modo: Modo, texto: string): string[] {
+  if (modo === "string") return texto.replace(/\s+/g, "").split("").slice(0, MAX);
+  return texto.split(",").map((t) => t.trim()).filter(Boolean).slice(0, MAX);
+}
+
+export function SubTypesVisualizer() {
+  const [modo, setModo] = useState<Modo>("array");
+  const [texto, setTexto] = useState(BASE_ARRAY);
+  const [picks, setPicks] = useState<number[]>([]);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const base = useMemo(() => tokens(modo, texto), [modo, texto]);
+  const n = base.length;
+
+  const trocarModo = (m: Modo) => {
+    setModo(m);
+    setTexto(m === "array" ? BASE_ARRAY : BASE_STRING);
+    setPicks([]);
+  };
+  const aoDigitar = (v: string) => { setTexto(v); setPicks([]); };
+  const clicar = (i: number) => setPicks((p) => (p.includes(i) ? p.filter((x) => x !== i) : [...p, i]));
+
+  const vazio = picks.length === 0;
+  // Ordem mantida = cada clique caiu à direita do anterior no array original.
+  const emOrdem = picks.every((p, i) => i === 0 || p > picks[i - 1]);
+  const contiguo = emOrdem && picks.every((p, i) => i === 0 || p === picks[i - 1] + 1);
+  const ordenados = [...picks].sort((a, b) => a - b);
+  const buracos = !vazio && emOrdem
+    ? Array.from({ length: picks[picks.length - 1] - picks[0] + 1 }, (_, k) => picks[0] + k).filter(
+        (i) => !picks.includes(i)
+      )
+    : [];
+
+  const mostrar = (idxs: number[]) =>
+    modo === "string" ? `"${idxs.map((i) => base[i]).join("")}"` : `[${idxs.map((i) => base[i]).join(", ")}]`;
+  // Subconjunto se escreve entre chaves, e essa notação é parte da explicação.
+  const mostrarConjunto = (idxs: number[]) => `{${idxs.map((i) => base[i]).join(", ")}}`;
+
+  const nomeFatia = modo === "string" ? "Substring" : "Subarray";
+  const gemeo = modo === "string" ? "em array, isso se chama subarray" : "em string, isso se chama substring";
+  const fatia = modo === "string" ? "substring" : "subarray";
+
+  const linhas = [
+    {
+      nome: nomeFatia,
+      sub: gemeo,
+      cor: "c-arr",
+      ok: contiguo,
+      txt: vazio
+        ? "Clique em pelo menos um elemento para classificar."
+        : contiguo
+          ? `Índices ${picks.join(", ")} colados e da esquerda para a direita: é uma fatia contígua do original.`
+          : !emOrdem
+            ? `Você clicou fora da ordem. Uma fatia é sempre lida da esquerda para a direita, então ${mostrar(picks)} não é ${fatia}.`
+            : `Pulou o índice ${buracos.join(", ")}. Fatia contígua não tem buraco: ou leva tudo do começo ao fim, ou não é ${fatia}.`,
+    },
+    {
+      nome: "Subsequence",
+      sub: "apaga elementos, nunca reordena",
+      cor: "c-seq",
+      ok: emOrdem,
+      txt: vazio
+        ? "A contiguidade some, mas a ordem continua valendo."
+        : emOrdem
+          ? "A ordem relativa do original foi mantida, então dá para chegar nesse pedaço só apagando o resto."
+          : `Ordem invertida. Com esses mesmos elementos, a única subsequência válida é ${mostrar(ordenados)}.`,
+    },
+    {
+      nome: "Subset",
+      sub: "conjunto, a ordem não existe",
+      cor: "c-set",
+      ok: !vazio,
+      txt: vazio
+        ? "O conjunto vazio também é um subconjunto, e é por isso que a contagem fecha em 2ⁿ."
+        : emOrdem
+          ? `Todos os elementos vieram do original. Como conjunto, ${mostrarConjunto(picks)} não tem primeiro nem último: clicar em outra sequência daria o mesmo subconjunto.`
+          : `${mostrarConjunto(picks)} e ${mostrarConjunto(ordenados)} são o mesmo subconjunto. Em conjunto a ordem não existe, então subset é o único dos três que sobrevive a um clique fora de ordem.`,
+    },
+  ];
+
+  const subarrays = (n * (n + 1)) / 2;
+  const potencia = 2 ** n;
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · monte um pedaço e veja o que ele é</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">n = {n}</span>
+          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="viz-inputs">
+          <div className="viz-field">
+            <span>Origem</span>
+            <div className="sub-modo">
+              <button className={`sub-modo-btn${modo === "array" ? " on" : ""}`} onClick={() => trocarModo("array")}>
+                Array
+              </button>
+              <button className={`sub-modo-btn${modo === "string" ? " on" : ""}`} onClick={() => trocarModo("string")}>
+                String
+              </button>
+            </div>
+          </div>
+          <label className="viz-field grow">
+            <span>{modo === "array" ? "Array (separe por vírgula)" : "String"}</span>
+            <input className="viz-input" value={texto} onChange={(e) => aoDigitar(e.target.value)} />
+          </label>
+        </div>
+
+        <div className="viz-cells">
+          {base.map((v, i) => {
+            const pos = picks.indexOf(i);
+            return (
+              <div className="viz-cell-wrap" key={i}>
+                <span className="viz-cell-idx">{i}</span>
+                <button
+                  type="button"
+                  className={`viz-cell sub-cell${pos >= 0 ? " in" : ""}`}
+                  aria-pressed={pos >= 0}
+                  aria-label={`Índice ${i}, valor ${v}`}
+                  onClick={() => clicar(i)}
+                >
+                  {v}
+                </button>
+                <span className={`viz-mark${pos >= 0 ? " show" : ""}`}>{pos >= 0 ? `${pos + 1}º` : "·"}</span>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="sub-montado">
+          <span className="sub-montado-label">Seu pedaço</span>
+          {vazio ? (
+            <span className="sub-vazio">clique nos elementos acima, na ordem que quiser</span>
+          ) : (
+            <code className="sub-montado-val">{mostrar(picks)}</code>
+          )}
+        </div>
+
+        <div className="sub-vereditos">
+          {linhas.map((l) => (
+            <div key={l.nome} className={`sub-veredito ${l.cor}${vazio ? " off" : l.ok ? " ok" : " no"}`}>
+              <div className="sub-veredito-cab">
+                <span className="sub-veredito-nome">{l.nome}</span>
+                <span className="sub-veredito-selo">{vazio ? "—" : l.ok ? "✓ é" : "✕ não é"}</span>
+              </div>
+              <span className="sub-veredito-sub">{l.sub}</span>
+              <p className="sub-veredito-txt">{l.txt}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="sub-contagem">
+          <div className="sub-conta">
+            <span className="sub-conta-val">{subarrays}</span>
+            <span className="sub-conta-lbl">{modo === "string" ? "substrings" : "subarrays"} não-vazios · n(n+1)/2</span>
+          </div>
+          <div className="sub-conta">
+            <span className="sub-conta-val">{potencia - 1}</span>
+            <span className="sub-conta-lbl">subsequências não-vazias · 2ⁿ − 1</span>
+          </div>
+          <div className="sub-conta">
+            <span className="sub-conta-val">{potencia}</span>
+            <span className="sub-conta-lbl">subconjuntos, contando o vazio · 2ⁿ</span>
+          </div>
+        </div>
+        <p className="sub-nota-contagem">Contagens para n elementos distintos. Com repetidos, o número de pedaços diferentes cai.</p>
+
+        <div className="viz-controls">
+          <span className="sub-exemplos-label">Tente:</span>
+          <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([1, 2])}>colado</button>
+          <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([0, 2])}>com buraco</button>
+          <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([2, 0])}>fora de ordem</button>
+          <button className="viz-btn" disabled={vazio} onClick={() => setPicks([])} style={{ marginLeft: "auto" }}>↺ Limpar</button>
+        </div>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,6 +1,7 @@
 import type { MDXComponents } from "mdx/types";
 import type { ReactNode } from "react";
 import { SlidingWindowVisualizer } from "@content/visualizers/SlidingWindowVisualizer";
+import { SubTypesVisualizer } from "@content/visualizers/SubTypesVisualizer";
 import { TwoPointersVisualizer } from "@content/visualizers/TwoPointersVisualizer";
 import { BigOChartVisualizer } from "@content/visualizers/BigOChartVisualizer";
 import { BigOCounterVisualizer } from "@content/visualizers/BigOCounterVisualizer";
@@ -61,6 +62,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     Colunas,
     Cartao,
     SlidingWindowVisualizer,
+    SubTypesVisualizer,
     TwoPointersVisualizer,
     BigOChartVisualizer,
     BigOCounterVisualizer,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -432,7 +432,8 @@ html { scroll-behavior: smooth; }
 .sub-modo-btn:hover { background: rgba(255, 255, 255, 0.05); color: #fff; }
 .sub-modo-btn.on { background: var(--ccc-accent-soft); color: #dbeafe; font-weight: 600; }
 .sub-cell { padding: 0; cursor: pointer; }
-.sub-cell:hover { border-color: rgba(255, 255, 255, 0.32); color: #fff; }
+/* :not(.in) para o hover não apagar a borda azul de quem já está selecionado. */
+.sub-cell:not(.in):hover { border-color: rgba(255, 255, 255, 0.32); color: #fff; }
 .sub-montado { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; margin: 14px 0 20px; padding: 12px 15px; border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-panel); }
 .sub-montado-label { font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ccc-muted); }
 .sub-montado-val { font-family: var(--mono); font-size: 15px; font-weight: 600; color: #fff; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -426,6 +426,37 @@ html { scroll-behavior: smooth; }
 .viz-progress-fill { height: 100%; background: var(--ccc-accent); transition: width 0.2s; }
 .viz-caption { margin: 0 0 34px; font-size: 12.5px; color: var(--ccc-muted); }
 
+/* --- classificador subarray / substring / subsequence / subset ----------- */
+.sub-modo { display: flex; border: 1px solid var(--ccc-line); border-radius: 8px; overflow: hidden; }
+.sub-modo-btn { padding: 8px 15px; border: none; background: transparent; color: #a9bcd4; font: inherit; font-size: 13px; cursor: pointer; }
+.sub-modo-btn:hover { background: rgba(255, 255, 255, 0.05); color: #fff; }
+.sub-modo-btn.on { background: var(--ccc-accent-soft); color: #dbeafe; font-weight: 600; }
+.sub-cell { padding: 0; cursor: pointer; }
+.sub-cell:hover { border-color: rgba(255, 255, 255, 0.32); color: #fff; }
+.sub-montado { display: flex; flex-wrap: wrap; align-items: center; gap: 14px; margin: 14px 0 20px; padding: 12px 15px; border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-panel); }
+.sub-montado-label { font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ccc-muted); }
+.sub-montado-val { font-family: var(--mono); font-size: 15px; font-weight: 600; color: #fff; }
+.sub-vazio { font-size: 13.5px; color: var(--ccc-muted); }
+.sub-vereditos { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; }
+.sub-veredito { min-width: 0; padding: 14px 15px; border: 1px solid var(--ccc-line); border-left-width: 3px; border-radius: 10px; background: #0e1725; }
+.sub-veredito.c-arr { border-left-color: var(--ccc-accent); }
+.sub-veredito.c-seq { border-left-color: var(--ccc-purple); }
+.sub-veredito.c-set { border-left-color: var(--ccc-coffee); }
+.sub-veredito.off { opacity: 0.6; }
+.sub-veredito-cab { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.sub-veredito-nome { font-size: 14px; font-weight: 600; }
+.sub-veredito-selo { font-family: var(--mono); font-size: 12px; font-weight: 700; color: var(--ccc-muted); white-space: nowrap; }
+.sub-veredito.ok .sub-veredito-selo { color: var(--ccc-green); }
+.sub-veredito.no .sub-veredito-selo { color: #fca5a5; }
+.sub-veredito-sub { display: block; margin-top: 2px; font-size: 11.5px; color: #61748c; }
+.sub-veredito-txt { margin: 9px 0 0; font-size: 13px; line-height: 1.55; color: #9db1c9; }
+.sub-contagem { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 12px; margin-top: 20px; }
+.sub-conta { min-width: 0; padding: 12px 15px; border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-surface-2); }
+.sub-conta-val { display: block; font-family: var(--mono); font-size: 21px; font-weight: 700; color: #fff; }
+.sub-conta-lbl { font-size: 11.5px; line-height: 1.45; color: var(--ccc-muted); }
+.sub-nota-contagem { margin: 10px 0 0; font-size: 11.5px; color: #61748c; }
+.sub-exemplos-label { font-size: 12px; color: var(--ccc-muted); }
+
 /* expanded / overlay ("meio a meio") */
 .viz-overlay { position: fixed; inset: 0; z-index: 90; display: flex; align-items: center; justify-content: center; padding: 24px; background: rgba(4, 8, 14, 0.78); backdrop-filter: blur(4px); }
 .viz-overlay .viz { width: min(1200px, 100%); max-height: calc(100vh - 48px); overflow: auto; margin: 0; box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.8); }
@@ -546,6 +577,8 @@ html { scroll-behavior: smooth; }
      (as células + variáveis já contam a história) e volta ao Expandir. */
   .viz-code { display: none; }
   .viz-overlay .viz-code { display: block; }
+  /* classificador dos "sub": três colunas não cabem, viram lista. */
+  .sub-vereditos, .sub-contagem { grid-template-columns: minmax(0, 1fr); }
 }
 @media (max-width: 560px) {
   .brand-name { display: none; } /* no celular, só o logo */


### PR DESCRIPTION
## O que entra

Novo tópico **ready** em **Arrays e Strings**, posicionado entre *Strings* e *Two Pointers*:
`/topico/subarray-substring-subsequence-subset/`.

É um tópico de vocabulário, e por isso vem cedo no grupo: quem troca os quatro termos resolve
o problema errado antes de escrever a primeira linha de código.

Conteúdo trazido do repo `content`, pasta `2026-08-01-dsa-subarray-substring-subsequence-subset`
(roteiro, apresentação e referências), reescrito em formato de artigo.

## O nome no menu

O tópico se chama **Os 4 "sub"** no menu e no h1: o nome longo quebrava em duas linhas na
barra lateral. O slug continua com os quatro termos (`/topico/subarray-substring-subsequence-subset/`),
e como o título curto não carrega mais as palavras-chave, elas passaram a abrir a `description`
(que vira a meta description) e a primeira frase do artigo.

## O artigo

Sete seções, organizadas em torno da tese do roteiro: **duas perguntas separam os quatro termos**
(é contíguo? a ordem importa?).

1. **As duas perguntas** com o mapa 2x2 em cards. O quarto quadrante (contíguo + ordem não importa)
   fica explicitamente vazio, porque contiguidade já implica ordem.
2. **Subarray e substring**, os gêmeos, com a contagem `n(n+1)/2` e por que a contiguidade é o que
   faz Kadane funcionar.
3. **Subsequence**, com `2ⁿ` e por que esse salto empurra o problema para programação dinâmica.
4. **Subset**, com o power set lido em binário (o truque de bits do *Cracking*, problema 8.4).
5. **A pegadinha subsequence x subset**: os dois contam `2ⁿ`, e a diferença só aparece em array
   desordenado. Exemplo cravado em `[3, 1, 2]`.
6. **O mesmo grid resolve substring e subsequence** (*Grokking*, cap. 9): mesma recorrência no
   match, e a diferença inteira mora no `else`.
7. **Lendo o enunciado em 5 segundos**: tabela de palavras-chave para o padrão que costuma resolver.

## O visualizador

`content/visualizers/SubTypesVisualizer.tsx` **quebra de propósito** o padrão gerador-de-passos dos
outros dois. Aqui não há algoritmo rodando: o que se aprende é uma **classificação**, então a linha
do tempo dá lugar a manipulação direta.

- Você monta um pedaço clicando nos elementos e **a ordem do clique conta** (o rótulo `1º`, `2º`
  abaixo da célula mostra em que ordem você pegou).
- Três painéis respondem **é / não é** com a justificativa escrita para aquele pedaço específico.
  Clique `1` e `2` e são três "é"; clique na ordem invertida e dois viram "não é", sobrando só o
  subset. É a pegadinha da seção 5 na mão do leitor.
- O botão **Array / String** roda a mesma lógica trocando só o rótulo (subarray vira substring),
  que é literalmente a tese de que os dois são o mesmo conceito.
- A faixa de contagens (`n(n+1)/2`, `2ⁿ − 1`, `2ⁿ`) recalcula conforme você edita a origem, com o
  aviso de que as fórmulas valem para elementos distintos.

A casca continua a mesma: cabeçalho com ponto, botão **Expandir** (portal + Esc) e as células
`viz-cell`. O CSS novo vive em um bloco próprio no `globals.css` e colapsa para uma coluna em ≤760px.

## Prática e referências

9 problemas cobrindo as quatro categorias (LC 53, 560, 3, 5, 300, 1143, 78, 416 + o guia da
GeeksforGeeks) e 4 referências externas. Todas as URLs foram verificadas com `curl` (a de
"subarray vs subsequence" da GfG só responde 200 no caminho `/dsa/`).

## Verificação

- `npm run build` ✅ (58 rotas, uma a mais)
- `npm test` ✅ (11 testes Playwright)
- Desktop 1280px e mobile 390px conferidos no build servido: sem overflow horizontal
  (`document.body.scrollWidth > window.innerWidth` → `false`), cards e contagens empilham no celular.
- Interação testada no build estático: modo Array com clique fora de ordem e modo String com buraco,
  os três veredictos respondem certo nos dois.

## Ponto para a revisão

O **vídeo ainda não foi publicado**, então o tópico entra sem o campo `youtube`. Quando o vídeo
subir, basta acrescentar o id em `content/roadmap.ts` e a seção "Vídeo da aula" aparece sozinha,
inclusive no índice lateral.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JVCRMnFgYiA4GCCZbwCRhD
