### PR TITLE
feat(ui): highlight de sintaxe no build, índice grudado e NOVO como tag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,12 @@ npm test         # Playwright (roda contra o ./out via python http.server). DEVE
   `youtube`, `article`, `viz` nem `extraVideos`. Só esses levam o selo "em breve" no menu lateral e
   o `noindex`; quem já tem qualquer material aparece normal. Tópico que nunca vai ter visualizador
   recebe `noViz: true` e deixa de mostrar o aviso de "visualização em construção".
+- **Código no MDX: sempre com linguagem na cerca** (` ```python `). O Shiki roda no build (plugin
+  rehype em `next.config.ts`) e o HTML já sai colorido: zero JS de highlight no cliente, SSG
+  intacto. A cerca também alimenta o selo discreto de linguagem no canto do bloco, montado em
+  `mdx-components.tsx` (mapa `LINGUAGENS`). Cerca **sem** linguagem fica sem cor e sem selo, o que
+  é o certo para diagrama em ASCII e pseudo-fórmula. Linguagem nova precisa entrar em duas listas:
+  `langs` (`next.config.ts`) e `LINGUAGENS` (`mdx-components.tsx`).
 - Visualizadores ficam em `content/visualizers/` (ex.: `SlidingWindowVisualizer`,
   `TwoPointersVisualizer`), expostos em `mdx-components.tsx`. A lista de apoiadores fica em
   `src/app/apoie/apoiadores.ts` (página fixa, não é conteúdo de DSA).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,9 @@ npm test         # Playwright (roda contra o ./out via python http.server). DEVE
   `youtube`, `article`, `viz` nem `extraVideos`. Só esses levam o selo "em breve" no menu lateral e
   o `noindex`; quem já tem qualquer material aparece normal. Tópico que nunca vai ter visualizador
   recebe `noViz: true` e deixa de mostrar o aviso de "visualização em construção".
+- **"NOVO" é tag manual, não data.** O selo do menu lateral vem de `isNew: true` no tópico. Quem
+  publica um tópico põe a tag no mesmo PR **e tira a dos anteriores** — sem data, nada envelhece
+  sozinho. Não derive o selo de outro campo (já foi `viz`, e virava "novo" permanente).
 - **Código no MDX: sempre com linguagem na cerca** (` ```python `). O Shiki roda no build (plugin
   rehype em `next.config.ts`) e o HTML já sai colorido: zero JS de highlight no cliente, SSG
   intacto. A cerca também alimenta o selo discreto de linguagem no canto do bloco, montado em

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ exibidos ficam em português.
      description: "Maior soma contígua, o clássico." }
    ```
 
+   O selo **"NOVO"** do menu lateral é uma tag manual: `isNew: true`. Como não
+   tem data, ele não sai sozinho — marque o tópico que você está publicando e
+   **tire a marca dos anteriores** no mesmo PR.
+
 2. **Artigo** — para virar `status: "ready"`, crie `content/topics/<slug>.mdx`.
    Dentro do MDX já dá para usar, sem importar: `<Callout>`, `<Colunas>`,
    `<Cartao>` e os visualizadores (ver `mdx-components.tsx`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,11 @@ exibidos ficam em português.
    Dentro do MDX já dá para usar, sem importar: `<Callout>`, `<Colunas>`,
    `<Cartao>` e os visualizadores (ver `mdx-components.tsx`).
 
+   **Sempre declare a linguagem na cerca do bloco de código** (` ```python `). O
+   destaque de sintaxe é gerado no build (Shiki), não no navegador, e é a cerca
+   que também põe o selo discreto de linguagem no canto do bloco. Cerca sem
+   linguagem fica sem cor e sem selo: é o certo para diagrama em ASCII.
+
 3. **Ligue o artigo** — registre em `content/topics/index.ts` e mude o `status`
    para `"ready"` em `content/roadmap.ts`. No registro vão o componente e o
    `summary`, que alimenta o índice "Nesta página" e precisa repetir os títulos

--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ mdx-components.tsx          componentes globais disponíveis em todo .mdx
    Dentro do MDX você já pode usar, sem importar: `<Callout>`, `<Colunas>`, `<Cartao>` e
    qualquer visualizador exposto em `mdx-components.tsx`.
 
+   Blocos de código levam **sempre a linguagem na cerca** (` ```python `): o destaque de sintaxe
+   é gerado no build pelo Shiki (nenhum JS extra no cliente) e é dela que sai o selo discreto de
+   linguagem no canto do bloco. Cerca sem linguagem sai sem cor e sem selo, que é justamente o
+   que se quer em diagrama ASCII e pseudo-fórmula.
+
 3. **Ligue o artigo:** registre em `content/topics/index.ts` e mude `status` para `"ready"`.
 
 ## Como adicionar um visualizador

--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ mdx-components.tsx          componentes globais disponíveis em todo .mdx
    um visualizador, o selo some sozinho, e tópico `ready` nunca leva o selo. Se o tópico não
    vai ter visualizador, marque `noViz: true` para a página não prometer um que não vem.
 
+   O selo **"NOVO"** é o oposto: uma **tag manual**, `isNew: true`. Não tem data, então não
+   envelhece sozinho. Quem publica um tópico marca o dele e **tira a marca dos anteriores**, no
+   mesmo PR. É a única forma de o selo continuar querendo dizer "chegou agora".
+
 2. **Escreva o artigo** (para virar `status: "ready"`): crie `content/topics/kadane.mdx`.
    Dentro do MDX você já pode usar, sem importar: `<Callout>`, `<Colunas>`, `<Cartao>` e
    qualquer visualizador exposto em `mdx-components.tsx`.

--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -47,6 +47,11 @@ export type Topic = {
   // não acrescenta nada). Marque `noViz: true` para não prometer um que não vem:
   // a página deixa de exibir o aviso de "visualização em construção".
   noViz?: boolean;
+  // Selo "NOVO" no menu lateral. É uma TAG manual, não uma data: quem entra na
+  // trilha recebe `isNew: true` no PR que publica o tópico, e perde a marca no
+  // PR seguinte, quando outro tópico assume o posto. Sem data para envelhecer
+  // sozinha, o combinado é simples: tirar daqui é parte de publicar o próximo.
+  isNew?: boolean;
   problems?: Problem[];
   readingTime?: string;
   language?: string;

--- a/content/topics/arrays.mdx
+++ b/content/topics/arrays.mdx
@@ -2,7 +2,7 @@
 Array parece o tópico que dá para pular: você usa desde o primeiro dia de programação. Só que quase toda estrutura de dados deste roadmap tem um array escondido embaixo. Uma string é um array de caracteres. Uma heap é uma árvore que mora dentro de um array. Uma tabela hash guarda os buckets num array. E a `list` que você usa todo dia é um array com um gerente em cima. Entender o custo real de cada operação aqui é entender por que todas as outras estruturas existem.
 </Callout>
 
-## O array é um endereço e uma conta
+## Espaço contíguo na memória
 
 A definição de dicionário diz que um array é "uma coleção de elementos do mesmo tipo". Está correta e não explica nada. O que faz o array ser o que é não é a coleção, é **onde ela mora**: em posições contíguas de memória.
 

--- a/content/topics/index.ts
+++ b/content/topics/index.ts
@@ -192,7 +192,7 @@ export const ARTICLES: Record<string, Article> = {
   "arrays": {
     Body: Arrays,
     summary: [
-      "O array é um endereço e uma conta",
+      "Espaço contíguo na memória",
       "Por que o processador gosta de memória contígua",
       "O preço de mexer no meio",
       "A tabela de custos, operação por operação",

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,5 +1,5 @@
 import type { MDXComponents } from "mdx/types";
-import type { ReactNode } from "react";
+import { isValidElement, type ComponentPropsWithoutRef, type ReactNode } from "react";
 import { SlidingWindowVisualizer } from "@content/visualizers/SlidingWindowVisualizer";
 import { SubTypesVisualizer } from "@content/visualizers/SubTypesVisualizer";
 import { TwoPointersVisualizer } from "@content/visualizers/TwoPointersVisualizer";
@@ -65,6 +65,56 @@ function Callout({ children, tipo = "info" }: { children: ReactNode; tipo?: "inf
   return <div className={`callout callout-${tipo}`}>{children}</div>;
 }
 
+const cx = (...classes: (string | false | undefined)[]) => classes.filter(Boolean).join(" ");
+
+// Nome bonito da linguagem para o selo do bloco de código. Quem não está no mapa
+// (inclusive `text` e bloco sem linguagem, que aqui são diagramas em ASCII e não
+// código) não ganha selo: o selo serve para dizer "isto aqui é Python", não para
+// rotular tudo.
+const LINGUAGENS: Record<string, string> = {
+  python: "Python",
+  elixir: "Elixir",
+  javascript: "JavaScript",
+  typescript: "TypeScript",
+  go: "Go",
+  java: "Java",
+  c: "C",
+  cpp: "C++",
+  rust: "Rust",
+  bash: "Bash",
+  json: "JSON",
+  sql: "SQL",
+};
+
+// A linguagem chega no `class="language-python"` do <code>, posto pelo Shiki
+// (option `addLanguageClass`) a partir da cerca ```python do MDX.
+function linguagemDoBloco(children: ReactNode): string | undefined {
+  if (!isValidElement<{ className?: string }>(children)) return undefined;
+  const classe = children.props.className?.split(/\s+/).find((c) => c.startsWith("language-"));
+  return classe?.slice("language-".length);
+}
+
+/**
+ * Bloco de código. O Shiki já entrega o HTML colorido do build; aqui só juntamos
+ * a casca do site: a classe `.prose-pre`, o selo discreto da linguagem e a
+ * remoção do fundo do tema (o bloco segue o painel do site, não abre um segundo
+ * tom de escuro). O selo vive FORA do <pre> de propósito, senão ele rolaria
+ * junto com o código quando a linha é larga.
+ */
+function Pre({ children, className, style, ...props }: ComponentPropsWithoutRef<"pre">) {
+  const lang = linguagemDoBloco(children);
+  const rotulo = lang ? LINGUAGENS[lang] : undefined;
+  const semFundo = style ? { ...style, background: undefined, backgroundColor: undefined } : style;
+  return (
+    <div className={cx("code-block", rotulo && "com-lang")}>
+      {rotulo && <span className="code-lang">{rotulo}</span>}
+      <pre className={cx("prose-pre", className)} style={semFundo} {...props}>
+        {children}
+      </pre>
+    </div>
+  );
+}
+
 function Colunas({ children }: { children: ReactNode }) {
   return <div className="mdx-colunas">{children}</div>;
 }
@@ -91,8 +141,8 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ol: (props) => <ol className="prose-ol" {...props} />,
     li: (props) => <li className="prose-li" {...props} />,
     a: (props) => <a className="prose-a" {...props} />,
-    code: (props) => <code className="prose-code" {...props} />,
-    pre: (props) => <pre className="prose-pre" {...props} />,
+    code: ({ className, ...props }) => <code className={cx("prose-code", className)} {...props} />,
+    pre: Pre,
     strong: (props) => <strong className="prose-strong" {...props} />,
     em: (props) => <em {...props} />,
     hr: () => <hr className="prose-hr" />,

--- a/next.config.ts
+++ b/next.config.ts
@@ -14,11 +14,42 @@ const nextConfig: NextConfig = {
 };
 
 // Turbopack serializa as options do loader, então os plugins precisam ser
-// referenciados por nome (string), não por função importada.
+// referenciados por nome (string), não por função importada. Pelo mesmo motivo,
+// as options de cada plugin só podem ser JSON (nada de funções/transformers).
 const withMDX = createMDX({
   options: {
     remarkPlugins: [["remark-gfm"]],
-    rehypePlugins: [],
+    rehypePlugins: [
+      // Shiki roda no BUILD, dentro do loader do MDX: o HTML já sai colorido e
+      // nenhum byte de JS de highlight vai para o cliente. O SSG continua igual.
+      [
+        "@shikijs/rehype",
+        {
+          theme: "github-dark-default",
+          // Só as gramáticas que o conteúdo usa (+ as prováveis de contribuição).
+          // Carregar as ~200 do bundle deixaria o build lento à toa.
+          langs: [
+            "python",
+            "elixir",
+            "javascript",
+            "typescript",
+            "go",
+            "java",
+            "c",
+            "cpp",
+            "rust",
+            "bash",
+            "json",
+            "sql",
+            "text",
+          ],
+          // Bloco com linguagem fora da lista não quebra o build: cai em texto puro.
+          fallbackLanguage: "text",
+          // Mantém `language-<lang>` no <code>: é daí que o selo de linguagem sai.
+          addLanguageClass: true,
+        },
+      ],
+    ],
   },
 });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,10 +18,12 @@
       },
       "devDependencies": {
         "@playwright/test": "^1.49.0",
+        "@shikijs/rehype": "^4.4.1",
         "@types/mdx": "^2.0.13",
         "@types/node": "^22",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "shiki": "^4.4.1",
         "typescript": "^5.7.0"
       }
     },
@@ -748,6 +750,132 @@
         "node": ">=20"
       }
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.4.1.tgz",
+      "integrity": "sha512-VeR2CY6Nn9/WbisoYLOQZ7HZOnwTrpBuOw4wExjqLnBCi62BNWynBUO6K2uPIASPFJwAv7cX1fUu+LrPlSstcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.4.1",
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.4.1.tgz",
+      "integrity": "sha512-6U4lJBh8LTvIkEVqRHv/rr3ruwtO6IweFQt1ME1ntHJMGHS+6N86vfYGO1o8c/DtOCTia2lfhdQBtBrps1sDfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.4.1.tgz",
+      "integrity": "sha512-p23RugMKss0r5DAtRJW1yAXUDl60JvhQYV20yuxei//26JyDSJefV3umyWzzwep2weblMnJGDYahuti6XkcMgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.4.1.tgz",
+      "integrity": "sha512-xb2kCMloBCIraIy2fS5MW0t/BxVY3q2nDyQKBoeSeq6KNrQbShHetCFlw2n35fGIJ6t3+hXDLQogP5ir9O9bvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.4.1.tgz",
+      "integrity": "sha512-ko2OfDoG89YuQ7xL5LtcQiWKb7NIv1Ephb7g48TVU198OzAMLC8lXVEwaJGHK4sUMYrfAGJDqYmNLOLiW/Kz8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/rehype": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/rehype/-/rehype-4.4.1.tgz",
+      "integrity": "sha512-lK6tl7wIQZ0vRynHs6w82KEFhtBhQI1zfPB3iDXXVVvDw8OLLKUYT1e8qK3QDYiMp8TIkq/q9PYVoIl+8YhCRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1",
+        "@types/hast": "^3.0.5",
+        "hast-util-to-string": "^3.0.1",
+        "shiki": "4.4.1",
+        "unified": "^11.0.5",
+        "unist-util-visit": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.4.1.tgz",
+      "integrity": "sha512-wudOaoFro+/Zl9gQv2W1Ur5XlVduqvTuYLI483Xi0wgc1A+cy1hfB2r6ac6ufBgF+ID7KJEW7L41MHrzQ4wH+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.4.1.tgz",
+      "integrity": "sha512-GOwCLQDHM5EjGUWNPrhzJbr6JP8V/Dx/CDVkWvbZ1Avw5JFnNUckrgbLmE07qtg4WlW7Q7QFndhjIkeU9XMPvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -1252,6 +1380,30 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1279,6 +1431,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -1290,6 +1456,17 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inline-style-parser": {
@@ -2467,6 +2644,25 @@
         }
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -2656,6 +2852,33 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/rehype-recma": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rehype-recma/-/rehype-recma-1.0.0.tgz",
@@ -2813,6 +3036,26 @@
         "@img/sharp-win32-arm64": "0.34.5",
         "@img/sharp-win32-ia32": "0.34.5",
         "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.4.1.tgz",
+      "integrity": "sha512-rFP+iYKzjLEIqiMiKANhARqiAbk4deDhWnBtnUO/K0D0dPxMGDH4N0FVfBY/VeI+lPrV4wNGCHQZp7EOr7NNBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.4.1",
+        "@shikijs/engine-javascript": "4.4.1",
+        "@shikijs/engine-oniguruma": "4.4.1",
+        "@shikijs/langs": "4.4.1",
+        "@shikijs/themes": "4.4.1",
+        "@shikijs/types": "4.4.1",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/source-map": {

--- a/package.json
+++ b/package.json
@@ -24,10 +24,12 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.49.0",
+    "@shikijs/rehype": "^4.4.1",
     "@types/mdx": "^2.0.13",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "shiki": "^4.4.1",
     "typescript": "^5.7.0"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -261,7 +261,7 @@ html { scroll-behavior: smooth; }
 .level-guia { border-color: rgba(255, 255, 255, 0.16); color: #9fb4cf; }
 
 /* ------ topic page ------ */
-.topic-layout { display: grid; grid-template-columns: minmax(0, 1fr) 200px; gap: 40px; padding: 40px 48px 80px; max-width: 1180px; }
+.topic-layout { display: grid; grid-template-columns: minmax(0, 1fr) 200px; gap: 40px; padding: 40px 48px 80px; max-width: 1180px; align-items: start; }
 .topic-layout > article { min-width: 0; }
 .breadcrumb { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--ccc-muted); }
 .breadcrumb .cur { color: #c9d6e6; }
@@ -294,6 +294,20 @@ html { scroll-behavior: smooth; }
 .prose-code { padding: 2px 6px; border-radius: 5px; background: rgba(255, 255, 255, 0.06); font-family: var(--mono); font-size: 14px; color: #93bbfd; }
 .prose-pre { min-width: 0; padding: 14px 16px; border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-panel); overflow-x: auto; font-family: var(--mono); font-size: 13px; line-height: 1.7; color: #cbd5e6; }
 .prose-pre .prose-code { background: none; padding: 0; color: inherit; }
+/* Bloco de código: casca do <pre> + selo discreto da linguagem no canto.
+   O selo fica FORA do <pre> para não rolar junto quando a linha estoura, e o
+   bloco com selo abre um vão no topo para ele morar — sem o vão, a primeira
+   linha passa por baixo do selo em tela estreita. */
+.code-block { position: relative; margin: 0 0 20px; }
+.code-block > .prose-pre { margin: 0; }
+.code-block.com-lang > .prose-pre { padding-top: 32px; }
+.code-lang {
+  position: absolute; top: 10px; right: 15px; z-index: 1;
+  font-family: var(--mono); font-size: 10.5px; font-weight: 600; letter-spacing: 0.07em;
+  color: #5b6d85; user-select: none; pointer-events: none;
+}
+/* O <pre> do Shiki é focável (tabindex=0) por ser área rolável: o anel de foco
+   global já cobre isso. O fundo do tema é removido no mdx-components. */
 .prose-hr { border: none; border-top: 1px solid var(--ccc-line); margin: 32px 0; }
 .prose-table-wrap { max-width: 100%; min-width: 0; margin: 0 0 20px; overflow-x: auto; }
 .prose-table { width: 100%; min-width: 380px; border-collapse: collapse; font-size: 14.5px; }
@@ -350,8 +364,6 @@ html { scroll-behavior: smooth; }
 .prevnext .nm { display: block; margin-top: 3px; font-size: 15px; font-weight: 600; }
 .prevnext .next { text-align: right; }
 
-/* TOC */
-.toc { position: sticky; top: 88px; padding-left: 18px; border-left: 1px solid var(--ccc-line); }
 .toc-title { font-size: 11.5px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ccc-muted); margin-bottom: 11px; }
 .toc-links { display: flex; flex-direction: column; gap: 9px; }
 .toc-links a { font-size: 13px; line-height: 1.4; color: var(--ccc-muted); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -261,6 +261,9 @@ html { scroll-behavior: smooth; }
 .level-guia { border-color: rgba(255, 255, 255, 0.16); color: #9fb4cf; }
 
 /* ------ topic page ------ */
+/* `align-items: start` é o que faz o índice colar: sem ele o <nav> estica até a
+   altura do artigo (stretch é o padrão do grid) e o `position: sticky` não tem
+   folga nenhuma para deslizar. */
 .topic-layout { display: grid; grid-template-columns: minmax(0, 1fr) 200px; gap: 40px; padding: 40px 48px 80px; max-width: 1180px; align-items: start; }
 .topic-layout > article { min-width: 0; }
 .breadcrumb { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--ccc-muted); }
@@ -364,6 +367,13 @@ html { scroll-behavior: smooth; }
 .prevnext .nm { display: block; margin-top: 3px; font-size: 15px; font-weight: 600; }
 .prevnext .next { text-align: right; }
 
+/* TOC — acompanha a rolagem do artigo (ver `align-items: start` em .topic-layout).
+   Índice mais alto que a tela rola sozinho, sem arrastar a página junto. */
+.toc {
+  position: sticky; top: 88px;
+  max-height: calc(100vh - 88px - 28px); overflow-y: auto; overscroll-behavior: contain;
+  padding-left: 18px; border-left: 1px solid var(--ccc-line);
+}
 .toc-title { font-size: 11.5px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ccc-muted); margin-bottom: 11px; }
 .toc-links { display: flex; flex-direction: column; gap: 9px; }
 .toc-links a { font-size: 13px; line-height: 1.4; color: var(--ccc-muted); }

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -175,7 +175,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
                             {feito ? "✓" : ""}
                           </span>
                           <span className="side-item-name">{t.name}</span>
-                          {t.viz && <span className="badge-novo">NOVO</span>}
+                          {t.isNew && <span className="badge-novo">NOVO</span>}
                           {vazio && <span className="badge-soon">em breve</span>}
                         </Link>
                       );

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from "@playwright/test";
+import { ALL_TOPICS } from "../content/roadmap";
 
 test("home mostra o hero e leva para o Big O", async ({ page }) => {
   await page.goto("/");
@@ -226,6 +227,23 @@ test("código Python sai colorido do build, com selo discreto da linguagem", asy
   const semSelo = page.locator(".code-block:not(.com-lang)");
   expect(await semSelo.count()).toBeGreaterThan(0);
   await expect(semSelo.locator(".code-lang")).toHaveCount(0);
+});
+
+test("selo NOVO segue a tag isNew, não a existência de visualizador", async ({ page }) => {
+  const marcados = ALL_TOPICS.filter((t) => t.isNew);
+  await page.goto("/topico/big-o/");
+
+  // abre todo grupo ainda fechado, para que os selos de todos os tópicos contem
+  const grupos = page.locator(".side-group");
+  for (let i = 0; i < (await grupos.count()); i++) {
+    const g = grupos.nth(i);
+    if ((await g.locator(".side-caret.open").count()) === 0) await g.locator(".side-group-btn").click();
+  }
+
+  await expect(page.locator(".side-item .badge-novo")).toHaveCount(marcados.length);
+  for (const t of marcados) {
+    await expect(page.locator(`.side-item[href="/topico/${t.slug}/"] .badge-novo`)).toBeVisible();
+  }
 });
 
 test("página de introdução explica o guia e leva ao primeiro tópico", async ({ page }) => {

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -191,6 +191,23 @@ test("índice 'Nesta página' tem links âncora funcionais", async ({ page }) =>
   await expect(page.locator(href!)).toHaveCount(1);
 });
 
+test("código Python sai colorido do build, com selo discreto da linguagem", async ({ page }) => {
+  await page.goto("/topico/prefix-sum/");
+  const bloco = page.locator(".code-block.com-lang").first();
+  await expect(bloco.locator(".code-lang")).toHaveText("Python");
+  // Shiki roda no build: o HTML já chega tokenizado (nada de highlight no cliente)
+  await expect(bloco.locator("pre.shiki code.language-python")).toHaveCount(1);
+  const cores = await bloco
+    .locator("pre span[style*='color']")
+    .evaluateAll((spans) => [...new Set(spans.map((s) => getComputedStyle(s).color))]);
+  expect(cores.length).toBeGreaterThan(3);
+
+  // diagrama em ASCII (cerca sem linguagem) continua sem selo e sem cor
+  const semSelo = page.locator(".code-block:not(.com-lang)");
+  expect(await semSelo.count()).toBeGreaterThan(0);
+  await expect(semSelo.locator(".code-lang")).toHaveCount(0);
+});
+
 test("página de introdução explica o guia e leva ao primeiro tópico", async ({ page }) => {
   await page.goto("/introducao/");
   await expect(page.getByRole("heading", { level: 1, name: "Introdução" })).toBeVisible();

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -207,14 +207,21 @@ test("índice 'Nesta página' fica grudado ao rolar o artigo", async ({ page }) 
 
   // grudado: a posição na janela não muda por mais que o artigo role
   expect(Math.round(depois.y)).toBe(Math.round(antes.y));
-  expect(Math.round(depois.y)).toBe(88);
+  // e para no offset que o próprio CSS declara (sem número mágico aqui)
+  const topoDoSticky = await toc.evaluate((n) => parseFloat(getComputedStyle(n).top));
+  expect(Math.round(depois.y)).toBe(Math.round(topoDoSticky));
   // e o índice nunca é mais alto que a janela (senão o fim dele ficaria inalcançável)
   expect(depois.height).toBeLessThanOrEqual(page.viewportSize()!.height);
 });
 
 test("código Python sai colorido do build, com selo discreto da linguagem", async ({ page }) => {
   await page.goto("/topico/prefix-sum/");
-  const bloco = page.locator(".code-block.com-lang").first();
+  // pega o bloco Python pelo conteúdo, não pela ordem: um bloco de outra
+  // linguagem pode entrar antes dele no artigo sem quebrar o teste
+  const bloco = page
+    .locator(".code-block.com-lang")
+    .filter({ has: page.locator("code.language-python") })
+    .first();
   await expect(bloco.locator(".code-lang")).toHaveText("Python");
   // Shiki roda no build: o HTML já chega tokenizado (nada de highlight no cliente)
   await expect(bloco.locator("pre.shiki code.language-python")).toHaveCount(1);

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -191,6 +191,26 @@ test("índice 'Nesta página' tem links âncora funcionais", async ({ page }) =>
   await expect(page.locator(href!)).toHaveCount(1);
 });
 
+test("índice 'Nesta página' fica grudado ao rolar o artigo", async ({ page }) => {
+  await page.goto("/topico/prefix-sum/");
+  const toc = page.locator(".toc");
+  const rolarPara = async (y: number) => {
+    await page.evaluate((alvo) => window.scrollTo({ top: alvo, behavior: "instant" }), y);
+    await page.waitForFunction((alvo) => Math.abs(window.scrollY - alvo) < 2, y);
+  };
+
+  await rolarPara(1500);
+  const antes = (await toc.boundingBox())!;
+  await rolarPara(3500);
+  const depois = (await toc.boundingBox())!;
+
+  // grudado: a posição na janela não muda por mais que o artigo role
+  expect(Math.round(depois.y)).toBe(Math.round(antes.y));
+  expect(Math.round(depois.y)).toBe(88);
+  // e o índice nunca é mais alto que a janela (senão o fim dele ficaria inalcançável)
+  expect(depois.height).toBeLessThanOrEqual(page.viewportSize()!.height);
+});
+
 test("código Python sai colorido do build, com selo discreto da linguagem", async ({ page }) => {
   await page.goto("/topico/prefix-sum/");
   const bloco = page.locator(".code-block.com-lang").first();


### PR DESCRIPTION
## O que muda

Três ajustes de leitura na página de tópico, mais um renome de título em Arrays. Cada um em seu próprio commit.

**1. Destaque de sintaxe nos blocos de código** (`397b6bc`)
Os blocos eram monocromáticos. O highlight passa a ser gerado **no build**, pelo plugin rehype do Shiki dentro do loader do MDX, então o HTML já sai tokenizado e o cliente não recebe JS de highlight nenhum. Medido no `out/`:

| | antes | depois |
| --- | --- | --- |
| JS do cliente | 1.117.517 B | 1.117.519 B (+2 bytes) |
| HTML gzip (hash-table) | 43 KB | 47 KB (+9%) |
| HTML gzip (recursao) | 43 KB | 46 KB (+6%) |

O HTML cru cresce mais (o Shiki põe `style="color:#…"` por token), mas as cores se repetem e o gzip absorve quase tudo. O `output: "export"` segue igual.

Junto vem um **selo discreto de linguagem** no canto do bloco, tirado da própria cerca (` ```python `). Ele fica fora do `<pre>` para não rolar junto com o código, e o bloco com selo abre um vão no topo, senão a primeira linha passa por baixo dele no celular. Cerca sem linguagem (os diagramas em ASCII) segue sem cor e sem selo, que é o certo.

**2. Índice "Nesta página" grudado** (`9adc315`)
O `position: sticky` já estava lá e nunca funcionou: sem `align-items: start`, o `<nav>` esticava até a altura do artigo (`stretch` é o padrão do grid) e ficava com 17.972px, sem folga para deslizar. Com o `start` ele volta para 632px e trava em `top: 88`. O `max-height` + `overflow-y` cobrem o índice mais alto que a janela.

**3. "NOVO" virou tag de verdade** (`95f626b`)
O selo saía de `t.viz`, ou seja, todo tópico com visualizador era "novo" para sempre (eram sete selos simultâneos). Agora é `isNew: true`, e **nenhum tópico está marcado**: o menu fica limpo para a marca ir nos próximos tópicos publicados. Como não tem data, o combinado está documentado no CLAUDE.md, README e CONTRIBUTING: marcar o novo e tirar a marca dos anteriores, no mesmo PR.

**4. Título de Arrays** (`69ddca8`)
"O array é um endereço e uma conta" vira "Espaço contíguo na memória", nos dois lugares que o título mora (h2 do MDX e `summary` do `content/topics/index.ts`, que alimenta a âncora do índice).

## Tipo

- [x] `feat` novo conteúdo/tópico/visualizador
- [x] `fix` correção
- [x] `docs` documentação
- [x] `refactor` / `style` / `perf`
- [ ] `ci` / `build` / `chore`

## Checklist

- [x] `npm run build` passa
- [x] `npm test` passa (36, sendo 3 novos: highlight + selo, índice grudado, tag `isNew`)
- [x] Segui o padrão de [Conventional Commits](https://conventionalcommits.org/)
- [x] Sem o caractere travessão (`—`) na copy do site
- [x] Li o [guia de contribuição](../CONTRIBUTING.md)

## Verificação

Além do build e dos testes, conferi no `agent-browser`: desktop (1440x900 e 1440x640, para o índice rolar por dentro) e mobile (390x844, sem overflow horizontal em nenhuma página de tópico).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PStn5fD4PMxqAeeGrY9Ki5