### PR TITLE
fix(ui): rótulo longo estourando o card e asserção que passava vazia

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -505,7 +505,11 @@ html { scroll-behavior: smooth; }
 .bigo-card-ex { margin-top: 3px; font-size: 11.5px; color: var(--ccc-muted); }
 .bigo-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(140px, 1fr)); gap: 8px; margin-top: 14px; }
 .bigo-stat { min-width: 0; padding: 10px 12px; border: 1px solid var(--ccc-line); border-radius: 9px; background: #0e1725; }
-.bigo-stat span { display: block; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--ccc-muted); }
+/* `overflow-wrap: anywhere` porque rótulo de card pode conter um token único e
+   longo ("Arrays.binarySearch"): sem ele o texto vaza para fora da borda em
+   390px, e o `minmax(140px, ...)` do grid não impede isso, só impede o estouro
+   da página. Ele também deixa a caixa encolher, o que ajuda o auto-fit. */
+.bigo-stat span { display: block; overflow-wrap: anywhere; font-size: 11px; letter-spacing: 0.04em; text-transform: uppercase; color: var(--ccc-muted); }
 .bigo-stat strong { display: block; margin-top: 3px; font-family: var(--mono); font-size: 19px; font-weight: 600; color: #fff; }
 
 .bigo-fam { margin: 0 0 30px; border: 1px solid var(--ccc-line); border-radius: 14px; background: var(--ccc-surface); overflow: hidden; }

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -383,9 +383,14 @@ test("MST: Kruskal e Prim fecham no mesmo peso total", async ({ page }) => {
 test("heap: inserir, remover e construir contam trabalho diferente sobre os mesmos dados", async ({ page }) => {
   await page.goto("/topico/binary-heap/");
   const viz = page.locator("figure.viz").filter({ hasText: "a árvore e o array do heap se movendo juntos" });
+  const proximo = viz.getByRole("button", { name: "Próximo ›" });
+  // O laço sai calado se o limite estourar, e aí a asserção seguinte roda num
+  // passo do meio. Pior: `trocas` vale 0 no passo 0 de TODO preset, então
+  // `toBe(0)` passaria sem um único clique. Exigir o botão desabilitado no fim
+  // é o que transforma "andei até o fim" em fato verificado.
   const irAteOFim = async () => {
-    const proximo = viz.getByRole("button", { name: "Próximo ›" });
     for (let i = 0; i < 120 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   };
   // O texto do card é rótulo + valor concatenados ("trocas16"), então a regex
   // ancorada casa só o card certo e evita depender da ordem no DOM.
@@ -517,6 +522,7 @@ test("busca binária: descarta metade por passo e para no ponto de inserção", 
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
   const irAteOFim = async () => {
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   };
 
   // 8 posições, alvo no meio: 3 comparações contra as 5 da busca linear
@@ -568,6 +574,7 @@ test("fronteira: a mesma busca devolve primeira, última e ponto de inserção",
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
   const resposta = async (rot: RegExp) => {
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     return viz.locator(".bigo-stat").filter({ hasText: rot });
   };
 

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -389,6 +389,12 @@ test("heap: inserir, remover e construir contam trabalho diferente sobre os mesm
   // `toBe(0)` passaria sem um único clique. Exigir o botão desabilitado no fim
   // é o que transforma "andei até o fim" em fato verificado.
   const irAteOFim = async () => {
+    // `isEnabled()` lê UMA vez e não reconsulta, então logo após trocar de preset
+    // ele ainda pode devolver o estado desabilitado do fim da rodada anterior. Aí
+    // o laço não clica e o `toBeDisabled()` passa sobre esse mesmo estado velho:
+    // a asserção volta a ser vazia por outro caminho. A espera web-first abaixo é
+    // o que garante que a animação reiniciou antes de o laço começar.
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 120 && (await proximo.isEnabled()); i++) await proximo.click();
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   };
@@ -521,6 +527,7 @@ test("busca binária: descarta metade por passo e para no ponto de inserção", 
   const viz = page.locator("figure.viz").filter({ hasText: "metade some a cada olhada" });
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
   const irAteOFim = async () => {
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   };
@@ -573,6 +580,7 @@ test("fronteira: a mesma busca devolve primeira, última e ponto de inserção",
   const viz = page.locator("figure.viz").filter({ hasText: "repetidos, bordas e a posição de inserção" });
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
   const resposta = async (rot: RegExp) => {
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     return viz.locator(".bigo-stat").filter({ hasText: rot });


### PR DESCRIPTION
## O que muda

Dois defeitos do PR #14 que a revisão não pegou e uma auditoria do próprio diff pegou, depois do merge. Um commit só, direto da `main`.

**1. Rótulo longo estourando a borda do card no celular.** O rótulo `retorno do Arrays.binarySearch` entrou num dos ajustes de revisão do #14, e depois disso a conferência de viewport não foi refeita. Em 390px ele ocupa **139px num espaço de 124px** e vaza para fora da borda. O `minmax(140px, 1fr)` do grid impede o estouro da **página**, não o do **texto**, e `Arrays.binarySearch` é um token de 19 caracteres sem ponto de quebra.

`overflow-wrap: anywhere` no rótulo resolve, e ainda deixa a caixa encolher, o que ajuda o `auto-fit`.

**2. Asserção que passava sem executar nada.** Os helpers que percorrem a animação (`irAteOFim`, `resposta`) saíam calados quando o limite do laço estourava, e a asserção seguinte rodava num passo do meio. Onde o valor esperado **também vale no passo 0**, isso vira asserção vazia:

```
preset crescente / min-heap:    swaps no passo 0 = 0  | no último = 0
preset decrescente / max-heap:  swaps no passo 0 = 0  | no último = 0
```

`expect(await trocas()).toBe(0)` passaria **sem um único clique**, e são justamente as duas asserções que carregam a tese de que a ordem de chegada decide o custo. Os três helpers passaram a exigir `await expect(proximo).toBeDisabled()` no fim.

## Tipo

- [ ] `feat` novo conteúdo/tópico/visualizador
- [x] `fix` correção
- [ ] `docs` documentação
- [ ] `refactor` / `style` / `perf`
- [ ] `ci` / `build` / `chore`

## Como foi verificado

**O rótulo**, medindo `scrollWidth` contra `clientWidth` do `<span>` em 390px, nas **29 páginas de tópico**, não só nas três novas: nenhum rótulo cortado e nenhum overflow horizontal. Antes do fix, `busca-binaria` acusava `sw 139 / cw 124`; depois, `sw 124 / cw 124`, quebrando em 3 linhas.

Um detalhe que quase me enganou e vale registrar: a primeira medição **pós-fix** ainda acusou o rótulo cortado, porque o navegador estava servindo a folha de estilo em cache. Refiz com cache furado e o número mudou. Medição de CSS depois de rebuild precisa disso.

**A asserção**, rodando o teste com o limite do laço em 0. Falha com a mensagem certa:

```
Error: a animação não chegou ao fim dentro do limite do laço
expect(locator).toBeDisabled() failed
```

Suíte em **64 testes verdes**, build e `tsc --noEmit` passando.

## Checklist

- [x] `npm run build` passa
- [x] `npm test` passa
- [x] Segui o padrão de Conventional Commits
- [x] Sem o caractere travessão na copy do site
- [x] Li o guia de contribuição
