### PR TITLE
feat(viz): casca adaptativa à altura da tela, estreando no contador do Big O

### DIFF
--- a/content/visualizers/BigOCounterVisualizer.tsx
+++ b/content/visualizers/BigOCounterVisualizer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
 // ---------------------------------------------------------------------------
@@ -10,7 +10,36 @@ import { createPortal } from "react-dom";
 // compartilhada), com um detalhe a mais: cada passo carrega o contador de
 // operações. A ideia é o aluno ver o contador parar em 1, em log n, em n e em
 // n² sobre o MESMO array, e conferir a conta do pior caso ao lado.
+//
+// É também o primeiro a usar a casca ADAPTATIVA (`viz-fit`), que resolve um
+// problema medido: numa tela de notebook a peça não cabe nem expandida, e como
+// o quadro inteiro rolava, o título e os botões de reprodução saíam de vista
+// junto com o conteúdo. Três mudanças, nesta ordem de importância:
+//
+//   1. no expandido, cabeçalho e controles ficam PARADOS e só o miolo rola;
+//   2. o bloco de código (o mais alto e o mais dispensável para acompanhar o
+//      passo a passo) recolhe, e as variáveis viram uma fileira;
+//   3. quem decide isso é uma MEDIÇÃO — a peça cabe na altura disponível? —,
+//      não um breakpoint chutado. Tela grande com peça leve abre tudo; tela
+//      baixa, ou array grande, ou código de 11 linhas, já abre recolhido.
+//
+// Escolha explícita do aluno vence a medição até ele sair do modo expandido.
 // ---------------------------------------------------------------------------
+
+// `useLayoutEffect` não existe no servidor, e o build estático pré-renderiza
+// este componente. O alias evita o aviso do React sem abrir mão de medir ANTES
+// da pintura no navegador — é isso que faz o código já nascer recolhido, em vez
+// de aparecer e sumir na cara do aluno.
+const useEfeitoLayout = typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+// Folga de arredondamento de layout: abaixo disso "estourar" é ruído de
+// subpixel, não conteúdo sem espaço.
+const FOLGA = 8;
+
+// Quanto do topo da janela já está ocupado quando a peça está no fluxo do
+// artigo: o cabeçalho fixo do site, mais um respiro para não colar na borda.
+const HEADER_H = 60;
+const RESPIRO_INLINE = 24;
 
 type Passo = {
   linha: number;
@@ -222,7 +251,37 @@ export function BigOCounterVisualizer() {
   const [mounted, setMounted] = useState(false);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // --- casca adaptativa: o código cabe ou não cabe? ------------------------
+  const idCodigo = useId();
+  const figRef = useRef<HTMLElement>(null);
+  const corpoRef = useRef<HTMLDivElement>(null);
+  const [codigoAberto, setCodigoAberto] = useState(true);
+  // `null` = ninguém escolheu na mão, a medição manda. Depois que o aluno
+  // clica, a escolha dele vale até ele entrar ou sair do modo expandido.
+  const escolhaManual = useRef<boolean | null>(null);
+  // Contador de rodadas de medição: cada bump pede uma decisão nova.
+  const [aferir, setAferir] = useState(0);
+  const rodadaMedida = useRef(-1);
+  // As fontes chegam com `display: swap`, então a primeira medição pegaria a
+  // altura da fonte de fallback. Espero elas antes de decidir.
+  const [fontesProntas, setFontesProntas] = useState(false);
+  // Decisão automática não anima; clique do aluno anima. Duas razões: a
+  // primeira decisão chega depois da pintura (as fontes são assíncronas) e ele
+  // veria o código aparecer e sumir sozinho; e medir com uma transição a
+  // caminho lê a altura do meio do percurso — foi exatamente esse o erro que
+  // deixou a peça passar 64px da janela dizendo que cabia.
+  const [animar, setAnimar] = useState(false);
+  const [medindo, setMedindo] = useState(false);
+
   useEffect(() => setMounted(true), []);
+
+  useEffect(() => {
+    let vivo = true;
+    const ok = () => { if (vivo) setFontesProntas(true); };
+    if (typeof document !== "undefined" && document.fonts) document.fonts.ready.then(ok, ok);
+    else ok();
+    return () => { vivo = false; };
+  }, []);
 
   const alg = ALGORITMOS[iAlg];
   const passos = useMemo(() => alg.gerar(nums.length ? nums : [1], alvo), [alg, nums, alvo]);
@@ -254,6 +313,83 @@ export function BigOCounterVisualizer() {
     return () => window.removeEventListener("keydown", onKey);
   }, [expanded]);
 
+  // Enquanto o painel está aberto ele é a única coisa que rola: sem isso a
+  // roda do mouse atravessa o overlay e leva o artigo embora por baixo.
+  useEffect(() => {
+    if (!expanded) return;
+    const corpo = document.body;
+    const overflowAntes = corpo.style.overflow;
+    const padAntes = corpo.style.paddingRight;
+    const barra = window.innerWidth - document.documentElement.clientWidth;
+    corpo.style.overflow = "hidden";
+    if (barra > 0) corpo.style.paddingRight = `${barra}px`;
+    return () => { corpo.style.overflow = overflowAntes; corpo.style.paddingRight = padAntes; };
+  }, [expanded]);
+
+  // Diálogo de verdade: o foco entra no painel ao abrir e volta para onde
+  // estava ao fechar, senão o teclado continua navegando o artigo escondido.
+  useEffect(() => {
+    if (!expanded) return;
+    const anterior = document.activeElement as HTMLElement | null;
+    figRef.current?.focus();
+    return () => anterior?.focus?.();
+  }, [expanded]);
+
+  // (1) trocar de contexto zera a escolha manual: abrir o painel grande é um
+  // pedido novo de "mostre isso do melhor jeito nesta tela".
+  useEfeitoLayout(() => { escolhaManual.current = null; }, [expanded]);
+
+  // (2) o que pede uma decisão nova: entrar/sair do expandido, trocar de
+  // algoritmo (o código vai de 2 a 11 linhas), mudar o tamanho do array e a
+  // chegada das fontes.
+  useEfeitoLayout(() => { setAferir((a) => a + 1); }, [expanded, iAlg, n, fontesProntas]);
+
+  // (3) a decisão, em duas passadas dentro do MESMO quadro (efeito de layout
+  // roda antes da pintura, então nada disso aparece na tela):
+  //   passada 1 — congela a animação e abre o código, que é o pior caso de
+  //               altura. Sem congelar, o passo seguinte mediria um bloco
+  //               ainda a caminho da altura final e concluiria "cabe";
+  //   passada 2 — mede o layout já estável e decide.
+  useEfeitoLayout(() => {
+    if (!fontesProntas || escolhaManual.current !== null) return;
+    if (rodadaMedida.current === aferir) return;
+    if (!medindo || !codigoAberto) { setMedindo(true); setCodigoAberto(true); return; }
+    const fig = figRef.current, corpo = corpoRef.current;
+    if (!fig || !corpo) return;
+    rodadaMedida.current = aferir;
+    const estoura = expanded
+      // Expandido: o miolo é a única área rolável, então "não coube" é ele
+      // precisar de mais altura do que a janela deixou para ele.
+      ? corpo.scrollHeight > corpo.clientHeight + FOLGA
+      // No fluxo do artigo a régua é a janela: se a peça inteira não cabe numa
+      // tela, o aluno olha o array sem enxergar os botões que o fazem andar.
+      : fig.getBoundingClientRect().height > window.innerHeight - HEADER_H - RESPIRO_INLINE - FOLGA;
+    if (estoura) setCodigoAberto(false);
+    // Só no quadro seguinte, para o recolhimento desta decisão não animar.
+    requestAnimationFrame(() => { setMedindo(false); setAnimar(true); });
+  }, [aferir, codigoAberto, expanded, fontesProntas, medindo]);
+
+  // Redimensionar a janela é a mudança de altura mais óbvia que existe.
+  useEffect(() => {
+    let quadro = 0;
+    const aoRedimensionar = () => {
+      cancelAnimationFrame(quadro);
+      quadro = requestAnimationFrame(() => setAferir((a) => a + 1));
+    };
+    window.addEventListener("resize", aoRedimensionar);
+    return () => { cancelAnimationFrame(quadro); window.removeEventListener("resize", aoRedimensionar); };
+  }, []);
+
+  const alternarCodigo = useCallback(() => {
+    setCodigoAberto((c) => {
+      // Anotar dentro do updater mantém a leitura e a escrita no mesmo valor
+      // mesmo em clique rápido; em StrictMode roda duas vezes com o mesmo
+      // resultado, então é idempotente.
+      escolhaManual.current = !c;
+      return !c;
+    });
+  }, []);
+
   const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
 
   const aoMudarEntrada = (v: string) => {
@@ -278,7 +414,14 @@ export function BigOCounterVisualizer() {
   const pctPasso = Math.round(((idx + 1) / total) * 100);
 
   const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
+    <figure
+      className="viz viz-fit"
+      data-codigo={codigoAberto ? "on" : "off"}
+      data-anim={animar && !medindo ? "on" : "off"}
+      style={{ margin: 0 }}
+      ref={figRef}
+      tabIndex={-1}
+    >
       <div className="viz-head">
         <div className="viz-head-title">
           <span className="dot" style={{ background: alg.cor }} />
@@ -286,13 +429,21 @@ export function BigOCounterVisualizer() {
         </div>
         <div className="viz-head-right">
           <span className="viz-step">passo {idx + 1} de {total}</span>
+          <button
+            className="viz-expand viz-toggle-codigo"
+            aria-expanded={codigoAberto}
+            aria-controls={idCodigo}
+            onClick={alternarCodigo}
+          >
+            {codigoAberto ? "Ocultar código" : "Mostrar código"}
+          </button>
           <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
             {expanded ? "✕ Fechar" : "⤢ Expandir"}
           </button>
         </div>
       </div>
 
-      <div className="viz-body">
+      <div className="viz-body" ref={corpoRef}>
         <div className="bigo-chips">
           {ALGORITMOS.map((a, i) => {
             const on = i === iAlg;
@@ -361,18 +512,27 @@ export function BigOCounterVisualizer() {
         <p className={notaCls}>{p.nota}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{alg.arquivo} · {alg.formula}</div>
-            <div className="viz-code-body">
-              {alg.codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuava com os 374px do
+              código (medido). O `.viz-code-slot` é o truque de grid 1fr→0fr,
+              a única forma de animar altura automática em CSS puro.
+              O código fica no DOM mesmo recolhido, e é isso que permite medir
+              o pior caso de altura; `inert` tira ele do teclado e dos leitores
+              de tela enquanto está fora de vista. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" id={idCodigo} inert={!codigoAberto}>
+              <div className="viz-code-head">{alg.arquivo} · {alg.formula}</div>
+              <div className="viz-code-body">
+                {alg.codigo.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div className={`viz-vars${codigoAberto ? "" : " linha"}`}>
             <div className="viz-vars-head">Variáveis</div>
             {p.vars.map((v) => (
               <div className="viz-var" key={v.nome}>
@@ -382,7 +542,11 @@ export function BigOCounterVisualizer() {
             ))}
           </div>
         </div>
+      </div>
 
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <div className="viz-foot">
         <div className="viz-controls">
           <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
           <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
@@ -403,7 +567,13 @@ export function BigOCounterVisualizer() {
 
   if (expanded && mounted) {
     return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
+      <div
+        className="viz-overlay viz-overlay-fit"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Visualizador · contando operações no mesmo array"
+        onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}
+      >
         {viz}
       </div>,
       document.body

--- a/content/visualizers/BigOCounterVisualizer.tsx
+++ b/content/visualizers/BigOCounterVisualizer.tsx
@@ -306,11 +306,41 @@ export function BigOCounterVisualizer() {
     if (tocando && idx >= total - 1) setTocando(false);
   }, [tocando, idx, total]);
 
+  // Teclado do painel: Esc fecha, e o Tab circula DENTRO dele. Sem a segunda
+  // parte o `aria-modal="true"` seria uma promessa falsa — o foco escapava para
+  // o artigo por baixo, que é justamente o que "modal" diz que não acontece.
   useEffect(() => {
     if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
+    const focaveis = () => {
+      const painel = figRef.current;
+      if (!painel) return [] as HTMLElement[];
+      const seletor = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+      return [...painel.querySelectorAll<HTMLElement>(seletor)].filter(
+        (el) => !el.hasAttribute("disabled") && !el.closest("[inert]") && el.offsetParent !== null
+      );
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { setExpanded(false); return; }
+      if (e.key !== "Tab") return;
+      const painel = figRef.current;
+      const itens = focaveis();
+      if (!painel || !itens.length) return;
+      const primeiro = itens[0], ultimo = itens[itens.length - 1];
+      const ativo = document.activeElement;
+      if (!painel.contains(ativo)) {
+        // O foco já estava fora (barra do navegador, por exemplo): traz de volta.
+        e.preventDefault();
+        (e.shiftKey ? ultimo : primeiro).focus();
+      } else if (e.shiftKey && (ativo === primeiro || ativo === painel)) {
+        e.preventDefault();
+        ultimo.focus();
+      } else if (!e.shiftKey && ativo === ultimo) {
+        e.preventDefault();
+        primeiro.focus();
+      }
+    };
+    document.addEventListener("keydown", onKey, true);
+    return () => document.removeEventListener("keydown", onKey, true);
   }, [expanded]);
 
   // Enquanto o painel está aberto ele é a única coisa que rola: sem isso a
@@ -518,9 +548,15 @@ export function BigOCounterVisualizer() {
               a única forma de animar altura automática em CSS puro.
               O código fica no DOM mesmo recolhido, e é isso que permite medir
               o pior caso de altura; `inert` tira ele do teclado e dos leitores
-              de tela enquanto está fora de vista. */}
+              de tela enquanto está fora de vista, com `aria-hidden` de reserva
+              para navegador ou leitor que ainda não honre `inert`. */}
           <div className="viz-code-slot">
-            <div className="viz-code" id={idCodigo} inert={!codigoAberto}>
+            <div
+              className="viz-code"
+              id={idCodigo}
+              inert={!codigoAberto}
+              aria-hidden={!codigoAberto || undefined}
+            >
               <div className="viz-code-head">{alg.arquivo} · {alg.formula}</div>
               <div className="viz-code-body">
                 {alg.codigo.map((txt, i) => (

--- a/content/visualizers/BigOCounterVisualizer.tsx
+++ b/content/visualizers/BigOCounterVisualizer.tsx
@@ -295,6 +295,28 @@ export function BigOCounterVisualizer() {
   }, []);
   useEffect(() => () => parar(), [parar]);
 
+  // --- comandos, compartilhados pelos botões e pelo teclado ----------------
+  // `total` e `tocando` vêm de ref porque a tecla REPETE muito mais rápido que
+  // o clique: ler o valor do closure engoliria repetições, que é o mesmo bug de
+  // clique perdido que já apareceu neste repo, só que mais fácil de disparar.
+  const totalRef = useRef(total);
+  const tocandoRef = useRef(false);
+  useEffect(() => { totalRef.current = total; }, [total]);
+  useEffect(() => { tocandoRef.current = tocando; }, [tocando]);
+
+  const irPasso = useCallback((delta: number) => {
+    parar();
+    setTocando(false);
+    setPasso((s) => Math.max(0, Math.min(s + delta, totalRef.current - 1)));
+  }, [parar]);
+
+  const alternarPlay = useCallback(() => {
+    if (tocandoRef.current) { parar(); setTocando(false); return; }
+    // no fim da animação, rodar de novo rebobina em vez de não fazer nada
+    setPasso((s) => (s >= totalRef.current - 1 ? 0 : s));
+    setTocando(true);
+  }, [parar]);
+
   useEffect(() => {
     parar();
     if (!tocando) return;
@@ -306,11 +328,19 @@ export function BigOCounterVisualizer() {
     if (tocando && idx >= total - 1) setTocando(false);
   }, [tocando, idx, total]);
 
-  // Teclado do painel: Esc fecha, e o Tab circula DENTRO dele. Sem a segunda
-  // parte o `aria-modal="true"` seria uma promessa falsa — o foco escapava para
-  // o artigo por baixo, que é justamente o que "modal" diz que não acontece.
+  // Teclado do painel: Esc fecha, o Tab circula DENTRO dele, e as setas e o
+  // espaço dirigem a animação. Sem a trava do Tab o `aria-modal="true"` seria
+  // uma promessa falsa — o foco escapava para o artigo por baixo, que é
+  // justamente o que "modal" diz que não acontece.
+  //
+  // As setas e o espaço só valem no expandido, e **só quando o cursor não está
+  // num campo**: com o array em edição, seta é mover o cursor e espaço é digitar
+  // um espaço. Mesma coisa no controle de velocidade, onde a seta é do próprio
+  // slider. E espaço com um botão em foco é o botão, não o atalho.
   useEffect(() => {
     if (!expanded) return;
+    const emCampo = (alvo: EventTarget | null) =>
+      !!(alvo as HTMLElement | null)?.closest?.("input, textarea, select, [contenteditable='true']");
     const focaveis = () => {
       const painel = figRef.current;
       if (!painel) return [] as HTMLElement[];
@@ -321,6 +351,18 @@ export function BigOCounterVisualizer() {
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") { setExpanded(false); return; }
+      if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+        if (emCampo(e.target)) return;
+        e.preventDefault(); // senão a seta rola o miolo junto
+        irPasso(e.key === "ArrowRight" ? 1 : -1);
+        return;
+      }
+      if (e.key === " " || e.key === "Spacebar") {
+        if (emCampo(e.target) || (e.target as HTMLElement | null)?.closest?.("button")) return;
+        e.preventDefault(); // espaço rolaria a área rolável
+        alternarPlay();
+        return;
+      }
       if (e.key !== "Tab") return;
       const painel = figRef.current;
       const itens = focaveis();
@@ -341,7 +383,7 @@ export function BigOCounterVisualizer() {
     };
     document.addEventListener("keydown", onKey, true);
     return () => document.removeEventListener("keydown", onKey, true);
-  }, [expanded]);
+  }, [expanded, irPasso, alternarPlay]);
 
   // Enquanto o painel está aberto ele é a única coisa que rola: sem isso a
   // roda do mouse atravessa o overlay e leva o artigo embora por baixo.
@@ -585,11 +627,16 @@ export function BigOCounterVisualizer() {
       <div className="viz-foot">
         <div className="viz-controls">
           <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
+          <button className="viz-btn" disabled={idx === 0} aria-keyshortcuts="ArrowLeft" onClick={() => irPasso(-1)}>‹ Anterior</button>
+          <button className="viz-play" aria-keyshortcuts="Space" onClick={alternarPlay}>
             {tocando ? "❚❚ Pausar" : "▶ Rodar"}
           </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
+          <button className="viz-btn" disabled={idx === total - 1} aria-keyshortcuts="ArrowRight" onClick={() => irPasso(1)}>Próximo ›</button>
+          {/* Atalho que ninguém descobre é atalho que não existe. Só aparece no
+              expandido, que é onde ele vale, e some em tela sem teclado. */}
+          <p className="viz-atalhos">
+            <kbd>←</kbd><kbd>→</kbd> passo <span>·</span> <kbd>espaço</kbd> roda
+          </p>
           <div className="viz-speed">
             <span>Velocidade</span>
             <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1628,7 +1628,12 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
        formato que aproveita a largura liberada;
      · a decisão de recolher vem de medição no componente, não daqui — este
        arquivo só descreve os dois estados e a transição entre eles. */
-.viz-fit .viz-body { padding-bottom: 0; }
+/* O respiro do pé do miolo mora no `.viz-body`, não na margem dos controles:
+   dentro de uma área rolável ele também serve de folga contra a borda, então o
+   último bloco nunca encosta na linha do rodapé fixo quando a rolagem chega ao
+   fim. Os 14 + 14 dão os 28px de gap, contra os 18 de antes. */
+.viz-fit .viz-body { padding-bottom: 14px; }
+.viz-fit .viz-controls { margin-top: 14px; }
 .viz-fit .viz-foot { padding: 0 20px 18px; }
 
 /* Duas trilhas em `fr` no lugar de `1fr 300px`: lista de trilhas só interpola
@@ -1672,9 +1677,13 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 }
 .viz-overlay-fit .viz-fit .viz-head, .viz-overlay-fit .viz-fit .viz-foot { flex: none; }
 .viz-overlay-fit .viz-fit .viz-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
-/* Sombra rasa nas duas bordas: diz que o conteúdo passa POR BAIXO delas. */
+/* Sombra rasa nas duas bordas: diz que o conteúdo passa POR BAIXO delas.
+   A de baixo é mais fraca de propósito, e não por simetria de números: o
+   cabeçalho tem fundo próprio (#0f1826) e a sombra dele se dilui nesse degrau,
+   enquanto o rodapé divide o fundo com o miolo e soma com o `border-top` dos
+   controles. Com os mesmos valores nos dois, a de baixo lia como o dobro. */
 .viz-overlay-fit .viz-fit .viz-head { box-shadow: 0 10px 18px -14px rgba(0, 0, 0, 0.9); }
-.viz-overlay-fit .viz-fit .viz-foot { box-shadow: 0 -10px 18px -14px rgba(0, 0, 0, 0.9); }
+.viz-overlay-fit .viz-fit .viz-foot { box-shadow: 0 -9px 16px -15px rgba(0, 0, 0, 0.45); }
 /* O cabeçalho ganhou um terceiro botão: em tela estreita ele quebra a linha em
    vez de espremer o título. */
 .viz-fit .viz-head { flex-wrap: wrap; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -484,7 +484,10 @@ html { scroll-behavior: smooth; }
 /* expanded / overlay ("meio a meio") */
 .viz-overlay { position: fixed; inset: 0; z-index: 90; display: flex; align-items: center; justify-content: center; padding: 24px; background: rgba(4, 8, 14, 0.78); backdrop-filter: blur(4px); }
 .viz-overlay .viz { width: min(1200px, 100%); max-height: calc(100vh - 48px); overflow: auto; margin: 0; box-shadow: 0 30px 80px -20px rgba(0, 0, 0, 0.8); }
-.viz-overlay .viz-split { grid-template-columns: 1fr 1fr; }
+/* `:not(.viz-fit)` porque a casca adaptativa manda no próprio grid (ela precisa
+   de trilhas todas em `fr` para animar). Sem isto a regra valeria por ordem de
+   cascata, que é o tipo de acoplamento que já colapsou painel neste arquivo. */
+.viz-overlay .viz:not(.viz-fit) .viz-split { grid-template-columns: 1fr 1fr; }
 .viz-overlay .viz-code-body { max-height: none; }
 .viz-overlay .viz-line { font-size: 14px; line-height: 1.9; }
 .viz-overlay .viz-cell { width: 58px; height: 58px; font-size: 19px; }
@@ -1613,6 +1616,70 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 .bn-passeio { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 10px; margin-top: 10px; }
 .bn-passeio-txt { font-size: 11.5px; color: var(--ccc-muted); }
 
+/* --- casca adaptativa (.viz-fit): o que faz a peça caber na altura da tela ---
+   Problema medido no contador de operações do Big O: num notebook de 16" a
+   janela útil tem ~900px e a peça pede ~1.150px. Como `.viz-overlay .viz` rola
+   INTEIRO, o título e os botões de reprodução iam embora junto com o conteúdo,
+   e o aluno ficava rolando para achar o "Próximo ›".
+   A casca resolve em três camadas, e cada uma vale sozinha:
+     · no expandido, `.viz-head` e `.viz-foot` são flex-none e só `.viz-body`
+       rola (`min-height: 0` é o que permite o item de flex encolher);
+     · o bloco de código recolhe, e as variáveis viram uma fileira, que é o
+       formato que aproveita a largura liberada;
+     · a decisão de recolher vem de medição no componente, não daqui — este
+       arquivo só descreve os dois estados e a transição entre eles. */
+.viz-fit .viz-body { padding-bottom: 0; }
+.viz-fit .viz-foot { padding: 0 20px 18px; }
+
+/* Duas trilhas em `fr` no lugar de `1fr 300px`: lista de trilhas só interpola
+   quando todas são da mesma natureza, e é isso que faz o código ENCOLHER junto
+   com a coluna em vez de sumir de um quadro para o outro. 2fr/1fr reproduz a
+   proporção antiga (~66% para o código num corpo de 1.000px). */
+.viz-fit .viz-split { grid-template-columns: minmax(0, 2fr) minmax(0, 1fr); }
+.viz-fit[data-codigo="off"] .viz-split { grid-template-columns: minmax(0, 0fr) minmax(0, 1fr); gap: 0; }
+/* A transição só liga DEPOIS da primeira decisão (`data-anim`), senão o aluno
+   vê o código aparecer e sumir sozinho quando as fontes chegam. */
+.viz-fit[data-anim="on"] .viz-split { transition: grid-template-columns 0.32s cubic-bezier(0.4, 0, 0.2, 1), gap 0.32s cubic-bezier(0.4, 0, 0.2, 1); }
+.viz-fit[data-anim="on"] .viz-code-slot { transition: grid-template-rows 0.32s cubic-bezier(0.4, 0, 0.2, 1); }
+.viz-fit[data-anim="on"] .viz-code-slot > .viz-code { transition: opacity 0.18s ease; }
+
+/* Zerar a trilha da coluna resolve a LARGURA e só ela: a linha do grid continua
+   com a altura do bloco (medido: 374px com o código recolhido, a peça inteira
+   em 941px onde cabiam 808). O slot é o truque de `grid-template-rows: 1fr →
+   0fr`, a única forma em CSS puro de animar altura automática. */
+.viz-fit .viz-code-slot { display: grid; grid-template-rows: 1fr; min-height: 0; }
+.viz-fit .viz-code-slot > .viz-code { min-height: 0; }
+.viz-fit[data-codigo="off"] .viz-code-slot { grid-template-rows: 0fr; }
+/* Com a trilha em 0 sobram os 2px de borda; a opacidade cobre esse resto. */
+.viz-fit[data-codigo="off"] .viz-code { opacity: 0; }
+
+/* Variáveis em fileira: o rótulo vira a primeira ficha da linha. */
+.viz-fit .viz-vars.linha { flex-flow: row wrap; align-items: center; gap: 8px; }
+.viz-fit .viz-vars.linha .viz-vars-head { margin: 0; }
+.viz-fit .viz-vars.linha .viz-var { flex: 0 1 auto; gap: 12px; padding: 8px 13px; animation: vizFichaEntra 0.24s cubic-bezier(0.2, 0.7, 0.3, 1) both; }
+@keyframes vizFichaEntra { from { opacity: 0; transform: translateY(-4px); } to { opacity: 1; transform: none; } }
+
+.viz-toggle-codigo[aria-expanded="true"] { border-color: rgba(59, 130, 246, 0.45); color: #cfe0f6; }
+
+/* --- o expandido: cabeçalho e controles parados, miolo rolando ----------- */
+.viz-overlay-fit { --viz-pad: clamp(10px, 2.4vh, 24px); padding: var(--viz-pad); }
+.viz-overlay-fit .viz.viz-fit {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  max-height: calc(100vh - 2 * var(--viz-pad));
+  max-height: calc(100dvh - 2 * var(--viz-pad));
+}
+.viz-overlay-fit .viz-fit .viz-head, .viz-overlay-fit .viz-fit .viz-foot { flex: none; }
+.viz-overlay-fit .viz-fit .viz-body { flex: 1 1 auto; min-height: 0; overflow-y: auto; overscroll-behavior: contain; }
+/* Sombra rasa nas duas bordas: diz que o conteúdo passa POR BAIXO delas. */
+.viz-overlay-fit .viz-fit .viz-head { box-shadow: 0 10px 18px -14px rgba(0, 0, 0, 0.9); }
+.viz-overlay-fit .viz-fit .viz-foot { box-shadow: 0 -10px 18px -14px rgba(0, 0, 0, 0.9); }
+/* O cabeçalho ganhou um terceiro botão: em tela estreita ele quebra a linha em
+   vez de espremer o título. */
+.viz-fit .viz-head { flex-wrap: wrap; }
+.viz-fit .viz-head-right { flex-wrap: wrap; justify-content: flex-end; }
+
 /* ------------------------------ responsive ------------------------------ */
 @media (max-width: 1000px) {
   .shell { grid-template-columns: minmax(0, 1fr); }
@@ -1631,6 +1698,12 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
   .mdx-colunas { grid-template-columns: 1fr; }
   .toc { display: none; }
   .viz-split { grid-template-columns: 1fr; }
+  /* A casca adaptativa também empilha aqui: abaixo de 1000px não há largura
+     para código e variáveis lado a lado. A animação não se perde — quem
+     recolhe a altura é o `.viz-code-slot`, que independe do número de
+     colunas; só o encolher horizontal deixa de existir. */
+  .viz-fit .viz-split { grid-template-columns: minmax(0, 1fr); }
+  .viz-fit[data-codigo="off"] .viz-split { grid-template-columns: minmax(0, 1fr); }
   .site-foot { padding: 24px 20px; }
 }
 @media (max-width: 760px) {
@@ -1652,6 +1725,9 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
      (as células + variáveis já contam a história) e volta ao Expandir. */
   .viz-code { display: none; }
   .viz-overlay .viz-code { display: block; }
+  /* Na casca adaptativa quem decide isso é o botão "Mostrar código": sem esta
+     linha o aluno de celular clicaria no botão e nada apareceria. */
+  .viz-fit .viz-code { display: block; }
   /* classificador dos "sub": três colunas não cabem, viram lista. */
   .sub-vereditos, .sub-contagem { grid-template-columns: minmax(0, 1fr); }
   /* pilha e saída empilham no celular, senão os dois ficam estreitos demais */
@@ -1693,4 +1769,21 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
   .ms-niveis .ms-seg { font-size: 0; }
   .prevnext { flex-direction: column; }
   .topic-done { flex-direction: column; align-items: flex-start; }
+}
+/* Consulta por ALTURA, que é a dimensão que estoura no notebook: a largura
+   está sobrando e a vertical não. Aperta o que é respiro, nunca conteúdo, e só
+   dentro do expandido da casca adaptativa.
+   A ordem importa: comprimir primeiro, esconder depois. Recolher o código é a
+   última carta, e o limiar de 950px cobre a faixa dos notebooks (13" e 16" em
+   tela cheia, 1080p com barras) — medido, é o que faz o expandido do contador
+   de operações caber com o código à mostra numa janela de 900px, em vez de
+   passar 48px e ter de esconder um bloco que o aluno veio ler. */
+@media (max-height: 950px) {
+  .viz-overlay-fit .viz-fit .viz-body { padding-top: 14px; }
+  .viz-overlay-fit .viz-fit .bigo-chips { margin-bottom: 10px; }
+  .viz-overlay-fit .viz-fit .viz-inputs { margin-bottom: 14px; }
+  .viz-overlay-fit .viz-fit .viz-note { margin: 10px 0 12px; }
+  .viz-overlay-fit .viz-fit .viz-cell { width: 46px; height: 46px; font-size: 16px; }
+  .viz-overlay-fit .viz-fit .viz-controls { margin-top: 12px; padding-top: 12px; }
+  .viz-overlay-fit .viz-fit .viz-line { line-height: 1.62; }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1666,6 +1666,16 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 
 .viz-toggle-codigo[aria-expanded="true"] { border-color: rgba(59, 130, 246, 0.45); color: #cfe0f6; }
 
+/* Dica dos atalhos: só no expandido (é onde as teclas valem) e só onde há
+   teclado — no celular ela seria uma instrução impossível de seguir. */
+.viz-atalhos { display: none; }
+.viz-overlay-fit .viz-fit .viz-atalhos { display: inline-flex; align-items: center; gap: 5px; margin: 0 0 0 14px; font-size: 11.5px; color: #64768f; }
+.viz-atalhos kbd { min-width: 20px; padding: 2px 5px; border: 1px solid var(--ccc-line); border-bottom-width: 2px; border-radius: 5px; background: #0e1725; color: #8ba0bb; font-family: var(--mono); font-size: 10.5px; line-height: 1.4; text-align: center; }
+.viz-atalhos span { color: #3c4c63; }
+@media (max-width: 760px), (pointer: coarse) {
+  .viz-overlay-fit .viz-fit .viz-atalhos { display: none; }
+}
+
 /* --- o expandido: cabeçalho e controles parados, miolo rolando ----------- */
 .viz-overlay-fit { --viz-pad: clamp(10px, 2.4vh, 24px); padding: var(--viz-pad); }
 .viz-overlay-fit .viz.viz-fit {

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -369,9 +369,18 @@ test("Big O: a escolha do aluno vence a medição até ele fechar o painel", asy
   await expect
     .poll(async () => await alturaCodigo(page), { message: "a escolha do aluno foi atropelada pela medição" })
     .toBeGreaterThan(100);
-  // e continua aberto depois que qualquer transição teria terminado
-  await page.waitForTimeout(500);
-  expect(await alturaCodigo(page), "o código recolheu sozinho depois do clique").toBeGreaterThan(100);
+
+  // Estar aberto num instante não é a promessa: a promessa é CONTINUAR aberto,
+  // e a medição que poderia desfazer a escolha chega em quadro posterior. Uma
+  // espera fixa seguida de uma leitura só olharia o instante depois dela;
+  // amostrar exige que nenhum dos instantes tenha recolhido, e a série entra na
+  // mensagem quando falha.
+  const alturas: number[] = [];
+  for (let i = 0; i < 6; i++) {
+    alturas.push(await alturaCodigo(page));
+    await page.waitForTimeout(80);
+  }
+  expect(Math.min(...alturas), `o código recolheu sozinho: ${alturas.join(", ")}`).toBeGreaterThan(100);
 });
 
 test("no celular, o botão do código funciona no contador do Big O", async ({ page }) => {

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -302,6 +302,68 @@ test("Big O expandido: o Tab circula dentro do painel, como manda o aria-modal",
   await expect(viz.locator(".viz-code")).not.toHaveAttribute("aria-hidden", "true");
 });
 
+test("Big O expandido: setas andam o passo e espaço roda, sem atrapalhar quem digita", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 720 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  await viz.getByRole("button", { name: /Expandir/ }).click();
+  await expect(viz.getByRole("button", { name: /Fechar/ })).toBeVisible();
+  const passo = viz.locator(".viz-step");
+  await expect(passo).toHaveText("passo 1 de 7");
+
+  // seta direita anda, seta esquerda volta
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 7");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 3 de 7");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 2 de 7");
+
+  // e não passa das pontas
+  for (let i = 0; i < 4; i++) await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 7");
+
+  // espaço roda e pausa, lido pelo rótulo do botão (que é o que promete o estado)
+  const play = viz.locator(".viz-play");
+  await expect(play).toHaveText(/Rodar/);
+  await page.keyboard.press("Space");
+  await expect(play).toHaveText(/Pausar/);
+  await page.keyboard.press("Space");
+  await expect(play).toHaveText(/Rodar/);
+
+  // A parte que importa: com o cursor num campo, seta é cursor e espaço é
+  // espaço. Sequestrar isso deixaria o array impossível de editar.
+  const entrada = viz.locator(".viz-input").first();
+  await entrada.click();
+  const antes = await passo.textContent();
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo, "a seta foi sequestrada com o cursor no campo").toHaveText(antes!);
+
+  // O espaço tem que chegar ao campo. Não asserto o passo aqui de propósito:
+  // editar o array reinicia a animação por regra própria do componente, e
+  // confundir uma coisa com a outra esconderia o sequestro em vez de pegá-lo.
+  // Comparo o valor com ele mesmo em vez de olhar o fim da string: no macOS a
+  // tecla End não leva o cursor ao fim do campo, então o espaço cai onde o
+  // clique deixou o cursor. O que precisa ser verdade é que ele CHEGOU.
+  const valorAntes = await entrada.inputValue();
+  await page.keyboard.press("Space");
+  await expect
+    .poll(async () => (await entrada.inputValue()).length, { message: "o espaço não chegou ao campo" })
+    .toBe(valorAntes.length + 1);
+  await expect(play, "o espaço rodou a animação em vez de digitar").toHaveText(/Rodar/);
+
+  // Mesma regra no controle de velocidade, onde a seta é do próprio slider.
+  const veloc = viz.locator(".viz-speed input[type=range]");
+  await veloc.focus();
+  const vAntes = await veloc.inputValue();
+  const pAntes = await passo.textContent();
+  await page.keyboard.press("ArrowLeft");
+  await expect(veloc, "a seta não chegou ao controle de velocidade").not.toHaveValue(vAntes);
+  await expect(passo).toHaveText(pAntes!);
+});
+
 test("Big O: em tela baixa o código já abre recolhido, com as variáveis em uma linha", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 560 });
   await page.goto("/topico/big-o/");

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -176,6 +176,179 @@ test("Big O traz o gráfico de crescimento, o contador de operações e a tabela
   await expect(page.getByRole("link", { name: /Big O Notation/ })).toHaveAttribute("href", /geeksforgeeks/);
 });
 
+// ---------------------------------------------------------------------------
+// Casca adaptativa (.viz-fit), estreando no contador de operações do Big O.
+//
+// O que motivou: numa janela de notebook a peça pede mais altura do que existe,
+// e o expandido rolava INTEIRO — o título e os botões de reprodução saíam da
+// tela junto com o conteúdo, então o aluno perdia de vista justamente o
+// "Próximo ›" que faz o algoritmo andar.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO: contar elemento não separa um
+// código recolhido de um código que nunca renderizou, e um bloco que aparece
+// com o botão ainda escrito "Mostrar código" ensina errado do mesmo jeito.
+// ---------------------------------------------------------------------------
+
+const CONTADOR = "figure.viz-fit";
+
+/** Caixas do quadro, do cabeçalho e do rodapé + o estado da rolagem do miolo. */
+function medirCasca(page: import("@playwright/test").Page) {
+  return page.locator(CONTADOR).evaluate((fig) => {
+    const cx = (el: Element) => {
+      const r = el.getBoundingClientRect();
+      return { topo: Math.round(r.top), base: Math.round(r.bottom) };
+    };
+    const corpo = fig.querySelector(".viz-body") as HTMLElement;
+    return {
+      quadro: cx(fig),
+      cabeca: cx(fig.querySelector(".viz-head")!),
+      rodape: cx(fig.querySelector(".viz-foot")!),
+      sobra: corpo.scrollHeight - corpo.clientHeight,
+      rolagem: Math.round(corpo.scrollTop),
+    };
+  });
+}
+
+/** Altura visível do bloco de código (recolhido ele fica com os 2px da borda). */
+function alturaCodigo(page: import("@playwright/test").Page) {
+  return page
+    .locator(`${CONTADOR} .viz-code`)
+    .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+test("Big O expandido: cabeçalho e controles ficam parados, só o miolo rola", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 620 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  await viz.getByRole("button", { name: /Expandir/ }).click();
+  await expect(viz.getByRole("button", { name: /Fechar/ })).toBeVisible();
+
+  // Abro o código na mão para garantir conteúdo maior que a janela: o teste é
+  // sobre o que acontece QUANDO sobra conteúdo, não sobre a decisão automática.
+  const alternar = viz.locator(".viz-toggle-codigo");
+  if ((await alternar.textContent())?.includes("Mostrar")) await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+
+  // A altura do código anima em 0,32s: espero ela assentar antes de medir a
+  // casca, senão eu mediria um layout a caminho do lugar.
+  await expect.poll(async () => await alturaCodigo(page)).toBeGreaterThan(150);
+
+  const antes = await medirCasca(page);
+  expect(antes.sobra, "o miolo precisa ter mais conteúdo do que altura para o teste valer").toBeGreaterThan(20);
+  // 1px de tolerância: a borda do quadro fica por fora do cabeçalho.
+  expect(antes.cabeca.topo - antes.quadro.topo, "cabeçalho colado no topo do quadro").toBeLessThanOrEqual(2);
+  expect(antes.quadro.base - antes.rodape.base, "rodapé colado na base do quadro").toBeLessThanOrEqual(2);
+
+  // Rolar o miolo até o fim não pode levar a casca junto.
+  await viz.locator(".viz-body").evaluate((el) => { el.scrollTop = el.scrollHeight; });
+  const depois = await medirCasca(page);
+  expect(depois.rolagem, "o miolo rolou de verdade").toBeGreaterThan(20);
+  expect(depois.cabeca, "o cabeçalho se mexeu ao rolar").toEqual(antes.cabeca);
+  expect(depois.rodape, "o rodapé se mexeu ao rolar").toEqual(antes.rodape);
+
+  // E o que importa: os controles continuam à mão, com o rótulo certo.
+  await expect(viz.getByRole("button", { name: /Rodar/ })).toBeInViewport();
+  await expect(viz.locator(".viz-head-title")).toBeInViewport();
+
+  // O artigo atrás fica travado: quem rola é o painel, não a página.
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+
+  // Fechar devolve a rolagem da página.
+  await viz.getByRole("button", { name: /Fechar/ }).click();
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+});
+
+test("Big O: em tela baixa o código já abre recolhido, com as variáveis em uma linha", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 560 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  const alternar = viz.locator(".viz-toggle-codigo");
+  // O rótulo é a asserção: ele é a única coisa que promete ao aluno o que o
+  // clique vai fazer.
+  await expect(alternar).toHaveText("Mostrar código");
+  await expect(alternar).toHaveAttribute("aria-expanded", "false");
+  expect(await alturaCodigo(page), "o código deveria estar recolhido").toBeLessThan(8);
+
+  // As variáveis viram fichas na mesma linha (é isso que a largura liberada
+  // compra); e continuam legíveis, com nome e valor.
+  const fichas = await viz.locator(".viz-var").evaluateAll((els) =>
+    els.map((e) => ({
+      topo: Math.round(e.getBoundingClientRect().top),
+      texto: (e.textContent ?? "").trim(),
+    }))
+  );
+  expect(fichas.length).toBeGreaterThanOrEqual(2);
+  expect(new Set(fichas.map((f) => f.topo)).size, "as variáveis não ficaram na mesma linha").toBe(1);
+  expect(fichas.map((f) => f.texto)).toContain("operações0");
+
+  // E recolher tem que valer a pena: o bloco que saiu responde por altura de
+  // verdade, não por 20px de nada.
+  const recolhido = await viz.evaluate((f) => Math.round(f.getBoundingClientRect().height));
+  await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect(alternar).toHaveAttribute("aria-expanded", "true");
+  await expect
+    .poll(async () => await alturaCodigo(page), { message: "o código não abriu ao clique" })
+    .toBeGreaterThan(150);
+  const aberto = await viz.evaluate((f) => Math.round(f.getBoundingClientRect().height));
+  expect(aberto - recolhido, "esconder o código precisa devolver altura de verdade").toBeGreaterThan(150);
+});
+
+test("Big O: em tela alta o código já vem aberto, sem precisar de clique", async ({ page }) => {
+  await page.setViewportSize({ width: 1500, height: 1400 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  await expect(viz.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+  expect(await alturaCodigo(page), "com folga de altura o código não deveria sumir").toBeGreaterThan(200);
+  // as 11 linhas da busca binária, não um bloco vazio com a borda certa
+  await expect(viz.locator(".viz-line")).toHaveCount(11);
+  await expect(viz.locator(".viz-code-head")).toContainText("busca_binaria.py");
+});
+
+test("Big O: a escolha do aluno vence a medição até ele fechar o painel", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 560 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  const alternar = viz.locator(".viz-toggle-codigo");
+  await expect(alternar).toHaveText("Mostrar código"); // a medição decidiu recolher
+  await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+
+  // Trocar de algoritmo troca o código (2 a 11 linhas) e pediria uma medição
+  // nova. Como o aluno já escolheu, a escolha dele manda.
+  await viz.getByRole("button", { name: /Todos os pares/ }).click();
+  await expect(viz.locator(".viz-code-head")).toContainText("tem_repetido.py");
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect
+    .poll(async () => await alturaCodigo(page), { message: "a escolha do aluno foi atropelada pela medição" })
+    .toBeGreaterThan(100);
+  // e continua aberto depois que qualquer transição teria terminado
+  await page.waitForTimeout(500);
+  expect(await alturaCodigo(page), "o código recolheu sozinho depois do clique").toBeGreaterThan(100);
+});
+
+test("no celular, o botão do código funciona no contador do Big O", async ({ page }) => {
+  // Regressão: a regra `@media (max-width: 760px) { .viz-code { display: none } }`
+  // apagava o bloco por CSS. Com o botão na tela, clicar nele não fazia nada —
+  // o aluno de celular clicava e continuava sem código.
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  const alternar = viz.locator(".viz-toggle-codigo");
+  await expect(alternar).toHaveText("Mostrar código");
+  await alternar.click();
+  await expect
+    .poll(async () => await alturaCodigo(page), { message: "o código não apareceu no celular" })
+    .toBeGreaterThan(150);
+  expect(await page.evaluate(() => document.body.scrollWidth > window.innerWidth)).toBe(false);
+});
+
 test("marcar um tópico como concluído persiste na sessão", async ({ page }) => {
   await page.goto("/topico/sliding-window/");
   // Há dois botões de concluir (topo e fim da página); ambos alternam juntos.

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -260,6 +260,48 @@ test("Big O expandido: cabeçalho e controles ficam parados, só o miolo rola", 
   expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
 });
 
+test("Big O expandido: o Tab circula dentro do painel, como manda o aria-modal", async ({ page }) => {
+  await page.setViewportSize({ width: 1280, height: 620 });
+  await page.goto("/topico/big-o/");
+
+  const viz = page.locator(CONTADOR);
+  await viz.getByRole("button", { name: /Expandir/ }).click();
+  await expect(viz.getByRole("button", { name: /Fechar/ })).toBeVisible();
+  await expect(page.locator(".viz-overlay")).toHaveAttribute("aria-modal", "true");
+
+  // Voltas suficientes para dar duas passadas na lista de focáveis: se o foco
+  // escapasse uma única vez, o artigo por baixo receberia o Tab.
+  const fugas: string[] = [];
+  for (let i = 0; i < 24; i++) {
+    await page.keyboard.press("Tab");
+    const onde = await page.evaluate(() => {
+      const a = document.activeElement;
+      const fig = document.querySelector("figure.viz-fit");
+      return { dentro: !!(fig && a && fig.contains(a)), quem: a?.className || a?.tagName || "?" };
+    });
+    if (!onde.dentro) fugas.push(`volta ${i + 1}: ${onde.quem}`);
+  }
+  expect(fugas, "o foco vazou do painel").toEqual([]);
+
+  // E para trás também, que é o lado que costuma ficar de fora do laço.
+  await page.keyboard.press("Shift+Tab");
+  await page.keyboard.press("Shift+Tab");
+  expect(
+    await page.evaluate(() => {
+      const fig = document.querySelector("figure.viz-fit");
+      return !!(fig && document.activeElement && fig.contains(document.activeElement));
+    })
+  ).toBe(true);
+
+  // O código recolhido some para leitor de tela, não só para o teclado.
+  const alternar = viz.locator(".viz-toggle-codigo");
+  if ((await alternar.textContent())?.includes("Ocultar")) await alternar.click();
+  await expect(alternar).toHaveText("Mostrar código");
+  await expect(viz.locator(".viz-code")).toHaveAttribute("aria-hidden", "true");
+  await alternar.click();
+  await expect(viz.locator(".viz-code")).not.toHaveAttribute("aria-hidden", "true");
+});
+
 test("Big O: em tela baixa o código já abre recolhido, com as variáveis em uma linha", async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 560 });
   await page.goto("/topico/big-o/");


### PR DESCRIPTION
## O problema

O visualizador **contando operações no mesmo array** (Notação Big O) não cabe
na tela de um notebook — **nem expandido**. Medido em 1512x900:

| estado | altura que a peça pede | altura disponível |
|---|---|---|
| no artigo, com o código à mostra | **941px** | 808px |
| expandido, com o código à mostra | **748px** de miolo | 700px |

E como `.viz-overlay .viz` rolava **inteiro**, o problema piorava justamente
onde deveria melhorar: no expandido o título e os botões de reprodução saíam
da tela junto com o conteúdo, e o aluno ficava rolando atrás do "Próximo ›"
que faz o algoritmo andar.

## A solução, em três camadas

A casca `.viz-fit` (opt-in, aplicada só a este visualizador por enquanto):

1. **Cabeçalho e controles parados.** No expandido, `.viz-head` e `.viz-foot`
   são `flex: none` e só `.viz-body` rola. O rodapé saiu de dentro do corpo
   para isso. A rolagem da página fica travada enquanto o painel está aberto,
   e o overlay virou um `role="dialog"` de verdade, com foco entrando ao abrir
   e voltando ao fechar.
2. **Comprimir antes de esconder.** Abaixo de 950px de **altura** o expandido
   aperta respiro — padding, margem, tamanho de célula —, nunca conteúdo. Isso
   sozinho faz a peça caber com o código à mostra numa janela de 900px.
3. **Só então recolher o código**, com as variáveis virando uma fileira de
   fichas, que é o formato que aproveita a largura liberada. Um botão
   **Mostrar código / Ocultar código** devolve o bloco a qualquer momento, e a
   escolha do aluno vence a medição até ele fechar o painel.

## Quem decide não é um breakpoint, é uma medição

A peça cabe na altura disponível? Tela grande com peça leve abre tudo; tela
baixa, array de 14 posições ou código de 11 linhas já abre recolhido. A régua
muda com o contexto: no artigo é a janela (se a peça não cabe numa tela, o
aluno olha o array sem enxergar os botões); no expandido é o miolo rolável.

| cenário | resultado |
|---|---|
| 1512x1200, array de 8 | código aberto (899px de 1108 disponíveis) |
| 1512x900, array de 8 | recolhido (941 > 808), peça cai para 603px |
| 1512x1200 → 900, array de 14 | recolhe sozinho ao redimensionar |
| 1512x900 expandido | **aberto**, sem rolagem: a compressão deu conta |
| 390x844 | recolhido, e agora dá para abrir |

## Dois detalhes que só apareceram medindo

- **Zerar a trilha da coluna (`0fr`) tira a largura e não a altura.** A linha do
  grid continuava com os 374px do bloco, e a peça "recolhida" seguia com 941px.
  Daí o `.viz-code-slot`, com o truque de `grid-template-rows: 1fr → 0fr`.
- **Medir logo depois de reabrir o código lê um layout a caminho.** A primeira
  versão concluía "cabe" para uma peça que passava 64px da janela, porque a
  transição de 0,32s ainda estava rodando. A decisão agora congela a animação
  antes de medir, tudo dentro do mesmo quadro (efeito de layout, antes da
  pintura), então nada disso pisca na tela.

## De quebra, o celular

A regra `@media (max-width: 760px) { .viz-code { display: none } }` apagava o
código por CSS, sem volta. Com o botão na tela, clicar nele não faria nada.
Agora quem manda é o botão, e o aluno de celular pode ler o código.

## Verificação

`npm run build` e `npm test` passam (**86 testes**). Cinco testes novos, todos
rodados **contra o código quebrado** antes de entrar:

| teste | quebra que ele pega |
|---|---|
| cabeçalho e controles ficam parados, só o miolo rola | tirar o flex do overlay |
| em tela baixa o código já abre recolhido, variáveis em uma linha | medição que nunca recolhe; `0fr` do slot; classe `linha` |
| em tela alta o código já vem aberto | recolher sempre |
| a escolha do aluno vence a medição | ignorar `escolhaManual` |
| no celular o botão do código funciona | voltar o `display: none` |

Todos leem **rótulo** além de número: comportamento certo com rótulo errado
ensina errado do mesmo jeito.

**Escopo:** nada muda para os outros 35 visualizadores. As regras novas moram
em `.viz-fit` / `.viz-overlay-fit`, e a única regra existente tocada ganhou um
`:not(.viz-fit)` para não depender de ordem de cascata (conferido: o overlay
dos outros continua `1fr 1fr` com `overflow: auto`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbVz4tVeJ8DFiFYGmjFhq5