### PR TITLE
feat: fecha o backlog de vídeo com backtracking e números binários

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -23,7 +23,7 @@ export type Problem = {
   url: string;
 };
 
-export type Visualizer = "a-star" | "arrays" | "arvores-binarias" | "bellman-ford" | "big-o" | "binary-heap" | "bst" | "busca-binaria" | "dfs-bfs" | "dijkstra" | "filas" | "grafos-intro" | "hash-table" | "heap-sort" | "intervals" | "listas-ligadas" | "merge-sort" | "mst" | "n-ary-trees" | "ordenacao-basica" | "pilhas" | "prefix-sum" | "quick-sort" | "recursao" | "recursao-funcional" | "shell-sort" | "skip-list" | "sliding-window" | "strings" | "sub-types" | "topological-sort" | "tree-traversals" | "two-pointers";
+export type Visualizer = "a-star" | "arrays" | "arvores-binarias" | "backtracking" | "bellman-ford" | "big-o" | "binary-heap" | "binary-numbers" | "bst" | "busca-binaria" | "dfs-bfs" | "dijkstra" | "filas" | "grafos-intro" | "hash-table" | "heap-sort" | "intervals" | "listas-ligadas" | "merge-sort" | "mst" | "n-ary-trees" | "negative-binary" | "ordenacao-basica" | "pilhas" | "prefix-sum" | "quick-sort" | "recursao" | "recursao-funcional" | "shell-sort" | "skip-list" | "sliding-window" | "strings" | "sub-types" | "topological-sort" | "tree-traversals" | "two-pointers";
 
 // Vídeos extras de um tópico: aparecem como links clicáveis (não embed).
 export type VideoLink = { title: string; youtube?: string; url?: string; duration?: string };
@@ -946,7 +946,6 @@ export const GROUPS: Group[] = [
         level: "Fácil",
         status: "ready",
         viz: "ordenacao-basica",
-        isNew: true,
         youtube: yt("GxhxsbbzaTI"),
         videoMinutes: "1:52:10",
         readingTime: "12 min",
@@ -975,7 +974,6 @@ export const GROUPS: Group[] = [
         level: "Médio",
         status: "ready",
         viz: "merge-sort",
-        isNew: true,
         youtube: yt("lbktBOwmmhg"),
         videoMinutes: "3:14:02",
         readingTime: "13 min",
@@ -1004,7 +1002,6 @@ export const GROUPS: Group[] = [
         level: "Médio",
         status: "ready",
         viz: "quick-sort",
-        isNew: true,
         youtube: yt("2T0Itw-oaEA"),
         videoMinutes: "1:58:04",
         readingTime: "13 min",
@@ -1033,7 +1030,6 @@ export const GROUPS: Group[] = [
         level: "Médio",
         status: "ready",
         viz: "shell-sort",
-        isNew: true,
         youtube: yt("symbT7Cgrr8"),
         videoMinutes: "1:58:45",
         readingTime: "12 min",
@@ -1069,10 +1065,30 @@ export const GROUPS: Group[] = [
         name: "Backtracking",
         group: "Backtracking",
         level: "Difícil",
-        status: "soon",
+        status: "ready",
+        viz: "backtracking",
+        isNew: true,
         youtube: yt("Vcm6mhLKU5A"),
+        videoMinutes: "2:08:38",
+        readingTime: "13 min",
+        language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-backtracking",
         description: "Tentar, falhar e voltar atrás, busca exaustiva com poda.",
+        problems: [
+          { id: "lc-78", name: "Subsets", number: "78", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/subsets/" },
+          { id: "lc-46", name: "Permutations", number: "46", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/permutations/" },
+          { id: "lc-79", name: "Word Search", number: "79", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/word-search/" },
+          { id: "lc-51", name: "N-Queens", number: "51", source: "LeetCode", level: "Difícil", url: "https://leetcode.com/problems/n-queens/" },
+          { id: "lc-37", name: "Sudoku Solver", number: "37", source: "LeetCode", level: "Difícil", url: "https://leetcode.com/problems/sudoku-solver/" },
+          { id: "gfg-backtracking", name: "Backtracking: guia completo", source: "GeeksforGeeks", level: "Guia", url: "https://www.geeksforgeeks.org/dsa/introduction-to-backtracking-2/" },
+        ],
+        references: [
+          { title: "Algoritmos de enumeração", source: "Paulo Feofiloff, IME-USP", url: "https://www.ime.usp.br/~pf/algoritmos/aulas/enum.html" },
+          { title: "Backtracking (MC-202)", source: "IC, UNICAMP", url: "https://www.ic.unicamp.br/~rafael/cursos/2s2018/mc202/slides/unidade09-backtracking.pdf" },
+          { title: "Backtracking, capítulo do livro Algorithms", source: "Jeff Erickson, University of Illinois", url: "https://jeffe.cs.illinois.edu/teaching/algorithms/book/02-backtracking.pdf" },
+          { title: "O problema das oito rainhas e a história dele", source: "Wikipedia", url: "https://en.wikipedia.org/wiki/Eight_queens_puzzle" },
+          { title: "Introduction to Backtracking", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/introduction-to-backtracking-2/" },
+        ],
         extraVideos: [
           { title: "Desvendando Backtracking", youtube: "GavxeYye6sg" },
           { title: "Na prática: Sudoku (corte)", youtube: "ThOaYVhOmbc" },
@@ -1113,8 +1129,64 @@ export const GROUPS: Group[] = [
     id: "bits",
     name: "Manipulação de Bits",
     topics: [
-      { slug: "binary-numbers", name: "Números Binários", group: "Manipulação de Bits", level: "Fácil", status: "soon", youtube: yt("8VHi44rAVFo"), description: "O sistema binário e a conversão decimal ⇄ binário." },
-      { slug: "negative-binary", name: "Binários Negativos", group: "Manipulação de Bits", level: "Médio", status: "soon", youtube: yt("93CpmUXLbzc"), description: "Sign-magnitude, complemento de um e de dois." },
+      {
+        slug: "binary-numbers",
+        name: "Números Binários",
+        group: "Manipulação de Bits",
+        level: "Fácil",
+        status: "ready",
+        viz: "binary-numbers",
+        isNew: true,
+        youtube: yt("8VHi44rAVFo"),
+        videoMinutes: "27:33",
+        readingTime: "10 min",
+        language: "Python",
+        description: "O sistema binário e a conversão decimal ⇄ binário.",
+        problems: [
+          { id: "lc-191", name: "Number of 1 Bits", number: "191", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/number-of-1-bits/" },
+          { id: "lc-67", name: "Add Binary", number: "67", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/add-binary/" },
+          { id: "lc-405", name: "Convert a Number to Hexadecimal", number: "405", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/convert-a-number-to-hexadecimal/" },
+          { id: "lc-338", name: "Counting Bits", number: "338", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/counting-bits/" },
+          { id: "lc-1009", name: "Complement of Base 10 Integer", number: "1009", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/complement-of-base-10-integer/" },
+          { id: "gfg-binary-numbers", name: "Sistemas de numeração e conversão de bases", source: "GeeksforGeeks", level: "Guia", url: "https://www.geeksforgeeks.org/dsa/number-system-and-base-conversions/" },
+        ],
+        references: [
+          { title: "Bytes, números e caracteres", source: "Paulo Feofiloff, IME-USP", url: "https://www.ime.usp.br/~pf/algoritmos/aulas/bytes.html" },
+          { title: "Os tipos int e char", source: "Paulo Feofiloff, IME-USP", url: "https://www.ime.usp.br/~pf/algoritmos/aulas/int.html" },
+          { title: "Operações sobre bits em inteiros", source: "docs.python.org", url: "https://docs.python.org/3/library/stdtypes.html#bitwise-operations-on-integer-types" },
+          { title: "Binary number: história e notação", source: "Wikipedia", url: "https://en.wikipedia.org/wiki/Binary_number" },
+          { title: "Number System and Base Conversions", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/number-system-and-base-conversions/" },
+        ],
+      },
+      {
+        slug: "negative-binary",
+        name: "Binários Negativos",
+        group: "Manipulação de Bits",
+        level: "Médio",
+        status: "ready",
+        viz: "negative-binary",
+        isNew: true,
+        youtube: yt("93CpmUXLbzc"),
+        videoMinutes: "26:13",
+        readingTime: "11 min",
+        language: "Python",
+        description: "Sign-magnitude, complemento de um e de dois.",
+        problems: [
+          { id: "lc-461", name: "Hamming Distance", number: "461", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/hamming-distance/" },
+          { id: "lc-190", name: "Reverse Bits", number: "190", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/reverse-bits/" },
+          { id: "lc-7", name: "Reverse Integer", number: "7", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/reverse-integer/" },
+          { id: "lc-371", name: "Sum of Two Integers", number: "371", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/sum-of-two-integers/" },
+          { id: "lc-29", name: "Divide Two Integers", number: "29", source: "LeetCode", level: "Médio", url: "https://leetcode.com/problems/divide-two-integers/" },
+          { id: "gfg-complemento", name: "Complemento de um e de dois", source: "GeeksforGeeks", level: "Guia", url: "https://www.geeksforgeeks.org/dsa/1s-2s-complement-binary-number/" },
+        ],
+        references: [
+          { title: "Os tipos int e char: representação e limites", source: "Paulo Feofiloff, IME-USP", url: "https://www.ime.usp.br/~pf/algoritmos/aulas/int.html" },
+          { title: "Two's complement: por que ela venceu", source: "Wikipedia", url: "https://en.wikipedia.org/wiki/Two%27s_complement" },
+          { title: "O problema do ano 2038", source: "Wikipedia", url: "https://en.wikipedia.org/wiki/Year_2038_problem" },
+          { title: "Operações sobre bits em inteiros", source: "docs.python.org", url: "https://docs.python.org/3/library/stdtypes.html#bitwise-operations-on-integer-types" },
+          { title: "1's and 2's Complement of a Binary Number", source: "GeeksforGeeks", url: "https://www.geeksforgeeks.org/dsa/1s-2s-complement-binary-number/" },
+        ],
+      },
       { slug: "operacoes-bitwise", name: "Operações Bitwise", group: "Manipulação de Bits", level: "Médio", status: "soon", description: "AND, OR, XOR, shifts e os truques de bit mais usados em entrevistas." },
     ],
   },
@@ -1157,8 +1229,17 @@ export function topicTags(t: Topic): Tag[] {
 // Tópico realmente vazio: ainda não tem nenhum material (vídeo, artigo ou
 // visualização). Só esses recebem o rótulo "em breve" no menu e ficam fora do
 // índice do Google; quem já tem ao menos um material não é mais "em breve".
+// "Em breve" é derivado, nunca marcado à mão: some sozinho no dia em que o
+// tópico ganha material. E material quer dizer as três coisas que a página
+// entrega de verdade: vídeo do encontro, artigo ou visualização.
+//
+// `extraVideos` NÃO conta, de propósito. Eles são links para resoluções soltas
+// de exercício, e um tópico que só tem isso continua sendo um tópico sem aula,
+// sem texto e sem visualização. Contá-los tirava o selo de quem não tinha nada
+// a mostrar, e ainda fazia a página entrar no índice do Google como conteúdo
+// raso.
 export function isEmptyTopic(t: Topic): boolean {
-  return t.status === "soon" && !t.youtube && !t.article && !t.viz && !t.extraVideos?.length;
+  return t.status === "soon" && !t.youtube && !t.article && !t.viz;
 }
 
 export function getNeighbors(slug: string): { previous?: Topic; next?: Topic } {

--- a/content/topics/backtracking.mdx
+++ b/content/topics/backtracking.mdx
@@ -1,0 +1,156 @@
+<Callout>
+Backtracking é a técnica que resolve problemas em que a resposta não se calcula, se **procura**: sudoku, n rainhas, todos os subconjuntos de um array, todos os caminhos de um labirinto. A ideia cabe em três palavras (escolher, explorar, desfazer) e a terceira é a que dá nome a ela e a que todo mundo esquece de escrever.
+</Callout>
+
+## Tentar, falhar, e desfazer
+
+Imagine percorrer um labirinto sem mapa. Você anda até bater numa parede, volta até a última bifurcação, e tenta o outro caminho. Se ele também acaba em parede, volta de novo. Você não é esperto, você é **sistemático**: nenhum caminho fica sem ser tentado, e nenhum é tentado duas vezes.
+
+Isso é backtracking, e o nome vem justamente do movimento de voltar. O algoritmo tem três passos, sempre os mesmos:
+
+<Colunas>
+<Cartao titulo="1. Escolher">
+Pegue uma das opções disponíveis e acrescente-a à solução parcial.
+</Cartao>
+<Cartao titulo="2. Explorar">
+Chame o algoritmo de novo, agora com essa escolha feita, e resolva o resto.
+</Cartao>
+<Cartao titulo="3. Desfazer">
+Tire a escolha da solução parcial, para poder tentar a próxima opção do mesmo ponto.
+</Cartao>
+</Colunas>
+
+O terceiro passo é o que separa backtracking de uma busca qualquer. Sem ele, a solução parcial acumula lixo das tentativas anteriores e o algoritmo passa a explorar combinações que nunca existiram. E ele é uma linha só, o que o torna fácil de esquecer e difícil de depurar quando falta.
+
+<BacktrackingVisualizer />
+
+## A árvore de decisão não existe
+
+Todo material sobre backtracking desenha uma árvore, e a árvore ajuda muito. Ela também engana, porque dá a impressão de que existe uma árvore sendo construída na memória.
+
+**Não existe.** O que existe é:
+
+- uma **lista** com a solução parcial, que cresce quando você escolhe e encolhe quando você desfaz;
+- a **pilha de chamadas** da recursão, que guarda em que ponto cada chamada parou.
+
+A árvore é o desenho do caminho que o algoritmo percorreu, feito depois. Dá para conferir isso no visualizador acima: no passo de retrocesso, a árvore não perde nenhum nó (ela é histórico), a lista encolhe um elemento e a pilha desempilha um quadro. Três coisas que parecem uma só andando em ritmos diferentes.
+
+Essa distinção não é preciosismo. Ela é o que permite entender o consumo de memória: um backtracking sobre 20 elementos pode visitar milhões de nós e nunca guardar mais do que 20 elementos na lista e 20 quadros na pilha.
+
+A semelhança com [DFS](/topico/dfs-bfs) é real e vale explorar: os dois vão fundo até não dar mais e voltam. A diferença é que o DFS percorre um grafo que **existe** e marca o que já visitou, enquanto o backtracking percorre um espaço de possibilidades que ele **gera** enquanto anda, e desfaz em vez de marcar.
+
+## O template, e as três peças que mudam
+
+Praticamente todo problema de backtracking cabe neste molde:
+
+```python
+def backtrack(parcial, opcoes):
+    if completo(parcial):
+        solucoes.append(parcial[:])   # cópia, e isso importa
+        return
+    for opcao in opcoes:
+        if valido(opcao, parcial):
+            parcial.append(opcao)     # 1. escolher
+            backtrack(parcial, ...)   # 2. explorar
+            parcial.pop()             # 3. desfazer
+```
+
+Trocar de problema é trocar três peças: **quais são as opções**, **o que é válido** e **o que é uma solução completa**. O esqueleto não muda.
+
+| Problema | opções | válido | completo |
+| --- | --- | --- | --- |
+| Subconjuntos | os elementos do índice atual em diante | tudo é válido | todo estado é resposta |
+| Permutações | todos os elementos ainda não usados | ainda não usado | usou todos |
+| Combinações de k | do índice atual em diante | tudo é válido | tamanho igual a k |
+| Sudoku | os dígitos de 1 a 9 | não repete na linha, coluna e quadrante | não sobrou célula vazia |
+| N rainhas | as colunas da linha atual | nenhuma rainha ataca | pôs n rainhas |
+
+Vale marcar a diferença entre os três primeiros, porque ela confunde bastante e cai em entrevista. **Permutação** usa todos os elementos e a ordem importa (`1 2 3` e `3 2 1` são respostas diferentes): são `n!`. **Combinação** escolhe alguns e a ordem não importa (`1 2` e `2 1` são a mesma): são `C(n, k)`. **Subconjunto** é qualquer seleção mantendo a ordem original, inclusive a vazia: são `2ⁿ`. Se essa distinção ainda embaralhar, vale passar em [Os 4 "sub"](/topico/subarray-substring-subsequence-subset).
+
+Os números do visualizador mostram o custo de cada um com três elementos: subconjuntos visitam **8 nós e devolvem 8 respostas**, permutações visitam **16 nós e devolvem 6**. Nas permutações, dez dos dezesseis nós são caminho e não resultado, e é esse desperdício que faz o backtracking custar caro.
+
+<Callout>
+Existe uma invariante bonita para conferir se o seu backtracking está correto: **o número de retrocessos é sempre igual ao número de arestas da árvore**, e no fim a solução parcial tem que voltar exatamente ao estado inicial. Se ela terminar com sobras, faltou um `pop`.
+</Callout>
+
+## A cópia que salva as respostas
+
+Aquele `parcial[:]` do template é o detalhe que mais causa bug em backtracking, e o motivo é sutil.
+
+A solução parcial é **uma lista só**, a mesma da primeira à última chamada. Quando você encontra uma resposta e faz `solucoes.append(parcial)`, você não guarda a resposta: guarda uma **referência** para a lista que continua sendo modificada. No fim da execução, a lista voltou a ficar vazia (porque todo escolher teve o seu desfazer), e todas as respostas guardadas apontam para ela.
+
+O resultado é um dos bugs mais desconcertantes de depurar: a função encontra as soluções certas, você vê cada uma delas passando no depurador, e o retorno é uma lista com o número certo de elementos, todos vazios.
+
+```python
+solucoes.append(parcial)      # errado: guarda a lista viva
+solucoes.append(parcial[:])   # certo: guarda uma foto dela
+solucoes.append(list(parcial))# idem
+```
+
+A mesma armadilha existe em Java, C#, JavaScript e qualquer linguagem em que listas sejam objetos passados por referência. E ela não aparece em teste pequeno com uma solução só, porque com uma resposta o momento da leitura pode ser antes de a lista mudar.
+
+## Sudoku é o mesmo algoritmo
+
+Sudoku parece um problema de outra natureza, e é o mesmo template com as três peças trocadas: as opções são os dígitos de 1 a 9, a validade é a regra do jogo (sem repetir na linha, na coluna e no quadrante), e desfazer é apagar a célula.
+
+```python
+def resolver(grade):
+    pos = primeira_vazia(grade)
+    if pos is None: return True      # completo
+    for d in range(1, 10):           # as opções
+        if valido(grade, pos, d):    # a validade
+            grade[pos] = d           # 1. escolher
+            if resolver(grade):      # 2. explorar
+                return True
+            grade[pos] = VAZIO       # 3. desfazer
+    return False                     # nenhum dígito serviu
+```
+
+<BacktrackingSudoku />
+
+Duas coisas ficam visíveis rodando isso que nenhum texto transmite bem.
+
+A primeira é que **caber não é estar certo**. Quando o algoritmo escreve um dígito, ele só verificou que aquele valor não conflita com o que já está no tabuleiro *agora*. É uma aposta, e ela pode ser desmentida vinte células adiante.
+
+A segunda é o preço. No tabuleiro com 48 lacunas, o algoritmo testa **882 dígitos para preencher 48 células**, com 120 escritas e 72 retrocessos: cerca de 18 tentativas por célula. Ele escreve e apaga a mesma posição várias vezes, e cada apagada é a descoberta de que uma escolha feita lá atrás não levava a lugar nenhum.
+
+<Callout tipo="aviso">
+Repare no que o algoritmo faz quando o tabuleiro tem várias soluções válidas: ele para na **primeira** que encontrar, não na "certa", porque para ele não existe uma certa. Se você precisa de todas, tire o `return True` e deixe a recursão continuar depois de registrar; se você precisa da melhor por algum critério, precisa comparar todas ou usar uma técnica diferente.
+</Callout>
+
+## Poda: a mesma resposta por uma fração do trabalho
+
+A otimização mais importante do backtracking não muda o algoritmo, muda **quando** a validade é conferida. Comparar as duas versões no problema das n rainhas deixa isso quantitativo.
+
+<BacktrackingPoda />
+
+**Sem poda**, o algoritmo monta todas as disposições possíveis de rainhas e só no fim pergunta se aquela disposição é válida. Com 7 rainhas, isso significa visitar **960.800 nós**.
+
+**Com poda**, antes de descer ele pergunta se a rainha nova já é atacada por alguma das que estão no tabuleiro. Quando é, o ramo inteiro que sairia daquela escolha deixa de existir. Mesmas 40 soluções, **552 nós**, 1.741 vezes menos trabalho.
+
+E a diferença cresce com o tamanho: 20 vezes com 4 rainhas, 366 com 6, 1.741 com 7. Com 8 rainhas, a versão sem poda visitaria `(8⁹ - 1) / 7 = 19.173.961` nós para achar as 92 soluções, contra 2.057 da versão com poda.
+
+**Podar não muda a classe de complexidade.** As duas continuam exponenciais, e existe entrada capaz de fazer a poda não cortar nada. O que ela muda é o expoente na prática, que costuma ser a diferença entre um algoritmo que roda e um que não termina.
+
+## O custo, e para onde isso vai
+
+O custo do backtracking se descreve por `O(b^d)`, onde `b` é o **fator de ramificação** (quantas opções existem em cada ponto) e `d` é a **profundidade** da solução. Os dois vêm do problema, não do código.
+
+| Problema | quantas respostas | ordem de grandeza |
+| --- | --- | --- |
+| Subconjuntos de n | 2ⁿ | exponencial |
+| Permutações de n | n! | fatorial |
+| Combinações de k entre n | C(n, k) | polinomial em n, para k fixo |
+| N rainhas | não tem fórmula fechada | exponencial |
+
+A diferença entre exponencial e fatorial não é acadêmica: com 10 elementos são 1.024 subconjuntos e 3.628.800 permutações; com 20, são cerca de um milhão contra 2,4 × 10¹⁸. Vale revisitar [Big O](/topico/big-o) para dimensionar isso antes de escrever o código, e não depois de o processo travar.
+
+Isso põe o backtracking num lugar específico do repertório. Ele é a resposta quando:
+
+- o problema pede **todas** as soluções, e não uma medida sobre elas;
+- o espaço de busca é grande mas as restrições cortam muito (é o caso do sudoku);
+- não existe estrutura melhor conhecida, e uma resposta correta e lenta vale mais que nenhuma.
+
+E ele é o **ponto de partida** de quase toda otimização seguinte. O caminho usual é: escreva o backtracking, veja que ele estoura o tempo, e então observe que muitos ramos recalculam a mesma coisa. Guardar esses resultados em vez de recalculá-los é **memoização**, e é a porta de entrada da [programação dinâmica](/topico/programacao-dinamica). A relação entre as duas técnicas é simples de dizer e difícil de enxergar na primeira vez: backtracking **explora todas as soluções**, programação dinâmica **quebra o problema em subproblemas que se repetem**. Quando o seu backtracking repete subproblemas, ele está pedindo para virar programação dinâmica.
+
+Daqui, [Recursão](/topico/recursao) é a base que sustenta tudo isto (o backtracking é uma recursão com um passo de desfazer), e [DFS e BFS](/topico/dfs-bfs) mostram o mesmo movimento de descer e voltar sobre uma estrutura que já existe.

--- a/content/topics/binary-numbers.mdx
+++ b/content/topics/binary-numbers.mdx
@@ -1,0 +1,142 @@
+<Callout>
+Binário não é um código secreto que o computador usa para esconder as coisas. É o **mesmo sistema de numeração que você já usa desde a escola**, com um parâmetro trocado: em vez de dez símbolos por posição, dois. Entender essa frase inteira é entender o tópico, e o resto do artigo é ela em detalhe.
+</Callout>
+
+## Dois símbolos, e o motivo é físico
+
+O sistema que usamos no dia a dia se chama **decimal** porque tem dez símbolos: 0, 1, 2, 3, 4, 5, 6, 7, 8 e 9. Não há nada de especial neles além de termos dez dedos.
+
+O computador usa **binário**, com dois símbolos: 0 e 1. Cada um deles é um **bit**, e um conjunto de oito bits é um **byte**.
+
+A escolha não foi estética, foi elétrica. Por dentro, um computador é um monte de circuitos por onde passa (ou não passa) corrente. Distinguir "tem corrente" de "não tem corrente" é trivial e resiste a ruído, variação de temperatura e componente envelhecido. Distinguir **dez níveis diferentes de tensão** para representar dez símbolos seria possível e péssimo: qualquer oscilação transformaria um 6 num 7, e o computador precisaria de circuitos de correção em cada ponto.
+
+Dois estados é o mínimo que ainda carrega informação, e por isso é o mais robusto. Todo o resto (números, texto, imagem, som, este parágrafo) é construído em cima dessa decisão.
+
+## Notação posicional: você já sabe fazer isso
+
+Pegue o número decimal **243**. O que ele significa, na matemática?
+
+```
+243 = 2 x 10²  +  4 x 10¹  +  3 x 10⁰
+    = 2 x 100  +  4 x 10   +  3 x 1
+    = 200      +  40       +  3
+```
+
+Repare na estrutura: cada dígito é multiplicado por uma potência da **base**, e o expoente é a posição, contada da direita para a esquerda começando em zero. O dígito é o **coeficiente**, o 10 é a **base**, e a posição é o **expoente**.
+
+A base é a única coisa que muda entre sistemas de numeração. Ela diz quantos símbolos existem por posição, e é ela que aparece na potência:
+
+| Sistema | Base | Símbolos |
+| --- | --- | --- |
+| Binário | 2 | 0 e 1 |
+| Octal | 8 | 0 a 7 |
+| Decimal | 10 | 0 a 9 |
+| Hexadecimal | 16 | 0 a 9 e A a F |
+
+Ou seja, não existem quatro regras diferentes para aprender. Existe **uma** regra, com um parâmetro.
+
+## Lendo um binário: a soma das posições ligadas
+
+Aplicando a mesma fórmula com base 2, o binário `00110101` vale:
+
+```
+0 x 2⁷ + 0 x 2⁶ + 1 x 2⁵ + 1 x 2⁴ + 0 x 2³ + 1 x 2² + 0 x 2¹ + 1 x 2⁰
+=   0  +   0    +  32    +  16    +   0    +   4    +   0    +   1     = 53
+```
+
+Como os únicos coeficientes possíveis são 0 e 1, a multiplicação some da conta: os bits em zero contribuem com nada, e os bits em um contribuem com a potência inteira. **Ler um binário é somar as potências de dois das posições ligadas.** Nada além disso.
+
+<BinarioConversor />
+
+Vale fixar o vocabulário, porque ele aparece o tempo todo: o bit da esquerda é o **mais significativo** (MSB, de *most significant bit*) e o da direita é o **menos significativo** (LSB). É a mesma ideia da centena e da unidade num número decimal: mexer no primeiro muda muito, mexer no último muda pouco.
+
+## Escrevendo em binário: dividir por 2 até acabar
+
+O caminho de volta é um algoritmo de três linhas: divida o número por 2, guarde o resto, repita com o quociente até chegar a zero, e leia os restos **de trás para frente**.
+
+```python
+def para_binario(n):
+    if n == 0: return '0'
+    bits = ''
+    while n > 0:
+        bits = str(n % 2) + bits   # o resto entra na FRENTE
+        n = n // 2                 # e o número encolhe pela metade
+    return bits
+```
+
+<BinarioDivisoes />
+
+Duas observações que transformam a receita em entendimento.
+
+A primeira é **por que os restos saem ao contrário**. Dividir por 2 é deslocar o número inteiro uma casa para a direita, e o resto é justamente o bit que cai fora nesse deslocamento. Ou seja, a **primeira** divisão devolve o bit **menos** significativo. Não é um truque de leitura, é a ordem em que a informação aparece.
+
+A segunda é que o resto da divisão por 2 é exatamente a pergunta "este número é ímpar?". Todo número ímpar tem o bit da direita ligado, todo par tem ele desligado, e é por isso que `n & 1` é a forma idiomática de testar paridade em código de baixo nível.
+
+<Callout>
+O número de divisões é o número de bits significativos, e ele cresce como `log₂ n`. O 201 precisa de 8 divisões; 201 mil precisaria de 18; 201 bilhões, de 38. É a mesma razão pela qual a [busca binária](/topico/busca-binaria) é barata, escrita de outro jeito: partir pela metade repetidamente chega ao fim depressa.
+</Callout>
+
+## Bit, byte, e quanto cabe
+
+Com `k` bits existem `2ᵏ` combinações diferentes. Um byte tem 8 bits, então são `2⁸ = 256` combinações, e os valores vão de **0 a 255**.
+
+O 255 costuma causar confusão, e a conta explica: `128 + 64 + 32 + 16 + 8 + 4 + 2 + 1 = 255`. Somar todas as potências de dois até `2ⁿ⁻¹` sempre dá `2ⁿ - 1`, um a menos que a próxima potência. São 256 valores porque o zero também conta.
+
+<BinarioBases />
+
+Essa conta é o orçamento de qualquer tipo numérico:
+
+| Tamanho | Combinações | Maior valor sem sinal |
+| --- | --- | --- |
+| 8 bits (byte) | 2⁸ = 256 | 255 |
+| 16 bits | 2¹⁶ = 65.536 | 65.535 |
+| 32 bits | 2³² ≈ 4,3 bilhões | 4.294.967.295 |
+| 64 bits | 2⁶⁴ ≈ 18,4 quintilhões | 18.446.744.073.709.551.615 |
+
+E o salto entre as linhas é exponencial, não linear: **dobrar a quantidade de bits eleva o alcance ao quadrado**. É por isso que a diferença entre 32 e 64 bits importa tanto na prática, e é por isso que quase nada mais é declarado com 32 bits quando se trata de identificador, dinheiro ou tempo.
+
+## Hexadecimal: binário com outra roupa
+
+Ninguém quer escrever `11011110101011011011111011101111` num código. Por outro lado, o valor decimal correspondente (3.735.928.559) esconde completamente quais bits estão ligados.
+
+O hexadecimal resolve os dois problemas porque **16 é uma potência de 2**. Precisamente, `16 = 2⁴`, então **cada dígito hexadecimal corresponde a exatamente 4 bits**, sem sobra e sem depender dos vizinhos:
+
+| Bits | Hexa | Bits | Hexa |
+| --- | --- | --- | --- |
+| 0000 | 0 | 1000 | 8 |
+| 0001 | 1 | 1001 | 9 |
+| 0010 | 2 | 1010 | A |
+| 0011 | 3 | 1011 | B |
+| 0100 | 4 | 1100 | C |
+| 0101 | 5 | 1101 | D |
+| 0110 | 6 | 1110 | E |
+| 0111 | 7 | 1111 | F |
+
+Converter passa a ser recortar de quatro em quatro, sem nenhuma conta: `11110011` vira `1111 0011`, que vira `F3`. E `0xF3` é 243, o mesmo número da seção sobre notação posicional.
+
+Com decimal essa correspondência não existe, porque 10 não é potência de 2. Um dígito decimal ocupa entre 3 e 4 bits e não se alinha com nada, então converter exige dividir. É essa a razão inteira de endereço de memória, cor, máscara de bits e dump de arquivo serem escritos em hexadecimal: não é tradição, é alinhamento.
+
+## Onde isso aparece no código do dia a dia
+
+A pergunta justa é o que fazer com isto num trabalho em que ninguém pede para converter números na mão. Quatro coisas, todas comuns:
+
+<Colunas>
+<Cartao titulo="Cor">
+`#FF8000` é RGB com um byte por canal: FF = 255 de vermelho, 80 = 128 de verde, 00 = 0 de azul. Três bytes, um valor de 0 a 255 cada.
+</Cartao>
+<Cartao titulo="Permissão">
+O `chmod 755` do Unix é octal: cada dígito são 3 bits (leitura, escrita, execução) para dono, grupo e outros. 7 é 111, 5 é 101.
+</Cartao>
+<Cartao titulo="Flags">
+Guardar dezenas de opções booleanas num inteiro só, uma por bit, e testar com máscaras. Cabe num campo de banco e viaja de graça na rede.
+</Cartao>
+<Cartao titulo="Limite">
+Todo `int` tem um teto. Saber que 32 bits param em 2,1 bilhões com sinal é o que evita descobrir isso em produção.
+</Cartao>
+</Colunas>
+
+<Callout tipo="aviso">
+O caso mais famoso do último cartão tem data marcada: o tempo em sistemas Unix é contado em segundos desde 1 de janeiro de 1970, e por muito tempo isso foi guardado num inteiro de 32 bits com sinal. Esse contador estoura em **19 de janeiro de 2038**, e sistemas que ainda usarem 32 bits nessa data vão passar a ver uma data em 1901. O conserto (mudar para 64 bits) é conhecido há décadas e ainda está sendo aplicado, o que diz bastante sobre quanto uma decisão de representação sobrevive.
+</Callout>
+
+Daqui, o próximo passo é entender como o mesmo conjunto de bits representa números **negativos**, que é um problema mais interessante do que parece: existem três convenções conhecidas, duas delas têm defeito, e a vencedora usa um truque que faz o processador subtrair sem saber subtrair. Está em [Binários Negativos](/topico/negative-binary). Depois disso, [Operações Bitwise](/topico/operacoes-bitwise) mostra o que dá para fazer manipulando esses bits diretamente, e vale ver como os mesmos bytes viram texto em [Strings](/topico/strings).

--- a/content/topics/index.ts
+++ b/content/topics/index.ts
@@ -32,6 +32,9 @@ import OrdenacaoBasica from "./ordenacao-basica.mdx";
 import MergeSort from "./merge-sort.mdx";
 import QuickSort from "./quick-sort.mdx";
 import ShellSort from "./shell-sort.mdx";
+import Backtracking from "./backtracking.mdx";
+import BinaryNumbers from "./binary-numbers.mdx";
+import NegativeBinary from "./negative-binary.mdx";
 
 // Registro dos artigos em MDX. Para adicionar um tópico "ready":
 //   1. crie content/topics/<slug>.mdx (use <SlidingWindowVisualizer /> etc.)
@@ -473,6 +476,42 @@ export const ARTICLES: Record<string, Article> = {
       "Onde ele ganha e onde ele perde",
       "In-place e instável",
       "Onde o shell sort ainda vive",
+    ],
+  },
+  backtracking: {
+    Body: Backtracking,
+    summary: [
+      "Tentar, falhar, e desfazer",
+      "A árvore de decisão não existe",
+      "O template, e as três peças que mudam",
+      "A cópia que salva as respostas",
+      "Sudoku é o mesmo algoritmo",
+      "Poda: a mesma resposta por uma fração do trabalho",
+      "O custo, e para onde isso vai",
+    ],
+  },
+  "binary-numbers": {
+    Body: BinaryNumbers,
+    summary: [
+      "Dois símbolos, e o motivo é físico",
+      "Notação posicional: você já sabe fazer isso",
+      "Lendo um binário: a soma das posições ligadas",
+      "Escrevendo em binário: dividir por 2 até acabar",
+      "Bit, byte, e quanto cabe",
+      "Hexadecimal: binário com outra roupa",
+      "Onde isso aparece no código do dia a dia",
+    ],
+  },
+  "negative-binary": {
+    Body: NegativeBinary,
+    summary: [
+      "O bit que deixa de valer magnitude",
+      "Tentativa 1: sinal e magnitude",
+      "Tentativa 2: complemento de um",
+      "Complemento de dois: inverter e somar 1",
+      "O truque de leitura: o peso da esquerda é negativo",
+      "A faixa assimétrica, e o padrão que não sabe o próprio sinal",
+      "Estouro: o erro que não avisa",
     ],
   },
   "busca-binaria": {

--- a/content/topics/negative-binary.mdx
+++ b/content/topics/negative-binary.mdx
@@ -1,0 +1,125 @@
+<Callout>
+Um byte tem oito bits e nenhum lugar para pôr um sinal de menos. A solução que o mundo inteiro adotou, o **complemento de dois**, parece uma receita arbitrária ("inverta todos os bits e some 1") e é o contrário disso: é a única convenção que faz `x + (-x)` dar zero dentro de uma quantidade fixa de bits, e é por isso que o processador consegue subtrair sem ter um circuito de subtração.
+</Callout>
+
+## O bit que deixa de valer magnitude
+
+Em [Números Binários](/topico/binary-numbers), os oito bits de um byte valiam todos magnitude: `11111111` era `128 + 64 + 32 + 16 + 8 + 4 + 2 + 1 = 255`.
+
+Para representar negativos é preciso guardar mais uma informação, o **sinal**, e não existe nono bit. A saída é sacrificar um dos oito, e o escolhido é sempre o mais significativo, o da esquerda. A convenção segue a do papel:
+
+- bit de sinal **desligado** quer dizer positivo (assim como escrever `5` sem sinal nenhum);
+- bit de sinal **ligado** quer dizer negativo (assim como escrever `-5`).
+
+O preço é imediato: sobram sete bits de magnitude, e o alcance cai de `0 a 255` para algo em torno de `-128 a 127`. Não muda quantos números cabem (são 256 padrões de bits nos dois casos), muda **quais**.
+
+O que ainda não foi decidido é o mais interessante: **o que fazer com os outros sete bits** quando o sinal está ligado. Existem três respostas conhecidas, e comparar as três é a melhor forma de entender por que a vencedora venceu.
+
+## Tentativa 1: sinal e magnitude
+
+A ideia mais direta que qualquer pessoa teria: escreva o número positivo normalmente e ligue o bit da esquerda para dizer que ele é negativo.
+
+```
+ 26  =  00011010
+-26  =  10011010     <- só o bit da esquerda mudou
+```
+
+Funciona para ler, é fácil de explicar, e tem dois defeitos graves.
+
+O primeiro é o **zero duplo**. Se `00000000` é zero, então `10000000` é "zero negativo". São dois padrões de bits para o mesmo número, o que obriga toda comparação de igualdade a tratar um caso especial, e desperdiça um dos 256 padrões disponíveis. Com essa convenção, oito bits escrevem só **255 números distintos**.
+
+O segundo é a **aritmética**. Somar `00011010` (26) com `10011010` (-26) dá `10110100`, que não é zero nem por acidente. O processador teria que olhar os bits de sinal, decidir se aquilo é uma soma ou uma subtração, comparar magnitudes para saber o sinal do resultado, e só então operar. Muito circuito para uma conta que deveria ser uma só.
+
+## Tentativa 2: complemento de um
+
+A segunda tentativa é mais esperta: para negar, **inverta todos os bits**. É a operação `NOT` bit a bit, escrita `~` na maioria das linguagens.
+
+```
+ 26  =  00011010
+-26  =  11100101     <- todos os bits invertidos
+```
+
+O bit da esquerda continua indicando o sinal (ele inverte junto), e a aritmética melhora bastante. Mas o defeito principal continua: `00000000` invertido é `11111111`, então de novo existem **dois zeros**, e de novo sobram só 255 números distintos.
+
+E a soma ainda não fecha: `00011010 + 11100101 = 11111111`, que é o outro zero. Dá para consertar com uma regra extra (somar o vai-um de volta no fim, o chamado *end-around carry*), e "regra extra" em hardware significa mais circuito e mais atraso.
+
+## Complemento de dois: inverter e somar 1
+
+A terceira convenção é a segunda com um passo a mais: inverta todos os bits **e some 1**.
+
+```
+ 26  =  00011010
+       ~00011010  =  11100101     1. inverte
+       11100101 + 1 = 11100110    2. soma 1
+-26  =  11100110
+```
+
+<BinarioComplemento />
+
+Esse `+1` desloca todo o lado negativo uma casa, e com isso os dois zeros se fundem num só. Vale seguir o preset do zero no visualizador acima, porque é ali que a mágica acontece: inverter `00000000` dá `11111111`, somar 1 dá `100000000`, o nono bit não cabe em oito e é descartado, e o que sobra é `00000000`. **O oposto de zero é o próprio zero, e existe uma representação só.**
+
+A prova de que a convenção está certa é a mesma da matemática: somar um número com o oposto dele tem que dar zero.
+
+```
+  00011010    (26)
++ 11100110    (-26)
+-----------
+ 100000000    -> o nono bit estoura os 8 bits e cai fora
+   00000000    -> zero
+```
+
+<BinarioTresFormas />
+
+E aqui está a razão de tudo. Como `x + (-x) = 0` vale sempre e sem correção nenhuma, **subtrair vira somar**: `a - b` é `a + (-b)`, e o processador usa exatamente o mesmo somador. Não existe circuito de subtração num processador moderno; existe um somador e um inversor.
+
+<Callout>
+As três convenções existiram de verdade em máquinas comerciais. O complemento de um foi usado em computadores da CDC e da Univac, e o sinal e magnitude sobrevive até hoje num lugar que você usa todo dia: o padrão IEEE 754, dos números de ponto flutuante, guarda o sinal num bit separado. Ou seja, o `-0.0` existe em ponto flutuante, é diferente de `0.0` na representação, e compara como igual por regra explícita da norma.
+</Callout>
+
+## O truque de leitura: o peso da esquerda é negativo
+
+Converter de volta invertendo e somando 1 funciona e é trabalhoso. Existe uma forma muito melhor de **ler** um complemento de dois, e ela não é uma regra nova: é a mesma soma de potências de sempre, com **um sinal trocado**.
+
+No complemento de dois, o bit mais significativo vale `-128` em vez de `+128`. Todo o resto continua idêntico:
+
+```
+11100110  =  -128 + 64 + 32 + 0 + 0 + 4 + 2 + 0  =  -26
+```
+
+Isso dispensa qualquer conversão. Também explica de imediato duas coisas que costumam parecer arbitrárias:
+
+- **Por que `11111111` é -1.** É `-128 + 64 + 32 + 16 + 8 + 4 + 2 + 1`, e a soma dos positivos dá 127. `-128 + 127 = -1`.
+- **Por que acender bits à direita, com o sinal ligado, aumenta o número.** Partindo de `10000000` (-128), cada bit ligado soma: `10000001` é -127, `10000010` é -126, e assim por diante até `11111111`, que é -1.
+
+## A faixa assimétrica, e o padrão que não sabe o próprio sinal
+
+<BinarioFaixa />
+
+Duas consequências desta seção valem mais do que qualquer definição.
+
+A primeira é que **a faixa com sinal nunca é simétrica**: com 8 bits ela vai de `-128` a `127`, e não de `-128` a `128`. São 256 padrões, o zero ocupa um deles, sobram 255 para distribuir, e o lado negativo fica com um a mais porque não precisa gastar padrão com o zero.
+
+Isso tem efeito prático e surpreendente: **o oposto do menor negativo não existe**. Em Java, `-Integer.MIN_VALUE` devolve `Integer.MIN_VALUE`, ainda negativo. Em C, `abs(-2147483648)` devolve um número negativo. Não é bug da biblioteca: é que o positivo correspondente não cabe no tipo, e a operação dá a volta.
+
+A segunda é que **o padrão de bits não sabe o próprio sinal**. `11111111` é 255 ou -1 conforme o tipo com que ele é lido, e não existe nada guardado na memória que decida entre os dois. Quem decide é a **declaração da variável**. Ler um valor com o tipo errado não dá erro, dá outro número, e esse é um dos bugs mais silenciosos que existem ao ler um formato binário ou uma resposta de rede.
+
+| Bits | Sem sinal | Com sinal |
+| --- | --- | --- |
+| 8 | 0 a 255 | -128 a 127 |
+| 16 | 0 a 65.535 | -32.768 a 32.767 |
+| 32 | 0 a 4.294.967.295 | -2.147.483.648 a 2.147.483.647 |
+| 64 | 0 a 18.446.744.073.709.551.615 | -9.223.372.036.854.775.808 a 9.223.372.036.854.775.807 |
+
+## Estouro: o erro que não avisa
+
+Some 1 a `01111111` (127). O vai-um sobe até o bit de sinal, e o resultado é `10000000`, que vale **-128**.
+
+O número não ficou grande demais e travou; ele **deu a volta**. Nenhuma exceção é lançada, nenhum aviso aparece no log, nenhuma flag chega ao seu código por padrão. Para a máquina, `10000000` é apenas o padrão de bits seguinte ao `01111111`, e a soma está aritmeticamente correta módulo 256.
+
+É exatamente esse silêncio que torna o estouro de inteiro com sinal um dos erros mais caros do ofício. Três consequências que valem guardar:
+
+- **Contadores que só crescem são candidatos.** Um `int` de 32 bits com sinal para em 2.147.483.647, e um contador de eventos numa empresa grande chega lá.
+- **A conta do meio da busca binária é o caso clássico.** `(lo + hi) / 2` estoura quando os dois índices são grandes, e o meio vira negativo. É o mesmo bug descrito em [Busca Binária](/topico/busca-binaria), e a correção (`lo + (hi - lo) / 2`) existe exatamente por isto.
+- **Linguagens diferentes reagem diferente.** Em C, o estouro de inteiro **com sinal** é comportamento indefinido, o que autoriza o compilador a assumir que ele nunca acontece e otimizar em cima disso. Em Java o resultado dá a volta e é definido. Em Python inteiro não tem tamanho fixo e o problema não existe, mas volta assim que você grava aquele número num formato binário ou numa coluna de banco.
+
+Daqui, [Operações Bitwise](/topico/operacoes-bitwise) mostra o que dá para fazer manipulando esses bits diretamente, e [Números Binários](/topico/binary-numbers) fica como a base para reler se a notação posicional ainda não estiver automática. Vale também revisitar [Big O](/topico/big-o) com esta lente: quando um artigo diz que uma operação é O(1), ele está assumindo que os números cabem numa palavra da máquina, e essa suposição tem exatamente o tamanho descrito na tabela acima.

--- a/content/visualizers/BacktrackingPoda.tsx
+++ b/content/visualizers/BacktrackingPoda.tsx
@@ -1,0 +1,260 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// BacktrackingPoda, a otimização que não muda o algoritmo, muda quando ele
+// desiste.
+//
+// A única coisa que o aluno precisa enxergar é que a poda não é um algoritmo
+// diferente nem uma heurística que abre mão da resposta: é a mesma busca, com a
+// verificação de validade acontecendo ANTES de descer em vez de depois. As duas
+// versões devolvem exatamente as mesmas soluções, e a barra de nós visitados
+// mostra a diferença de trabalho.
+//
+// O problema é o das n rainhas porque ele tem a propriedade rara de deixar as
+// duas versões comparáveis linha a linha: sem poda é "monte todas as
+// disposições e confira no fim", com poda é "não ponha uma rainha onde ela já é
+// atacada". A diferença explode com n, e o card de razão é o que transforma
+// isso em argumento.
+//
+// A tela mostra o tabuleiro de UMA solução, e não a busca inteira: a busca é
+// assunto do visualizador de passo a passo, e aqui o que interessa é o total.
+// Por isso é interativo sem linha do tempo: a variável é o tamanho do
+// tabuleiro.
+// ---------------------------------------------------------------------------
+
+type Resultado = { nos: number; solucoes: number[][]; podas: number };
+
+// Sem poda: escolhe uma coluna por linha sem olhar nada, e só no fim confere se
+// a disposição inteira é válida. É o "gere tudo e filtre" escrito em recursão.
+function semPoda(n: number): Resultado {
+  const solucoes: number[][] = [];
+  const parcial: number[] = [];
+  let nos = 0;
+  const valida = (v: number[]) => {
+    for (let i = 0; i < v.length; i++)
+      for (let j = i + 1; j < v.length; j++)
+        if (v[i] === v[j] || Math.abs(v[i] - v[j]) === j - i) return false;
+    return true;
+  };
+  const rec = () => {
+    nos++;
+    if (parcial.length === n) {
+      if (valida(parcial)) solucoes.push([...parcial]);
+      return;
+    }
+    for (let c = 0; c < n; c++) {
+      parcial.push(c);
+      rec();
+      parcial.pop();
+    }
+  };
+  rec();
+  return { nos, solucoes, podas: 0 };
+}
+
+// Com poda: antes de descer, confere se a rainha nova é atacada por alguma das
+// já postas. O ramo inteiro que sairia daquela escolha deixa de existir.
+function comPoda(n: number): Resultado {
+  const solucoes: number[][] = [];
+  const parcial: number[] = [];
+  let nos = 0;
+  let podas = 0;
+  const seguro = (c: number) => {
+    for (let i = 0; i < parcial.length; i++)
+      if (parcial[i] === c || Math.abs(parcial[i] - c) === parcial.length - i) return false;
+    return true;
+  };
+  const rec = () => {
+    nos++;
+    if (parcial.length === n) {
+      solucoes.push([...parcial]);
+      return;
+    }
+    for (let c = 0; c < n; c++) {
+      if (!seguro(c)) {
+        podas++;
+        continue;
+      }
+      parcial.push(c);
+      rec();
+      parcial.pop();
+    }
+  };
+  rec();
+  return { nos, solucoes, podas };
+}
+
+// Para em 7 de propósito: com 8 rainhas a versão sem poda visita 19.173.961
+// nós, e rodar isso no navegador para desenhar uma barra seria cobrar segundos
+// de CPU do leitor. O número de 8 rainhas está no artigo, calculado pela
+// fórmula da árvore cheia, e não medido aqui.
+const TAMANHOS = [4, 5, 6, 7];
+
+// Formatador determinístico: Intl.NumberFormat diverge entre build e cliente.
+function num(v: number): string {
+  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+}
+
+export function BacktrackingPoda() {
+  const [n, setN] = useState(6);
+  const sem = useMemo(() => semPoda(n), [n]);
+  const com = useMemo(() => comPoda(n), [n]);
+  const [qual, setQual] = useState(0);
+
+  const mesmasSolucoes =
+    sem.solucoes.map((s) => s.join(",")).sort().join("|") === com.solucoes.map((s) => s.join(",")).sort().join("|");
+  const razao = sem.nos / com.nos;
+  const sol = com.solucoes.length > 0 ? com.solucoes[Math.min(qual, com.solucoes.length - 1)] : [];
+
+  return (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · a poda: mesma resposta, uma fração do trabalho</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            {n} rainhas · {com.solucoes.length} soluções · {razao.toFixed(1)}x menos nós com poda
+          </span>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {TAMANHOS.map((t) => (
+            <button
+              key={t}
+              className={`bigo-chip${n === t ? " on" : ""}`}
+              onClick={() => {
+                setN(t);
+                setQual(0);
+              }}
+              aria-pressed={n === t}
+            >
+              {t} rainhas
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">
+          O problema: pôr {n} rainhas num tabuleiro {n}x{n} sem que nenhuma ataque outra, ou seja, sem duas na
+          mesma linha, coluna ou diagonal. As duas versões abaixo são o mesmo backtracking, e a única diferença
+          é <strong>quando</strong> a validade é conferida.
+        </p>
+
+        <div className="ord-corrida">
+          <div className="ord-linha">
+            <div className="ord-linha-nome">
+              Sem poda <span className="qs-explica">monta todas as disposições e confere no fim</span>
+            </div>
+            <div className="ord-medidas">
+              <div className="ord-medida">
+                <span className="ord-medida-rot">nós visitados</span>
+                <div className="bb-barra">
+                  <div className="bb-barra-fill" style={{ width: "100%" }} />
+                  <span className="bb-barra-txt">{num(sem.nos)}</span>
+                </div>
+                <span className="ord-lei">
+                  {num(Math.pow(n, n))} disposições possíveis, todas percorridas até o fim
+                </span>
+              </div>
+              <div className="ord-medida">
+                <span className="ord-medida-rot">soluções encontradas</span>
+                <div className="bb-barra">
+                  <div className="bb-barra-fill esc" style={{ width: "100%" }} />
+                  <span className="bb-barra-txt">{sem.solucoes.length}</span>
+                </div>
+                <span className="ord-lei">a resposta certa, pelo caminho caro</span>
+              </div>
+            </div>
+          </div>
+          <div className="ord-linha">
+            <div className="ord-linha-nome">
+              Com poda <span className="qs-explica">não desce por um ramo que já é inválido</span>
+            </div>
+            <div className="ord-medidas">
+              <div className="ord-medida melhor">
+                <span className="ord-medida-rot">nós visitados</span>
+                <div className="bb-barra">
+                  <div className="bb-barra-fill" style={{ width: `${(com.nos / sem.nos) * 100}%` }} />
+                  <span className="bb-barra-txt">{num(com.nos)}</span>
+                </div>
+                <span className="ord-lei">
+                  {num(com.podas)} escolhas cortadas antes de virarem ramo
+                </span>
+              </div>
+              <div className={`ord-medida${mesmasSolucoes ? " melhor" : ""}`}>
+                <span className="ord-medida-rot">soluções encontradas</span>
+                <div className="bb-barra">
+                  <div className="bb-barra-fill esc" style={{ width: "100%" }} />
+                  <span className="bb-barra-txt">{com.solucoes.length}</span>
+                </div>
+                <span className="ord-lei">
+                  {mesmasSolucoes ? "exatamente as mesmas da versão sem poda" : "DIVERGIU da versão sem poda"}
+                </span>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            Uma das soluções <em>clique para ver as outras</em>
+          </div>
+          <div className="bt-rainhas-topo">
+            {com.solucoes.map((_, k) => (
+              <button
+                key={k}
+                className={`bigo-chip${k === Math.min(qual, com.solucoes.length - 1) ? " on" : ""}`}
+                onClick={() => setQual(k)}
+                aria-pressed={k === Math.min(qual, com.solucoes.length - 1)}
+              >
+                {k + 1}
+              </button>
+            ))}
+          </div>
+          <div className="bt-sudoku-wrap">
+            <div
+              className="bt-rainhas"
+              style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}
+              role="img"
+              aria-label={`Tabuleiro ${n} por ${n} com uma solução das ${n} rainhas: ${sol.map((c, r) => `linha ${r + 1} coluna ${c + 1}`).join(", ")}`}
+            >
+              {Array.from({ length: n * n }, (_, i) => {
+                const r = Math.floor(i / n);
+                const c = i % n;
+                const temRainha = sol[r] === c;
+                return (
+                  <span key={i} className={`bt-casa${(r + c) % 2 === 0 ? " clara" : ""}${temRainha ? " rainha" : ""}`}>
+                    {temRainha ? "♛" : ""}
+                  </span>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+
+        <p className="viz-note ok">
+          As duas versões devolvem <strong>{com.solucoes.length} soluções</strong>
+          {mesmasSolucoes ? ", e são as mesmas soluções, uma a uma" : ""}. A poda não troca a resposta por uma
+          aproximação, ela só evita descer por caminhos que já são impossíveis: com {n} rainhas, ela corta{" "}
+          {num(com.podas)} escolhas antes de virarem ramo e visita <strong>{num(com.nos)}</strong> nós contra{" "}
+          <strong>{num(sem.nos)}</strong>, {razao.toFixed(1)} vezes menos. É a diferença entre perguntar
+          &quot;isto ainda pode dar certo?&quot; a cada passo e perguntar só no fim.
+        </p>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          Repare em como a razão cresce com o tabuleiro: 20x com 4 rainhas, 366x com 6 e 1.741x com 7. Podar
+          não muda a classe de complexidade (as duas continuam exponenciais) e muda o expoente na prática, que
+          é o que separa um algoritmo que roda de um que não termina. Com 8 rainhas a versão sem poda visitaria
+          19.173.961 nós, e é por isso que ela não está aqui: desenhar essa barra custaria segundos de CPU do
+          seu navegador. É a mesma ideia que aparece depois em programação dinâmica,
+          com um nome diferente: em vez de cortar o ramo impossível, guardar o resultado do ramo já calculado.
+        </p>
+      </div>
+    </figure>
+  );
+}

--- a/content/visualizers/BacktrackingSudoku.tsx
+++ b/content/visualizers/BacktrackingSudoku.tsx
@@ -232,15 +232,19 @@ export function gerarPassos(preset: Preset): Passo[] {
     return false;
   };
 
-  const ok = resolver();
+  const resolveu = resolver();
+  const ok = resolveu && !estourou;
   prof = 0;
   out.push(
     base({
+      // O verde do card é uma afirmação: só vale quando o tabuleiro foi mesmo
+      // resolvido. Interrupção por limite e tabuleiro sem solução são os dois
+      // casos em que ele mentiria.
+      ok,
       linha: 2,
-      ok: true,
       nota: estourou
         ? `Parei em ${LIMITE_PASSOS} passos para não travar o navegador. Isso já é a lição: este tabuleiro exige mais passos do que uma animação consegue mostrar.`
-        : ok
+        : resolveu
           ? `Resolvido. Foram ${tentativas} tentativas de dígito para ${vazias.length} lacunas, com ${retrocessos} retrocessos. A razão entre esses dois primeiros números é o preço da força bruta: cada célula custou em média ${(tentativas / vazias.length).toFixed(1)} tentativas.`
           : `Este tabuleiro não tem solução, e o backtracking provou isso do único jeito que ele sabe: tentando tudo.`,
     })

--- a/content/visualizers/BacktrackingSudoku.tsx
+++ b/content/visualizers/BacktrackingSudoku.tsx
@@ -1,0 +1,500 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// BacktrackingSudoku, o mesmo template num problema que ninguém chama de
+// algoritmo.
+//
+// A única coisa que o aluno precisa enxergar é que este é EXATAMENTE o mesmo
+// algoritmo do visualizador anterior, com três peças trocadas: as opções são os
+// dígitos, a validade é a regra do sudoku, e o desfazer é apagar a célula. É
+// por isso que o painel de código mostra o template com as três peças marcadas
+// em vez de um solucionador de sudoku sob medida.
+//
+// A segunda ideia é o custo. O aluno vê o algoritmo escrever, apagar e
+// reescrever a mesma célula várias vezes, e vê o contador de tentativas subir
+// muito mais rápido que o de células preenchidas. Essa razão é o argumento
+// inteiro sobre por que backtracking puro não escala.
+//
+// Presets em escada de propósito. O 4x4 fecha em 60 passos e dá para acompanhar
+// cada decisão; os dois 9x9 são o tabuleiro que a pessoa reconhece, e neles o
+// interessante não é seguir clique a clique, é rodar até o fim e olhar a razão
+// entre tentativas e células, que vai de 4,6 no 4x4 para 18 no de 48 lacunas.
+// ---------------------------------------------------------------------------
+
+type Passo = {
+  grade: number[];
+  foco: number; // índice da célula sendo preenchida, ou -1
+  tentativa: number; // valor sendo testado
+  conflito: "linha" | "coluna" | "quadrante" | null;
+  colocou: boolean;
+  apagou: boolean;
+  tentativas: number;
+  colocacoes: number;
+  retrocessos: number;
+  prof: number;
+  linha: number;
+  nota: string;
+  ok?: boolean;
+};
+
+const CODIGO = [
+  "def resolver(grade):",
+  "    pos = primeira_vazia(grade)",
+  "    if pos is None: return True      # completo",
+  "    for d in range(1, N + 1):        # as opções",
+  "        if valido(grade, pos, d):    # a validade",
+  "            grade[pos] = d           # 1. escolher",
+  "            if resolver(grade):      # 2. explorar",
+  "                return True",
+  "            grade[pos] = VAZIO       # 3. desfazer",
+  "    return False                     # nenhum dígito serviu",
+];
+
+type Preset = {
+  key: string;
+  rotulo: string;
+  n: number; // 4 ou 9
+  caixa: [number, number]; // altura e largura do quadrante
+  dados: number[];
+  dica: string;
+};
+
+// prettier-ignore
+const P4 = [
+  0, 0, 4, 0,
+  4, 0, 0, 2,
+  0, 4, 0, 0,
+  0, 3, 0, 0,
+];
+
+// Os dois 9x9 saem da mesma solução conhecida, com lacunas escolhidas para
+// caberem numa animação: o solucionador ingênuo anda da primeira célula vazia
+// para a frente, então apagar do fim para o começo mantém o custo domável e
+// ainda assim força retrocesso.
+// prettier-ignore
+const P9_VINTE = [
+  5, 3, 4, 6, 7, 8, 9, 1, 2,
+  6, 7, 2, 1, 9, 5, 3, 4, 8,
+  1, 9, 8, 3, 4, 2, 5, 6, 7,
+  8, 5, 9, 7, 6, 1, 4, 2, 3,
+  4, 2, 6, 8, 5, 3, 7, 9, 1,
+  7, 1, 3, 9, 2, 4, 8, 5, 6,
+  9, 6, 1, 5, 3, 7, 2, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+// prettier-ignore
+const P9_QUARENTA = [
+  5, 3, 4, 6, 7, 8, 9, 1, 2,
+  6, 7, 2, 1, 9, 5, 3, 4, 8,
+  1, 9, 8, 3, 4, 2, 5, 6, 7,
+  8, 5, 9, 7, 6, 1, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+  0, 0, 0, 0, 0, 0, 0, 0, 0,
+];
+
+const PRESETS: Preset[] = [
+  {
+    key: "quatro",
+    rotulo: "Sudoku 4x4, para acompanhar passo a passo",
+    n: 4,
+    caixa: [2, 2],
+    dados: P4,
+    dica: "As mesmas regras num tabuleiro que cabe na cabeça: dígitos de 1 a 4, sem repetir na linha, na coluna e no quadrante 2x2. Acompanhe uma célula específica e conte quantas vezes ela é escrita e apagada antes de ficar.",
+  },
+  {
+    key: "vinte",
+    rotulo: "9x9 com 20 lacunas",
+    n: 9,
+    caixa: [3, 3],
+    dados: P9_VINTE,
+    dica: "O tabuleiro que a pessoa reconhece, com as duas últimas linhas em aberto. São 12 retrocessos para 20 lacunas: mesmo com o tabuleiro quase pronto, o algoritmo escreve coisa errada e precisa voltar.",
+  },
+  {
+    key: "quarenta",
+    rotulo: "9x9 com 48 lacunas",
+    n: 9,
+    caixa: [3, 3],
+    dados: P9_QUARENTA,
+    dica: "Só as três primeiras linhas dadas. Rode até o fim e olhe a razão entre dígitos testados e lacunas. Com tão poucas pistas existem muitas soluções válidas, e é bom saber o que o algoritmo faz nesse caso: ele para na PRIMEIRA que encontrar, não na certa, porque para ele não existe uma certa.",
+  },
+];
+
+const VELOCIDADES = [0, 300, 160, 80, 30, 8];
+const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
+const LIMITE_PASSOS = 20000;
+
+export function gerarPassos(preset: Preset): Passo[] {
+  const { n, caixa, dados } = preset;
+  const [ch, cw] = caixa;
+  const g = [...dados];
+  const out: Passo[] = [];
+  let tentativas = 0;
+  let colocacoes = 0;
+  let retrocessos = 0;
+  let prof = 0;
+  let estourou = false;
+
+  const base = (extra: Partial<Passo>): Passo => ({
+    grade: [...g],
+    foco: -1,
+    tentativa: 0,
+    conflito: null,
+    colocou: false,
+    apagou: false,
+    tentativas,
+    colocacoes,
+    retrocessos,
+    prof,
+    linha: 0,
+    nota: "",
+    ...extra,
+  });
+
+  const lin = (i: number) => Math.floor(i / n);
+  const col = (i: number) => i % n;
+  const quad = (i: number) => `${Math.floor(lin(i) / ch)},${Math.floor(col(i) / cw)}`;
+
+  // Devolve qual regra barrou o dígito, ou null se ele cabe. Devolver a REGRA em
+  // vez de um booleano é o que deixa a nota dizer por que não deu.
+  const conflitoDe = (i: number, d: number): "linha" | "coluna" | "quadrante" | null => {
+    for (let k = 0; k < n; k++) if (g[lin(i) * n + k] === d) return "linha";
+    for (let k = 0; k < n; k++) if (g[k * n + col(i)] === d) return "coluna";
+    for (let k = 0; k < n * n; k++) if (quad(k) === quad(i) && g[k] === d) return "quadrante";
+    return null;
+  };
+
+  const vazias = g.map((v, i) => (v === 0 ? i : -1)).filter((i) => i >= 0);
+
+  out.push(
+    base({
+      linha: 0,
+      nota: `Tabuleiro ${n}x${n} com ${vazias.length} lacuna${vazias.length === 1 ? "" : "s"}. As opções de cada célula são os dígitos de 1 a ${n}, a validade é a regra do sudoku (linha, coluna e quadrante) e o desfazer é apagar. O algoritmo é o mesmo de sempre.`,
+    })
+  );
+
+  const resolver = (): boolean => {
+    if (out.length > LIMITE_PASSOS) {
+      estourou = true;
+      return true;
+    }
+    const i = g.indexOf(0);
+    if (i < 0) return true;
+    prof++;
+    for (let d = 1; d <= n; d++) {
+      tentativas++;
+      const c = conflitoDe(i, d);
+      if (c) {
+        out.push(
+          base({
+            foco: i,
+            tentativa: d,
+            conflito: c,
+            linha: 4,
+            nota: `Célula da linha ${lin(i) + 1}, coluna ${col(i) + 1}: tento ${d}. Já existe um ${d} ${c === "linha" ? "nesta linha" : c === "coluna" ? "nesta coluna" : "neste quadrante"}, então este dígito não serve. Passo para o próximo.`,
+          })
+        );
+        continue;
+      }
+      g[i] = d;
+      colocacoes++;
+      out.push(
+        base({
+          foco: i,
+          tentativa: d,
+          colocou: true,
+          linha: 5,
+          nota: `${d} cabe na linha ${lin(i) + 1}, coluna ${col(i) + 1}: nenhum conflito nas três regras. Escrevo e desço para a próxima célula vazia. Cuidado: caber agora não quer dizer estar certo, é só uma aposta.`,
+        })
+      );
+      if (resolver()) return true;
+      g[i] = 0;
+      retrocessos++;
+      out.push(
+        base({
+          foco: i,
+          tentativa: d,
+          apagou: true,
+          linha: 8,
+          nota: `Nenhum dígito serviu daqui para a frente, então a aposta de pôr ${d} na linha ${lin(i) + 1}, coluna ${col(i) + 1} estava errada. Apago e tento o próximo valor. É o retrocesso, e é o único jeito de descobrir que uma escolha antiga era ruim.`,
+        })
+      );
+    }
+    prof--;
+    return false;
+  };
+
+  const ok = resolver();
+  prof = 0;
+  out.push(
+    base({
+      linha: 2,
+      ok: true,
+      nota: estourou
+        ? `Parei em ${LIMITE_PASSOS} passos para não travar o navegador. Isso já é a lição: este tabuleiro exige mais passos do que uma animação consegue mostrar.`
+        : ok
+          ? `Resolvido. Foram ${tentativas} tentativas de dígito para ${vazias.length} lacunas, com ${retrocessos} retrocessos. A razão entre esses dois primeiros números é o preço da força bruta: cada célula custou em média ${(tentativas / vazias.length).toFixed(1)} tentativas.`
+          : `Este tabuleiro não tem solução, e o backtracking provou isso do único jeito que ele sabe: tentando tudo.`,
+    })
+  );
+  return out;
+}
+
+export function BacktrackingSudoku() {
+  const [presetKey, setPresetKey] = useState("quatro");
+  const [passo, setPasso] = useState(0);
+  const [tocando, setTocando] = useState(false);
+  const [velocidade, setVelocidade] = useState(4);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
+  const passos = useMemo(() => gerarPassos(preset), [preset]);
+  const total = passos.length;
+  const idx = Math.min(passo, total - 1);
+  const p = passos[idx];
+  const n = preset.n;
+  const [ch, cw] = preset.caixa;
+  const fixas = useMemo(() => new Set(preset.dados.map((v, i) => (v !== 0 ? i : -1)).filter((i) => i >= 0)), [preset]);
+
+  const parar = useCallback(() => {
+    if (timer.current) {
+      clearInterval(timer.current);
+      timer.current = null;
+    }
+  }, []);
+  useEffect(() => () => parar(), [parar]);
+  useEffect(() => {
+    parar();
+    if (!tocando) return;
+    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
+    return parar;
+  }, [tocando, velocidade, total, parar]);
+  useEffect(() => {
+    if (tocando && idx >= total - 1) setTocando(false);
+  }, [tocando, idx, total]);
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const reiniciar = () => {
+    parar();
+    setTocando(false);
+    setPasso(0);
+  };
+  const trocarPreset = (k: string) => {
+    reiniciar();
+    setPresetKey(k);
+  };
+
+  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const lacunas = preset.dados.filter((v) => v === 0).length;
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · o mesmo backtracking resolvendo sudoku</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            passo {idx + 1} de {total}
+          </span>
+          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {PRESETS.map((pr) => (
+            <button
+              key={pr.key}
+              className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
+              onClick={() => trocarPreset(pr.key)}
+              aria-pressed={presetKey === pr.key}
+            >
+              {pr.rotulo}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">{preset.dica}</p>
+
+        <div className={`hs-fase ${p.apagou ? "f-ordenar" : p.colocou ? "f-fim" : ""}`}>
+          <span className="hs-fase-selo">
+            {p.apagou ? "3 · desfazer" : p.colocou ? "1 · escolher" : p.conflito ? "opção inválida" : "início"}
+          </span>
+          <span className="hs-fase-txt">
+            {p.foco >= 0
+              ? `linha ${Math.floor(p.foco / n) + 1}, coluna ${(p.foco % n) + 1} · testando ${p.tentativa}`
+              : `${lacunas} lacunas para preencher`}
+          </span>
+        </div>
+
+        <div className="bt-sudoku-wrap">
+          <div
+            className={`bt-sudoku n${n}`}
+            style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}
+            role="img"
+            aria-label={`Tabuleiro de sudoku ${n} por ${n}. ${p.nota}`}
+          >
+            {p.grade.map((v, i) => {
+              const cls = ["bt-cel"];
+              if (fixas.has(i)) cls.push("fixa");
+              if (i === p.foco) cls.push(p.conflito ? "conflito" : p.apagou ? "apagou" : "foco");
+              if (Math.floor(i / n) % ch === 0) cls.push("topo");
+              if ((i % n) % cw === 0) cls.push("esq");
+              return (
+                <span key={i} className={cls.join(" ")}>
+                  {i === p.foco && p.conflito ? p.tentativa : v === 0 ? "" : v}
+                </span>
+              );
+            })}
+          </div>
+        </div>
+
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+
+        <div className="viz-split">
+          <div className="viz-code">
+            <div className="viz-code-head">sudoku.py</div>
+            <div className="viz-code-body">
+              {CODIGO.map((txt, k) => (
+                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
+                  <span className="ln">{k + 1}</span>
+                  {txt}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="viz-vars">
+            <div className="viz-vars-head">Variáveis</div>
+            <div className="viz-var">
+              <span className="viz-var-name">dígito em teste</span>
+              <span className="viz-var-val best">{p.tentativa > 0 ? p.tentativa : "-"}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">regra que barrou</span>
+              <span className="viz-var-val">{p.conflito ?? (p.colocou ? "nenhuma" : "-")}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">células ainda vazias</span>
+              <span className="viz-var-val">{p.grade.filter((v) => v === 0).length}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="bigo-stats">
+          <div className="bigo-stat">
+            <span>lacunas do tabuleiro</span>
+            <strong>{lacunas}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>dígitos testados</span>
+            <strong>{p.tentativas}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>escritas na grade</span>
+            <strong>{p.colocacoes}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>retrocessos</span>
+            <strong>{p.retrocessos}</strong>
+          </div>
+        </div>
+
+        <div className="viz-controls">
+          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
+            ↺
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === 0}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.max(0, s - 1));
+            }}
+          >
+            ‹ Anterior
+          </button>
+          <button
+            className="viz-play"
+            onClick={() => {
+              if (tocando) {
+                setTocando(false);
+                return;
+              }
+              setPasso(idx >= total - 1 ? 0 : idx);
+              setTocando(true);
+            }}
+          >
+            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === total - 1}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.min(s + 1, total - 1));
+            }}
+          >
+            Próximo ›
+          </button>
+          <div className="viz-speed">
+            <span>Velocidade</span>
+            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
+            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+          </div>
+        </div>
+        <div className="viz-progress">
+          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
+        </div>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          Rode o preset de 48 lacunas até o fim, na velocidade 2x, e compare os cards: 882 dígitos testados
+          para 48 lacunas, com 120 escritas e 72 retrocessos. São 18 tentativas por célula, e o algoritmo
+          escreve e apaga a mesma posição várias vezes; cada apagada é a descoberta de que uma escolha feita
+          lá atrás não levava a lugar nenhum. É o mesmo
+          template do visualizador anterior, com três peças trocadas: as opções viraram os dígitos, a validade
+          virou a regra do sudoku, e o desfazer virou apagar a célula.
+        </p>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div
+        className="viz-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) setExpanded(false);
+        }}
+      >
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/content/visualizers/BacktrackingVisualizer.tsx
+++ b/content/visualizers/BacktrackingVisualizer.tsx
@@ -1,0 +1,564 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// BacktrackingVisualizer, a árvore que não existe.
+//
+// A única coisa que o aluno precisa enxergar é que o backtracking tem TRÊS
+// movimentos e que o terceiro é o que dá nome a ele: escolher, explorar e
+// DESFAZER. Quase todo material desenha a árvore de decisão e para por aí, o
+// que deixa a impressão de que existe uma árvore sendo construída na memória.
+// Não existe. O que existe é uma lista sendo mexida e uma pilha de chamadas, e
+// a árvore é só o desenho do caminho que o algoritmo percorreu.
+//
+// Por isso a tela mostra as três coisas ao mesmo tempo e no mesmo passo: a
+// árvore (o mapa), a solução parcial (a única lista que existe de verdade) e a
+// pilha de chamadas. No passo de retrocesso a árvore não muda, a lista encolhe
+// e a pilha desempilha, e é essa dessincronia que ensina quem é quem.
+//
+// A geometria vem da árvore COMPLETA, calculada antes de qualquer passo, e não
+// do que já foi explorado. Com o envelope fixo, os nós aparecem no lugar em que
+// vão ficar, e dá para seguir um ramo específico do começo ao fim. Se o layout
+// acompanhasse a exploração, tudo se moveria a cada passo e o aluno leria
+// movimento onde só houve descoberta.
+// ---------------------------------------------------------------------------
+
+type Acao = "inicio" | "escolher" | "registrar" | "descer" | "retroceder" | "fim";
+
+type No = { id: string; rotulo: string; prof: number; filhos: No[]; x: number; y: number };
+
+type Passo = {
+  noAtual: string;
+  visitados: string[];
+  registrados: string[];
+  parcial: number[];
+  pilha: string[];
+  solucoes: number[][];
+  acao: Acao;
+  nos: number;
+  retrocessos: number;
+  linha: number;
+  nota: string;
+  ok?: boolean;
+};
+
+const CODIGO = [
+  "def backtrack(parcial, opcoes):",
+  "    if completo(parcial):",
+  "        solucoes.append(parcial[:])   # cópia, e isso importa",
+  "        return",
+  "    for opcao in opcoes:",
+  "        if valido(opcao, parcial):",
+  "            parcial.append(opcao)     # 1. escolher",
+  "            backtrack(parcial, ...)   # 2. explorar",
+  "            parcial.pop()             # 3. desfazer",
+];
+
+type Modo = "subconjuntos" | "permutacoes" | "combinacoes";
+
+const NOMES: Record<Modo, string> = {
+  subconjuntos: "Subconjuntos de 1, 2, 3",
+  permutacoes: "Permutações de 1, 2, 3",
+  combinacoes: "Combinações de 2 entre 1, 2, 3, 4",
+};
+
+const DICAS: Record<Modo, string> = {
+  subconjuntos:
+    "Todo nó da árvore é uma resposta, inclusive a raiz (o conjunto vazio). Repare que o algoritmo registra a solução na ENTRADA de cada chamada, antes de olhar as opções, e por isso são 2^3 = 8 respostas para 8 nós.",
+  permutacoes:
+    "Aqui só as folhas são resposta: uma permutação precisa usar todos os elementos. A árvore tem 16 nós e devolve 3! = 6 soluções, ou seja, mais da metade do trabalho é caminho, não resultado.",
+  combinacoes:
+    "Combinação fixa o tamanho: dois elementos entre quatro, sem repetir e sem ligar para a ordem. Só os nós de profundidade 2 são resposta, e a regra de nunca voltar para trás no array é o que impede 1,2 e 2,1 de aparecerem os dois.",
+};
+
+const MODOS: Modo[] = ["subconjuntos", "permutacoes", "combinacoes"];
+
+const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
+const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
+const rotuloDe = (v: number[]) => (v.length === 0 ? "∅" : v.join(" "));
+
+// Gera a árvore inteira e a lista de passos numa passada só. A árvore é o mapa
+// do percurso, e os passos são o percurso: os dois saem do mesmo laço, então
+// não têm como divergir.
+export function gerar(modo: Modo): { raiz: No; passos: Passo[]; folhas: number } {
+  const valores = modo === "combinacoes" ? [1, 2, 3, 4] : [1, 2, 3];
+  const k = 2; // tamanho fixo das combinações
+  const passos: Passo[] = [];
+  const parcial: number[] = [];
+  const solucoes: number[][] = [];
+  const visitados: string[] = [];
+  const registrados: string[] = [];
+  const pilha: string[] = [];
+  let contaNos = 0;
+  let retrocessos = 0;
+
+  const raiz: No = { id: "r", rotulo: "∅", prof: 0, filhos: [], x: 0, y: 0 };
+
+  const base = (noAtual: string, acao: Acao, linha: number, nota: string, ok?: boolean): Passo => ({
+    noAtual,
+    visitados: [...visitados],
+    registrados: [...registrados],
+    parcial: [...parcial],
+    pilha: [...pilha],
+    solucoes: solucoes.map((s) => [...s]),
+    acao,
+    nos: contaNos,
+    retrocessos,
+    linha,
+    nota,
+    ok,
+  });
+
+  const completo = () =>
+    modo === "subconjuntos" ? true : modo === "permutacoes" ? parcial.length === valores.length : parcial.length === k;
+
+  const explorar = (no: No, inicio: number, usados: boolean[]) => {
+    contaNos++;
+    visitados.push(no.id);
+    pilha.push(rotuloDe(parcial));
+    passos.push(
+      base(
+        no.id,
+        "descer",
+        0,
+        `Entrei na chamada com a solução parcial [${rotuloDe(parcial)}]. A pilha tem ${pilha.length} chamada${pilha.length === 1 ? "" : "s"} agora.`
+      )
+    );
+
+    if (completo()) {
+      solucoes.push([...parcial]);
+      registrados.push(no.id);
+      passos.push(
+        base(
+          no.id,
+          "registrar",
+          2,
+          `[${rotuloDe(parcial)}] é uma solução completa, então guardo. Repare no [:] do código: eu guardo uma CÓPIA. A lista parcial é uma só e vai continuar mudando; sem a cópia, todas as ${solucoes.length} respostas apontariam para ela e terminariam vazias.`,
+          true
+        )
+      );
+      if (modo !== "subconjuntos") {
+        pilha.pop();
+        return;
+      }
+    }
+
+    for (let i = modo === "permutacoes" ? 0 : inicio; i < valores.length; i++) {
+      if (modo === "permutacoes" && usados[i]) continue;
+      const v = valores[i];
+      if (modo === "combinacoes" && parcial.length + (valores.length - i) < k) break;
+
+      parcial.push(v);
+      if (modo === "permutacoes") usados[i] = true;
+      const filho: No = { id: `${no.id}-${v}`, rotulo: rotuloDe(parcial), prof: no.prof + 1, filhos: [], x: 0, y: 0 };
+      no.filhos.push(filho);
+      passos.push(
+        base(
+          filho.id,
+          "escolher",
+          6,
+          `Escolho ${v} e ponho na solução parcial: [${rotuloDe(parcial)}]. ${
+            modo === "subconjuntos"
+              ? `Como só olho do índice ${i + 1} em diante daqui para frente, nunca vou montar um subconjunto fora da ordem original.`
+              : modo === "permutacoes"
+                ? `Marco ${v} como usado: numa permutação cada elemento entra uma vez só, mas em qualquer posição.`
+                : `Daqui em diante só olho do índice ${i + 1} para a frente, que é o que impede 1,2 e 2,1 de contarem como combinações diferentes.`
+          }`
+        )
+      );
+
+      explorar(filho, i + 1, usados);
+
+      const removido = parcial.pop();
+      if (modo === "permutacoes") usados[i] = false;
+      retrocessos++;
+      passos.push(
+        base(
+          filho.id,
+          "retroceder",
+          8,
+          `Retrocesso: tiro ${removido} da solução parcial, que volta a ser [${rotuloDe(parcial)}]. Repare que a árvore não perdeu nada, porque ela é só o desenho do caminho. Quem encolheu foi a lista, que é a única coisa que existe de verdade na memória.`
+        )
+      );
+    }
+
+    if (!(completo() && modo !== "subconjuntos")) pilha.pop();
+  };
+
+  passos.push(
+    base(
+      "r",
+      "inicio",
+      0,
+      `${NOMES[modo]}. A solução parcial começa vazia e o algoritmo vai fazer sempre a mesma coisa: escolher uma opção, explorar tudo que sai dela, e desfazer a escolha para poder tentar a próxima.`
+    )
+  );
+  explorar(raiz, 0, new Array(valores.length).fill(false));
+  passos.push(
+    base(
+      "r",
+      "fim",
+      0,
+      `Acabou: ${solucoes.length} soluções, ${contaNos} nós visitados e ${retrocessos} retrocessos. A solução parcial voltou a ficar vazia, exatamente como começou, porque todo escolher teve o seu desfazer.`,
+      true
+    )
+  );
+
+  // Layout: x por posição de folha, y por profundidade. Calculado sobre a
+  // árvore COMPLETA, para o desenho não se mexer durante a animação.
+  let slot = 0;
+  const posicionar = (n: No): number => {
+    if (n.filhos.length === 0) {
+      n.x = slot++;
+      return n.x;
+    }
+    const xs = n.filhos.map(posicionar);
+    n.x = (xs[0] + xs[xs.length - 1]) / 2;
+    return n.x;
+  };
+  posicionar(raiz);
+  const marcarY = (n: No) => {
+    n.y = n.prof;
+    n.filhos.forEach(marcarY);
+  };
+  marcarY(raiz);
+
+  return { raiz, passos, folhas: slot };
+}
+
+function achatar(n: No, saida: No[] = []): No[] {
+  saida.push(n);
+  n.filhos.forEach((f) => achatar(f, saida));
+  return saida;
+}
+
+const NO_R = 17;
+
+export function BacktrackingVisualizer() {
+  const [modo, setModo] = useState<Modo>("subconjuntos");
+  const [passo, setPasso] = useState(0);
+  const [tocando, setTocando] = useState(false);
+  const [velocidade, setVelocidade] = useState(4);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  const { raiz, passos, folhas } = useMemo(() => gerar(modo), [modo]);
+  const nos = useMemo(() => achatar(raiz), [raiz]);
+  const total = passos.length;
+  const idx = Math.min(passo, total - 1);
+  const p = passos[idx];
+
+  const parar = useCallback(() => {
+    if (timer.current) {
+      clearInterval(timer.current);
+      timer.current = null;
+    }
+  }, []);
+  useEffect(() => () => parar(), [parar]);
+  useEffect(() => {
+    parar();
+    if (!tocando) return;
+    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
+    return parar;
+  }, [tocando, velocidade, total, parar]);
+  useEffect(() => {
+    if (tocando && idx >= total - 1) setTocando(false);
+  }, [tocando, idx, total]);
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const reiniciar = () => {
+    parar();
+    setTocando(false);
+    setPasso(0);
+  };
+  const trocarModo = (m: Modo) => {
+    reiniciar();
+    setModo(m);
+  };
+
+  const profMax = Math.max(...nos.map((n) => n.prof));
+  const passoX = 74;
+  const largura = Math.max(320, folhas * passoX);
+  const W = largura + NO_R * 2;
+  const H = 40 + profMax * 62 + NO_R * 2;
+  const cx = (n: No) => NO_R + ((n.x + 0.5) * largura) / folhas;
+  const cy = (n: No) => 22 + NO_R + n.y * 62;
+
+  const vistos = new Set(p.visitados);
+  const registrados = new Set(p.registrados);
+  const pctPasso = Math.round(((idx + 1) / total) * 100);
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · backtracking: escolher, explorar, desfazer</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            passo {idx + 1} de {total}
+          </span>
+          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {MODOS.map((m) => (
+            <button key={m} className={`bigo-chip${modo === m ? " on" : ""}`} onClick={() => trocarModo(m)} aria-pressed={modo === m}>
+              {NOMES[m]}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">{DICAS[modo]}</p>
+
+        <div className={`hs-fase ${p.acao === "retroceder" ? "f-ordenar" : p.acao === "registrar" ? "f-fim" : ""}`}>
+          <span className="hs-fase-selo">
+            {p.acao === "escolher"
+              ? "1 · escolher"
+              : p.acao === "descer"
+                ? "2 · explorar"
+                : p.acao === "retroceder"
+                  ? "3 · desfazer"
+                  : p.acao === "registrar"
+                    ? "solução completa"
+                    : "início"}
+          </span>
+          <span className="hs-fase-txt">
+            solução parcial: [{rotuloDe(p.parcial)}] · soluções guardadas: {p.solucoes.length}
+          </span>
+        </div>
+
+        <div className="tt-arv-wrap">
+          <svg
+            className="tt-arv"
+            width={W}
+            height={H}
+            viewBox={`0 0 ${W} ${H}`}
+            role="img"
+            aria-label={`Árvore de decisão do backtracking. ${p.nota}`}
+          >
+            {nos.map((n) =>
+              n.filhos.map((f) => (
+                <line
+                  key={`${n.id}->${f.id}`}
+                  className={`tt-aresta${vistos.has(f.id) ? " ativa" : ""}`}
+                  x1={cx(n)}
+                  y1={cy(n) + NO_R}
+                  x2={cx(f)}
+                  y2={cy(f) - NO_R}
+                  opacity={vistos.has(f.id) ? 1 : 0.18}
+                />
+              ))
+            )}
+            {nos.map((n) => {
+              const cls = ["tt-no", "bt-no"];
+              if (n.id === p.noAtual) cls.push("on");
+              else if (registrados.has(n.id)) cls.push("filho");
+              else if (!vistos.has(n.id)) cls.push("porvir");
+              return (
+                <g key={n.id} className={cls.join(" ")}>
+                  <circle cx={cx(n)} cy={cy(n)} r={NO_R} />
+                  <text x={cx(n)} y={cy(n) + 4} textAnchor="middle">
+                    {n.rotulo}
+                  </text>
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+
+        <div className="bt-paineis">
+          <div className="hp-bloco">
+            <div className="tt-painel-tit">
+              A solução parcial <em>a única lista que existe na memória</em>
+            </div>
+            <div className="hp-arr">
+              {p.parcial.length === 0 ? (
+                <span className="bb-array-nota">vazia</span>
+              ) : (
+                p.parcial.map((v, k) => (
+                  <span key={k} className={`hp-cel${p.acao === "escolher" && k === p.parcial.length - 1 ? " foco troca" : " fixo"}`}>
+                    <i>{k}</i>
+                    {v}
+                  </span>
+                ))
+              )}
+            </div>
+          </div>
+          <div className="hp-bloco">
+            <div className="tt-painel-tit">
+              A pilha de chamadas <em>o que a recursão guarda de verdade</em>
+            </div>
+            <div className="bt-pilha">
+              {p.pilha.length === 0 ? (
+                <span className="bb-array-nota">vazia</span>
+              ) : (
+                [...p.pilha].reverse().map((t, k) => (
+                  <span key={k} className={`bt-quadro${k === 0 ? " topo" : ""}`}>
+                    backtrack([{t}])
+                  </span>
+                ))
+              )}
+            </div>
+          </div>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            As soluções guardadas <em>cada uma é uma cópia, tirada no instante em que foi encontrada</em>
+          </div>
+          <div className="bt-solucoes">
+            {p.solucoes.length === 0 ? (
+              <span className="bb-array-nota">nenhuma ainda</span>
+            ) : (
+              p.solucoes.map((s, k) => (
+                <span key={k} className={`bt-sol${k === p.solucoes.length - 1 && p.acao === "registrar" ? " nova" : ""}`}>
+                  [{rotuloDe(s)}]
+                </span>
+              ))
+            )}
+          </div>
+        </div>
+
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+
+        <div className="viz-split">
+          <div className="viz-code">
+            <div className="viz-code-head">backtrack.py</div>
+            <div className="viz-code-body">
+              {CODIGO.map((txt, k) => (
+                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
+                  <span className="ln">{k + 1}</span>
+                  {txt}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="viz-vars">
+            <div className="viz-vars-head">Variáveis</div>
+            <div className="viz-var">
+              <span className="viz-var-name">parcial</span>
+              <span className="viz-var-val best">[{rotuloDe(p.parcial)}]</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">profundidade da pilha</span>
+              <span className="viz-var-val">{p.pilha.length}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">soluções guardadas</span>
+              <span className="viz-var-val">{p.solucoes.length}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="bigo-stats">
+          <div className="bigo-stat">
+            <span>nós visitados</span>
+            <strong>{p.nos}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>soluções encontradas</span>
+            <strong>{p.solucoes.length}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>retrocessos</span>
+            <strong>{p.retrocessos}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>nós da árvore inteira</span>
+            <strong>{nos.length}</strong>
+          </div>
+        </div>
+
+        <div className="viz-controls">
+          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
+            ↺
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === 0}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.max(0, s - 1));
+            }}
+          >
+            ‹ Anterior
+          </button>
+          <button
+            className="viz-play"
+            onClick={() => {
+              if (tocando) {
+                setTocando(false);
+                return;
+              }
+              setPasso(idx >= total - 1 ? 0 : idx);
+              setTocando(true);
+            }}
+          >
+            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === total - 1}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.min(s + 1, total - 1));
+            }}
+          >
+            Próximo ›
+          </button>
+          <div className="viz-speed">
+            <span>Velocidade</span>
+            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
+            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+          </div>
+        </div>
+        <div className="viz-progress">
+          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
+        </div>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          Rode os três até o fim e compare nós visitados com soluções encontradas: 8 e 8 nos subconjuntos, 16
+          e 6 nas permutações, 10 e 6 nas combinações. Nas permutações, dez dos dezesseis nós são caminho e
+          não resposta, e é esse desperdício que faz o custo do backtracking ser exponencial. O número de
+          retrocessos é sempre igual ao de arestas da árvore: todo escolher tem exatamente um desfazer.
+        </p>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div
+        className="viz-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) setExpanded(false);
+        }}
+      >
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/content/visualizers/BacktrackingVisualizer.tsx
+++ b/content/visualizers/BacktrackingVisualizer.tsx
@@ -411,8 +411,12 @@ export function BacktrackingVisualizer() {
               {p.pilha.length === 0 ? (
                 <span className="bb-array-nota">vazia</span>
               ) : (
-                [...p.pilha].reverse().map((t, k) => (
-                  <span key={k} className={`bt-quadro${k === 0 ? " topo" : ""}`}>
+                // A inversão é só do CSS (column-reverse): o primeiro quadro do
+                // array é a chamada mais antiga e aparece embaixo, o último é o
+                // topo da pilha e aparece em cima. Inverter também aqui era
+                // desfazer o efeito e deixar o destaque no quadro errado.
+                p.pilha.map((t, k) => (
+                  <span key={k} className={`bt-quadro${k === p.pilha.length - 1 ? " topo" : ""}`}>
                     backtrack([{t}])
                   </span>
                 ))

--- a/content/visualizers/BinarioBases.tsx
+++ b/content/visualizers/BinarioBases.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// BinarioBases, o mesmo número em quatro sistemas, e o que cabe em cada tipo.
+//
+// Duas ideias numa tela só, e elas são a mesma ideia lida em duas direções.
+//
+// A primeira: a base é um PARÂMETRO, não uma identidade. O mesmo valor escrito
+// em 2, 8, 10 e 16 muda de aparência e não muda de tamanho, e por isso a
+// tabela mostra as quatro escritas lado a lado com o mesmo número por trás.
+// Hexadecimal ganha destaque porque ele é o motivo prático de tudo isto: cada
+// dígito hexadecimal é exatamente 4 bits, então ler 0xF3 é ler dois grupos de
+// quatro bits, e é por isso que endereço de memória, cor e máscara vêm em hexa.
+//
+// A segunda: quantos bits você tem decide quanto cabe, e a conta é 2^bits.
+// Aqui a tabela vai até 64 bits porque o salto entre 32 e 64 é o argumento
+// inteiro sobre por que ninguém guarda dinheiro em int de 32 bits.
+//
+// Componente estático seria possível para a segunda tabela, mas a primeira
+// precisa do valor escolhido, então as duas ficam no mesmo interativo sem linha
+// do tempo: a variável é o número.
+// ---------------------------------------------------------------------------
+
+const VALORES = [53, 201, 255, 4095, 48879];
+
+const BASES: { base: number; nome: string; nota: string }[] = [
+  { base: 2, nome: "binário", nota: "2 símbolos: 0 e 1. É o que existe no hardware." },
+  { base: 8, nome: "octal", nota: "8 símbolos. Cada dígito vale exatamente 3 bits. Sobrevive nas permissões de arquivo do Unix." },
+  { base: 10, nome: "decimal", nota: "10 símbolos. É o único da lista que não tem relação com potências de dois." },
+  { base: 16, nome: "hexadecimal", nota: "16 símbolos, de 0 a F. Cada dígito vale exatamente 4 bits, e é por isso que ele é a forma curta de escrever binário." },
+];
+
+// Formatador determinístico: Intl.NumberFormat diverge entre build e cliente.
+function num(v: number): string {
+  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+}
+
+function compacto(v: number): string {
+  if (v >= 1e18) return `${num(v / 1e18)} qui`;
+  if (v >= 1e15) return `${num(v / 1e15)} quatri`;
+  if (v >= 1e12) return `${num(v / 1e12)} tri`;
+  if (v >= 1e9) return `${num(v / 1e9)} bi`;
+  if (v >= 1e6) return `${num(v / 1e6)} mi`;
+  return num(v);
+}
+
+const TIPOS = [
+  { bits: 8, nome: "byte", exemplo: "byte, char, uint8" },
+  { bits: 16, nome: "16 bits", exemplo: "short, uint16" },
+  { bits: 32, nome: "32 bits", exemplo: "int, float, cor RGBA" },
+  { bits: 64, nome: "64 bits", exemplo: "long, double, ponteiro" },
+];
+
+export function BinarioBases() {
+  const [valor, setValor] = useState(255);
+  const bin = useMemo(() => valor.toString(2), [valor]);
+  const hex = useMemo(() => valor.toString(16).toUpperCase(), [valor]);
+
+  // Os grupos de 4 bits que formam cada dígito hexadecimal, alinhados pela
+  // direita: é a demonstração de que hexa é binário com outra roupa.
+  const grupos = useMemo(() => {
+    const preenchido = bin.padStart(Math.ceil(bin.length / 4) * 4, "0");
+    const out: string[] = [];
+    for (let i = 0; i < preenchido.length; i += 4) out.push(preenchido.slice(i, i + 4));
+    return out;
+  }, [bin]);
+
+  return (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · a base é um parâmetro, e os bits são um orçamento</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            {num(valor)} = 0x{hex} = 0b{bin}
+          </span>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {VALORES.map((v) => (
+            <button key={v} className={`bigo-chip${valor === v ? " on" : ""}`} onClick={() => setValor(v)} aria-pressed={valor === v}>
+              {num(v)}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">
+          O mesmo valor escrito em quatro sistemas. Nenhuma das quatro escritas é &quot;o número&quot;: o número
+          é a quantidade, e cada linha é uma forma de anotá-la. O que muda de base para base é quantos símbolos
+          existem por posição, e por consequência quantas posições são necessárias.
+        </p>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            O mesmo {num(valor)} em quatro bases <em>quanto menor a base, mais dígitos</em>
+          </div>
+          <div className="bigo-fam-scroll">
+            <table className="bigo-fam-table">
+              <thead>
+                <tr>
+                  <th>base</th>
+                  <th>escrita</th>
+                  <th className="nums">dígitos</th>
+                  <th>por que ela existe</th>
+                </tr>
+              </thead>
+              <tbody>
+                {BASES.map((b) => {
+                  const escrita = valor.toString(b.base).toUpperCase();
+                  return (
+                    <tr key={b.base} className={b.base === 16 ? "hp-destaque" : ""}>
+                      <td>
+                        <div className="bigo-fam-not hp-nome">
+                          {b.nome} ({b.base})
+                        </div>
+                      </td>
+                      <td>
+                        <span className="bn-escrita">{escrita}</span>
+                      </td>
+                      <td className="nums">{escrita.length}</td>
+                      <td>
+                        <div className="hp-veredito">{b.nota}</div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            Por que hexadecimal e não decimal <em>cada dígito hexa é um grupo de 4 bits, sem sobra</em>
+          </div>
+          <div className="bn-grupos">
+            {grupos.map((g, k) => (
+              <span className="bn-grupo" key={k}>
+                <span className="bn-grupo-bits">{g}</span>
+                <span className="bn-grupo-hex">{parseInt(g, 2).toString(16).toUpperCase()}</span>
+              </span>
+            ))}
+          </div>
+          <p className="bb-array-nota" style={{ marginTop: 8 }}>
+            Com decimal essa correspondência não existe: 10 não é potência de 2, então um dígito decimal não
+            corresponde a um número inteiro de bits e converter exige dividir. Com hexadecimal, converter é
+            recortar de quatro em quatro.
+          </p>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            Quantos bits, quanto cabe <em>a conta é sempre 2 elevado ao número de bits</em>
+          </div>
+          <div className="bigo-fam-scroll">
+            <table className="bigo-fam-table">
+              <thead>
+                <tr>
+                  <th>tamanho</th>
+                  <th className="nums">combinações</th>
+                  <th className="nums">maior valor sem sinal</th>
+                  <th>onde aparece</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TIPOS.map((t) => {
+                  const combos = Math.pow(2, t.bits);
+                  const cabe = valor < combos;
+                  return (
+                    <tr key={t.bits}>
+                      <td>
+                        <div className="bigo-fam-not hp-nome">{t.nome}</div>
+                        <div className="bigo-fam-nome">{t.bits} bits</div>
+                      </td>
+                      <td className="nums">
+                        <span className="hp-custo c-bom">2^{t.bits}</span>
+                      </td>
+                      <td className="nums">
+                        <span className={`hp-custo ${cabe ? "c-otimo" : "c-ruim"}`}>{compacto(combos - 1)}</span>
+                      </td>
+                      <td>
+                        <div className="hp-veredito">
+                          {t.exemplo}
+                          {cabe ? "" : ` · o ${num(valor)} escolhido acima NÃO cabe aqui`}
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <p className="viz-note ok">
+          Os {num(valor)} escolhidos precisam de <strong>{bin.length} bits</strong> para serem escritos, ou{" "}
+          {hex.length} dígitos hexadecimais. Repare que dobrar a quantidade de bits não dobra o alcance, ele
+          eleva ao quadrado: 8 bits vão até 255, 16 até 65.535, e 32 até mais de 4 bilhões. É a mesma curva
+          exponencial de sempre, vista do lado de dentro.
+        </p>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          O salto de 32 para 64 bits é o que mais aparece na prática. Um inteiro de 32 bits com sinal vai até
+          2.147.483.647, e isso é pouco para coisas comuns: contar milissegundos desde 1970 estoura em 2038, e
+          somar centavos de uma empresa grande estoura antes disso. Guardar identificador, dinheiro ou tempo em
+          32 bits é uma decisão, não um detalhe.
+        </p>
+      </div>
+    </figure>
+  );
+}

--- a/content/visualizers/BinarioComplemento.tsx
+++ b/content/visualizers/BinarioComplemento.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// BinarioComplemento, os dois passos que viram o sinal.
+//
+// A única coisa que o aluno precisa enxergar é que "inverter e somar 1" não é
+// uma receita arbitrária: ela é a única operação que faz x + (-x) dar zero
+// dentro de uma quantidade fixa de bits. Por isso o visualizador não para na
+// conversão: ele termina somando o número com o oposto dele, bit a bit, e
+// mostrando o vai-um saindo pela esquerda e sendo descartado.
+//
+// A soma aparece dígito a dígito, da direita para a esquerda, porque o vai-um é
+// exatamente o mesmo mecanismo da soma decimal que a pessoa aprendeu na escola,
+// só que com dois símbolos em vez de dez. Mostrar o carry andando é o que liga
+// as duas coisas.
+//
+// Os presets incluem os dois casos que quebram a intuição: o zero (que prova a
+// ausência de ambiguidade, porque o vai-um estoura e some) e o 128, cujo oposto
+// é ele mesmo. Preset que só mostra o caso bonito ensina a receita, não a
+// regra.
+// ---------------------------------------------------------------------------
+
+const N = 8;
+
+type Passo = {
+  bits: number[];
+  destaque: number;
+  carry: number[]; // vai-um por posição, -1 quando não se aplica
+  fase: "inicio" | "inverter" | "somar" | "pronto" | "prova";
+  soma: number[] | null; // resultado da prova x + (-x)
+  linha: number;
+  nota: string;
+  ok?: boolean;
+};
+
+const CODIGO = [
+  "# complemento de dois, em 8 bits",
+  "positivo = 0b00011010            # 26",
+  "invertido = ~positivo & 0xFF     # 1. inverte todos",
+  "negativo  = (invertido + 1) & 0xFF  # 2. soma 1",
+  "",
+  "# a prova: somar os dois tem que dar zero",
+  "(positivo + negativo) & 0xFF     # o vai-um cai fora",
+];
+
+type Preset = { key: string; rotulo: string; valor: number; dica: string };
+
+const PRESETS: Preset[] = [
+  {
+    key: "vinteseis",
+    rotulo: "26",
+    valor: 26,
+    dica: "O caso comum. Acompanhe os dois passos e depois a prova: somar 26 com o resultado tem que dar zero em oito bits, senão a representação não serviria para o processador fazer subtração somando.",
+  },
+  {
+    key: "um",
+    rotulo: "1",
+    valor: 1,
+    dica: "O menor caso, e o mais revelador: o oposto de 1 é 11111111, ou seja, todos os bits ligados. Faz sentido, porque somar 1 a 11111111 dá zero com um vai-um que cai fora.",
+  },
+  {
+    key: "cento",
+    rotulo: "127, o maior positivo",
+    valor: 127,
+    dica: "O teto do lado positivo com 8 bits. Repare que o resultado, 10000001, tem o bit de sinal ligado e é lido como -127. Um a mais no positivo já não caberia: 128 não existe no tipo com sinal.",
+  },
+  {
+    key: "zero",
+    rotulo: "0, o teste da ambiguidade",
+    valor: 0,
+    dica: "Aqui está o motivo de o complemento de dois ter vencido. Inverter dá 11111111, somar 1 estoura e volta a 00000000: o oposto de zero é o próprio zero, e existe UMA representação só. Nas outras duas convenções existem duas, e a máquina precisa decidir o que fazer com a segunda.",
+  },
+  {
+    key: "cento28",
+    rotulo: "128, o que é o próprio oposto",
+    valor: 128,
+    dica: "O caso que quebra a simetria. O complemento de dois de 10000000 é 10000000: ele é o oposto de si mesmo. Por isso a faixa com sinal vai de -128 a 127, e não de -127 a 127: o -128 existe e o +128 não.",
+  },
+];
+
+const VELOCIDADES = [0, 1400, 900, 600, 380, 220];
+const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
+const paraBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
+const paraNum = (b: number[]) => b.reduce((acc, x, k) => acc + (x << (N - 1 - k)), 0);
+const comSinal = (b: number[]) => (b[0] === 1 ? paraNum(b) - 256 : paraNum(b));
+
+export function gerarPassos(valor: number): Passo[] {
+  const out: Passo[] = [];
+  const original = paraBits(valor);
+  const semCarry = new Array(N).fill(-1);
+
+  out.push({
+    bits: [...original],
+    destaque: -1,
+    carry: semCarry,
+    fase: "inicio",
+    soma: null,
+    linha: 1,
+    nota: `Ponto de partida: ${valor} em oito bits é ${original.join("")}. O objetivo é achar a representação de -${valor} sem inventar um símbolo de menos, usando só os mesmos oito bits.`,
+  });
+
+  // ---- passo 1: inverter -----------------------------------------------
+  const invertido: number[] = original.map((b) => (b === 1 ? 0 : 1));
+  for (let k = 0; k < N; k++) {
+    const parcial = original.map((b, i) => (i <= k ? (b === 1 ? 0 : 1) : b));
+    out.push({
+      bits: parcial,
+      destaque: k,
+      carry: semCarry,
+      fase: "inverter",
+      soma: null,
+      linha: 2,
+      nota: `Passo 1, inverter: o bit de expoente ${N - 1 - k} era ${original[k]} e vira ${1 - original[k]}. Isto sozinho é o complemento de UM, e ele já quase funciona: o problema dele é que sobra um zero a mais.`,
+    });
+  }
+
+  // ---- passo 2: somar 1 -------------------------------------------------
+  const resultado = [...invertido];
+  const carry = new Array(N).fill(-1);
+  let vai = 1;
+  for (let k = N - 1; k >= 0; k--) {
+    const soma = resultado[k] + vai;
+    const bit = soma % 2;
+    const novoVai = soma > 1 ? 1 : 0;
+    carry[k] = novoVai;
+    resultado[k] = bit;
+    out.push({
+      bits: [...resultado],
+      destaque: k,
+      carry: [...carry],
+      fase: "somar",
+      soma: null,
+      linha: 3,
+      nota:
+        vai === 0
+          ? `Não há mais vai-um, então os bits à esquerda ficam como estão. A soma acabou de fato aqui.`
+          : `Passo 2, somar 1: nesta posição tenho ${invertido[k]} + ${vai}. ${
+              soma > 1
+                ? `Em binário 1 + 1 é 0 e vai um, exatamente como 5 + 5 é 0 e vai um no decimal. Escrevo ${bit} e levo o vai-um para a esquerda.`
+                : `Dá ${bit}, sem vai-um, e a propagação para aqui.`
+            }`,
+    });
+    vai = novoVai;
+    if (vai === 0) {
+      // os bits restantes não mudam; um passo só resume isso
+      break;
+    }
+  }
+
+  const valorFinal = comSinal(resultado);
+  out.push({
+    bits: [...resultado],
+    destaque: -1,
+    carry: semCarry,
+    fase: "pronto",
+    soma: null,
+    linha: 3,
+    ok: true,
+    nota: `Pronto: ${resultado.join("")}. Lendo com o truque do peso negativo, o bit da esquerda vale -128 em vez de +128, então isto é ${resultado
+      .map((b, k) => (b === 1 ? (k === 0 ? -128 : 1 << (N - 1 - k)) : 0))
+      .filter((x) => x !== 0)
+      .join(" + ")
+      .replace(/\+ -/g, "- ")} = ${valorFinal}.`,
+  });
+
+  // ---- a prova: x + (-x) --------------------------------------------------
+  const soma: number[] = new Array(N).fill(0);
+  const carrySoma = new Array(N).fill(-1);
+  let v2 = 0;
+  for (let k = N - 1; k >= 0; k--) {
+    const s = original[k] + resultado[k] + v2;
+    soma[k] = s % 2;
+    carrySoma[k] = s > 1 ? 1 : 0;
+    v2 = s > 1 ? 1 : 0;
+  }
+  out.push({
+    bits: [...resultado],
+    destaque: -1,
+    carry: carrySoma,
+    fase: "prova",
+    soma: [...soma],
+    linha: 6,
+    ok: true,
+    nota: `A prova: ${original.join("")} + ${resultado.join("")} = ${soma.join("")}${
+      v2 === 1
+        ? `, com um vai-um sobrando na ponta esquerda. Esse nono bit não cabe em oito, então o tipo simplesmente o descarta, e o que fica é zero. Não é um acidente conveniente: é o motivo de a convenção ser esta, porque assim o processador subtrai somando, sem nenhum circuito a mais.`
+        : `. Somar um número com o oposto dele dá zero, que é a definição de oposto.`
+    }`,
+  });
+
+  return out;
+}
+
+export function BinarioComplemento() {
+  const [presetKey, setPresetKey] = useState("vinteseis");
+  const [passo, setPasso] = useState(0);
+  const [tocando, setTocando] = useState(false);
+  const [velocidade, setVelocidade] = useState(4);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
+  const passos = useMemo(() => gerarPassos(preset.valor), [preset]);
+  const total = passos.length;
+  const idx = Math.min(passo, total - 1);
+  const p = passos[idx];
+  const original = useMemo(() => paraBits(preset.valor), [preset]);
+
+  const parar = useCallback(() => {
+    if (timer.current) {
+      clearInterval(timer.current);
+      timer.current = null;
+    }
+  }, []);
+  useEffect(() => () => parar(), [parar]);
+  useEffect(() => {
+    parar();
+    if (!tocando) return;
+    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
+    return parar;
+  }, [tocando, velocidade, total, parar]);
+  useEffect(() => {
+    if (tocando && idx >= total - 1) setTocando(false);
+  }, [tocando, idx, total]);
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const reiniciar = () => {
+    parar();
+    setTocando(false);
+    setPasso(0);
+  };
+  const trocarPreset = (k: string) => {
+    reiniciar();
+    setPresetKey(k);
+  };
+
+  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const rotuloFase =
+    p.fase === "inverter" ? "1 · inverter todos os bits" : p.fase === "somar" ? "2 · somar 1" : p.fase === "prova" ? "a prova: x + (-x)" : p.fase === "pronto" ? "resultado" : "início";
+
+  const Fita = ({ bits, destaque, marca }: { bits: number[]; destaque: number; marca?: string }) => (
+    <div className="bn-fita">
+      {bits.map((b, k) => (
+        <span key={k} className={`bn-bit estatico${b ? " on" : ""}${k === destaque ? " novo" : ""}${k === 0 ? " sinal" : ""}`}>
+          <span className="bn-bit-val">{b}</span>
+          <span className="bn-bit-exp">
+            {k === 0 && marca === "sinal" ? (
+              "sinal"
+            ) : (
+              <>
+                2<sup>{N - 1 - k}</sup>
+              </>
+            )}
+          </span>
+          <span className="bn-bit-peso">{k === 0 && marca === "sinal" ? "-128" : 1 << (N - 1 - k)}</span>
+        </span>
+      ))}
+    </div>
+  );
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · complemento de dois: inverter e somar 1</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            passo {idx + 1} de {total}
+          </span>
+          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {PRESETS.map((pr) => (
+            <button
+              key={pr.key}
+              className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
+              onClick={() => trocarPreset(pr.key)}
+              aria-pressed={presetKey === pr.key}
+            >
+              {pr.rotulo}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">{preset.dica}</p>
+
+        <div className={`hs-fase ${p.fase === "prova" || p.fase === "pronto" ? "f-fim" : p.fase === "somar" ? "f-ordenar" : ""}`}>
+          <span className="hs-fase-selo">{rotuloFase}</span>
+          <span className="hs-fase-txt">
+            {preset.valor} · em construção: {p.bits.join("")} ({comSinal(p.bits)} lido com sinal)
+          </span>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            O positivo de partida <em>o bit da esquerda desligado quer dizer positivo</em>
+          </div>
+          <Fita bits={original} destaque={-1} />
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            Em construção <em>{p.fase === "somar" ? "somando 1, com o vai-um andando para a esquerda" : "invertendo bit a bit"}</em>
+          </div>
+          <Fita bits={p.bits} destaque={p.destaque} marca="sinal" />
+          {p.carry.some((c) => c >= 0) ? (
+            <div className="bn-carrys">
+              {p.carry.map((c, k) => (
+                <span key={k} className={`bn-carry${c === 1 ? " on" : ""}`}>
+                  {c === 1 ? "1" : c === 0 ? "0" : ""}
+                </span>
+              ))}
+              <span className="bn-carry-rot">vai-um</span>
+            </div>
+          ) : null}
+        </div>
+
+        {p.soma ? (
+          <div className="hp-bloco">
+            <div className="tt-painel-tit">
+              A prova <em>somar o número com o oposto dele</em>
+            </div>
+            <Fita bits={p.soma} destaque={-1} />
+          </div>
+        ) : null}
+
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+
+        <div className="viz-split">
+          <div className="viz-code">
+            <div className="viz-code-head">complemento.py</div>
+            <div className="viz-code-body">
+              {CODIGO.map((txt, k) => (
+                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
+                  <span className="ln">{k + 1}</span>
+                  {txt}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="viz-vars">
+            <div className="viz-vars-head">Variáveis</div>
+            <div className="viz-var">
+              <span className="viz-var-name">positivo</span>
+              <span className="viz-var-val best">{preset.valor}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">em construção (sem sinal)</span>
+              <span className="viz-var-val">{paraNum(p.bits)}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">em construção (com sinal)</span>
+              <span className="viz-var-val">{comSinal(p.bits)}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="viz-controls">
+          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
+            ↺
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === 0}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.max(0, s - 1));
+            }}
+          >
+            ‹ Anterior
+          </button>
+          <button
+            className="viz-play"
+            onClick={() => {
+              if (tocando) {
+                setTocando(false);
+                return;
+              }
+              setPasso(idx >= total - 1 ? 0 : idx);
+              setTocando(true);
+            }}
+          >
+            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === total - 1}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.min(s + 1, total - 1));
+            }}
+          >
+            Próximo ›
+          </button>
+          <div className="viz-speed">
+            <span>Velocidade</span>
+            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
+            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+          </div>
+        </div>
+        <div className="viz-progress">
+          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
+        </div>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          Rode o preset do zero até o fim: inverter dá 11111111, somar 1 estoura para 00000000, e o oposto de
+          zero é o próprio zero. É esse resultado, e só ele, que elimina a ambiguidade das outras duas
+          convenções. Depois rode o 128 e repare que ele é o oposto de si mesmo: é por isso que a faixa com
+          sinal vai de -128 a 127 e não é simétrica.
+        </p>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div
+        className="viz-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) setExpanded(false);
+        }}
+      >
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/content/visualizers/BinarioConversor.tsx
+++ b/content/visualizers/BinarioConversor.tsx
@@ -1,0 +1,195 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// BinarioConversor, o número binário como uma soma que dá para ver.
+//
+// A única coisa que o aluno precisa enxergar é que binário não é um código
+// secreto a ser decorado: é **notação posicional**, a mesma coisa que ele já
+// faz com o sistema decimal desde a escola, com a base trocada de 10 para 2.
+// Por isso a conta aparece por extenso, termo a termo, e cada termo acende ou
+// apaga junto com o bit. Uma tabela de conversão ensina a consultar; a soma
+// escrita ensina a derivar.
+//
+// Os bits são botões de verdade (não divs com onClick) porque o aluno precisa
+// poder clicar, tabular e usar o teclado, e porque `aria-pressed` já diz o
+// estado sem precisar de rótulo extra.
+//
+// Interativo sem linha do tempo: a variável aqui é o NÚMERO, e uma animação
+// sobre oito bits só atrapalharia a experimentação livre, que é o ponto.
+// ---------------------------------------------------------------------------
+
+const N = 8;
+
+type Preset = { key: string; rotulo: string; valor: number; dica: string };
+
+const PRESETS: Preset[] = [
+  {
+    key: "cinquenta",
+    rotulo: "53",
+    valor: 53,
+    dica: "Um número qualquer. Repare que os únicos termos que entram na soma são os dos bits ligados: os zeros multiplicam a potência por zero e somem da conta, e é literalmente por isso que eles não valem nada.",
+  },
+  {
+    key: "duzentos",
+    rotulo: "201",
+    valor: 201,
+    dica: "Mais um caso comum. Este é o número que aparece no visualizador seguinte, o das divisões por 2: vale conferir se os dois caminhos chegam ao mesmo lugar.",
+  },
+  {
+    key: "todos",
+    rotulo: "255, todos os bits ligados",
+    valor: 255,
+    dica: "O teto de um byte. Repare que 255 é 256 menos 1, e não 256: com 8 bits existem 256 combinações, mas uma delas é o zero. A soma 128 + 64 + 32 + 16 + 8 + 4 + 2 + 1 sempre dá um a menos que a próxima potência.",
+  },
+  {
+    key: "potencia",
+    rotulo: "128, um bit só",
+    valor: 128,
+    dica: "Com um único bit ligado, o valor é a própria potência de dois. Ligue o bit da direita em vez do da esquerda e o número cai de 128 para 1: mesma quantidade de bits ligados, valores separados por um fator de 128.",
+  },
+  {
+    key: "zero",
+    rotulo: "0, nenhum bit",
+    valor: 0,
+    dica: "Todos os bits desligados. Vale reparar que o zero tem uma representação e só uma, o que parece óbvio agora e vai deixar de ser quando os números negativos entrarem.",
+  },
+];
+
+export function BinarioConversor() {
+  const [valor, setValor] = useState(53);
+  const bits = useMemo(() => Array.from({ length: N }, (_, k) => (valor >> (N - 1 - k)) & 1), [valor]);
+
+  const alternar = (k: number) => setValor((v) => v ^ (1 << (N - 1 - k)));
+  const ligados = bits.filter((b) => b === 1).length;
+  const termos = bits.map((b, k) => ({ bit: b, exp: N - 1 - k, peso: 1 << (N - 1 - k) })).filter((t) => t.bit === 1);
+  const presetAtivo = PRESETS.find((p) => p.valor === valor);
+
+  return (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · o binário é uma soma de potências de dois</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            {bits.join("")} = {valor}
+          </span>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {PRESETS.map((p) => (
+            <button
+              key={p.key}
+              className={`bigo-chip${valor === p.valor ? " on" : ""}`}
+              onClick={() => setValor(p.valor)}
+              aria-pressed={valor === p.valor}
+            >
+              {p.rotulo}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">
+          {presetAtivo
+            ? presetAtivo.dica
+            : "Clique nos bits para ligar e desligar. Cada posição vale o dobro da posição à direita dela, e o número é só a soma das posições ligadas."}
+        </p>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            Os oito bits <em>clique para ligar e desligar</em>
+          </div>
+          <div className="bn-fita">
+            {bits.map((b, k) => {
+              const exp = N - 1 - k;
+              return (
+                <button
+                  key={k}
+                  className={`bn-bit${b ? " on" : ""}`}
+                  onClick={() => alternar(k)}
+                  aria-pressed={b === 1}
+                  aria-label={`Bit de expoente ${exp}, valor ${1 << exp}, ${b ? "ligado" : "desligado"}`}
+                >
+                  <span className="bn-bit-val">{b}</span>
+                  <span className="bn-bit-exp">
+                    2<sup>{exp}</sup>
+                  </span>
+                  <span className="bn-bit-peso">{1 << exp}</span>
+                </button>
+              );
+            })}
+          </div>
+          <p className="bb-array-nota" style={{ marginTop: 8 }}>
+            O bit da esquerda é o <strong>mais significativo</strong> e o da direita o <strong>menos
+            significativo</strong>, exatamente como a centena e a unidade num número decimal.
+          </p>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            A conta, escrita por extenso <em>os bits desligados multiplicam por zero e somem</em>
+          </div>
+          <p className="bn-conta">
+            {termos.length === 0 ? (
+              <span className="bn-termo">0</span>
+            ) : (
+              termos.map((t, k) => (
+                <span key={t.exp}>
+                  {k > 0 ? <span className="bn-mais"> + </span> : null}
+                  <span className="bn-termo">
+                    1 x 2<sup>{t.exp}</sup>
+                  </span>
+                </span>
+              ))
+            )}
+          </p>
+          <p className="bn-conta">
+            {termos.length === 0 ? (
+              <span className="bn-termo">0</span>
+            ) : (
+              termos.map((t, k) => (
+                <span key={t.exp}>
+                  {k > 0 ? <span className="bn-mais"> + </span> : null}
+                  <span className="bn-termo forte">{t.peso}</span>
+                </span>
+              ))
+            )}
+            <span className="bn-igual"> = {valor}</span>
+          </p>
+        </div>
+
+        <div className="bigo-stats">
+          <div className="bigo-stat">
+            <span>valor decimal</span>
+            <strong>{valor}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>bits ligados</span>
+            <strong>{ligados}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>combinações com 8 bits</span>
+            <strong>256</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>maior valor possível</span>
+            <strong>255</strong>
+          </div>
+        </div>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          A mesma ideia vale no decimal: 243 é 2 x 10² + 4 x 10¹ + 3 x 10⁰. Muda a base, e com ela quantos
+          símbolos existem por posição. É por isso que aprender binário não é aprender um sistema novo, é
+          reconhecer o sistema que você já usa com outra base. Ligue e desligue o bit da esquerda para ver o
+          número saltar 128 de uma vez: essa é a diferença entre a posição mais significativa e a menos, e é a
+          mesma diferença entre a centena e a unidade.
+        </p>
+      </div>
+    </figure>
+  );
+}

--- a/content/visualizers/BinarioDivisoes.tsx
+++ b/content/visualizers/BinarioDivisoes.tsx
@@ -1,0 +1,394 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+
+// ---------------------------------------------------------------------------
+// BinarioDivisoes, o caminho de volta: de decimal para binário.
+//
+// A única coisa que o aluno precisa enxergar é POR QUE os restos saem de trás
+// para a frente. A regra costuma ser ensinada como um truque ("junte os restos
+// de baixo para cima"), e ela é consequência de uma coisa só: a primeira
+// divisão pergunta pelo bit menos significativo, porque dividir por 2 é
+// deslocar tudo uma casa para a direita e o resto é o que cai fora.
+//
+// Por isso a fita de bits vai sendo preenchida da DIREITA para a esquerda, ao
+// vivo, ao lado da divisão que a produziu. Uma tabela de divisões com uma seta
+// dizendo "leia ao contrário" ensina o truque; a fita mostra a razão.
+//
+// O passo a passo tem linha do tempo porque aqui existe uma sequência de
+// verdade, com estado que evolui, ao contrário do conversor ao lado, em que a
+// variável é o número.
+// ---------------------------------------------------------------------------
+
+type Linha = { n: number; quociente: number; resto: number };
+
+type Passo = {
+  linhas: Linha[];
+  bits: (number | null)[];
+  destaque: number; // índice da linha em foco
+  posicao: number; // posição do bit que acabou de ser escrito
+  linha: number;
+  nota: string;
+  ok?: boolean;
+};
+
+const CODIGO = [
+  "def para_binario(n):",
+  "    if n == 0: return '0'",
+  "    bits = ''",
+  "    while n > 0:",
+  "        bits = str(n % 2) + bits   # o resto entra na FRENTE",
+  "        n = n // 2                 # e o número encolhe pela metade",
+  "    return bits",
+];
+
+type Preset = { key: string; rotulo: string; valor: number; dica: string };
+
+const PRESETS: Preset[] = [
+  {
+    key: "duzentos",
+    rotulo: "201",
+    valor: 201,
+    dica: "Oito divisões para oito bits. Acompanhe a fita da direita: o primeiro resto ocupa a última posição, e não a primeira. É esse detalhe que faz a regra de ler os restos de baixo para cima.",
+  },
+  {
+    key: "cinquenta",
+    rotulo: "53",
+    valor: 53,
+    dica: "O mesmo número do visualizador anterior, agora pelo caminho inverso. Se as duas contas fecharem no mesmo 00110101, é porque as duas são a mesma ideia lida em direções opostas.",
+  },
+  {
+    key: "potencia",
+    rotulo: "64, uma potência de dois",
+    valor: 64,
+    dica: "Potência de dois é o caso mais limpo: todas as divisões dão resto zero até a última. Um número com um bit ligado só é um número que se divide por 2 sem sobra até virar 1.",
+  },
+  {
+    key: "impar",
+    rotulo: "255, todos ímpares",
+    valor: 255,
+    dica: "O oposto: toda divisão sobra 1, então todos os bits saem ligados. Repare que o resto de dividir por 2 é exatamente a pergunta se o número é ímpar, e ímpar em binário é bit da direita ligado.",
+  },
+];
+
+const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
+const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
+export function gerarPassos(valor: number): Passo[] {
+  const largura = Math.max(8, valor.toString(2).length);
+  const out: Passo[] = [];
+  const linhas: Linha[] = [];
+  const bits: (number | null)[] = new Array(largura).fill(null);
+  let n = valor;
+  let pos = largura - 1;
+
+  out.push({
+    linhas: [],
+    bits: [...bits],
+    destaque: -1,
+    posicao: -1,
+    linha: 0,
+    nota: `Vou converter ${valor} para binário dividindo por 2 sem parar. Cada divisão responde a uma pergunta só: "sobra alguma coisa?". O resto é o bit, e o quociente é o que ainda falta converter.`,
+  });
+
+  if (valor === 0) {
+    out.push({
+      linhas: [],
+      bits: bits.map(() => 0),
+      destaque: -1,
+      posicao: -1,
+      linha: 1,
+      ok: true,
+      nota: "O zero é o único caso que o laço não trata, porque ele nem chega a rodar. Por isso o código devolve '0' antes de começar.",
+    });
+    return out;
+  }
+
+  while (n > 0) {
+    const q = Math.floor(n / 2);
+    const r = n % 2;
+    linhas.push({ n, quociente: q, resto: r });
+    bits[pos] = r;
+    out.push({
+      linhas: [...linhas],
+      bits: [...bits],
+      destaque: linhas.length - 1,
+      posicao: pos,
+      linha: 4,
+      nota: `${n} dividido por 2 dá ${q} com resto ${r}. ${
+        r === 1
+          ? `Sobrou 1, ou seja, ${n} é ímpar, e todo número ímpar tem o bit da direita ligado.`
+          : `Não sobrou nada, ou seja, ${n} é par, e todo número par tem o bit da direita desligado.`
+      } Esse resto vai para a posição ${largura - 1 - pos === 0 ? "mais à direita" : `de expoente ${largura - 1 - pos}`} da fita, e não para a próxima posição livre da esquerda: cada divisão pergunta por um bit mais significativo que a anterior.`,
+    });
+    n = q;
+    pos--;
+  }
+
+  const bin = bits.map((b) => b ?? 0);
+  out.push({
+    linhas: [...linhas],
+    bits: bin,
+    destaque: -1,
+    posicao: -1,
+    linha: 6,
+    ok: true,
+    nota: `Cheguei a zero, então acabou: ${valor} em binário é ${bin.join("")}. Foram ${linhas.length} divisões para ${linhas.length} bits significativos, e os zeros à esquerda entram só para completar o byte. Conferindo pelo outro caminho: ${bits
+      .map((b, k) => (b ? 1 << (largura - 1 - k) : 0))
+      .filter((x) => x > 0)
+      .join(" + ")} = ${valor}.`,
+  });
+  return out;
+}
+
+export function BinarioDivisoes() {
+  const [presetKey, setPresetKey] = useState("duzentos");
+  const [passo, setPasso] = useState(0);
+  const [tocando, setTocando] = useState(false);
+  const [velocidade, setVelocidade] = useState(4);
+  const [expanded, setExpanded] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => setMounted(true), []);
+
+  const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
+  const passos = useMemo(() => gerarPassos(preset.valor), [preset]);
+  const total = passos.length;
+  const idx = Math.min(passo, total - 1);
+  const p = passos[idx];
+
+  const parar = useCallback(() => {
+    if (timer.current) {
+      clearInterval(timer.current);
+      timer.current = null;
+    }
+  }, []);
+  useEffect(() => () => parar(), [parar]);
+  useEffect(() => {
+    parar();
+    if (!tocando) return;
+    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
+    return parar;
+  }, [tocando, velocidade, total, parar]);
+  useEffect(() => {
+    if (tocando && idx >= total - 1) setTocando(false);
+  }, [tocando, idx, total]);
+  useEffect(() => {
+    if (!expanded) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setExpanded(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [expanded]);
+
+  const reiniciar = () => {
+    parar();
+    setTocando(false);
+    setPasso(0);
+  };
+  const trocarPreset = (k: string) => {
+    reiniciar();
+    setPresetKey(k);
+  };
+
+  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const largura = p.bits.length;
+
+  const viz = (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · de decimal para binário, dividindo por 2</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            passo {idx + 1} de {total}
+          </span>
+          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
+            {expanded ? "✕ Fechar" : "⤢ Expandir"}
+          </button>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {PRESETS.map((pr) => (
+            <button
+              key={pr.key}
+              className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
+              onClick={() => trocarPreset(pr.key)}
+              aria-pressed={presetKey === pr.key}
+            >
+              {pr.rotulo}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">{preset.dica}</p>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            A fita de bits <em>preenchida da direita para a esquerda, um por divisão</em>
+          </div>
+          <div className="bn-fita">
+            {p.bits.map((b, k) => (
+              <span key={k} className={`bn-bit estatico${b === 1 ? " on" : ""}${b === null ? " vazio" : ""}${k === p.posicao ? " novo" : ""}`}>
+                <span className="bn-bit-val">{b === null ? "?" : b}</span>
+                <span className="bn-bit-exp">
+                  2<sup>{largura - 1 - k}</sup>
+                </span>
+                <span className="bn-bit-peso">{1 << (largura - 1 - k)}</span>
+              </span>
+            ))}
+          </div>
+        </div>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            As divisões <em>o quociente vira a próxima linha, o resto vira um bit</em>
+          </div>
+          <ol className="bb-passos">
+            {p.linhas.length === 0 ? (
+              <li>
+                <span>nenhuma divisão ainda</span>
+              </li>
+            ) : (
+              p.linhas.map((l, k) => (
+                <li key={k} className={k === p.destaque ? "ruim" : ""}>
+                  <span>
+                    {l.n} ÷ 2 = {l.quociente}
+                  </span>
+                  <b>resto {l.resto}</b>
+                </li>
+              ))
+            )}
+          </ol>
+        </div>
+
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+
+        <div className="viz-split">
+          <div className="viz-code">
+            <div className="viz-code-head">para_binario.py</div>
+            <div className="viz-code-body">
+              {CODIGO.map((txt, k) => (
+                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
+                  <span className="ln">{k + 1}</span>
+                  {txt}
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="viz-vars">
+            <div className="viz-vars-head">Variáveis</div>
+            <div className="viz-var">
+              <span className="viz-var-name">n (o que falta converter)</span>
+              <span className="viz-var-val best">{p.linhas.length > 0 ? p.linhas[p.linhas.length - 1].quociente : preset.valor}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">último resto</span>
+              <span className="viz-var-val">{p.linhas.length > 0 ? p.linhas[p.linhas.length - 1].resto : "-"}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">bits já escritos</span>
+              <span className="viz-var-val">{p.bits.filter((b) => b !== null).length}</span>
+            </div>
+          </div>
+        </div>
+
+        <div className="bigo-stats">
+          <div className="bigo-stat">
+            <span>número de partida</span>
+            <strong>{preset.valor}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>divisões feitas</span>
+            <strong>{p.linhas.length}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>bits significativos</span>
+            <strong>{preset.valor.toString(2).length}</strong>
+          </div>
+          <div className="bigo-stat">
+            <span>bits já ligados na fita</span>
+            <strong>{p.bits.filter((b) => b === 1).length}</strong>
+          </div>
+        </div>
+
+        <div className="viz-controls">
+          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
+            ↺
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === 0}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.max(0, s - 1));
+            }}
+          >
+            ‹ Anterior
+          </button>
+          <button
+            className="viz-play"
+            onClick={() => {
+              if (tocando) {
+                setTocando(false);
+                return;
+              }
+              setPasso(idx >= total - 1 ? 0 : idx);
+              setTocando(true);
+            }}
+          >
+            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+          </button>
+          <button
+            className="viz-btn"
+            disabled={idx === total - 1}
+            onClick={() => {
+              parar();
+              setTocando(false);
+              setPasso((s) => Math.min(s + 1, total - 1));
+            }}
+          >
+            Próximo ›
+          </button>
+          <div className="viz-speed">
+            <span>Velocidade</span>
+            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
+            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+          </div>
+        </div>
+        <div className="viz-progress">
+          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
+        </div>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          O número de divisões é o número de bits significativos, e ele cresce como log₂ do valor: 201 precisa
+          de 8 divisões, e 201 mil precisaria de 18. É a mesma razão pela qual a busca binária é barata,
+          escrita de outro jeito: dividir por dois repetidamente chega ao fim depressa.
+        </p>
+      </div>
+    </figure>
+  );
+
+  if (expanded && mounted) {
+    return createPortal(
+      <div
+        className="viz-overlay"
+        onClick={(e) => {
+          if (e.target === e.currentTarget) setExpanded(false);
+        }}
+      >
+        {viz}
+      </div>,
+      document.body
+    );
+  }
+  return viz;
+}

--- a/content/visualizers/BinarioDivisoes.tsx
+++ b/content/visualizers/BinarioDivisoes.tsx
@@ -258,7 +258,7 @@ export function BinarioDivisoes() {
               </li>
             ) : (
               p.linhas.map((l, k) => (
-                <li key={k} className={k === p.destaque ? "ruim" : ""}>
+                <li key={k} className={k === p.destaque ? "foco" : ""}>
                   <span>
                     {l.n} ÷ 2 = {l.quociente}
                   </span>

--- a/content/visualizers/BinarioFaixa.tsx
+++ b/content/visualizers/BinarioFaixa.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// BinarioFaixa, o mesmo padrão de bits lido de dois jeitos.
+//
+// A única coisa que o aluno precisa enxergar é que **o padrão de bits não sabe
+// o próprio sinal**. 11111111 é 255 ou -1 conforme o tipo com que você o lê, e
+// não existe nada guardado na memória que decida entre os dois: quem decide é a
+// declaração da variável. Por isso as duas leituras aparecem lado a lado, do
+// mesmo padrão, o tempo todo.
+//
+// A segunda ideia é o truque de leitura que dispensa a conta de inverter e
+// somar: no complemento de dois, o bit da esquerda vale MENOS 128 em vez de
+// mais 128, e o resto continua igual. Com isso, ler um negativo vira a mesma
+// soma de sempre, com um termo negativo. Por isso a decomposição escrita
+// aparece com o sinal de menos no primeiro termo, e não como uma regra à parte.
+//
+// O passo a passo pelos padrões vizinhos existe por causa da fronteira: andar
+// de 01111111 para 10000000 é somar 1 e cair de 127 para -128, e ver isso
+// acontecer é o que torna o estouro de inteiro concreto em vez de folclórico.
+// ---------------------------------------------------------------------------
+
+const N = 8;
+
+const paraBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
+const comSinal = (v: number) => (v >= 128 ? v - 256 : v);
+
+type Marco = { valor: number; rotulo: string; nota: string };
+
+const MARCOS: Marco[] = [
+  {
+    valor: 0,
+    rotulo: "00000000",
+    nota: "O zero, e ele é o mesmo nos dois mundos. É o único padrão em que as duas leituras coincidem por definição, e não por acaso.",
+  },
+  {
+    valor: 1,
+    rotulo: "00000001",
+    nota: "Um bit ligado, o da direita. Com o bit de sinal desligado, as duas leituras continuam iguais, e vão continuar assim em toda a metade de baixo da tabela.",
+  },
+  {
+    valor: 127,
+    rotulo: "01111111",
+    nota: "O último padrão em que as duas leituras coincidem: 127 nos dois. Some 1 e veja o que acontece, porque é aqui que mora o estouro de inteiro com sinal.",
+  },
+  {
+    valor: 128,
+    rotulo: "10000000",
+    nota: "O salto. Somar 1 a 127 acende o bit de sinal, e a leitura com sinal desaba de 127 para -128. Nenhum erro é reportado: para a máquina isso é só o padrão seguinte. Este é o estouro de inteiro que derruba sistema de verdade.",
+  },
+  {
+    valor: 129,
+    rotulo: "10000001",
+    nota: "Continuando a partir do fundo: com o bit de sinal ligado, acender bits à direita SOMA. -128 + 1 = -127, e daqui até 11111111 os números negativos vão subindo até chegar a -1.",
+  },
+  {
+    valor: 255,
+    rotulo: "11111111",
+    nota: "Todos os bits ligados. É 255 sem sinal e -1 com sinal, e as duas coisas são verdade ao mesmo tempo: o padrão é o mesmo, o que muda é o tipo com que ele é lido.",
+  },
+];
+
+const TIPOS = [
+  { bits: 8, semSinal: "0 a 255", comSinal: "-128 a 127" },
+  { bits: 16, semSinal: "0 a 65.535", comSinal: "-32.768 a 32.767" },
+  { bits: 32, semSinal: "0 a 4.294.967.295", comSinal: "-2.147.483.648 a 2.147.483.647" },
+  { bits: 64, semSinal: "0 a mais de 18 quintilhões", comSinal: "cerca de -9,2 a 9,2 quintilhões" },
+];
+
+export function BinarioFaixa() {
+  const [valor, setValor] = useState(128);
+  const bits = useMemo(() => paraBits(valor), [valor]);
+  const marco = MARCOS.find((m) => m.valor === valor);
+  const assinado = comSinal(valor);
+
+  // A decomposição com o peso do bit de sinal negativo: é a regra de leitura
+  // inteira do complemento de dois, escrita como soma.
+  const termos = bits
+    .map((b, k) => ({ b, peso: k === 0 ? -128 : 1 << (N - 1 - k) }))
+    .filter((t) => t.b === 1);
+
+  const andar = (d: number) => setValor((v) => (v + d + 256) % 256);
+
+  return (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · o mesmo padrão, duas leituras</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            {bits.join("")} · sem sinal {valor} · com sinal {assinado}
+          </span>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {MARCOS.map((m) => (
+            <button
+              key={m.valor}
+              className={`bigo-chip${valor === m.valor ? " on" : ""}`}
+              onClick={() => setValor(m.valor)}
+              aria-pressed={valor === m.valor}
+            >
+              {m.rotulo}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">
+          {marco
+            ? marco.nota
+            : "Use os botões de menos 1 e mais 1 para andar pelos padrões vizinhos e acompanhar as duas leituras."}
+        </p>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            O padrão de bits <em>o bit da esquerda vale -128, e é só isso que muda na leitura com sinal</em>
+          </div>
+          <div className="bn-fita">
+            {bits.map((b, k) => (
+              <span key={k} className={`bn-bit estatico${b ? " on" : ""}${k === 0 ? " sinal" : ""}`}>
+                <span className="bn-bit-val">{b}</span>
+                <span className="bn-bit-exp">
+                  {k === 0 ? (
+                    "sinal"
+                  ) : (
+                    <>
+                      2<sup>{N - 1 - k}</sup>
+                    </>
+                  )}
+                </span>
+                <span className="bn-bit-peso">{k === 0 ? "-128" : 1 << (N - 1 - k)}</span>
+              </span>
+            ))}
+          </div>
+          <div className="bn-passeio">
+            <button className="viz-btn" onClick={() => andar(-1)} aria-label="Padrão anterior">
+              ‹ menos 1
+            </button>
+            <span className="bn-passeio-txt">andar pelos padrões vizinhos</span>
+            <button className="viz-btn" onClick={() => andar(1)} aria-label="Próximo padrão">
+              mais 1 ›
+            </button>
+          </div>
+        </div>
+
+        <div className="ms-operadores">
+          <div className="ms-op">
+            <div className="bb-formula-cab">
+              <span className="bb-formula-tit">Lido como sem sinal</span>
+              <span className="bb-formula-selo">byte, uint8</span>
+            </div>
+            <p className="bn-conta">
+              {bits.every((b) => b === 0) ? (
+                <span className="bn-termo forte">0</span>
+              ) : (
+                bits
+                  .map((b, k) => ({ b, peso: 1 << (N - 1 - k) }))
+                  .filter((t) => t.b === 1)
+                  .map((t, k) => (
+                    <span key={t.peso}>
+                      {k > 0 ? <span className="bn-mais"> + </span> : null}
+                      <span className="bn-termo forte">{t.peso}</span>
+                    </span>
+                  ))
+              )}
+              <span className="bn-igual"> = {valor}</span>
+            </p>
+            <p className="bb-formula-fim">Todos os oito bits valem magnitude. A faixa vai de 0 a 255.</p>
+          </div>
+          <div className={`ms-op${bits[0] === 1 ? " quebrou" : " ok"}`}>
+            <div className="bb-formula-cab">
+              <span className="bb-formula-tit">Lido como com sinal</span>
+              <span className="bb-formula-selo">sbyte, int8</span>
+            </div>
+            <p className="bn-conta">
+              {termos.length === 0 ? (
+                <span className="bn-termo forte">0</span>
+              ) : (
+                termos.map((t, k) => (
+                  <span key={t.peso}>
+                    {k > 0 ? <span className="bn-mais"> + </span> : null}
+                    <span className={`bn-termo forte${t.peso < 0 ? " negativo" : ""}`}>{t.peso}</span>
+                  </span>
+                ))
+              )}
+              <span className="bn-igual"> = {assinado}</span>
+            </p>
+            <p className="bb-formula-fim">
+              O bit da esquerda vale <strong>-128</strong> em vez de +128. Todo o resto da conta é idêntico, e é
+              por isso que não existe uma "regra de ler negativo": existe um peso negativo.
+            </p>
+          </div>
+        </div>
+
+        <p className={`viz-note${valor === 128 ? " invalid" : " ok"}`}>
+          {valor === 128 ? (
+            <>
+              Este é o padrão da virada. Vindo de <strong>01111111</strong> (127) e somando 1, o vai-um sobe até
+              o bit de sinal e o número desaba para <strong>-128</strong>. Nenhuma exceção é lançada e nenhum
+              aviso aparece: para a máquina isso é só o padrão de bits seguinte. É exatamente esse silêncio que
+              torna o estouro de inteiro com sinal um dos erros mais difíceis de achar depois que acontece.
+            </>
+          ) : (
+            <>
+              O padrão <strong>{bits.join("")}</strong> vale <strong>{valor}</strong> lido como byte sem sinal e{" "}
+              <strong>{assinado}</strong> lido como byte com sinal. Os dois números estão certos: nada na
+              memória diz qual é o correto, quem decide é o tipo declarado na variável. Um valor lido com o tipo
+              errado não dá erro, dá outro número.
+            </>
+          )}
+        </p>
+
+        <div className="hp-bloco">
+          <div className="tt-painel-tit">
+            As faixas por tamanho <em>com e sem sinal, o mesmo número de padrões</em>
+          </div>
+          <div className="bigo-fam-scroll">
+            <table className="bigo-fam-table">
+              <thead>
+                <tr>
+                  <th>bits</th>
+                  <th>sem sinal</th>
+                  <th>com sinal</th>
+                </tr>
+              </thead>
+              <tbody>
+                {TIPOS.map((t) => (
+                  <tr key={t.bits} className={t.bits === 8 ? "hp-destaque" : ""}>
+                    <td>
+                      <div className="bigo-fam-not hp-nome">{t.bits}</div>
+                    </td>
+                    <td>
+                      <span className="bn-escrita">{t.semSinal}</span>
+                    </td>
+                    <td>
+                      <span className="bn-escrita">{t.comSinal}</span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          Repare que a faixa com sinal nunca é simétrica: com 8 bits vai de -128 a 127, e não de -128 a 128. O
+          motivo não é arbitrário: são 256 padrões e o zero ocupa um deles, então sobram 255 para distribuir
+          entre positivos e negativos, e o lado negativo fica com um a mais porque não precisa gastar padrão com
+          o zero. Essa assimetria é a razão de `-Integer.MIN_VALUE` continuar negativo em Java e de
+          `abs(-2147483648)` devolver um número negativo em C: não existe o positivo correspondente.
+        </p>
+      </div>
+    </figure>
+  );
+}

--- a/content/visualizers/BinarioFaixa.tsx
+++ b/content/visualizers/BinarioFaixa.tsx
@@ -149,6 +149,10 @@ export function BinarioFaixa() {
           </div>
         </div>
 
+        {/* Os dois cards ficam neutros de propósito. Nenhuma das duas leituras é
+            errada: o mesmo padrão vale 255 ou -1 conforme o tipo, e pintar a
+            leitura com sinal de vermelho quando o bit de sinal acende diria o
+            contrário do que o texto ao lado afirma. */}
         <div className="ms-operadores">
           <div className="ms-op">
             <div className="bb-formula-cab">
@@ -173,7 +177,7 @@ export function BinarioFaixa() {
             </p>
             <p className="bb-formula-fim">Todos os oito bits valem magnitude. A faixa vai de 0 a 255.</p>
           </div>
-          <div className={`ms-op${bits[0] === 1 ? " quebrou" : " ok"}`}>
+          <div className="ms-op">
             <div className="bb-formula-cab">
               <span className="bb-formula-tit">Lido como com sinal</span>
               <span className="bb-formula-selo">sbyte, int8</span>

--- a/content/visualizers/BinarioTresFormas.tsx
+++ b/content/visualizers/BinarioTresFormas.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// BinarioTresFormas, por que o complemento de dois venceu.
+//
+// A única coisa que o aluno precisa enxergar é que as três convenções não são
+// alternativas de gosto: duas delas têm um defeito concreto e nomeável, e a
+// terceira não tem. Por isso a tela não é uma tabela comparativa com colunas de
+// prós e contras; ela é um teste, aplicado às três, com o resultado calculado.
+//
+// Os três testes são os que decidiram a história: existe mais de uma forma de
+// escrever zero? somar o número com o oposto dele dá zero? e quantos números
+// distintos os 256 padrões conseguem escrever? Sinal-magnitude e complemento de
+// um reprovam nos três; complemento de dois passa nos três. Nada disso é
+// opinião, e por isso tudo aqui é computado sobre os 256 padrões.
+//
+// Interativo sem linha do tempo: a variável é o número, e as três convenções
+// respondem juntas.
+// ---------------------------------------------------------------------------
+
+const N = 8;
+
+type Forma = "sinal" | "um" | "dois";
+
+const NOMES: Record<Forma, string> = {
+  sinal: "Sinal e magnitude",
+  um: "Complemento de um",
+  dois: "Complemento de dois",
+};
+
+const COMO: Record<Forma, string> = {
+  sinal: "liga o bit da esquerda e deixa o resto como está",
+  um: "inverte todos os bits",
+  dois: "inverte todos os bits e soma 1",
+};
+
+const paraBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
+const paraNum = (b: number[]) => b.reduce((acc, x, k) => acc + (x << (N - 1 - k)), 0);
+
+function negar(v: number, forma: Forma): number[] {
+  const b = paraBits(v);
+  if (forma === "sinal") return [1, ...b.slice(1)];
+  const inv = b.map((x) => 1 - x);
+  if (forma === "um") return inv;
+  return paraBits((paraNum(inv) + 1) & 0xff);
+}
+
+// Como cada convenção LÊ um padrão de bits de volta para um número. É a leitura
+// que fecha o par com a escrita, e é ela que diz se a convenção é coerente.
+function ler(b: number[], forma: Forma): number {
+  const semSinal = paraNum(b);
+  if (forma === "sinal") return b[0] === 1 ? -(semSinal - 128) : semSinal;
+  if (forma === "um") return b[0] === 1 ? -(255 - semSinal) : semSinal;
+  return b[0] === 1 ? semSinal - 256 : semSinal;
+}
+
+const VALORES = [26, 1, 127, 0];
+
+export function BinarioTresFormas() {
+  const [valor, setValor] = useState(26);
+  const FORMAS: Forma[] = ["sinal", "um", "dois"];
+
+  const linhas = useMemo(
+    () =>
+      FORMAS.map((f) => {
+        const neg = negar(valor, f);
+        const pos = paraBits(valor);
+        // teste 1: quantos padrões de bits são lidos como zero
+        const zeros = Array.from({ length: 256 }, (_, k) => paraBits(k)).filter((b) => ler(b, f) === 0).length;
+        // teste 2: somar os dois padrões (em 8 bits, descartando o vai-um) dá zero?
+        const soma = (paraNum(pos) + paraNum(neg)) & 0xff;
+        // teste 3: quantos números DISTINTOS os 256 padrões conseguem escrever.
+        // Zero duplicado é padrão desperdiçado, e o desperdício aparece aqui.
+        const distintos = new Set(Array.from({ length: 256 }, (_, k) => ler(paraBits(k), f))).size;
+        const faixa = Array.from({ length: 256 }, (_, k) => ler(paraBits(k), f));
+        return { forma: f, pos, neg, zeros, soma, distintos, min: Math.min(...faixa), max: Math.max(...faixa), lido: ler(neg, f) };
+      }),
+    [valor]
+  );
+
+  return (
+    <figure className="viz" style={{ margin: 0 }}>
+      <div className="viz-head">
+        <div className="viz-head-title">
+          <span className="dot" />
+          <span>Visualizador · três formas de escrever um negativo, e três testes</span>
+        </div>
+        <div className="viz-head-right">
+          <span className="viz-step">
+            {linhas.filter((l) => l.zeros === 1 && l.soma === 0 && l.distintos === 256).length} de 3 passam nos três testes
+          </span>
+        </div>
+      </div>
+
+      <div className="viz-body">
+        <div className="bigo-chips">
+          {VALORES.map((v) => (
+            <button key={v} className={`bigo-chip${valor === v ? " on" : ""}`} onClick={() => setValor(v)} aria-pressed={valor === v}>
+              negar {v}
+            </button>
+          ))}
+        </div>
+
+        <p className="tt-legenda-arvore">
+          Todas as três resolvem o problema de escrever um número negativo sem inventar um símbolo de menos:
+          elas sacrificam o bit da esquerda, que deixa de valer magnitude e passa a valer sinal. A diferença
+          está no que acontece com o zero e com a aritmética, e é isso que os três testes medem: quantos
+          padrões de bits valem zero, se somar um número com o oposto dá zero, e quantos números distintos os
+          256 padrões conseguem escrever.
+        </p>
+
+        <div className="ms-operadores">
+          {linhas.map((l) => {
+            const passa = l.zeros === 1 && l.soma === 0 && l.distintos === 256;
+            return (
+              <div className={`ms-op${passa ? " ok" : " quebrou"}`} key={l.forma}>
+                <div className="bb-formula-cab">
+                  <span className="bb-formula-tit">{NOMES[l.forma]}</span>
+                  <span className="bb-formula-selo">{passa ? "passa nos três" : "reprova"}</span>
+                </div>
+                <p className="bb-array-nota" style={{ marginBottom: 8 }}>
+                  Para negar, {COMO[l.forma]}.
+                </p>
+                <div className="bn-fita compacta">
+                  {l.neg.map((b, k) => (
+                    <span key={k} className={`bn-bit estatico${b ? " on" : ""}${k === 0 ? " sinal" : ""}`}>
+                      <span className="bn-bit-val">{b}</span>
+                    </span>
+                  ))}
+                </div>
+                <p className="bb-formula-fim">
+                  Lido de volta: <strong>{l.lido}</strong>
+                  {l.lido === -valor ? "" : " (não bate com o esperado)"}
+                </p>
+                <ol className="bb-passos">
+                  <li className={l.zeros === 1 ? "" : "ruim"}>
+                    <span>padrões de bits que valem zero</span>
+                    <b>{l.zeros}</b>
+                  </li>
+                  <li className={l.soma === 0 ? "" : "ruim"}>
+                    <span>x + (-x) em 8 bits</span>
+                    <b>{l.soma}</b>
+                  </li>
+                  <li className={l.distintos === 256 ? "" : "ruim"}>
+                    <span>números distintos nos 256 padrões</span>
+                    <b>{l.distintos}</b>
+                  </li>
+                  <li>
+                    <span>faixa que ela alcança</span>
+                    <b>
+                      {l.min} a {l.max}
+                    </b>
+                  </li>
+                </ol>
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="viz-note ok">
+          O primeiro teste é o do <strong>zero duplo</strong>. Em sinal e magnitude, 00000000 e 10000000 são os
+          dois lidos como zero; em complemento de um, 00000000 e 11111111. Ter duas escritas para o mesmo
+          número obriga toda comparação de igualdade a tratar um caso especial, e desperdiça um dos 256
+          padrões disponíveis. Só o complemento de dois tem um zero e um só.
+          <br />
+          <br />O segundo é o da <strong>aritmética</strong>. Somar um número com o oposto dele tem que dar
+          zero, e é isso que permite ao processador subtrair usando o mesmo circuito que soma. No complemento
+          de dois isso vale sempre, com o vai-um final estourando os oito bits e sendo descartado. Nas outras
+          duas não vale, e a máquina precisaria de correções extras.
+        </p>
+
+        <p className="viz-caption" style={{ margin: "12px 0 0" }}>
+          Vale registrar o preço que as três pagam igual: com o bit da esquerda reservado para o sinal, sobram
+          sete bits de magnitude, e o alcance sai de 0 a 255 para algo em torno de -128 a 127. E vale reparar
+          numa consequência do zero duplo que passa despercebida: com 256 padrões de bits, sinal-magnitude e
+          complemento de um escrevem só <strong>255 números distintos</strong>, porque dois padrões dizem a
+          mesma coisa. O complemento de dois escreve 256, e é por isso que a faixa dele é -128 a 127, assimétrica
+          de propósito.
+        </p>
+      </div>
+    </figure>
+  );
+}

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -77,6 +77,15 @@ import { QuickSortTresVias } from "@content/visualizers/QuickSortTresVias";
 import { ShellSortVisualizer } from "@content/visualizers/ShellSortVisualizer";
 import { ShellSortSubsequencias } from "@content/visualizers/ShellSortSubsequencias";
 import { ShellSortGaps } from "@content/visualizers/ShellSortGaps";
+import { BacktrackingVisualizer } from "@content/visualizers/BacktrackingVisualizer";
+import { BacktrackingSudoku } from "@content/visualizers/BacktrackingSudoku";
+import { BacktrackingPoda } from "@content/visualizers/BacktrackingPoda";
+import { BinarioConversor } from "@content/visualizers/BinarioConversor";
+import { BinarioDivisoes } from "@content/visualizers/BinarioDivisoes";
+import { BinarioBases } from "@content/visualizers/BinarioBases";
+import { BinarioComplemento } from "@content/visualizers/BinarioComplemento";
+import { BinarioTresFormas } from "@content/visualizers/BinarioTresFormas";
+import { BinarioFaixa } from "@content/visualizers/BinarioFaixa";
 import { slugify, textOf } from "@/lib/slug";
 
 /**
@@ -264,6 +273,15 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ShellSortVisualizer,
     ShellSortSubsequencias,
     ShellSortGaps,
+    BacktrackingVisualizer,
+    BacktrackingSudoku,
+    BacktrackingPoda,
+    BinarioConversor,
+    BinarioDivisoes,
+    BinarioBases,
+    BinarioComplemento,
+    BinarioTresFormas,
+    BinarioFaixa,
     ...components,
   };
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1534,6 +1534,81 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 .ss-selo.nao { border-color: rgba(255, 255, 255, 0.1); }
 .ord-linha.ss-base { border-style: dashed; }
 
+/* --- backtracking: a árvore explorada, a pilha, o sudoku e as rainhas ------
+   A árvore reusa a família tt-no; o que entra aqui é o estado "ainda não
+   visitado", que não existia (nas outras árvores todo nó já está lá desde o
+   começo), mais os dois tabuleiros. */
+.tt-no.porvir circle { fill: #0e1725; stroke: rgba(255, 255, 255, 0.1); }
+.tt-no.porvir text { fill: #3d4d63; }
+.bt-no text { font-size: 10.5px; }
+
+.bt-paineis { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 12px; }
+.bt-pilha { display: flex; flex-direction: column-reverse; gap: 4px; }
+.bt-quadro { padding: 5px 10px; border: 1px solid var(--ccc-line); border-left: 3px solid rgba(255, 255, 255, 0.14); border-radius: 7px; background: #0f1826; font-family: var(--mono); font-size: 11.5px; color: #8ba0bb; }
+.bt-quadro.topo { border-left-color: var(--ccc-accent); background: rgba(59, 130, 246, 0.14); color: #dbeafe; }
+
+.bt-solucoes { display: flex; flex-wrap: wrap; gap: 6px; }
+.bt-sol { padding: 4px 10px; border: 1px solid rgba(52, 211, 153, 0.4); border-radius: 999px; background: rgba(52, 211, 153, 0.1); font-family: var(--mono); font-size: 12px; color: #a7f3d0; }
+.bt-sol.nova { border-color: var(--ccc-green); background: rgba(52, 211, 153, 0.24); color: #fff; animation: cccPulse 1s ease-out; }
+
+.bt-sudoku-wrap { overflow-x: auto; }
+.bt-sudoku { display: grid; gap: 0; width: max-content; min-width: 100%; max-width: 420px; margin: 0 auto; border: 2px solid rgba(255, 255, 255, 0.3); border-radius: 6px; overflow: hidden; }
+.bt-cel { display: grid; place-items: center; aspect-ratio: 1; min-width: 26px; border: 1px solid rgba(255, 255, 255, 0.08); font-family: var(--mono); font-size: 15px; font-weight: 600; color: #93bbfd; transition: background 0.15s ease, color 0.15s ease; }
+.bt-cel.topo { border-top: 2px solid rgba(255, 255, 255, 0.28); }
+.bt-cel.esq { border-left: 2px solid rgba(255, 255, 255, 0.28); }
+.bt-cel.fixa { background: rgba(255, 255, 255, 0.05); color: #cbd9ea; }
+.bt-cel.foco { background: rgba(52, 211, 153, 0.28); color: #fff; }
+.bt-cel.conflito { background: rgba(248, 113, 113, 0.26); color: #fecaca; text-decoration: line-through; }
+.bt-cel.apagou { background: rgba(251, 191, 36, 0.24); color: #fcd34d; text-decoration: line-through; }
+.bt-sudoku.n4 .bt-cel { font-size: 17px; }
+
+.bt-rainhas-topo { display: flex; flex-wrap: wrap; gap: 5px; margin-bottom: 10px; }
+.bt-rainhas { display: grid; width: max-content; min-width: 240px; max-width: 320px; margin: 0 auto; border: 2px solid rgba(255, 255, 255, 0.25); border-radius: 6px; overflow: hidden; }
+.bt-casa { display: grid; place-items: center; aspect-ratio: 1; min-width: 28px; background: #0d1421; font-size: 19px; line-height: 1; }
+.bt-casa.clara { background: #16202f; }
+.bt-casa.rainha { color: #fcd34d; }
+
+/* --- números binários: a fita de bits, a conta por extenso e o vai-um ------
+   A fita é flex com itens de base zero, e não largura fixa: com 8 a 16 bits ela
+   precisa caber em 390px sem rolagem, e deixar cada bit encolher é o que
+   garante isso sem media query por quantidade. */
+.bn-fita { display: flex; gap: 4px; }
+.bn-bit { display: flex; flex: 1 1 0; flex-direction: column; align-items: center; gap: 1px; min-width: 0; padding: 7px 2px 5px; border: 1.5px solid rgba(255, 255, 255, 0.12); border-radius: 8px; background: #0f1826; font: inherit; color: #6b7f99; cursor: pointer; transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease; }
+.bn-bit.estatico { cursor: default; }
+.bn-bit:hover:not(.estatico) { border-color: rgba(255, 255, 255, 0.3); }
+.bn-bit:focus-visible { outline: 2px solid var(--ccc-accent); outline-offset: 2px; }
+.bn-bit.on { border-color: var(--ccc-accent); background: rgba(59, 130, 246, 0.22); color: #dbeafe; }
+.bn-bit.vazio { border-style: dashed; opacity: 0.55; }
+.bn-bit.novo { animation: cccPulse 1s ease-out; border-color: var(--ccc-green); }
+.bn-bit.sinal { border-color: rgba(251, 191, 36, 0.55); }
+.bn-bit.sinal.on { border-color: #f87171; background: rgba(248, 113, 113, 0.24); color: #fecaca; }
+.bn-bit-val { font-family: var(--mono); font-size: 17px; font-weight: 700; line-height: 1.1; }
+.bn-bit-exp { font-family: var(--mono); font-size: 9px; color: #4c5f79; }
+.bn-bit-peso { font-family: var(--mono); font-size: 9.5px; color: #6b7f99; }
+.bn-fita.compacta .bn-bit { padding: 5px 2px; }
+.bn-fita.compacta .bn-bit-val { font-size: 14px; }
+
+.bn-conta { margin: 0 0 6px; font-family: var(--mono); font-size: 13px; line-height: 1.9; color: #8ba0bb; }
+.bn-termo { padding: 2px 6px; border-radius: 6px; background: rgba(255, 255, 255, 0.05); }
+.bn-termo.forte { background: rgba(59, 130, 246, 0.16); color: #93bbfd; }
+.bn-termo.forte.negativo { background: rgba(248, 113, 113, 0.16); color: #fca5a5; }
+.bn-mais { color: #4c5f79; }
+.bn-igual { font-weight: 700; color: #fff; }
+
+.bn-carrys { display: flex; gap: 4px; align-items: center; margin-top: 6px; }
+.bn-carry { display: grid; flex: 1 1 0; place-items: center; min-width: 0; height: 20px; border-radius: 5px; font-family: var(--mono); font-size: 11px; color: #4c5f79; }
+.bn-carry.on { background: rgba(251, 191, 36, 0.18); color: #fcd34d; }
+.bn-carry-rot { flex: 0 0 auto; padding-left: 6px; font-size: 10px; color: #6b7f99; }
+
+.bn-escrita { font-family: var(--mono); font-size: 13.5px; color: #cbd9ea; word-break: break-all; }
+.bn-grupos { display: flex; flex-wrap: wrap; gap: 8px; }
+.bn-grupo { display: flex; flex-direction: column; align-items: center; gap: 3px; padding: 7px 10px; border: 1px solid var(--ccc-line); border-radius: 9px; background: #0e1725; }
+.bn-grupo-bits { font-family: var(--mono); font-size: 13px; color: #93bbfd; letter-spacing: 0.08em; }
+.bn-grupo-hex { font-family: var(--mono); font-size: 15px; font-weight: 700; color: #fcd34d; }
+
+.bn-passeio { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 10px; margin-top: 10px; }
+.bn-passeio-txt { font-size: 11.5px; color: var(--ccc-muted); }
+
 /* ------------------------------ responsive ------------------------------ */
 @media (max-width: 1000px) {
   .shell { grid-template-columns: minmax(0, 1fr); }
@@ -1584,6 +1659,15 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
   .bb-formulas, .hp-formulas { grid-template-columns: minmax(0, 1fr); }
   /* os dois lados da intercalação e as duas versões do operador viram lista */
   .ms-merge, .ms-operadores { grid-template-columns: minmax(0, 1fr); }
+  /* solução parcial e pilha de chamadas empilham: lado a lado em telas
+     estreitas as duas ficam sem largura para o rótulo do quadro. */
+  .bt-paineis { grid-template-columns: minmax(0, 1fr); }
+  /* a fita de bits encolhe junto: com 8 colunas em 300px de largura útil,
+     o peso da posição não cabe e o dígito precisa diminuir para o bit não
+     virar uma coluna de 20px. */
+  .bn-bit { padding: 5px 1px 4px; }
+  .bn-bit-val { font-size: 14px; }
+  .bn-bit-exp, .bn-bit-peso { font-size: 8px; }
 }
 @media (max-width: 560px) {
   .brand-name { display: none; } /* no celular, só o logo */

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1455,6 +1455,10 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 .bb-passos li b { font-family: var(--mono); font-size: 14px; color: #cbd9ea; }
 .bb-passos li.ruim { background: rgba(248, 113, 113, 0.1); }
 .bb-passos li.ruim b { color: #fca5a5; }
+/* Foco NÃO é falha: o vermelho do .ruim afirma que algo deu errado, e usá-lo
+   para marcar a linha corrente de uma lista faz o passo atual parecer defeito. */
+.bb-passos li.foco { background: rgba(59, 130, 246, 0.14); }
+.bb-passos li.foco b { color: #93bbfd; }
 .bb-formula-fim { margin: 10px 0 0; font-size: 12.5px; line-height: 1.55; color: #8ba0bb; }
 
 .bb-bits { display: flex; flex-wrap: wrap; gap: 2px; margin: 8px 0 10px; }

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { ALL_TOPICS } from "../content/roadmap";
+import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 
 test("home mostra o hero e leva para o Big O", async ({ page }) => {
   await page.goto("/");
@@ -297,6 +297,9 @@ const TOPICOS_PRONTOS = [
   { slug: "merge-sort", h1: "Merge Sort", vizMin: 3 },
   { slug: "quick-sort", h1: "Quick Sort", vizMin: 3 },
   { slug: "shell-sort", h1: "Shell Sort", vizMin: 3 },
+  { slug: "backtracking", h1: "Backtracking", vizMin: 3 },
+  { slug: "binary-numbers", h1: "Números Binários", vizMin: 3 },
+  { slug: "negative-binary", h1: "Binários Negativos", vizMin: 3 },
 ];
 
 for (const t of TOPICOS_PRONTOS) {
@@ -861,6 +864,184 @@ test("shell sort: a h-ordenação não se perde e o gap só compensa com n grand
   await expect(gaps.locator(".viz-note")).toContainText("Aumentar o tamanho não vira essa conta");
 });
 
+test("backtracking: escolher, explorar e desfazer, com a lista voltando ao início", async ({ page }) => {
+  await page.goto("/topico/backtracking/");
+  const viz = page.locator("figure.viz").filter({ hasText: "escolher, explorar, desfazer" });
+  const proximo = viz.getByRole("button", { name: "Próximo ›" });
+  const stat = (rot: RegExp) => viz.locator(".bigo-stat").filter({ hasText: rot }).locator("strong");
+  const irAteOFim = async () => {
+    await expect(proximo).toBeEnabled();
+    for (let i = 0; i < 200 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo).toBeDisabled();
+  };
+
+  // subconjuntos de 1,2,3: todo nó é resposta, então 8 nós e 8 soluções
+  await irAteOFim();
+  await expect(stat(/^nós visitados\d/)).toHaveText("8");
+  await expect(stat(/^soluções encontradas\d/)).toHaveText("8");
+  // a invariante: um retrocesso por aresta, ou seja, nós - 1
+  await expect(stat(/^retrocessos\d/)).toHaveText("7");
+  // e a solução parcial termina vazia, porque todo escolher teve o seu desfazer
+  await expect(viz.locator(".hp-bloco").first()).toContainText("vazia");
+
+  // permutações: só as folhas são resposta, então 16 nós para 6 soluções
+  await viz.getByRole("button", { name: /Permutações/ }).click();
+  await irAteOFim();
+  await expect(stat(/^nós visitados\d/)).toHaveText("16");
+  await expect(stat(/^soluções encontradas\d/)).toHaveText("6");
+  await expect(stat(/^retrocessos\d/)).toHaveText("15");
+  await expect(viz.locator(".bt-sol")).toHaveCount(6);
+
+  // combinações de 2 entre 4: C(4,2) = 6, com 10 nós
+  await viz.getByRole("button", { name: /Combinações/ }).click();
+  await irAteOFim();
+  await expect(stat(/^nós visitados\d/)).toHaveText("10");
+  await expect(stat(/^soluções encontradas\d/)).toHaveText("6");
+});
+
+test("backtracking: o sudoku fecha válido e a poda não muda a resposta", async ({ page }) => {
+  await page.goto("/topico/backtracking/");
+  const sud = page.locator("figure.viz").filter({ hasText: "resolvendo sudoku" });
+  const proximo = sud.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeEnabled();
+  for (let i = 0; i < 400 && (await proximo.isEnabled()); i++) await proximo.click();
+  await expect(proximo).toBeDisabled();
+
+  // 4x4 resolvido: nenhuma célula vazia e os quatro dígitos em cada linha
+  const celulas = sud.locator(".bt-cel");
+  await expect(celulas).toHaveCount(16);
+  const valores = await celulas.allTextContents();
+  expect(valores.filter((v) => v.trim() === ""), "sobrou célula vazia no fim").toHaveLength(0);
+  for (let r = 0; r < 4; r++) {
+    const linha = valores.slice(r * 4, r * 4 + 4).sort();
+    expect(linha, `linha ${r + 1} do sudoku`).toEqual(["1", "2", "3", "4"]);
+  }
+  await expect(sud.locator(".bigo-stat").filter({ hasText: /^dígitos testados\d/ }).locator("strong")).toHaveText("51");
+
+  // a poda visita muito menos nós E devolve exatamente as mesmas soluções
+  const poda = page.locator("figure.viz").filter({ hasText: "mesma resposta, uma fração" });
+  const barras = poda.locator(".bb-barra-txt");
+  await expect(barras.nth(0)).toHaveText("55.987"); // sem poda, 6 rainhas
+  await expect(barras.nth(1)).toHaveText("4"); // soluções sem poda
+  await expect(barras.nth(2)).toHaveText("153"); // com poda
+  await expect(barras.nth(3)).toHaveText("4"); // soluções com poda
+  await expect(poda).toContainText("exatamente as mesmas da versão sem poda");
+  // e a razão cresce com o tabuleiro: com 4 rainhas ela é bem menor
+  await poda.getByRole("button", { name: "4 rainhas" }).click();
+  await expect(barras.nth(0)).toHaveText("341");
+  await expect(barras.nth(2)).toHaveText("17");
+});
+
+test("números binários: a soma das posições ligadas e as divisões por 2", async ({ page }) => {
+  await page.goto("/topico/binary-numbers/");
+  const conv = page.locator("figure.viz").filter({ hasText: "soma de potências de dois" });
+  const stat = (rot: RegExp) => conv.locator(".bigo-stat").filter({ hasText: rot }).locator("strong");
+
+  // abre em 53 = 00110101, com quatro bits ligados
+  await expect(conv.locator(".viz-step")).toHaveText("00110101 = 53");
+  await expect(stat(/^valor decimal\d/)).toHaveText("53");
+  await expect(stat(/^bits ligados\d/)).toHaveText("4");
+
+  // clicar no bit mais significativo soma 128, e não 1: é o teste de que o
+  // peso da posição está sendo aplicado e não só contado
+  await conv.getByRole("button", { name: /Bit de expoente 7/ }).click();
+  await expect(stat(/^valor decimal\d/)).toHaveText("181");
+  await conv.getByRole("button", { name: /Bit de expoente 7/ }).click();
+  await expect(stat(/^valor decimal\d/)).toHaveText("53");
+  // e o da direita soma 1
+  await conv.getByRole("button", { name: /Bit de expoente 0/ }).click();
+  await expect(stat(/^valor decimal\d/)).toHaveText("52");
+
+  // as divisões: 201 precisa de 8 divisões e fecha em 11001001
+  const div = page.locator("figure.viz").filter({ hasText: "dividindo por 2" });
+  const proximo = div.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeEnabled();
+  for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
+  await expect(proximo).toBeDisabled();
+  await expect(div.locator(".bigo-stat").filter({ hasText: /^divisões feitas\d/ }).locator("strong")).toHaveText("8");
+  await expect(div.locator(".viz-note")).toContainText("11001001");
+  await expect(div.locator(".viz-note")).toContainText("128 + 64 + 8 + 1 = 201");
+
+  // as bases: o mesmo número escrito de quatro formas, e hexa em grupos de 4 bits
+  const bases = page.locator("figure.viz").filter({ hasText: "a base é um parâmetro" });
+  await bases.getByRole("button", { name: "48.879" }).click();
+  await expect(bases.locator(".viz-step")).toContainText("0xBEEF");
+  await expect(bases.locator(".bn-grupo-hex")).toHaveText(["B", "E", "E", "F"]);
+});
+
+test("binários negativos: complemento de dois, zero único e o padrão sem sinal", async ({ page }) => {
+  await page.goto("/topico/negative-binary/");
+  const comp = page.locator("figure.viz").filter({ hasText: "inverter e somar 1" });
+  const proximo = comp.getByRole("button", { name: "Próximo ›" });
+  const irAteOFim = async () => {
+    await expect(proximo).toBeEnabled();
+    for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo).toBeDisabled();
+  };
+
+  // 26 -> 11100110, e a prova soma zero
+  await irAteOFim();
+  await expect(comp.locator(".viz-note")).toContainText("11100110");
+  await expect(comp.locator(".viz-note")).toContainText("vai-um sobrando");
+
+  // o zero é o caso que prova a ausência de ambiguidade: o oposto dele é ele
+  await comp.getByRole("button", { name: /teste da ambiguidade/ }).click();
+  await irAteOFim();
+  await expect(comp.locator(".viz-var").nth(2)).toContainText("0");
+
+  // as três convenções: só o complemento de dois tem um zero e soma zero
+  const tres = page.locator("figure.viz").filter({ hasText: "três formas de escrever um negativo" });
+  await expect(tres.locator(".viz-step")).toHaveText("1 de 3 passam nos três testes");
+  const zeros = (col: number) => tres.locator(".ms-op").nth(col).locator(".bb-passos li b").first();
+  await expect(zeros(0)).toHaveText("2"); // sinal e magnitude
+  await expect(zeros(1)).toHaveText("2"); // complemento de um
+  await expect(zeros(2)).toHaveText("1"); // complemento de dois
+  // e o desperdício que vem junto: 255 números distintos contra 256
+  const distintos = (col: number) => tres.locator(".ms-op").nth(col).locator(".bb-passos li b").nth(2);
+  await expect(distintos(0)).toHaveText("255");
+  await expect(distintos(2)).toHaveText("256");
+
+  // o mesmo padrão lido de dois jeitos, e a virada de 127 para -128
+  const faixa = page.locator("figure.viz").filter({ hasText: "o mesmo padrão, duas leituras" });
+  await expect(faixa.locator(".viz-step")).toHaveText("10000000 · sem sinal 128 · com sinal -128");
+  await faixa.getByRole("button", { name: "01111111" }).click();
+  await expect(faixa.locator(".viz-step")).toHaveText("01111111 · sem sinal 127 · com sinal 127");
+  await faixa.getByRole("button", { name: "Próximo padrão" }).click();
+  await expect(faixa.locator(".viz-step")).toHaveText("10000000 · sem sinal 128 · com sinal -128");
+  await expect(faixa.locator(".viz-note")).toContainText("desaba");
+});
+
+// Regressão: "em breve" é derivado, e a regra de derivação já esteve errada.
+// Vídeo extra é link para resolução de exercício, não material do tópico, e um
+// tópico que só tem isso continua sem aula, sem texto e sem visualização.
+test("o selo em breve aparece em quem não tem vídeo, artigo nem visualização", async ({ page }) => {
+  // O menu lateral só renderiza o grupo aberto, então a conferência é por grupo.
+  // Ler de ALL_TOPICS em vez de fixar uma lista faz o teste sobreviver ao dia
+  // em que qualquer um destes tópicos for publicado.
+  const conferirGrupo = async (slug: string) => {
+    await page.goto(`/topico/${slug}/`);
+    const grupo = ALL_TOPICS.find((t) => t.slug === slug)!.group;
+    const doGrupo = ALL_TOPICS.filter((t) => t.group === grupo);
+    const vazios = doGrupo.filter((t) => isEmptyTopic(t));
+    await expect(page.locator(".sidebar .badge-soon")).toHaveCount(vazios.length);
+    for (const t of doGrupo) {
+      const item = page.locator(`.sidebar a[href="/topico/${t.slug}/"]`);
+      if (isEmptyTopic(t)) await expect(item, `${t.slug} devia estar em breve`).toHaveClass(/\bsoon\b/);
+      else await expect(item, `${t.slug} NÃO devia estar em breve`).not.toHaveClass(/\bsoon\b/);
+    }
+  };
+
+  // Programação Dinâmica só tem vídeos extras (recortes de resolução), e isso
+  // não é material do tópico: ela continua em breve.
+  await conferirGrupo("programacao-dinamica");
+  await expect(page.locator('.sidebar a[href="/topico/programacao-dinamica/"]')).toHaveClass(/\bsoon\b/);
+
+  // Manipulação de Bits tem dois publicados e um vazio, no mesmo grupo
+  await conferirGrupo("binary-numbers");
+  // Ordenação tem quatro publicados e três vazios
+  await conferirGrupo("ordenacao-basica");
+});
+
 // Regressão: cinco visualizadores foram parar num PR com o estado de animação
 // completo (passo, tocando, velocidade) e SEM os controles renderizados, então o
 // aluno ficava preso no passo 1 sem nenhum aviso. Os testes de contrato não
@@ -916,7 +1097,8 @@ test("no celular, nenhum painel de visualizador colapsa", async ({ page }) => {
           "article figure.viz .hp-bloco, article figure.viz .hs-fila, " +
           "article figure.viz .bb-formula, article figure.viz .hp-formula, " +
           "article figure.viz .ord-linha, article figure.viz .ord-medida, " +
-          "article figure.viz .ms-lado, article figure.viz .ms-op"
+          "article figure.viz .ms-lado, article figure.viz .ms-op, " +
+          "article figure.viz .bt-paineis > .hp-bloco"
       )
       .evaluateAll((els) =>
         els.map((e) => ({ cls: e.className, w: Math.round(e.getBoundingClientRect().width) }))


### PR DESCRIPTION
## O que muda

Fecha o **backlog inteiro de vídeo**: os três últimos tópicos com gravação e sem artigo (`backtracking`, `binary-numbers`, `negative-binary`) saem de "em breve" com artigo completo, três visualizadores cada e teste que interage. **Dos 34 tópicos com vídeo, agora nenhum está sem artigo.**

A plataforma vai de **33 para 36 tópicos prontos**, de 33 para 36 visualizadores e de 209 para 227 problemas.

Vai junto a mudança de regra do selo "em breve" pedida na issue de conversa: `isEmptyTopic` deixa de contar `extraVideos` como material. Vídeo extra é link para resolução de exercício, e um tópico que só tem isso continua sem aula, sem texto e sem visualização. `programacao-dinamica` era o único caso e volta a mostrar "em breve".

## Tipo

- [x] `feat` novo conteúdo/tópico/visualizador
- [ ] `fix` correção
- [ ] `docs` documentação
- [ ] `refactor` / `style` / `perf`
- [ ] `ci` / `build` / `chore`

## O que cada visualizador faz

**Backtracking**
- `BacktrackingVisualizer`: a árvore, a solução parcial e a pilha de chamadas **no mesmo passo**. No retrocesso a árvore não perde nó nenhum (ela é histórico), a lista encolhe e a pilha desempilha, e é essa dessincronia que ensina que a árvore de decisão não existe na memória. Subconjuntos, permutações e combinações no mesmo componente, para o template aparecer como um só.
- `BacktrackingSudoku`: o mesmo template com três peças trocadas (as opções viraram os dígitos, a validade virou a regra do jogo, o desfazer virou apagar). Em escada: 4x4 com 60 passos para acompanhar clique a clique, e 9x9 com 48 lacunas para ver 882 dígitos testados.
- `BacktrackingPoda`: n rainhas com e sem poda, medindo nós visitados. Mesmas soluções, 366 vezes menos trabalho com 6 rainhas.

**Números Binários**
- `BinarioConversor`: os oito bits como botões de verdade, com a conta escrita por extenso acendendo e apagando junto.
- `BinarioDivisoes`: a fita preenchida da direita para a esquerda ao vivo, que é a **razão** de a regra dos restos ser "de baixo para cima" e não um truque de leitura.
- `BinarioBases`: o mesmo número em 4 bases, os grupos de 4 bits que viram cada dígito hexa, e o orçamento de 8 a 64 bits.

**Binários Negativos**
- `BinarioComplemento`: inverter e somar 1, com o vai-um andando bit a bit, e terminando na **prova** de que x + (-x) dá zero com o carry estourando.
- `BinarioTresFormas`: as três convenções submetidas a três testes calculados sobre os 256 padrões.
- `BinarioFaixa`: o mesmo padrão lido como com e sem sinal, e a virada de 01111111 para 10000000 acontecendo no clique.

## O que a medição e a auditoria mudaram

- O 9x9 clássico de 51 lacunas precisava de **mais de 18 mil passos** com o solucionador ingênuo, o que não cabe numa animação. Em vez de esconder, medi onde a conta fecha e montei uma escada de presets (60, 224 e 956 passos), com o maior deles nomeando o que acontece: com poucas pistas existem várias soluções válidas, e o backtracking para na **primeira**, não na certa.
- As 8 rainhas sem poda visitam **19.173.961 nós**. Desenhar essa barra custaria segundos de CPU do leitor, então o componente para em 7 e o número de 8 está no artigo, calculado pela fórmula da árvore cheia e marcado como calculado, não medido.
- A **auditoria de rótulo contra valor** pegou três problemas antes do push: o rótulo da posição mostrava só `2`, sem o expoente, em dois componentes; `bits ligados` falava do resultado enquanto mostrava o estado parcial; e o painel prometia "dois testes" depois de eu ter acrescentado o terceiro.

## Como foi verificado

- `npm run build`, `npm test` (**81 testes, todos verdes**) e `npx tsc --noEmit`.
- **Os cinco testes novos foram rodados contra o código quebrado antes de entrar**, um defeito por arquivo: contador de retrocessos desligado, sudoku sem a checagem de linha, peso do bit fixo em 1, complemento de dois sem o passo do `+1`, e a regra do selo voltando a contar vídeo extra. Os cinco falharam, cada um pela asserção que devia falhar.
- Geradores provados em Node antes da interface, com verificação de invariante e não só de resultado: o sudoku confere que a grade final é um sudoku **válido com as pistas preservadas**; o backtracking confere que a solução parcial e a pilha terminam vazias; o complemento de dois confere os 5 presets contra `(-v) mod 256` e a soma dando zero; e as três convenções são medidas sobre os 256 padrões.
- Navegador nas três alturas (1440x900, 1440x640 e 390x844) nas três páginas: zero erro de console, zero overflow horizontal, nenhum painel abaixo de 280px e nenhum texto estourando a própria caixa.
- Todas as 15 referências conferidas com `curl` (200). Fontes brasileiras nos três tópicos: Feofiloff (IME-USP) nos três, MC-202 (IC-UNICAMP) no backtracking, mais o capítulo de backtracking do Jeff Erickson e a documentação do Python.

## Checklist

- [x] `npm run build` passa
- [x] `npm test` passa
- [x] Segui o padrão de [Conventional Commits](https://conventionalcommits.org/)
- [x] Sem o caractere travessão (`—`) na copy do site
- [x] Li o [guia de contribuição](../CONTRIBUTING.md)
