### PR TITLE
feat(viz): casca adaptativa no classificador de subarray e afins

### DIFF
--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -246,12 +246,12 @@ Reprodução, quando você precisa mexer nela de fora: `viz.step` (já limitado 
 | botões extras nos controles | `<VizFooter>{seus botões}</VizFooter>` |
 | **sem linha do tempo E com botões extras** | escreva o rodapé à mão (abaixo) |
 
-As duas últimas linhas se contradizem, e a contradição é real: **`VizFooter` é o
-rodapé de REPRODUÇÃO e retorna `null` quando `total <= 1`, descartando os
-`children` em silêncio.** Um classificador com presets — que é o caso do
-`SubTypesVisualizer` — cai exatamente aí, e passar os botões para o `VizFooter`
-faz eles sumirem sem erro nenhum. Nesse caso os controles são seus e o `.viz-foot`
-também:
+A linha do `total: 1` e a dos **botões extras** se contradizem, e a contradição é
+real: **`VizFooter` é o rodapé de REPRODUÇÃO e retorna `null` quando
+`total <= 1`, descartando os `children` em silêncio.** Um classificador com
+presets — que é o caso do `SubTypesVisualizer` — cai exatamente aí, e passar os
+botões para o `VizFooter` some com eles sem erro nenhum. Nesse caso os controles
+são seus e o `.viz-foot` também:
 
 ```tsx
 {/* Fora do `.viz-body` de propósito: é o que os deixa parados no pé do
@@ -325,9 +325,9 @@ Nos testes (`tests/`), o mínimo por visualizador adaptado:
 4. a escolha do aluno sobrevive a uma troca de estado que pediria medição nova;
 5. `←`/`→`/espaço andam a animação, **e não roubam a tecla de quem digita**.
 
-Os itens 2, 3 e 4 não existem quando `collapsible: false`. No lugar deles, prove
-que a ausência tem o rótulo certo: **nenhum botão pode prometer esconder um
-bloco que o visualizador não tem.**
+Os itens 2, 3 e 4 — os três que falam do bloco recolhível — não existem quando
+`collapsible: false`. No lugar deles, prove que a ausência tem o rótulo certo:
+**nenhum botão pode prometer esconder um bloco que o visualizador não tem.**
 
 Duas armadilhas medidas ao escrever esses testes:
 

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -58,6 +58,13 @@ nós JSX ficaram de fora, e três rótulos passaram batido — `<span>Array (fic
 sorted)</span>` entre eles. Depois, confira no navegador: contador, botões,
 notas, rótulos e o bloco de código.
 
+**E saiba o que ele não olha: ele compara o CONJUNTO de textos, não onde cada um
+aparece.** Trocar dois campos de lugar num rename (o subtítulo de um cartão indo
+para o corpo e vice-versa) mantém o conjunto idêntico e passa verde. Medido: com
+`{l.subtitle}` e `{l.body}` invertidos no `SubTypesVisualizer`, o guarda não
+acusa nada e a tela mente. Quem pega isso é teste que lê **rótulo e valor
+juntos**, no mesmo cartão — veja a §8.
+
 Duas notas de execução: renomear um campo pode **colidir com uma variável local**
 de mesmo nome (`fora` → `out` bateu num `out` que já existia, e o `tsc` reclamou
 de tipo em vez de nome); e a substituição por palavra inteira estraga
@@ -237,6 +244,31 @@ Reprodução, quando você precisa mexer nela de fora: `viz.step` (já limitado 
 | ritmo próprio | `speeds: [...]` — um passo de sudoku e uma troca de array não pedem o mesmo tempo |
 | só passo a passo, sem animação contínua | `<VizFooter noSpeed />` |
 | botões extras nos controles | `<VizFooter>{seus botões}</VizFooter>` |
+| **sem linha do tempo E com botões extras** | escreva o rodapé à mão (abaixo) |
+
+As duas últimas linhas se contradizem, e a contradição é real: **`VizFooter` é o
+rodapé de REPRODUÇÃO e retorna `null` quando `total <= 1`, descartando os
+`children` em silêncio.** Um classificador com presets — que é o caso do
+`SubTypesVisualizer` — cai exatamente aí, e passar os botões para o `VizFooter`
+faz eles sumirem sem erro nenhum. Nesse caso os controles são seus e o `.viz-foot`
+também:
+
+```tsx
+{/* Fora do `.viz-body` de propósito: é o que os deixa parados no pé do
+    painel enquanto o miolo rola. */}
+<div className="viz-foot">
+  <div className="viz-controls">…seus botões…</div>
+</div>
+```
+
+Não é um atalho: `.viz-foot` é parte da API de CSS (§4), e `.viz-controls`
+dentro dele recebe a mesma linha divisória e o mesmo respiro que o rodapé do
+hook. O que você não ganha — progresso, velocidade, atalhos — é justamente o que
+um visualizador sem linha do tempo não tem.
+
+`measureOn` não faz nada quando `collapsible: false`: sem bloco para recolher,
+não há decisão a tomar e o hook nem espera as fontes. Passar a lista ali é ruído
+que sugere uma medição que não acontece.
 
 O que continua por sua conta: envolver o bloco recolhível no `.viz-code-slot`
 (zerar a coluna tira a largura, não a altura — §7) e escolher um `titulo` que
@@ -292,6 +324,22 @@ Nos testes (`tests/`), o mínimo por visualizador adaptado:
 3. em tela alta ele já vem aberto;
 4. a escolha do aluno sobrevive a uma troca de estado que pediria medição nova;
 5. `←`/`→`/espaço andam a animação, **e não roubam a tecla de quem digita**.
+
+Os itens 2, 3 e 4 não existem quando `collapsible: false`. No lugar deles, prove
+que a ausência tem o rótulo certo: **nenhum botão pode prometer esconder um
+bloco que o visualizador não tem.**
+
+Duas armadilhas medidas ao escrever esses testes:
+
+- **`click()` do Playwright ROLA o contêiner para alcançar o alvo.** Um teste
+  que clica no botão do rodapé e conclui "está ao alcance" passa igualzinho com
+  o rodapé de volta dentro do miolo — medido, com a quebra aplicada e o build
+  visível. *Alcançável* não é *à vista*. Ancore no `scrollTop`: clique só no que
+  está no topo do miolo e exija `scrollTop` igual a `0` **depois** do clique no
+  controle.
+- **Um teste de rolagem sem sobra para rolar não testa nada.** Afirme primeiro
+  que `scrollHeight - clientHeight` passa de zero; senão o dia em que a peça
+  encolher o teste vira decoração verde.
 
 E rode cada teste novo **contra o código quebrado** antes de confiar nele. Duas
 regras que custaram caro:

--- a/content/visualizers/SubTypesVisualizer.tsx
+++ b/content/visualizers/SubTypesVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // SubTypesVisualizer, subarray / substring / subsequence / subset.
@@ -14,138 +15,141 @@ import { createPortal } from "react-dom";
 //
 // O botão Array/String existe para provar que substring é subarray em uma
 // string: a lógica de classificação é literalmente a mesma, só muda o rótulo.
+//
+// A casca vem do `useVisualizer`, mas este é o canto de fora do padrão dela, e
+// as três escolhas estão aqui para não serem desfeitas por engano:
+//
+//   · `total: 1` — não há linha do tempo. Some o contador de passo, o rodapé de
+//     reprodução e os atalhos de seta/espaço, que aqui só atrapalhariam: o
+//     campo de texto é a interação principal.
+//   · `collapsible: false` — não existe bloco dispensável (nem código, nem
+//     painel de variáveis). Inventar um só para ganhar o botão "Mostrar" seria
+//     esconder conteúdo que o aluno veio ver.
+//   · o rodapé é escrito à mão. `VizFooter` é o rodapé de REPRODUÇÃO e não
+//     renderiza nada quando `total <= 1` — inclusive descartando `children`.
+//     Como os presets são os controles deste visualizador, eles precisam do
+//     `.viz-foot` (irmão do `.viz-body`) para ficarem parados no pé do painel
+//     enquanto o miolo rola. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Modo = "array" | "string";
+type Mode = "array" | "string";
 
 const BASE_ARRAY = "3, 1, 2, 4";
 const BASE_STRING = "code";
 const MAX = 8;
 
-function tokens(modo: Modo, texto: string): string[] {
-  if (modo === "string") return texto.replace(/\s+/g, "").split("").slice(0, MAX);
-  return texto.split(",").map((t) => t.trim()).filter(Boolean).slice(0, MAX);
+function tokens(mode: Mode, text: string): string[] {
+  if (mode === "string") return text.replace(/\s+/g, "").split("").slice(0, MAX);
+  return text.split(",").map((t) => t.trim()).filter(Boolean).slice(0, MAX);
 }
 
 export function SubTypesVisualizer() {
-  const [modo, setModo] = useState<Modo>("array");
-  const [texto, setTexto] = useState(BASE_ARRAY);
+  const [mode, setMode] = useState<Mode>("array");
+  const [text, setText] = useState(BASE_ARRAY);
   const [picks, setPicks] = useState<number[]>([]);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
 
-  useEffect(() => setMounted(true), []);
+  const viz = useVisualizer({
+    title: "Visualizador · monte um pedaço e veja o que ele é",
+    total: 1,
+    collapsible: false,
+  });
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const base = useMemo(() => tokens(modo, texto), [modo, texto]);
+  const base = useMemo(() => tokens(mode, text), [mode, text]);
   const n = base.length;
 
-  const trocarModo = (m: Modo) => {
-    setModo(m);
-    setTexto(m === "array" ? BASE_ARRAY : BASE_STRING);
+  const pickMode = (m: Mode) => {
+    setMode(m);
+    setText(m === "array" ? BASE_ARRAY : BASE_STRING);
     setPicks([]);
   };
-  const aoDigitar = (v: string) => { setTexto(v); setPicks([]); };
-  const clicar = (i: number) => setPicks((p) => (p.includes(i) ? p.filter((x) => x !== i) : [...p, i]));
+  const onType = (v: string) => { setText(v); setPicks([]); };
+  const toggleIndex = (i: number) => setPicks((p) => (p.includes(i) ? p.filter((x) => x !== i) : [...p, i]));
 
-  const vazio = picks.length === 0;
+  const empty = picks.length === 0;
   // Ordem mantida = cada clique caiu à direita do anterior no array original.
-  const emOrdem = picks.every((p, i) => i === 0 || p > picks[i - 1]);
-  const contiguo = emOrdem && picks.every((p, i) => i === 0 || p === picks[i - 1] + 1);
-  const ordenados = [...picks].sort((a, b) => a - b);
-  const buracos = !vazio && emOrdem
+  const inOrder = picks.every((p, i) => i === 0 || p > picks[i - 1]);
+  const contiguous = inOrder && picks.every((p, i) => i === 0 || p === picks[i - 1] + 1);
+  const sorted = [...picks].sort((a, b) => a - b);
+  const gaps = !empty && inOrder
     ? Array.from({ length: picks[picks.length - 1] - picks[0] + 1 }, (_, k) => picks[0] + k).filter(
         (i) => !picks.includes(i)
       )
     : [];
 
-  const mostrar = (idxs: number[]) =>
-    modo === "string" ? `"${idxs.map((i) => base[i]).join("")}"` : `[${idxs.map((i) => base[i]).join(", ")}]`;
+  const format = (idxs: number[]) =>
+    mode === "string" ? `"${idxs.map((i) => base[i]).join("")}"` : `[${idxs.map((i) => base[i]).join(", ")}]`;
   // Subconjunto se escreve entre chaves, e essa notação é parte da explicação.
-  const mostrarConjunto = (idxs: number[]) => `{${idxs.map((i) => base[i]).join(", ")}}`;
+  const formatSet = (idxs: number[]) => `{${idxs.map((i) => base[i]).join(", ")}}`;
 
-  const nomeFatia = modo === "string" ? "Substring" : "Subarray";
-  const gemeo = modo === "string" ? "em array, isso se chama subarray" : "em string, isso se chama substring";
-  const fatia = modo === "string" ? "substring" : "subarray";
+  const sliceName = mode === "string" ? "Substring" : "Subarray";
+  const twin = mode === "string" ? "em array, isso se chama subarray" : "em string, isso se chama substring";
+  const slice = mode === "string" ? "substring" : "subarray";
 
-  const linhas = [
+  const verdicts = [
     {
-      nome: nomeFatia,
-      sub: gemeo,
-      cor: "c-arr",
-      ok: contiguo,
-      txt: vazio
+      name: sliceName,
+      subtitle: twin,
+      color: "c-arr",
+      ok: contiguous,
+      body: empty
         ? "Clique em pelo menos um elemento para classificar."
-        : contiguo
+        : contiguous
           ? `Índices ${picks.join(", ")} colados e da esquerda para a direita: é uma fatia contígua do original.`
-          : !emOrdem
-            ? `Você clicou fora da ordem. Uma fatia é sempre lida da esquerda para a direita, então ${mostrar(picks)} não é ${fatia}.`
-            : `Pulou o índice ${buracos.join(", ")}. Fatia contígua não tem buraco: ou leva tudo do começo ao fim, ou não é ${fatia}.`,
+          : !inOrder
+            ? `Você clicou fora da ordem. Uma fatia é sempre lida da esquerda para a direita, então ${format(picks)} não é ${slice}.`
+            : `Pulou o índice ${gaps.join(", ")}. Fatia contígua não tem buraco: ou leva tudo do começo ao fim, ou não é ${slice}.`,
     },
     {
-      nome: "Subsequence",
-      sub: "apaga elementos, nunca reordena",
-      cor: "c-seq",
-      ok: emOrdem,
-      txt: vazio
+      name: "Subsequence",
+      subtitle: "apaga elementos, nunca reordena",
+      color: "c-seq",
+      ok: inOrder,
+      body: empty
         ? "A contiguidade some, mas a ordem continua valendo."
-        : emOrdem
+        : inOrder
           ? "A ordem relativa do original foi mantida, então dá para chegar nesse pedaço só apagando o resto."
-          : `Ordem invertida. Com esses mesmos elementos, a única subsequência válida é ${mostrar(ordenados)}.`,
+          : `Ordem invertida. Com esses mesmos elementos, a única subsequência válida é ${format(sorted)}.`,
     },
     {
-      nome: "Subset",
-      sub: "conjunto, a ordem não existe",
-      cor: "c-set",
-      ok: !vazio,
-      txt: vazio
+      name: "Subset",
+      subtitle: "conjunto, a ordem não existe",
+      color: "c-set",
+      ok: !empty,
+      body: empty
         ? "O conjunto vazio também é um subconjunto, e é por isso que a contagem fecha em 2ⁿ."
-        : emOrdem
-          ? `Todos os elementos vieram do original. Como conjunto, ${mostrarConjunto(picks)} não tem primeiro nem último: clicar em outra sequência daria o mesmo subconjunto.`
-          : `${mostrarConjunto(picks)} e ${mostrarConjunto(ordenados)} são o mesmo subconjunto. Em conjunto a ordem não existe, então subset é o único dos três que sobrevive a um clique fora de ordem.`,
+        : inOrder
+          ? `Todos os elementos vieram do original. Como conjunto, ${formatSet(picks)} não tem primeiro nem último: clicar em outra sequência daria o mesmo subconjunto.`
+          : `${formatSet(picks)} e ${formatSet(sorted)} são o mesmo subconjunto. Em conjunto a ordem não existe, então subset é o único dos três que sobrevive a um clique fora de ordem.`,
     },
   ];
 
   const subarrays = (n * (n + 1)) / 2;
-  const potencia = 2 ** n;
+  const power = 2 ** n;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · monte um pedaço e veja o que ele é</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">n = {n}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo, o `n` é o único número de estado que vale no
+          cabeçalho — ele entra pelo slot de `children`, à esquerda do Expandir. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">n = {n}</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <div className="viz-field">
             <span>Origem</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${modo === "array" ? " on" : ""}`} onClick={() => trocarModo("array")}>
+              <button className={`sub-modo-btn${mode === "array" ? " on" : ""}`} onClick={() => pickMode("array")}>
                 Array
               </button>
-              <button className={`sub-modo-btn${modo === "string" ? " on" : ""}`} onClick={() => trocarModo("string")}>
+              <button className={`sub-modo-btn${mode === "string" ? " on" : ""}`} onClick={() => pickMode("string")}>
                 String
               </button>
             </div>
           </div>
           <label className="viz-field grow">
-            <span>{modo === "array" ? "Array (separe por vírgula)" : "String"}</span>
-            <input className="viz-input" value={texto} onChange={(e) => aoDigitar(e.target.value)} />
+            <span>{mode === "array" ? "Array (separe por vírgula)" : "String"}</span>
+            <input className="viz-input" value={text} onChange={(e) => onType(e.target.value)} />
           </label>
         </div>
 
@@ -160,7 +164,7 @@ export function SubTypesVisualizer() {
                   className={`viz-cell sub-cell${pos >= 0 ? " in" : ""}`}
                   aria-pressed={pos >= 0}
                   aria-label={`Índice ${i}, valor ${v}`}
-                  onClick={() => clicar(i)}
+                  onClick={() => toggleIndex(i)}
                 >
                   {v}
                 </button>
@@ -172,22 +176,22 @@ export function SubTypesVisualizer() {
 
         <div className="sub-montado">
           <span className="sub-montado-label">Seu pedaço</span>
-          {vazio ? (
+          {empty ? (
             <span className="sub-vazio">clique nos elementos acima, na ordem que quiser</span>
           ) : (
-            <code className="sub-montado-val">{mostrar(picks)}</code>
+            <code className="sub-montado-val">{format(picks)}</code>
           )}
         </div>
 
         <div className="sub-vereditos">
-          {linhas.map((l) => (
-            <div key={l.nome} className={`sub-veredito ${l.cor}${vazio ? " off" : l.ok ? " ok" : " no"}`}>
+          {verdicts.map((l) => (
+            <div key={l.name} className={`sub-veredito ${l.color}${empty ? " off" : l.ok ? " ok" : " no"}`}>
               <div className="sub-veredito-cab">
-                <span className="sub-veredito-nome">{l.nome}</span>
-                <span className="sub-veredito-selo">{vazio ? "·" : l.ok ? "✓ é" : "✕ não é"}</span>
+                <span className="sub-veredito-nome">{l.name}</span>
+                <span className="sub-veredito-selo">{empty ? "·" : l.ok ? "✓ é" : "✕ não é"}</span>
               </div>
-              <span className="sub-veredito-sub">{l.sub}</span>
-              <p className="sub-veredito-txt">{l.txt}</p>
+              <span className="sub-veredito-sub">{l.subtitle}</span>
+              <p className="sub-veredito-txt">{l.body}</p>
             </div>
           ))}
         </div>
@@ -195,37 +199,34 @@ export function SubTypesVisualizer() {
         <div className="sub-contagem">
           <div className="sub-conta">
             <span className="sub-conta-val">{subarrays}</span>
-            <span className="sub-conta-lbl">{modo === "string" ? "substrings" : "subarrays"} não-vazios · n(n+1)/2</span>
+            <span className="sub-conta-lbl">{mode === "string" ? "substrings" : "subarrays"} não-vazios · n(n+1)/2</span>
           </div>
           <div className="sub-conta">
-            <span className="sub-conta-val">{potencia - 1}</span>
+            <span className="sub-conta-val">{power - 1}</span>
             <span className="sub-conta-lbl">subsequências não-vazias · 2ⁿ − 1</span>
           </div>
           <div className="sub-conta">
-            <span className="sub-conta-val">{potencia}</span>
+            <span className="sub-conta-val">{power}</span>
             <span className="sub-conta-lbl">subconjuntos, contando o vazio · 2ⁿ</span>
           </div>
         </div>
         <p className="sub-nota-contagem">Contagens para n elementos distintos. Com repetidos, o número de pedaços diferentes cai.</p>
+      </div>
 
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé da
+          janela enquanto o miolo rola. Sem isso os presets sobem junto com o
+          conteúdo e o aluno perde de vista os botões que movem o visualizador. */}
+      <div className="viz-foot">
         <div className="viz-controls">
           <span className="sub-exemplos-label">Tente:</span>
           <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([1, 2])}>colado</button>
           <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([0, 2])}>com buraco</button>
           <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([2, 0])}>fora de ordem</button>
-          <button className="viz-btn" disabled={vazio} onClick={() => setPicks([])} style={{ marginLeft: "auto" }}>↺ Limpar</button>
+          <button className="viz-btn" disabled={empty} onClick={() => setPicks([])} style={{ marginLeft: "auto" }}>↺ Limpar</button>
         </div>
       </div>
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/tests/viz-subarray-substring-subsequence-subset.spec.ts
+++ b/tests/viz-subarray-substring-subsequence-subset.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Casca adaptativa do classificador de subarray / substring / subsequence /
+// subset. Ele é o canto fora do padrão da casca: `total: 1` (não há linha do
+// tempo) e `collapsible: false` (não há bloco dispensável), então os testes de
+// "Mostrar código" do contrato não se aplicam aqui. O que sobra, e é o que este
+// arquivo prova, é a camada 1 — cabeçalho e controles parados — mais o inverso
+// dos atalhos: sem linha do tempo, seta e espaço são de quem está digitando.
+//
+// Todos leem RÓTULO, não só número: veredito certo debaixo do nome errado
+// ensina errado do mesmo jeito.
+
+const URL = "/topico/subarray-substring-subsequence-subset/";
+
+/** Abre o painel expandido com as fontes prontas e a animação congelada. */
+async function expandir(page: Page) {
+  await page.goto(URL);
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({
+    content: "*, *::before, *::after { transition: none !important; animation: none !important; }",
+  });
+  await page.getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({
+    content: "*, *::before, *::after { transition: none !important; animation: none !important; }",
+  });
+  return painel;
+}
+
+/** O cartão de veredito que leva ESTE nome. Ler o selo sem ele não prova nada. */
+function veredito(painel: ReturnType<Page["locator"]>, nome: string) {
+  return painel.locator(".sub-veredito", { has: painel.page().getByText(nome, { exact: true }) });
+}
+
+test("no expandido, cabeçalho e presets ficam parados quando o miolo rola", async ({ page }) => {
+  // 600px de altura é onde o miolo passa a sobrar de verdade (medido: 73px).
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page);
+  await painel.getByRole("button", { name: "fora de ordem" }).click();
+
+  const antes = await painel.evaluate((f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const ctrl = f.querySelector<HTMLElement>(".viz-controls")!;
+    return {
+      sobra: body.scrollHeight - body.clientHeight,
+      head: Math.round(head.getBoundingClientRect().top),
+      ctrl: Math.round(ctrl.getBoundingClientRect().top),
+    };
+  });
+  // Sem sobra o teste não testaria nada: ele precisa de miolo para rolar.
+  expect(antes.sobra).toBeGreaterThan(20);
+
+  const depois = await painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    body.scrollTop = body.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const ctrl = f.querySelector<HTMLElement>(".viz-controls")!;
+    return {
+      rolou: Math.round(body.scrollTop),
+      head: Math.round(head.getBoundingClientRect().top),
+      ctrl: Math.round(ctrl.getBoundingClientRect().top),
+    };
+  });
+
+  expect(depois.rolou).toBeGreaterThan(20); // o miolo rolou mesmo
+  expect(depois.head).toBe(antes.head); // e o cabeçalho não foi junto
+  expect(depois.ctrl).toBe(antes.ctrl); // nem os presets
+
+  // O título continua legível depois de rolar: é ele que diz o que a peça é.
+  await expect(painel.getByText("Visualizador · monte um pedaço e veja o que ele é")).toBeInViewport();
+});
+
+test("em janela baixa, o preset fica ao alcance SEM rolar o miolo", async ({ page }) => {
+  // Antes da casca, medido em 1440x520: o "↺ Limpar" era desenhado 177px ABAIXO
+  // do pé da peça — no DOM, inalcançável para o aluno.
+  //
+  // O `scrollTop` é o que dá o teste de pé, e ele custou uma rodada: a primeira
+  // versão clicava num preset antes de medir, e o Playwright ROLA o contêiner
+  // para alcançar o alvo. Com o rodapé de volta dentro do miolo, o clique
+  // continuava funcionando — depois de rolar — e o teste passava contra o
+  // código quebrado. "Alcançável" não é "está à vista".
+  await page.setViewportSize({ width: 1440, height: 520 });
+  const painel = await expandir(page);
+  const miolo = painel.locator(".viz-body");
+
+  // Só um clique numa célula, que fica no topo do miolo e não pede rolagem.
+  await painel.getByRole("button", { name: "Índice 1, valor 1" }).click();
+  await expect(painel.locator(".sub-montado-val")).toHaveText("[1]");
+  await expect(miolo).toHaveJSProperty("scrollTop", 0);
+
+  const limpar = painel.getByRole("button", { name: "↺ Limpar" });
+  await expect(limpar).toBeInViewport();
+  await limpar.click();
+  await expect(painel.getByText("clique nos elementos acima, na ordem que quiser")).toBeVisible();
+  // E o clique não precisou rolar nada para acontecer.
+  await expect(miolo).toHaveJSProperty("scrollTop", 0);
+});
+
+test("sem linha do tempo, espaço e seta são de quem digita e Esc fecha", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 700 });
+  const painel = await expandir(page);
+  const campo = painel.locator("input.viz-input");
+
+  // `fill` deixa o cursor no fim sem depender de `End`, que no macOS não leva
+  // o cursor ao fim de um input.
+  await campo.fill("1, 2, 3");
+  // O cabeçalho lê o n de verdade, e é o único número que ele mostra: sem linha
+  // do tempo não existe "passo 1 de N" para exibir.
+  await expect(painel.locator(".viz-step")).toHaveText("n = 3");
+  // E nenhum botão promete esconder um bloco que este visualizador não tem.
+  await expect(painel.getByRole("button", { name: /código/ })).toHaveCount(0);
+
+  // Espaço digitou espaço: o painel não sequestrou a tecla para "rodar".
+  await campo.press("Space");
+  await expect(campo).toHaveValue("1, 2, 3 ");
+  await expect(painel).toBeVisible();
+
+  // Seta anda o cursor. Comparo o cursor com ele mesmo em vez de olhar o fim da
+  // string: se alguém desse `preventDefault` na seta, o cursor ficaria parado.
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(painel).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+test("o selo de cada veredito responde à ordem do clique, sob o nome certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(URL);
+  const peca = page.locator("article figure.viz");
+
+  // Índices 1 e 2, nessa ordem: colados e da esquerda para a direita.
+  await peca.getByRole("button", { name: "Índice 1, valor 1" }).click();
+  await peca.getByRole("button", { name: "Índice 2, valor 2" }).click();
+  await expect(peca.locator(".sub-montado-val")).toHaveText("[1, 2]");
+  await expect(veredito(peca, "Subarray").locator(".sub-veredito-selo")).toHaveText("✓ é");
+  await expect(veredito(peca, "Subsequence").locator(".sub-veredito-selo")).toHaveText("✓ é");
+  await expect(veredito(peca, "Subset").locator(".sub-veredito-selo")).toHaveText("✓ é");
+
+  // Mesmos dois elementos, ordem invertida: só o subconjunto sobrevive.
+  await peca.getByRole("button", { name: "↺ Limpar" }).click();
+  await peca.getByRole("button", { name: "Índice 2, valor 2" }).click();
+  await peca.getByRole("button", { name: "Índice 1, valor 1" }).click();
+  await expect(veredito(peca, "Subarray").locator(".sub-veredito-selo")).toHaveText("✕ não é");
+  await expect(veredito(peca, "Subsequence").locator(".sub-veredito-selo")).toHaveText("✕ não é");
+  await expect(veredito(peca, "Subset").locator(".sub-veredito-selo")).toHaveText("✓ é");
+  // O texto do cartão explica o selo que está ao lado dele, não o do vizinho.
+  await expect(veredito(peca, "Subarray").locator(".sub-veredito-txt")).toContainText("fora da ordem");
+  await expect(veredito(peca, "Subset").locator(".sub-veredito-txt")).toContainText("mesmo subconjunto");
+});
+
+test("trocar de Array para String troca o rótulo da fatia e as contagens", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(URL);
+  const peca = page.locator("article figure.viz");
+
+  // n = 4 → 10 fatias, 15 subsequências não-vazias, 16 subconjuntos.
+  await expect(peca.locator(".viz-step")).toHaveText("n = 4");
+  const contas = peca.locator(".sub-conta");
+  await expect(contas.nth(0)).toContainText("10");
+  await expect(contas.nth(0)).toContainText("subarrays não-vazios · n(n+1)/2");
+  await expect(contas.nth(1)).toContainText("15");
+  await expect(contas.nth(2)).toContainText("16");
+
+  await peca.getByRole("button", { name: "String", exact: true }).click();
+  // "code" também tem 4 elementos: o número não muda, o RÓTULO muda — que é o
+  // ponto do botão (substring é subarray numa string).
+  await expect(peca.locator(".viz-step")).toHaveText("n = 4");
+  await expect(contas.nth(0)).toContainText("substrings não-vazios · n(n+1)/2");
+  await expect(veredito(peca, "Substring")).toBeVisible();
+  await expect(veredito(peca, "Substring").locator(".sub-veredito-sub")).toHaveText(
+    "em array, isso se chama subarray"
+  );
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) no único visualizador do tópico
**subarray / substring / subsequence / subset**, traduz os identificadores do
componente para inglês (contrato §0) e devolve ao contrato o caso-limite que
este tópico exercitou primeiro.

## Inventário

| arquivo | overlay | code | vars | ctrl | entrou? |
|---|---|---|---|---|---|
| `SubTypesVisualizer.tsx` | sim | – | – | sim | **sim** |

**1 de 1 adaptado, 0 fora.** O tópico tem um visualizador só.

Ele é o canto de fora do padrão: overlay e controles, mas **sem bloco de código
e sem painel de variáveis**. Daí as três escolhas, todas comentadas no arquivo:

- `total: 1` — não há linha do tempo. Some o contador de passo e os atalhos de
  seta/espaço, que aqui roubariam o campo de texto, que é a interação principal.
- `collapsible: false` — não há bloco dispensável. Inventar um só para ganhar o
  botão "Mostrar" seria esconder o que o aluno veio ver. **Camada 3 não se
  aplica a este tópico.**
- **o rodapé é escrito à mão** — ver "o que o contrato ganhou", abaixo.

## Medições

Janela real, painel expandido, `document.fonts.ready` cumprido e **animação
congelada** antes de qualquer leitura de layout. Estado "fora de ordem", que é o
veredito mais longo e portanto o pior caso de altura.

### 1512x900, a régua do contrato — **já cabia, e continua cabendo**

| | antes | depois |
|---|---|---|
| altura no artigo | 703px (orçamento 816px) | 713px |
| altura da figura no expandido | 668px (janela 900px) | 644px |
| sobra do miolo no expandido | 0px | 0px |

Nada a consertar aqui, e não vou inventar problema: **em 1512x900 esta peça
sempre coube**. Os 10px a mais no fluxo do artigo são a soma de dois respiros
(o `padding-bottom` do miolo mais o do `.viz-foot`) que a casca separa de
propósito, e cabem de sobra nos 113px de folga.

### Onde o problema era real: janelas mais baixas

| janela | | antes | depois |
|---|---|---|---|
| 1440x700 | sobra do miolo | 16px | **0px** |
| | cabeçalho e presets se moveram | −16px | **0px** |
| 1440x600 | sobra do miolo | 116px | 73px |
| | cabeçalho e presets se moveram | −116px | **0px** |
| 1440x520 | sobra do miolo | 196px | 149px |
| | cabeçalho e presets se moveram | −196px | **0px** |

Antes, o `.viz` inteiro rolava: o título e os quatro presets subiam junto com o
conteúdo. Agora só o miolo rola.

E o número que resume: **onde o "↺ Limpar" era desenhado**, medido do pé da peça
(negativo = fora dela, inalcançável):

| janela | antes | depois |
|---|---|---|
| 1512x900 | 19px acima do pé | 19px |
| 1440x700 | 3px | 19px |
| 1440x600 | **−97px, `elementFromPoint` não o encontra** | 19px |
| 1440x520 | **−177px, idem** | 19px |

Camada 2 (comprimir) veio de graça com o `.viz-fit`: a figura no expandido
encolheu 24px em 1512x900, e é o que zerou a sobra de 16px em 1440x700.

### O que a medição contrariou

Eu ia escrever que a peça não cabe. **Em 1512x900 ela cabe com 113px de folga**,
e o que estava quebrado não era altura, era *onde* os controles ficavam. Mas o
número também contrariou o inverso: em **1100x900** a peça pede **1077px** no
fluxo do artigo contra 816px de orçamento — e a casca **não resolve isso**,
porque não há bloco dispensável para recolher. Fica registrado como limite
conhecido deste visualizador, não como algo que este PR conserta.

## Idioma

`Modo→Mode`, `texto→text`, `contiguo→contiguous`, `buracos→gaps`,
`mostrar→format`, `linhas→verdicts` e companhia. Guarda rodado:

```
$ python3 scripts/guarda-idioma.py <antes> content/visualizers/SubTypesVisualizer.tsx
SUMIRAM:    'Escape' 'dot' 'keydown' 'react-dom' 'viz' 'viz-body' 'viz-expand'
            'viz-head' 'viz-head-right' 'viz-head-title' 'viz-overlay'
            '✕ Fechar' '⤢ Expandir'
APARECERAM: '@/lib/visualizer' 'viz-foot'
```

Tudo nome de classe, de evento ou de import. `✕ Fechar` e `⤢ Expandir` saíram do
arquivo porque quem os renderiza agora é o `expandButtonProps` do hook, com o
texto idêntico. **Nenhum texto didático mudou.**

## Testes — `tests/viz-subarray-substring-subsequence-subset.spec.ts`

Arquivo novo, para não disputar o `navegacao.spec.ts` com os outros tópicos em
adaptação. Cinco testes, todos lendo rótulo além de número.

**Cada um rodado contra o código quebrado, com o build visível e quebras que
compilam** (`assert` de que o alvo casa antes de substituir; restauração por
`cp`, nunca `git checkout --`):

| quebra (compila) | quem reprovou |
|---|---|
| A — `.viz-foot` de volta para dentro do `.viz-body` | 1 e 2 |
| B — `collapsible: false` → `true` | 3 |
| C — `ok: inOrder` → `ok: !inOrder` na subsequência | 4 |
| D — `{l.subtitle}` e `{l.body}` invertidos | 4 e 5 |
| E — `total: 1` → `total: 2` | 3 e 5 |

**Uma das quebras derrubou um teste meu, e essa é a parte que vale contar.** Na
primeira rodada a quebra A reprovou o teste 1 e o teste 2 **passou**. O
experimento estava certo; o teste é que era fraco: ele clicava num preset antes
de medir, e **o `click()` do Playwright rola o contêiner para alcançar o alvo** —
com o rodapé de volta dentro do miolo, o clique continuava funcionando, depois
de rolar. *Alcançável* não é *à vista*. O teste agora ancora no `scrollTop`:
clica só numa célula (topo do miolo) e exige `scrollTop === 0` **depois** de
clicar no controle. Reprovado contra a quebra A na segunda rodada.

`npm run test:build`: **95 passed**.

## O que o contrato ganhou (`content/visualizers/README.md`)

Três regras de produto que o contrato prometia e ninguém tinha exercitado:

1. **§6 — `total: 1` e "botões extras no `VizFooter`" se contradizem.**
   `VizFooter` é o rodapé de *reprodução* e retorna `null` quando `total <= 1`,
   **descartando os `children` em silêncio**. Um classificador com presets cai
   exatamente aí, e seguir a tabela ao pé da letra faz os botões sumirem sem erro
   nenhum. Documentado o conserto (escrever o `.viz-foot`, que é API de CSS
   pública) e o fato de que `measureOn` é inerte com `collapsible: false`.
2. **§0 — o guarda de idioma compara o *conjunto* de textos, não onde cada um
   aparece.** A quebra D é a prova: com subtítulo e corpo invertidos, o guarda
   passa verde e a tela mente.
3. **§8 — os itens 2 a 4 do mínimo não existem com `collapsible: false`**; no
   lugar deles, prove que nenhum botão promete esconder um bloco inexistente. E
   as duas armadilhas medidas aqui: o `click()` que rola, e o teste de rolagem
   sem sobra para rolar.

## Fora de escopo, reportado em vez de feito

O silêncio do `VizFooter` ao descartar `children` é um defeito do componente
compartilhado, não deste tópico. Consertar `src/lib/visualizer.tsx` no meio de
sete adaptações em paralelo criaria conflito para todo mundo, então este PR
**documenta** o comportamento e deixa o conserto para um PR de plataforma.

Não toquei no bloco `viz-fit` do `globals.css`, em `content/roadmap.ts`, no
`mdx-components.tsx` nem no `navegacao.spec.ts`. **Nenhum CSS novo foi
necessário.**
