### PR TITLE
ci(test): porta do servidor de teste vem do ambiente, e sem reuso

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,15 @@ a passo (visualizador), artigo, vídeo, problemas (LeetCode/GeeksforGeeks) e ref
 npm run dev      # desenvolvimento
 npm run build    # DEVE passar (gera ./out). 55+ páginas.
 npm test         # Playwright (roda contra o ./out via python http.server). DEVE passar.
+PORT=3101 npm test   # porta alternativa: obrigatório quando há mais de uma suíte na máquina
 ```
 
 ## Verificação (faça sempre)
 
 1. Depois de mudar código, rode `npm run build` **e** `npm test`. Os dois têm que passar.
+   A suíte **não reusa** servidor que já esteja na porta: reusar fazia ela testar o `out/` de
+   outro worktree (ou o dev server, que serve da fonte) e **passar verde com código quebrado**.
+   Porta ocupada agora falha dizendo isso; use `PORT=<outra> npm test`.
 2. Para conferência visual, use o **`agent-browser`** (Vercel Labs CLI, instalado na máquina):
    - Servir o build: `python3 -m http.server 4321 --directory out` e abrir nele; ou usar o dev server.
    - Screenshot da página inteira: flag é **`--full`** (não `--full-page`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,6 +206,10 @@ npx --yes --package @commitlint/cli --package @commitlint/config-conventional \
 - ✅ **FAÇA** `npm test` passar (navegação, links e âncoras).
 - ✅ **CONSIDERE** adicionar um teste quando o PR resolve um bug ou adiciona algo
   navegável (nav, links, âncoras do índice).
+- ℹ️ A suíte sobe um servidor estático na porta **3000**, servindo o `./out`. Se
+  a porta estiver ocupada (um `npm run dev` esquecido, outra suíte rodando), o
+  Playwright **falha dizendo isso** em vez de testar o que está lá — rode com
+  outra: `PORT=3101 npm test`.
 
 
 ## <a name="ci-forks"></a> CI e Pull Requests de forks

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,10 +206,10 @@ npx --yes --package @commitlint/cli --package @commitlint/config-conventional \
 - ✅ **FAÇA** `npm test` passar (navegação, links e âncoras).
 - ✅ **CONSIDERE** adicionar um teste quando o PR resolve um bug ou adiciona algo
   navegável (nav, links, âncoras do índice).
-- ℹ️ A suíte sobe um servidor estático na porta **3000**, servindo o `./out`. Se
-  a porta estiver ocupada (um `npm run dev` esquecido, outra suíte rodando), o
-  Playwright **falha dizendo isso** em vez de testar o que está lá — rode com
-  outra: `PORT=3101 npm test`.
+- ℹ️ A suíte sobe um servidor estático servindo o `./out`, na porta **3000 por
+  padrão** (`PORT` muda). Se a porta estiver ocupada (um `npm run dev`
+  esquecido, outra suíte rodando), o Playwright **falha dizendo isso** em vez de
+  testar o que está lá — rode com outra: `PORT=3101 npm test`.
 
 
 ## <a name="ci-forks"></a> CI e Pull Requests de forks

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,7 +8,24 @@ import { defineConfig, devices } from "@playwright/test";
 //     PORT=3101 npm test
 //
 // Sem isso, duas suítes simultâneas disputam a mesma porta.
-const PORT = Number(process.env.PORT) || 3000;
+//
+// A validação não é preciosismo: `Number(process.env.PORT) || 3000` engole
+// `PORT=310l` (com "L") caindo no padrão em silêncio, e passa `3000.5` adiante
+// para o `http.server` falhar de um jeito que não parece com o erro que é. Este
+// arquivo existe justamente para trocar silêncio por erro claro.
+function resolvePort(): number {
+  const raw = process.env.PORT;
+  if (raw === undefined || raw.trim() === "") return 3000;
+  const n = Number(raw);
+  if (!Number.isInteger(n) || n < 1 || n > 65535) {
+    throw new Error(
+      `PORT inválida: ${JSON.stringify(raw)}. Use um inteiro entre 1 e 65535, por exemplo PORT=3101.`
+    );
+  }
+  return n;
+}
+
+const PORT = resolvePort();
 
 export default defineConfig({
   testDir: "./tests",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,15 @@
 import { defineConfig, devices } from "@playwright/test";
 
-// Testes leves de fumaça: navegação e links funcionando. Sobem o dev server
-// automaticamente. Rode com `npm test`.
+// Testes leves de fumaça: navegação e links funcionando. Rode com `npm test`.
+//
+// A porta vem do ambiente porque o repositório é trabalhado em vários worktrees
+// ao mesmo tempo, cada um com o seu `out/`:
+//
+//     PORT=3101 npm test
+//
+// Sem isso, duas suítes simultâneas disputam a mesma porta.
+const PORT = Number(process.env.PORT) || 3000;
+
 export default defineConfig({
   testDir: "./tests",
   fullyParallel: true,
@@ -11,16 +19,24 @@ export default defineConfig({
   timeout: 30_000,
   expect: { timeout: 10_000 },
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: `http://localhost:${PORT}`,
     trace: "on-first-retry",
   },
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   // Testa o artefato real (SSG em ./out), não o dev server. Rode `npm run build`
-  // antes de `npm test` (ou use o script combinado).
+  // antes de `npm test` (ou use `npm run test:build`).
   webServer: {
-    command: "python3 -m http.server 3000 --directory out",
-    url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    command: `python3 -m http.server ${PORT} --directory out`,
+    url: `http://localhost:${PORT}`,
+    // `false` de propósito, e não `!process.env.CI` como era: reusar o servidor
+    // que já está na porta faz a suíte testar o `out/` DE OUTRA PESSOA sem dizer
+    // nada. Medido: com o build de outro worktree na 3000, um teste que reprova
+    // no código local passa verde. Também pega o caso mais comum, que é o
+    // `npm run dev` esquecido na 3000 — ele serve da fonte, não do `out/`, e
+    // mascara justamente o que o build estático faz.
+    // Falha alta na cara é melhor que resultado bonito e falso: se a porta
+    // estiver ocupada, o Playwright avisa e você escolhe outra pelo `PORT`.
+    reuseExistingServer: false,
     timeout: 60_000,
   },
 });

--- a/scripts/guarda-commit.py
+++ b/scripts/guarda-commit.py
@@ -1,0 +1,26 @@
+"""Guarda dos headers de commit: tamanho E caixa.
+
+    git log --format="%s" origin/main..HEAD | python3 guarda-commit.py
+
+O commitlint reprova por duas coisas que passam despercebidas:
+  · header acima de 72 CARACTERES (não bytes: um `ê` vale 2 em `awk length`);
+  · `subject-case` — o assunto não pode começar em maiúscula, e isso inclui
+    sigla e nome de variável de ambiente (`PORT`, `CSS`, `SEO`).
+"""
+import re, sys
+
+ruim = False
+for linha in sys.stdin:
+    h = linha.rstrip()
+    if not h:
+        continue
+    n = len(h)
+    assunto = h.split(":", 1)[1].strip() if ":" in h else h
+    problemas = []
+    if n > 72:
+        problemas.append(f"{n} caracteres (máx. 72)")
+    if assunto[:1].isupper():
+        problemas.append(f"assunto começa em maiúscula ({assunto.split()[0]!r})")
+    print(("✖ " if problemas else "✓ ") + h + ("  → " + "; ".join(problemas) if problemas else ""))
+    ruim = ruim or bool(problemas)
+sys.exit(1 if ruim else 0)


### PR DESCRIPTION
Último pré-requisito antes de aplicar a casca adaptativa nos outros 61
visualizadores com vários agentes em paralelo.

## O problema, medido

A suíte fixava a porta 3000 e tinha `reuseExistingServer: !process.env.CI` —
ou seja, **ligado** fora de CI. Como o repositório é trabalhado em vários
worktrees ao mesmo tempo, cada um com o seu `./out`, a segunda suíte a rodar
não sobe servidor nenhum: ela testa o build da primeira.

Com o código local propositalmente quebrado (o hook recolhendo sempre, mesmo
com folga de altura):

```
porta 3000 ocupada por outro build  ->  1 passed     ← o código está quebrado
porta 3000 livre                    ->  1 failed     ← a verdade
```

Não sobra rastro: sem aviso, sem log, só um `1 passed`. E o caso não é
hipotético — os agentes do fan-out vão estar todos aplicando **o mesmo padrão**
na mesma semana, então o build do vizinho quase sempre tem a feature que o
teste procura.

O mesmo mecanismo pega o caso mais comum de todos, que não tem nada a ver com
paralelismo: **um `npm run dev` esquecido na 3000**. Ele serve da fonte, não do
`out/`, e mascara justamente o que o build estático faz (Shiki no build, export
estático). Aconteceu comigo nesta sequência de trabalho.

## O conserto

- **`PORT` do ambiente**, com 3000 de padrão: dois worktrees rodam ao mesmo
  tempo sem se pisar (`PORT=3101 npm test`).
- **`reuseExistingServer: false`**: porta ocupada agora falha dizendo isso, em
  vez de devolver um verde que não é seu. Resultado bonito e falso é pior que
  erro — é o mesmo princípio dos testes que medem comportamento em vez de
  contar elemento.

## Verificação, nos quatro casos

| cenário | resultado |
|---|---|
| sozinho, sem setar nada (o caso normal) | **90 passed em 28,3s** — sem degradação |
| `PORT=3456 npm test` | passa |
| duas suítes ao mesmo tempo, 3101 e 3102 | **as duas passam** |
| 3000 ocupada | `Error: http://localhost:3000 is already used…` |

**O CI não muda:** lá `reuseExistingServer` já era `false` (`!process.env.CI`).

Documentado no `CLAUDE.md` (com o porquê) e no `CONTRIBUTING.md` (com a saída
prática para quem esbarrar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GbVz4tVeJ8DFiFYGmjFhq5