### PR TITLE
sliding-window: casca adaptativa nos dois visualizadores

### DIFF
--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -242,6 +242,14 @@ O que continua por sua conta: envolver o bloco recolhível no `.viz-code-slot`
 (zerar a coluna tira a largura, não a altura — §7) e escolher um `titulo` que
 seja o desse visualizador, porque ele vira o `aria-label` do diálogo.
 
+**`measureOn` tem que cobrir o que liga ou desliga um pedaço da casca, não só o
+que muda o miolo.** Quando o `total` é derivado da entrada, ele pode atravessar
+1 durante o uso: o gerador da comparação da sliding window devolve **um passo
+só** no caso de borda `k > n`, e aí o contador, o rodapé e os atalhos somem
+inteiros — cerca de 90px a menos de peça — sem que o tamanho da entrada tenha
+mudado. Um `measureOn: [n]` não pediria medição nova nessa travessia. O que
+resolveu foi `measureOn: [n, steps.length]`.
+
 ## 7. Armadilhas medidas
 
 - **Zerar a trilha da coluna (`0fr`) tira a largura e NÃO a altura.** A linha do

--- a/content/visualizers/SlidingWindowForcaBruta.tsx
+++ b/content/visualizers/SlidingWindowForcaBruta.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // SlidingWindowForcaBruta, os dois algoritmos correndo lado a lado.
@@ -11,30 +12,32 @@ import { createPortal } from "react-dom";
 // sobre o mesmo array, com um contador de operações para cada, e a diferença
 // entre os dois números é o argumento inteiro da técnica.
 //
-// Mesma casca dos outros (gerador puro de passos + controles + Expandir).
+// A casca (medição de altura, painel com cabeçalho e controles parados, código
+// recolhível, teclado) vem do `useVisualizer`. Contrato em
+// `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   // Índices da janela atualmente sob análise nos dois lados.
-  ini: number;
-  fim: number;
+  start: number;
+  end: number;
   // Quem está sendo somado agora na força bruta (null quando não é leitura).
-  lendo: number | null;
+  reading: number | null;
   // Na janela: quem entrou e quem saiu neste passo.
-  entrou: number | null;
-  saiu: number | null;
-  opsForca: number;
-  opsJanela: number;
-  somaForca: number;
-  somaJanela: number;
-  melhorForca: number;
-  melhorJanela: number;
-  linha: number;
-  nota: string;
-  fim_?: boolean;
+  entered: number | null;
+  removed: number | null;
+  bruteOps: number;
+  windowOps: number;
+  bruteSum: number;
+  windowSum: number;
+  bruteBest: number;
+  windowBest: number;
+  line: number;
+  note: string;
+  done?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "# força bruta: refaz a soma inteira de cada janela",
   "for i in range(n - k + 1):",
   "    soma = 0",
@@ -48,196 +51,162 @@ const CODIGO = [
   "    soma -= nums[direita - k]  # sai 1",
 ];
 
-const VELOCIDADES = [0, 1100, 750, 480, 300, 160];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1100, 750, 480, 300, 160];
 
-const PADRAO = [2, 3, 4, 5, 6, 7, 1, 9];
-const K_PADRAO = 3;
+const DEFAULT_ARRAY = [2, 3, 4, 5, 6, 7, 1, 9];
+const DEFAULT_K = 3;
 
-function gerarPassos(nums: number[], k: number): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(nums: number[], k: number): Step[] {
+  const steps: Step[] = [];
   const n = nums.length;
   if (k < 1 || k > n) {
-    out.push({
-      ini: 0, fim: -1, lendo: null, entrou: null, saiu: null,
-      opsForca: 0, opsJanela: 0, somaForca: 0, somaJanela: 0,
-      melhorForca: 0, melhorJanela: 0, linha: 1, fim_: true,
-      nota: `k = ${k} não cabe num array de ${n} posições. Não existe janela nenhuma para analisar, e este é um caso de borda que todo código precisa tratar.`,
+    steps.push({
+      start: 0, end: -1, reading: null, entered: null, removed: null,
+      bruteOps: 0, windowOps: 0, bruteSum: 0, windowSum: 0,
+      bruteBest: 0, windowBest: 0, line: 1, done: true,
+      note: `k = ${k} não cabe num array de ${n} posições. Não existe janela nenhuma para analisar, e este é um caso de borda que todo código precisa tratar.`,
     });
-    return out;
+    return steps;
   }
 
   // A força bruta roda inteira primeiro (só para termos o total dela por janela),
   // mas os passos são intercalados: cada janela mostra os dois custos juntos.
-  let opsF = 0, opsJ = 0;
-  let melhorF = -Infinity, melhorJ = -Infinity;
-  let somaJ = 0;
+  let bruteOps = 0, windowOps = 0;
+  let bruteBest = -Infinity, windowBest = -Infinity;
+  let windowSum = 0;
 
   // Montagem da primeira janela: os dois pagam k leituras aqui.
-  let somaF = 0;
+  let bruteSum = 0;
   for (let j = 0; j < k; j++) {
-    somaF += nums[j];
-    opsF++;
-    somaJ += nums[j];
-    opsJ++;
-    out.push({
-      ini: 0, fim: k - 1, lendo: j, entrou: null, saiu: null,
-      opsForca: opsF, opsJanela: opsJ, somaForca: somaF, somaJanela: somaJ,
-      melhorForca: melhorF === -Infinity ? 0 : melhorF,
-      melhorJanela: melhorJ === -Infinity ? 0 : melhorJ,
-      linha: 4,
-      nota: `Primeira janela: os dois somam nums[${j}] = ${nums[j]}. Até aqui empatados, ninguém tem estado guardado ainda.`,
+    bruteSum += nums[j];
+    bruteOps++;
+    windowSum += nums[j];
+    windowOps++;
+    steps.push({
+      start: 0, end: k - 1, reading: j, entered: null, removed: null,
+      bruteOps, windowOps, bruteSum, windowSum,
+      bruteBest: bruteBest === -Infinity ? 0 : bruteBest,
+      windowBest: windowBest === -Infinity ? 0 : windowBest,
+      line: 4,
+      note: `Primeira janela: os dois somam nums[${j}] = ${nums[j]}. Até aqui empatados, ninguém tem estado guardado ainda.`,
     });
   }
-  melhorF = somaF;
-  melhorJ = somaJ;
-  out.push({
-    ini: 0, fim: k - 1, lendo: null, entrou: null, saiu: null,
-    opsForca: opsF, opsJanela: opsJ, somaForca: somaF, somaJanela: somaJ,
-    melhorForca: melhorF, melhorJanela: melhorJ, linha: 7,
-    nota: `Janela [0..${k - 1}] fechada, soma ${somaF}. Custou ${k} leituras para os dois. A diferença começa agora.`,
+  bruteBest = bruteSum;
+  windowBest = windowSum;
+  steps.push({
+    start: 0, end: k - 1, reading: null, entered: null, removed: null,
+    bruteOps, windowOps, bruteSum, windowSum,
+    bruteBest, windowBest, line: 7,
+    note: `Janela [0..${k - 1}] fechada, soma ${bruteSum}. Custou ${k} leituras para os dois. A diferença começa agora.`,
   });
 
   // Da segunda janela em diante os caminhos separam.
   for (let i = 1; i <= n - k; i++) {
-    const fim = i + k - 1;
+    const end = i + k - 1;
 
     // Força bruta: relê a janela inteira.
-    somaF = 0;
-    for (let j = i; j <= fim; j++) {
-      somaF += nums[j];
-      opsF++;
-      out.push({
-        ini: i, fim, lendo: j, entrou: null, saiu: null,
-        opsForca: opsF, opsJanela: opsJ, somaForca: somaF, somaJanela: somaJ,
-        melhorForca: melhorF, melhorJanela: melhorJ, linha: 4,
-        nota: `Força bruta relendo: nums[${j}] = ${nums[j]}. Ela já tinha lido ${j > i ? `nums[${j}]` : "quase tudo isso"} na janela anterior e joga esse trabalho fora a cada passo.`,
+    bruteSum = 0;
+    for (let j = i; j <= end; j++) {
+      bruteSum += nums[j];
+      bruteOps++;
+      steps.push({
+        start: i, end, reading: j, entered: null, removed: null,
+        bruteOps, windowOps, bruteSum, windowSum,
+        bruteBest, windowBest, line: 4,
+        note: `Força bruta relendo: nums[${j}] = ${nums[j]}. Ela já tinha lido ${j > i ? `nums[${j}]` : "quase tudo isso"} na janela anterior e joga esse trabalho fora a cada passo.`,
       });
     }
-    melhorF = Math.max(melhorF, somaF);
+    bruteBest = Math.max(bruteBest, bruteSum);
 
     // Janela: uma soma e uma subtração.
-    const entrou = fim;
-    const saiu = i - 1;
-    somaJ = somaJ + nums[entrou] - nums[saiu];
-    opsJ += 2;
-    melhorJ = Math.max(melhorJ, somaJ);
-    out.push({
-      ini: i, fim, lendo: null, entrou, saiu,
-      opsForca: opsF, opsJanela: opsJ, somaForca: somaF, somaJanela: somaJ,
-      melhorForca: melhorF, melhorJanela: melhorJ, linha: 10,
-      nota: `Janela: entrou nums[${entrou}] = ${nums[entrou]}, saiu nums[${saiu}] = ${nums[saiu]}. Duas operações, e a soma ${somaJ} bate com a da força bruta, que gastou ${k}.`,
+    const entered = end;
+    const removed = i - 1;
+    windowSum = windowSum + nums[entered] - nums[removed];
+    windowOps += 2;
+    windowBest = Math.max(windowBest, windowSum);
+    steps.push({
+      start: i, end, reading: null, entered, removed,
+      bruteOps, windowOps, bruteSum, windowSum,
+      bruteBest, windowBest, line: 10,
+      note: `Janela: entrou nums[${entered}] = ${nums[entered]}, saiu nums[${removed}] = ${nums[removed]}. Duas operações, e a soma ${windowSum} bate com a da força bruta, que gastou ${k}.`,
     });
   }
 
-  const janelas = n - k + 1;
-  out.push({
-    ini: n - k, fim: n - 1, lendo: null, entrou: null, saiu: null,
-    opsForca: opsF, opsJanela: opsJ, somaForca: somaF, somaJanela: somaJ,
-    melhorForca: melhorF, melhorJanela: melhorJ, linha: 10, fim_: true,
-    nota: `Fim. Mesma resposta (${melhorF}) com ${opsF} operações na força bruta contra ${opsJ} na janela, em ${janelas} janelas. Aumente o k e veja a força bruta disparar enquanto a janela quase não se mexe.`,
+  const windows = n - k + 1;
+  steps.push({
+    start: n - k, end: n - 1, reading: null, entered: null, removed: null,
+    bruteOps, windowOps, bruteSum, windowSum,
+    bruteBest, windowBest, line: 10, done: true,
+    note: `Fim. Mesma resposta (${bruteBest}) com ${bruteOps} operações na força bruta contra ${windowOps} na janela, em ${windows} janelas. Aumente o k e veja a força bruta disparar enquanto a janela quase não se mexe.`,
   });
-  return out;
+  return steps;
 }
 
-function num(v: number): string {
+function fmt(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
 export function SlidingWindowForcaBruta() {
-  const [nums, setNums] = useState<number[]>(PADRAO);
-  const [entrada, setEntrada] = useState(PADRAO.join(", "));
-  const [k, setK] = useState(K_PADRAO);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [nums, setNums] = useState<number[]>(DEFAULT_ARRAY);
+  const [input, setInput] = useState(DEFAULT_ARRAY.join(", "));
+  const [k, setK] = useState(DEFAULT_K);
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(nums.length ? nums : [1], k), [nums, k]);
+  const n = nums.length;
 
-  const passos = useMemo(() => gerarPassos(nums.length ? nums : [1], k), [nums, k]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · força bruta contra janela, no mesmo array",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o tamanho do array (as células quebram
+    // linha) e a quantidade de passos, porque com k > n não sobra linha do
+    // tempo e o rodapé inteiro sai da peça.
+    measureOn: [n, steps.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-
-  const aoMudarEntrada = (v: string) => {
+  const onInputChange = (v: string) => {
     const arr = v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 14);
-    reiniciar();
-    setEntrada(v);
+    viz.reset();
+    setInput(v);
     setNums(arr.length ? arr : [1]);
   };
 
-  const preset = (arr: number[], kk: number) => {
-    reiniciar();
-    setNums(arr); setEntrada(arr.join(", ")); setK(kk);
+  const applyPreset = (arr: number[], kk: number) => {
+    viz.reset();
+    setNums(arr);
+    setInput(arr.join(", "));
+    setK(kk);
   };
 
-  const economia = p.opsForca > 0 ? Math.round(((p.opsForca - p.opsJanela) / p.opsForca) * 100) : 0;
+  const saved = p.bruteOps > 0 ? Math.round(((p.bruteOps - p.windowOps) / p.bruteOps) * 100) : 0;
 
   const cells = nums.map((v, i) => {
     let cls = "viz-cell";
-    if (i >= p.ini && i <= p.fim) cls += " in";
-    if (i < p.ini || i > p.fim) cls += " drop";
-    if (p.lendo === i) cls += " entra";
-    if (p.entrou === i) cls += " entra";
-    if (p.saiu === i) cls += " sai";
-    let marca = "";
-    if (p.lendo === i) marca = "lê";
-    if (p.entrou === i) marca = "entra";
-    if (p.saiu === i) marca = "sai";
-    return { i, v, cls, marca };
+    if (i >= p.start && i <= p.end) cls += " in";
+    if (i < p.start || i > p.end) cls += " drop";
+    if (p.reading === i) cls += " entra";
+    if (p.entered === i) cls += " entra";
+    if (p.removed === i) cls += " sai";
+    let mark = "";
+    if (p.reading === i) mark = "lê";
+    if (p.entered === i) mark = "entra";
+    if (p.removed === i) mark = "sai";
+    return { i, v, cls, mark };
   });
 
-  const notaCls = "viz-note" + (p.fim_ ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.done ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · força bruta contra janela, no mesmo array</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Array</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>k</span>
@@ -246,17 +215,17 @@ export function SlidingWindowForcaBruta() {
               type="number"
               min={1}
               value={k}
-              onChange={(e) => { reiniciar(); setK(parseInt(e.target.value, 10) || 1); }}
+              onChange={(e) => { viz.reset(); setK(parseInt(e.target.value, 10) || 1); }}
             />
           </label>
         </div>
 
         <div className="bigo-chips">
-          <button className="bigo-chip" onClick={() => preset(PADRAO, 3)}>k pequeno (3)</button>
-          <button className="bigo-chip" onClick={() => preset(PADRAO, 6)}>k grande (6)</button>
-          <button className="bigo-chip" onClick={() => preset([4, 4, 4, 4, 4, 4, 4, 4], 3)}>tudo igual</button>
-          <button className="bigo-chip" onClick={() => preset([9], 1)}>um elemento</button>
-          <button className="bigo-chip" onClick={() => preset(PADRAO, 12)}>k maior que n</button>
+          <button className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 3)}>k pequeno (3)</button>
+          <button className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 6)}>k grande (6)</button>
+          <button className="bigo-chip" onClick={() => applyPreset([4, 4, 4, 4, 4, 4, 4, 4], 3)}>tudo igual</button>
+          <button className="bigo-chip" onClick={() => applyPreset([9], 1)}>um elemento</button>
+          <button className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 12)}>k maior que n</button>
         </div>
 
         <div className="viz-cells">
@@ -264,7 +233,7 @@ export function SlidingWindowForcaBruta() {
             <div className="viz-cell-wrap" key={c.i}>
               <span className="viz-cell-idx">{c.i}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
@@ -272,49 +241,55 @@ export function SlidingWindowForcaBruta() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>operações da força bruta</span>
-            <strong style={{ color: "#f87171" }}>{num(p.opsForca)}</strong>
+            <strong style={{ color: "#f87171" }}>{fmt(p.bruteOps)}</strong>
           </div>
           <div className="bigo-stat">
             <span>operações da janela</span>
-            <strong style={{ color: "#34d399" }}>{num(p.opsJanela)}</strong>
+            <strong style={{ color: "#34d399" }}>{fmt(p.windowOps)}</strong>
           </div>
           <div className="bigo-stat">
             <span>trabalho economizado</span>
-            <strong>{economia}%</strong>
+            <strong>{saved}%</strong>
           </div>
           <div className="bigo-stat">
             <span>maior soma (as duas)</span>
-            <strong>{num(Math.max(p.melhorForca, p.melhorJanela))}</strong>
+            <strong>{fmt(Math.max(p.bruteBest, p.windowBest))}</strong>
           </div>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">comparacao.py · O(n·k) contra O(n)</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">comparacao.py · O(n·k) contra O(n)</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">soma (força bruta)</span>
-              <span className="viz-var-val">{num(p.somaForca)}</span>
+              <span className="viz-var-val">{fmt(p.bruteSum)}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">soma (janela)</span>
-              <span className="viz-var-val best">{num(p.somaJanela)}</span>
+              <span className="viz-var-val best">{fmt(p.windowSum)}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">janela</span>
-              <span className="viz-var-val">{p.fim < p.ini ? "-" : `[${p.ini}..${p.fim}]`}</span>
+              <span className="viz-var-val">{p.end < p.start ? "-" : `[${p.start}..${p.end}]`}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">k</span>
@@ -322,32 +297,13 @@ export function SlidingWindowForcaBruta() {
             </div>
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/SlidingWindowVisualizer.tsx
+++ b/content/visualizers/SlidingWindowVisualizer.tsx
@@ -319,10 +319,16 @@ export function SlidingWindowVisualizer({ variant = "fixed" }: { variant?: Varia
 
   const onInputChange = (v: string) => {
     const arr = v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 14);
+    const novo = arr.length ? arr : [1];
     viz.reset();
     setPresetKey("");
     setInput(v);
-    setNums(arr.length ? arr : [1]);
+    setNums(novo);
+    // Na janela fixa k é o TAMANHO da janela: encurtar o array tem que encurtar
+    // o k junto. Sem isso o campo continuava mostrando o k antigo enquanto o
+    // algoritmo já rodava com `min(k, n)` — o aluno lia 8 e via janelas de 3.
+    // Forma funcional porque este handler dispara a cada tecla digitada.
+    if (mode === "fixed") setK((atual) => Math.min(atual, novo.length));
   };
   const onKChange = (v: string) => {
     const raw = parseInt(v, 10) || 1;

--- a/content/visualizers/SlidingWindowVisualizer.tsx
+++ b/content/visualizers/SlidingWindowVisualizer.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // SlidingWindowVisualizer, visualização passo a passo da Sliding Window.
-//
-// Padrão para novos visualizadores: um gerador puro de "passos" + a mesma
-// casca de UI (células, código sincronizado, variáveis, controles, expandir).
-// Para uma técnica nova, copie este arquivo, troque `gerarPassos` e o `CODIGO`.
 //
 // variant="fixed"    → maior soma de uma janela de tamanho k (tamanho travado)
 // variant="dynamic"  → maior subarray com soma ≤ k (cresce/encolhe)
@@ -16,34 +13,34 @@ import { createPortal } from "react-dom";
 // Os dois modos contam LEITURAS DO ARRAY (cada `nums[i]` executado) e mostram,
 // ao lado, quantas leituras a força bruta faria. É esse par de números que
 // transforma "a janela é O(n)" em algo que o aluno vê acontecendo:
-//   janela fixa    → 2n - k          força bruta → (n - k + 1) · k
+//   janela fixa    → 2n - k             força bruta → (n - k + 1) · k
 //   janela variável→ n + encolhimentos  força bruta → n(n+1)/2 no pior caso
 //
-// O array padrão da janela variável, [2, 3, 4, 5, 6, 7, 9] com soma ≤ 15, é o
-// mesmo que a galera desenhou no encontro: as somas saem 2, 5, 9, 14, depois
-// estoura em 20, volta para 15, estoura em 22, volta para 13, e a resposta é 4.
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
 type Variant = "fixed" | "dynamic";
 
-type Passo = {
+type Step = {
   l: number;
   r: number;
   curr: number; // métrica da janela (soma)
   ans: number; // resposta acumulada (fixa: melhor soma / dinâmica: maior tamanho)
-  linha: number;
-  leituras: number; // acessos a nums[...] executados até aqui
-  entra?: number;
-  sai?: number;
+  line: number;
+  reads: number; // acessos a nums[...] executados até aqui
+  entering?: number;
+  leaving?: number;
   invalid?: boolean;
   ok?: boolean;
-  fim?: boolean;
-  nota: string;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com os passos (campo `linha` em gerarPassos*), então a
+// As linhas mapeiam 1:1 com os passos (campo `line` nos geradores), então a
 // ordem e a quantidade de linhas não podem mudar.
-const CODIGO_FIXA = [
+const FIXED_CODE = [
   "def melhor_soma(nums, k):",
   "    soma = sum(nums[:k])",
   "    melhor = soma",
@@ -56,7 +53,7 @@ const CODIGO_FIXA = [
   "    return melhor",
 ];
 
-const CODIGO_DINAMICA = [
+const DYNAMIC_CODE = [
   "def maior_subarray(nums, k):",
   "    esquerda = 0",
   "    soma = 0",
@@ -70,390 +67,348 @@ const CODIGO_DINAMICA = [
   "    return melhor",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-function plural(v: number, um: string, muitos: string): string {
-  return `${v} ${v === 1 ? um : muitos}`;
+function plural(v: number, one: string, many: string): string {
+  return `${v} ${v === 1 ? one : many}`;
 }
 
-function gerarPassosFixa(nums: number[], k: number): Passo[] {
-  const out: Passo[] = [];
+function generateFixedSteps(nums: number[], k: number): Step[] {
+  const steps: Step[] = [];
   const n = nums.length;
-  let soma = 0;
-  for (let i = 0; i < k; i++) soma += nums[i];
-  let leituras = k;
-  let melhor = soma;
-  let esq = 0;
+  let sum = 0;
+  for (let i = 0; i < k; i++) sum += nums[i];
+  let reads = k;
+  let best = sum;
+  let left = 0;
 
-  out.push({
+  steps.push({
     l: 0,
     r: k - 1,
-    curr: soma,
-    ans: melhor,
-    linha: 1,
-    leituras,
-    nota: `Monto a primeira janela somando do zero: ${nums.slice(0, k).join(" + ")} = ${soma}. É a única vez que eu faço isso, e me custou ${plural(k, "leitura", "leituras")}.`,
+    curr: sum,
+    ans: best,
+    line: 1,
+    reads,
+    note: `Monto a primeira janela somando do zero: ${nums.slice(0, k).join(" + ")} = ${sum}. É a única vez que eu faço isso, e me custou ${plural(k, "leitura", "leituras")}.`,
   });
-  out.push({
+  steps.push({
     l: 0,
     r: k - 1,
-    curr: soma,
-    ans: melhor,
-    linha: 2,
-    leituras,
+    curr: sum,
+    ans: best,
+    line: 2,
+    reads,
     ok: true,
-    nota: `Ainda não tenho com quem comparar, então a primeira janela já é a melhor: ${melhor}.`,
+    note: `Ainda não tenho com quem comparar, então a primeira janela já é a melhor: ${best}.`,
   });
 
   for (let d = k; d < n; d++) {
-    soma += nums[d];
-    leituras++;
-    out.push({
-      l: esq,
+    sum += nums[d];
+    reads++;
+    steps.push({
+      l: left,
       r: d,
-      curr: soma,
-      ans: melhor,
-      linha: 5,
-      leituras,
-      entra: d,
-      nota: `Entra nums[${d}] = ${nums[d]} pela direita. Agora tenho ${k + 1} elementos e soma ${soma}: sobrou um, preciso devolver o mais antigo.`,
+      curr: sum,
+      ans: best,
+      line: 5,
+      reads,
+      entering: d,
+      note: `Entra nums[${d}] = ${nums[d]} pela direita. Agora tenho ${k + 1} elementos e soma ${sum}: sobrou um, preciso devolver o mais antigo.`,
     });
 
-    const saiu = esq;
-    soma -= nums[saiu];
-    leituras++;
-    esq++;
-    out.push({
-      l: esq,
+    const removed = left;
+    sum -= nums[removed];
+    reads++;
+    left++;
+    steps.push({
+      l: left,
       r: d,
-      curr: soma,
-      ans: melhor,
-      linha: 6,
-      leituras,
-      sai: saiu,
-      nota: `Sai nums[${saiu}] = ${nums[saiu]} pela esquerda. soma = ${soma}, de volta aos ${k} elementos, e esquerda passa a ser ${esq}. Duas leituras, não ${k}.`,
+      curr: sum,
+      ans: best,
+      line: 6,
+      reads,
+      leaving: removed,
+      note: `Sai nums[${removed}] = ${nums[removed]} pela esquerda. soma = ${sum}, de volta aos ${k} elementos, e esquerda passa a ser ${left}. Duas leituras, não ${k}.`,
     });
 
-    const superou = soma > melhor;
-    if (superou) melhor = soma;
-    out.push({
-      l: esq,
+    const improved = sum > best;
+    if (improved) best = sum;
+    steps.push({
+      l: left,
       r: d,
-      curr: soma,
-      ans: melhor,
-      linha: 8,
-      leituras,
-      ok: superou,
-      nota: superou
-        ? `A janela [${esq}..${d}] soma ${soma} e é a melhor até agora.`
-        : `A janela [${esq}..${d}] soma ${soma}, não supera ${melhor}. Sigo em frente.`,
+      curr: sum,
+      ans: best,
+      line: 8,
+      reads,
+      ok: improved,
+      note: improved
+        ? `A janela [${left}..${d}] soma ${sum} e é a melhor até agora.`
+        : `A janela [${left}..${d}] soma ${sum}, não supera ${best}. Sigo em frente.`,
     });
   }
 
-  const bruta = (n - k + 1) * k;
-  out.push({
-    l: esq,
+  const brute = (n - k + 1) * k;
+  steps.push({
+    l: left,
     r: n - 1,
-    curr: soma,
-    ans: melhor,
-    linha: 9,
-    leituras,
-    fim: true,
-    nota: `Fim: a maior soma de ${k} elementos seguidos é ${melhor}. Gastei ${plural(leituras, "leitura", "leituras")} do array, contra ${bruta} da força bruta.`,
+    curr: sum,
+    ans: best,
+    line: 9,
+    reads,
+    done: true,
+    note: `Fim: a maior soma de ${k} elementos seguidos é ${best}. Gastei ${plural(reads, "leitura", "leituras")} do array, contra ${brute} da força bruta.`,
   });
-  return out;
+  return steps;
 }
 
-function gerarPassosDinamica(nums: number[], k: number): Passo[] {
-  const out: Passo[] = [];
+function generateDynamicSteps(nums: number[], k: number): Step[] {
+  const steps: Step[] = [];
   const n = nums.length;
-  let soma = 0;
-  let melhor = 0;
-  let esq = 0;
-  let leituras = 0;
+  let sum = 0;
+  let best = 0;
+  let left = 0;
+  let reads = 0;
 
-  out.push({
+  steps.push({
     l: 0,
     r: -1,
     curr: 0,
     ans: 0,
-    linha: 2,
-    leituras,
-    nota: `Janela vazia: esquerda e direita em 0, soma 0. Vou crescer pela direita enquanto a soma couber em ${k}.`,
+    line: 2,
+    reads,
+    note: `Janela vazia: esquerda e direita em 0, soma 0. Vou crescer pela direita enquanto a soma couber em ${k}.`,
   });
 
   for (let d = 0; d < n; d++) {
-    soma += nums[d];
-    leituras++;
-    out.push({
-      l: esq,
+    sum += nums[d];
+    reads++;
+    steps.push({
+      l: left,
       r: d,
-      curr: soma,
-      ans: melhor,
-      linha: 5,
-      leituras,
-      entra: d,
-      nota: `Entra nums[${d}] = ${nums[d]} pela direita. soma = ${soma}.`,
+      curr: sum,
+      ans: best,
+      line: 5,
+      reads,
+      entering: d,
+      note: `Entra nums[${d}] = ${nums[d]} pela direita. soma = ${sum}.`,
     });
 
-    let guarda = 0;
-    while (soma > k && esq <= d && guarda++ < 200) {
-      out.push({
-        l: esq,
+    let guard = 0;
+    while (sum > k && left <= d && guard++ < 200) {
+      steps.push({
+        l: left,
         r: d,
-        curr: soma,
-        ans: melhor,
-        linha: 6,
-        leituras,
+        curr: sum,
+        ans: best,
+        line: 6,
+        reads,
         invalid: true,
-        sai: esq,
-        nota: `soma ${soma} passou de k = ${k}: janela inválida. Como todo mundo aqui é positivo, só encolhendo pela esquerda ela volta a valer.`,
+        leaving: left,
+        note: `soma ${sum} passou de k = ${k}: janela inválida. Como todo mundo aqui é positivo, só encolhendo pela esquerda ela volta a valer.`,
       });
-      soma -= nums[esq];
-      leituras++;
-      esq++;
-      out.push({
-        l: esq,
+      sum -= nums[left];
+      reads++;
+      left++;
+      steps.push({
+        l: left,
         r: d,
-        curr: soma,
-        ans: melhor,
-        linha: 7,
-        leituras,
-        nota: `Sai nums[${esq - 1}] = ${nums[esq - 1]} pela esquerda. soma = ${soma}. O índice ${esq - 1} nunca mais volta.`,
+        curr: sum,
+        ans: best,
+        line: 7,
+        reads,
+        note: `Sai nums[${left - 1}] = ${nums[left - 1]} pela esquerda. soma = ${sum}. O índice ${left - 1} nunca mais volta.`,
       });
     }
 
-    const len = d - esq + 1;
-    const superou = len > melhor;
-    if (superou) melhor = len;
-    out.push({
-      l: esq,
+    const len = d - left + 1;
+    const improved = len > best;
+    if (improved) best = len;
+    steps.push({
+      l: left,
       r: d,
-      curr: soma,
-      ans: melhor,
-      linha: 9,
-      leituras,
+      curr: sum,
+      ans: best,
+      line: 9,
+      reads,
       ok: true,
-      nota:
+      note:
         len <= 0
-          ? `A janela ficou vazia: nums[${d}] = ${nums[d]} sozinho já estoura ${k}. Melhor resposta segue ${melhor}.`
-          : superou
-            ? `Janela válida [${esq}..${d}], ${plural(len, "elemento", "elementos")}. É a maior até agora: ${melhor}.`
-            : `Janela válida [${esq}..${d}], ${plural(len, "elemento", "elementos")}, que não supera ${melhor}.`,
+          ? `A janela ficou vazia: nums[${d}] = ${nums[d]} sozinho já estoura ${k}. Melhor resposta segue ${best}.`
+          : improved
+            ? `Janela válida [${left}..${d}], ${plural(len, "elemento", "elementos")}. É a maior até agora: ${best}.`
+            : `Janela válida [${left}..${d}], ${plural(len, "elemento", "elementos")}, que não supera ${best}.`,
     });
   }
 
-  const bruta = (n * (n + 1)) / 2;
-  out.push({
-    l: esq,
+  const brute = (n * (n + 1)) / 2;
+  steps.push({
+    l: left,
     r: n - 1,
-    curr: soma,
-    ans: melhor,
-    linha: 10,
-    leituras,
-    fim: true,
-    nota: `Fim: o maior subarray com soma ≤ ${k} tem ${melhor} ${melhor === 1 ? "elemento" : "elementos"}. Cada índice entrou uma vez e saiu no máximo uma: ${plural(leituras, "leitura", "leituras")}, contra ${bruta} da força bruta no pior caso.`,
+    curr: sum,
+    ans: best,
+    line: 10,
+    reads,
+    done: true,
+    note: `Fim: o maior subarray com soma ≤ ${k} tem ${best} ${best === 1 ? "elemento" : "elementos"}. Cada índice entrou uma vez e saiu no máximo uma: ${plural(reads, "leitura", "leituras")}, contra ${brute} da força bruta no pior caso.`,
   });
-  return out;
+  return steps;
 }
 
-type Preset = { key: string; rotulo: string; nums: number[]; k: number };
+type Preset = { key: string; label: string; nums: number[]; k: number };
 
-const CENARIOS: Record<Variant, Preset[]> = {
+const PRESETS: Record<Variant, Preset[]> = {
   // Casos escolhidos a dedo: o padrão, o k grande, o k = n e a borda de tudo igual.
   fixed: [
-    { key: "padrao", rotulo: "Padrão: k = 3", nums: [3, 6, 2, 8, 1, 4, 1, 5], k: 3 },
-    { key: "k5", rotulo: "Janela maior: k = 5", nums: [3, 6, 2, 8, 1, 4, 1, 5], k: 5 },
-    { key: "kn", rotulo: "k = n: uma janela só", nums: [3, 6, 2, 8, 1, 4, 1, 5], k: 8 },
-    { key: "iguais", rotulo: "Tudo igual: k = 2", nums: [4, 4, 4, 4, 4], k: 2 },
+    { key: "padrao", label: "Padrão: k = 3", nums: [3, 6, 2, 8, 1, 4, 1, 5], k: 3 },
+    { key: "k5", label: "Janela maior: k = 5", nums: [3, 6, 2, 8, 1, 4, 1, 5], k: 5 },
+    { key: "kn", label: "k = n: uma janela só", nums: [3, 6, 2, 8, 1, 4, 1, 5], k: 8 },
+    { key: "iguais", label: "Tudo igual: k = 2", nums: [4, 4, 4, 4, 4], k: 2 },
   ],
-  // O do encontro, um que encolhe várias vezes seguidas, a borda do elemento
-  // que sozinho estoura k, e o caso em que nada estoura (a janela nunca encolhe).
+  // Um array crescente (as somas sobem 2, 5, 9, 14, estouram em 20, voltam para
+  // 15, estouram em 22, voltam para 13, e a resposta é 4), um que encolhe várias
+  // vezes seguidas, a borda do elemento que sozinho estoura k, e o caso em que
+  // nada estoura (a janela nunca encolhe).
   dynamic: [
-    { key: "encontro", rotulo: "Do encontro: soma ≤ 15", nums: [2, 3, 4, 5, 6, 7, 9], k: 15 },
-    { key: "encolhe", rotulo: "Encolhe em série: soma ≤ 8", nums: [3, 1, 2, 7, 4, 2, 1, 1, 5], k: 8 },
-    { key: "estoura", rotulo: "Um elemento maior que k", nums: [1, 2, 20, 1, 1], k: 5 },
-    { key: "nunca", rotulo: "Nada estoura: k folgado", nums: [1, 1, 1, 1, 1], k: 9 },
+    { key: "encontro", label: "Do encontro: soma ≤ 15", nums: [2, 3, 4, 5, 6, 7, 9], k: 15 },
+    { key: "encolhe", label: "Encolhe em série: soma ≤ 8", nums: [3, 1, 2, 7, 4, 2, 1, 1, 5], k: 8 },
+    { key: "estoura", label: "Um elemento maior que k", nums: [1, 2, 20, 1, 1], k: 5 },
+    { key: "nunca", label: "Nada estoura: k folgado", nums: [1, 1, 1, 1, 1], k: 9 },
   ],
 };
 
-const TITULOS: Record<Variant, string> = {
+const TITLES: Record<Variant, string> = {
   fixed: "janela fixa, a maior soma de k elementos seguidos",
   dynamic: "janela variável, o maior subarray com soma ≤ k",
 };
 
-const ROTULO_K: Record<Variant, string> = { fixed: "k", dynamic: "soma máx (k)" };
+const K_LABEL: Record<Variant, string> = { fixed: "k", dynamic: "soma máx (k)" };
 
 export function SlidingWindowVisualizer({ variant = "fixed" }: { variant?: Variant }) {
-  const modo = variant;
-  const cenarios = CENARIOS[modo];
-  const inicial = cenarios[0];
-  const CODIGO = modo === "fixed" ? CODIGO_FIXA : CODIGO_DINAMICA;
+  const mode = variant;
+  const presets = PRESETS[mode];
+  const initial = presets[0];
+  const CODE = mode === "fixed" ? FIXED_CODE : DYNAMIC_CODE;
 
-  const [nums, setNums] = useState<number[]>(inicial.nums);
-  const [entrada, setEntrada] = useState(inicial.nums.join(", "));
-  const [k, setK] = useState(inicial.k);
-  const [cenario, setCenario] = useState(inicial.key);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [nums, setNums] = useState<number[]>(initial.nums);
+  const [input, setInput] = useState(initial.nums.join(", "));
+  const [k, setK] = useState(initial.k);
+  const [presetKey, setPresetKey] = useState(initial.key);
 
   // Na janela fixa, k é o tamanho e não pode passar de n. Na variável, k é um
   // teto de soma e pode ser qualquer número.
-  const kEfetivo = modo === "fixed" ? Math.max(1, Math.min(k, nums.length)) : Math.max(1, k);
+  const effectiveK = mode === "fixed" ? Math.max(1, Math.min(k, nums.length)) : Math.max(1, k);
 
-  const passos = useMemo(() => {
+  const steps = useMemo(() => {
     const arr = nums.length ? nums : [1];
-    const kk = modo === "fixed" ? Math.max(1, Math.min(k, arr.length)) : Math.max(1, k);
-    return modo === "fixed" ? gerarPassosFixa(arr, kk) : gerarPassosDinamica(arr, kk);
-  }, [nums, k, modo]);
+    const kk = mode === "fixed" ? Math.max(1, Math.min(k, arr.length)) : Math.max(1, k);
+    return mode === "fixed" ? generateFixedSteps(arr, kk) : generateDynamicSteps(arr, kk);
+  }, [nums, k, mode]);
 
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const n = nums.length;
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
+  const viz = useVisualizer({
+    title: `Visualizador · ${TITLES[mode]}`,
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o modo (o código vai de 10 a 11 linhas) e o
+    // tamanho do array (as células quebram linha).
+    measureOn: [mode, n],
+  });
 
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  // Loop de reprodução, reinicia o intervalo quando play/velocidade mudam.
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => {
-      setPasso((s) => (s >= total - 1 ? s : s + 1));
-    }, VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  // Pausa automaticamente ao chegar no fim.
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  // Esc fecha o modo expandido.
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aoMudarEntrada = (v: string) => {
+  const onInputChange = (v: string) => {
     const arr = v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 14);
-    reiniciar();
-    setCenario("");
-    setEntrada(v);
+    viz.reset();
+    setPresetKey("");
+    setInput(v);
     setNums(arr.length ? arr : [1]);
   };
-  const aoMudarK = (v: string) => {
-    const bruto = parseInt(v, 10) || 1;
-    const kk = modo === "fixed" ? Math.max(1, Math.min(bruto, nums.length)) : Math.max(1, bruto);
-    reiniciar();
-    setCenario("");
+  const onKChange = (v: string) => {
+    const raw = parseInt(v, 10) || 1;
+    const kk = mode === "fixed" ? Math.max(1, Math.min(raw, nums.length)) : Math.max(1, raw);
+    viz.reset();
+    setPresetKey("");
     setK(kk);
   };
-  const aplicar = (pr: Preset) => {
-    reiniciar();
-    setCenario(pr.key);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setPresetKey(pr.key);
     setNums(pr.nums);
-    setEntrada(pr.nums.join(", "));
+    setInput(pr.nums.join(", "));
     setK(pr.k);
   };
   // Math.random só aqui, num handler de clique: no caminho de render ele
   // quebraria a hidratação (o HTML do build divergiria do cliente).
-  const sortear = () => {
-    const n = 7 + Math.floor(Math.random() * 3);
-    const arr = Array.from({ length: n }, () => 1 + Math.floor(Math.random() * 9));
-    reiniciar();
-    setCenario("");
+  const shuffle = () => {
+    const size = 7 + Math.floor(Math.random() * 3);
+    const arr = Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 9));
+    viz.reset();
+    setPresetKey("");
     setNums(arr);
-    setEntrada(arr.join(", "));
-    setK(modo === "fixed" ? Math.min(k, n) : k);
+    setInput(arr.join(", "));
+    setK(mode === "fixed" ? Math.min(k, size) : k);
   };
 
-  const janelaVazia = p.l > p.r;
-  const janelaAtiva = p.r >= 0 && !p.fim && !janelaVazia;
+  const emptyWindow = p.l > p.r;
+  const activeWindow = p.r >= 0 && !p.done && !emptyWindow;
 
   const cells = nums.map((v, i) => {
-    const dentro = janelaAtiva && i >= p.l && i <= p.r;
+    const inside = activeWindow && i >= p.l && i <= p.r;
     let cls = "viz-cell";
-    if (dentro) cls += " in";
+    if (inside) cls += " in";
     if (p.r >= 0 && i < p.l) cls += " drop";
-    if (p.entra === i) cls += " entra";
-    if (p.sai === i) cls += " sai";
-    let marca = "";
-    if (janelaAtiva && i === p.l) marca = "esq";
-    if (janelaAtiva && i === p.r) marca = marca ? "esq/dir" : "dir";
-    return { i, v, cls, marca };
+    if (p.entering === i) cls += " entra";
+    if (p.leaving === i) cls += " sai";
+    let mark = "";
+    if (activeWindow && i === p.l) mark = "esq";
+    if (activeWindow && i === p.r) mark = mark ? "esq/dir" : "dir";
+    return { i, v, cls, mark };
   });
 
-  const variaveis =
-    modo === "fixed"
+  const vars: { name: string; value: string; best?: boolean }[] =
+    mode === "fixed"
       ? [
-          { nome: "esquerda", valor: `${p.l}` },
-          { nome: "direita", valor: p.r < 0 ? "-" : `${p.r}` },
-          { nome: "soma", valor: `${p.curr}` },
-          { nome: "melhor", valor: `${p.ans}`, best: true },
+          { name: "esquerda", value: `${p.l}` },
+          { name: "direita", value: p.r < 0 ? "-" : `${p.r}` },
+          { name: "soma", value: `${p.curr}` },
+          { name: "melhor", value: `${p.ans}`, best: true },
         ]
       : [
-          { nome: "esquerda", valor: `${p.l}` },
-          { nome: "direita", valor: p.r < 0 ? "-" : `${p.r}` },
-          { nome: "soma", valor: `${p.curr}` },
-          { nome: "melhor (tam.)", valor: `${p.ans}`, best: true },
+          { name: "esquerda", value: `${p.l}` },
+          { name: "direita", value: p.r < 0 ? "-" : `${p.r}` },
+          { name: "soma", value: `${p.curr}` },
+          { name: "melhor (tam.)", value: `${p.ans}`, best: true },
         ];
 
-  const n = nums.length;
-  const bruta = modo === "fixed" ? (n - kEfetivo + 1) * kEfetivo : (n * (n + 1)) / 2;
-  const estatisticas = [
-    { k: "n", rot: "tamanho (n)", val: `${n}` },
-    { k: "leituras", rot: "leituras da janela", val: `${p.leituras}` },
-    { k: "bruta", rot: modo === "fixed" ? "leituras da força bruta" : "força bruta (pior caso)", val: `${bruta}` },
-    { k: "espaco", rot: "memória extra", val: "O(1)" },
+  const brute = mode === "fixed" ? (n - effectiveK + 1) * effectiveK : (n * (n + 1)) / 2;
+  const stats = [
+    { key: "n", label: "tamanho (n)", value: `${n}` },
+    { key: "leituras", label: "leituras da janela", value: `${p.reads}` },
+    {
+      key: "bruta",
+      label: mode === "fixed" ? "leituras da força bruta" : "força bruta (pior caso)",
+      value: `${brute}`,
+    },
+    { key: "espaco", label: "memória extra", value: "O(1)" },
   ];
 
-  const notaCls = "viz-note" + (p.invalid ? " invalid" : p.ok || p.fim ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.invalid ? " invalid" : p.ok || p.done ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · {TITULOS[modo]}</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {cenarios.map((pr) => (
+          {presets.map((pr) => (
             <button
               key={pr.key}
-              className={`bigo-chip${cenario === pr.key ? " on" : ""}`}
-              onClick={() => aplicar(pr)}
-              aria-pressed={cenario === pr.key}
+              className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
+              onClick={() => applyPreset(pr)}
+              aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -461,13 +416,13 @@ export function SlidingWindowVisualizer({ variant = "fixed" }: { variant?: Varia
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Seu array</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
           <label className="viz-field">
-            <span>{ROTULO_K[modo]}</span>
-            <input className="viz-input k" type="number" value={k} onChange={(e) => aoMudarK(e.target.value)} />
+            <span>{K_LABEL[mode]}</span>
+            <input className="viz-input k" type="number" value={k} onChange={(e) => onKChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="viz-cells">
@@ -475,71 +430,59 @@ export function SlidingWindowVisualizer({ variant = "fixed" }: { variant?: Varia
             <div className="viz-cell-wrap" key={c.i}>
               <span className="viz-cell-idx">{c.i}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">solucao.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso de
+              altura; `inert` tira ele do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">solucao.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
-            <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+          {stats.map((s) => (
+            <div className="bigo-stat" key={s.key}>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/tests/viz-sliding-window.spec.ts
+++ b/tests/viz-sliding-window.spec.ts
@@ -1,0 +1,263 @@
+import { expect, test, type Locator, type Page } from "@playwright/test";
+
+// Casca adaptativa dos visualizadores de sliding-window.
+//
+// Os testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova nada:
+// já passaram por uma suíte verde um visualizador sem botão nenhum e um painel
+// com 0px de largura. E aqui o rótulo é conteúdo didático — o `ForcaBruta`
+// existe justamente para contrastar dois contadores, então um número certo sob
+// o rótulo errado ensina errado do mesmo jeito.
+
+const URL = "/topico/sliding-window/";
+
+// Ordem no artigo.
+const FORCA_BRUTA = 0;
+const JANELA_FIXA = 1;
+
+async function abrirPainel(page: Page, n: number): Promise<Locator> {
+  await page.locator("article figure.viz").nth(n).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+/** O número do card cujo RÓTULO é exatamente este. Ler pelo rótulo é o ponto. */
+function estatistica(raiz: Locator, rotulo: string): Locator {
+  return raiz.locator(`.bigo-stat:has(span:text-is(${JSON.stringify(rotulo)}))`).locator("strong");
+}
+
+/** O valor da variável cujo NOME é exatamente este. */
+function variavel(raiz: Locator, nome: string): Locator {
+  return raiz
+    .locator(`.viz-var:has(.viz-var-name:text-is(${JSON.stringify(nome)}))`)
+    .locator(".viz-var-val");
+}
+
+function alturaDe(alvo: Locator): Promise<number> {
+  return alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+/**
+ * Altura só depois que a transição PARA. Ler no meio dela devolve o layout a
+ * caminho, e quem age em cima dessa leitura decide errado — foi assim que uma
+ * versão anterior deste arquivo passou contra o código quebrado: o clique
+ * seguinte caía com o bloco a 164px dos 306px finais, a medição concluía
+ * "cabe" e o defeito não aparecia.
+ */
+async function alturaEstavel(page: Page, alvo: Locator): Promise<number> {
+  let anterior = -1;
+  for (let i = 0; i < 40; i++) {
+    const agora = await alturaDe(alvo);
+    if (agora === anterior) return agora;
+    anterior = agora;
+    await page.waitForTimeout(80);
+  }
+  throw new Error("a altura não estabilizou");
+}
+
+/** O que sobra de altura para a peça no fluxo do artigo. */
+function orcamentoDaTela(page: Page): Promise<number> {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60) -
+      24
+  );
+}
+
+test.describe("sliding-window · casca adaptativa", () => {
+  test("no painel, cabeçalho e controles não se mexem enquanto o miolo rola", async ({ page }) => {
+    // Janela baixa de propósito: é onde o miolo tem mesmo o que rolar.
+    await page.setViewportSize({ width: 1280, height: 680 });
+    await page.goto(URL);
+    const painel = await abrirPainel(page, FORCA_BRUTA);
+
+    // Com o código à mostra o miolo passa da altura da janela. Sem essa
+    // garantia o teste rolaria zero pixel e passaria sem exercitar nada.
+    const botaoCodigo = painel.getByRole("button", { name: /código/ });
+    if ((await botaoCodigo.textContent())?.includes("Mostrar")) await botaoCodigo.click();
+    await expect(botaoCodigo).toHaveText("Ocultar código");
+
+    const corpo = painel.locator(".viz-body");
+    await expect
+      .poll(() => corpo.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .toBeGreaterThan(20);
+
+    const cabeca = painel.locator(".viz-head");
+    const rodape = painel.locator(".viz-foot");
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+    const cabecaAntes = (await cabeca.boundingBox())!;
+    const rodapeAntes = (await rodape.boundingBox())!;
+
+    await corpo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await expect.poll(() => corpo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(20);
+
+    const cabecaDepois = (await cabeca.boundingBox())!;
+    const rodapeDepois = (await rodape.boundingBox())!;
+    const rodarDepois = (await rodar.boundingBox())!;
+
+    expect(Math.abs(cabecaDepois.y - cabecaAntes.y)).toBeLessThanOrEqual(1);
+    expect(Math.abs(rodapeDepois.y - rodapeAntes.y)).toBeLessThanOrEqual(1);
+
+    // O botão que faz o algoritmo andar continua inteiro dentro da janela.
+    const janela = page.viewportSize()!.height;
+    expect(rodarDepois.y).toBeGreaterThanOrEqual(0);
+    expect(rodarDepois.y + rodarDepois.height).toBeLessThanOrEqual(janela);
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+
+  test("em tela baixa o código vem recolhido, o rótulo diz o que some e a peça cabe", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto(URL);
+    const figura = page.locator("article figure.viz").nth(JANELA_FIXA);
+
+    await expect(figura.getByRole("button", { name: /código/ })).toHaveText("Mostrar código");
+
+    // Recolhido de verdade: zerar só a trilha da coluna tiraria a largura e
+    // deixaria a altura de pé, que foi o defeito medido no Big O.
+    await expect.poll(() => alturaDe(figura.locator(".viz-code-slot"))).toBeLessThan(8);
+
+    const orcamento = await orcamentoDaTela(page);
+    await expect.poll(() => alturaDe(figura)).toBeLessThan(orcamento);
+  });
+
+  test("em tela alta o código já vem à mostra", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 1400 });
+    await page.goto(URL);
+    const figura = page.locator("article figure.viz").nth(JANELA_FIXA);
+
+    await expect(figura.getByRole("button", { name: /código/ })).toHaveText("Ocultar código");
+    await expect.poll(() => alturaDe(figura.locator(".viz-code-slot"))).toBeGreaterThan(100);
+  });
+
+  test("a escolha do aluno sobrevive a uma troca de estado que pediria medição nova", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto(URL);
+    const figura = page.locator("article figure.viz").nth(JANELA_FIXA);
+    const botaoCodigo = figura.getByRole("button", { name: /código/ });
+    const fatia = figura.locator(".viz-code-slot");
+
+    // A medição recolheu sozinha, então o aluno abrir é uma escolha explícita.
+    await expect(botaoCodigo).toHaveText("Mostrar código");
+    await botaoCodigo.click();
+    expect(await alturaEstavel(page, fatia)).toBeGreaterThan(100);
+
+    // A premissa do teste, medida e não suposta: com o código à mostra a peça
+    // NÃO cabe. Uma medição nova pediria para recolher; é isso que a escolha
+    // do aluno tem que vencer.
+    const orcamento = await orcamentoDaTela(page);
+    expect(await alturaDe(figura)).toBeGreaterThan(orcamento);
+
+    // Duas trocas de estado que pedem medição nova: o tamanho da entrada e o
+    // tamanho da janela.
+    await figura.getByRole("button", { name: "Tudo igual: k = 2" }).click();
+    await expect(figura.locator(".viz-cell-wrap")).toHaveCount(5);
+    await page.setViewportSize({ width: 1512, height: 700 });
+
+    // "Está aberto agora" não é "continua aberto": amostra ao longo do
+    // intervalo em que a medição poderia desfazer a escolha.
+    const leituras: number[] = [];
+    for (let i = 0; i < 8; i++) {
+      leituras.push(await alturaDe(fatia));
+      await page.waitForTimeout(120);
+    }
+    expect(Math.min(...leituras)).toBeGreaterThan(100);
+    await expect(botaoCodigo).toHaveText("Ocultar código");
+  });
+
+  test("no painel as setas e o espaço andam a animação, e o campo em edição manda", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto(URL);
+    const painel = await abrirPainel(page, JANELA_FIXA);
+    const passo = painel.locator(".viz-step");
+
+    await expect(passo).toHaveText("passo 1 de 18");
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 2 de 18");
+    await page.keyboard.press("ArrowLeft");
+    await expect(passo).toHaveText("passo 1 de 18");
+
+    await page.keyboard.press("Space");
+    await expect(painel.getByRole("button", { name: /Pausar/ })).toBeVisible();
+    await page.keyboard.press("Space");
+    await expect(painel.getByRole("button", { name: /Rodar/ })).toBeVisible();
+
+    await painel.locator('.viz-btn[title="Reiniciar"]').click();
+    await expect(passo).toHaveText("passo 1 de 18");
+    for (let i = 0; i < 4; i++) await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 5 de 18");
+
+    // Com o cursor no campo, a seta é do campo e a animação não anda.
+    const campo = painel.locator("input.viz-input").first();
+    const valorAntes = await campo.inputValue();
+    await campo.click();
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 5 de 18");
+    await expect(campo).toHaveValue(valorAntes);
+
+    // E o espaço é um espaço digitado, não o play. Comparo o valor com ele
+    // mesmo: no macOS não dá para confiar em onde o cursor está.
+    await page.keyboard.press("Space");
+    await expect(painel.getByRole("button", { name: /Rodar/ })).toBeVisible();
+    const valorDepois = await campo.inputValue();
+    expect(valorDepois.length).toBe(valorAntes.length + 1);
+    expect(valorDepois.replace(/ /g, "")).toBe(valorAntes.replace(/ /g, ""));
+  });
+
+  test("força bruta contra janela: cada número está sob o rótulo certo, e a nota repete os mesmos", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto(URL);
+    const painel = await abrirPainel(page, FORCA_BRUTA);
+
+    const forca = estatistica(painel, "operações da força bruta");
+    const janela = estatistica(painel, "operações da janela");
+    const economia = estatistica(painel, "trabalho economizado");
+    const maior = estatistica(painel, "maior soma (as duas)");
+
+    // No primeiro passo ninguém tem estado guardado: os dois pagam a mesma
+    // leitura, e é isso que os cards precisam dizer.
+    await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 25");
+    await expect(forca).toHaveText("1");
+    await expect(janela).toHaveText("1");
+    await expect(economia).toHaveText("0%");
+
+    const proximo = painel.getByRole("button", { name: "Próximo ›" });
+    for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(painel.locator(".viz-step")).toHaveText("passo 25 de 25");
+
+    // [2,3,4,5,6,7,1,9] com k = 3: 6 janelas. A força bruta relê k por janela
+    // (3 + 5·3 = 18); a janela paga 3 na montagem e 2 por passo (3 + 5·2 = 13).
+    await expect(forca).toHaveText("18");
+    await expect(janela).toHaveText("13");
+    await expect(economia).toHaveText("28%");
+    await expect(maior).toHaveText("18");
+    await expect(variavel(painel, "k")).toHaveText("3");
+
+    await expect(painel.locator(".viz-note")).toHaveText(
+      /Mesma resposta \(18\) com 18 operações na força bruta contra 13 na janela, em 6 janelas/
+    );
+  });
+
+  test("janela fixa: as leituras batem com o rótulo do card e com a nota final", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto(URL);
+    const painel = await abrirPainel(page, JANELA_FIXA);
+
+    const proximo = painel.getByRole("button", { name: "Próximo ›" });
+    for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(painel.locator(".viz-step")).toHaveText("passo 18 de 18");
+
+    // [3,6,2,8,1,4,1,5] com k = 3: a janela lê 3 + 2·5 = 13; a força bruta
+    // leria (8-3+1)·3 = 18. A maior soma de 3 seguidos é [6,2,8] = 16.
+    await expect(estatistica(painel, "tamanho (n)")).toHaveText("8");
+    await expect(estatistica(painel, "leituras da janela")).toHaveText("13");
+    await expect(estatistica(painel, "leituras da força bruta")).toHaveText("18");
+    await expect(estatistica(painel, "memória extra")).toHaveText("O(1)");
+    await expect(variavel(painel, "melhor")).toHaveText("16");
+
+    await expect(painel.locator(".viz-note")).toHaveText(
+      /Gastei 13 leituras do array, contra 18 da força bruta/
+    );
+  });
+});

--- a/tests/viz-sliding-window.spec.ts
+++ b/tests/viz-sliding-window.spec.ts
@@ -239,6 +239,35 @@ test.describe("sliding-window · casca adaptativa", () => {
     );
   });
 
+  test("janela fixa: encurtar o array encurta o k, e o campo não passa a mentir", async ({ page }) => {
+    await page.setViewportSize({ width: 1512, height: 900 });
+    await page.goto(URL);
+    const figura = page.locator("article figure.viz").nth(JANELA_FIXA);
+    const campoK = figura.locator("input.viz-input.k");
+    const campoArray = figura.locator("input.viz-input").first();
+
+    // Preset que deixa a janela do tamanho do array.
+    await figura.getByRole("button", { name: "k = n: uma janela só" }).click();
+    await expect(campoK).toHaveValue("8");
+
+    // Agora o array encolhe para três elementos. O k de 8 não cabe mais.
+    await campoArray.fill("4, 9, 2");
+    await expect(figura.locator(".viz-cell-wrap")).toHaveCount(3);
+
+    // O campo tem que dizer o k que está VALENDO. Antes ele seguia em 8
+    // enquanto o algoritmo já usava 3, e o aluno lia um e via o outro.
+    await expect(campoK).toHaveValue("3");
+    await expect(estatistica(figura, "tamanho (n)")).toHaveText("3");
+    await expect(estatistica(figura, "leituras da força bruta")).toHaveText("3");
+
+    // E a aula fecha com o mesmo número do campo: 4 + 9 + 2 = 15.
+    const proximo = figura.getByRole("button", { name: "Próximo ›" });
+    for (let i = 0; i < 20 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(figura.locator(".viz-note")).toHaveText(
+      /a maior soma de 3 elementos seguidos é 15/
+    );
+  });
+
   test("janela fixa: as leituras batem com o rótulo do card e com a nota final", async ({ page }) => {
     await page.setViewportSize({ width: 1512, height: 900 });
     await page.goto(URL);


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit` / `useVisualizer`) nos dois visualizadores do tópico **sliding-window**, traduz os identificadores deles para inglês (contrato §0) e prova os dois com testes que medem comportamento e leem rótulo.

## Inventário

| arquivo | overlay | código | vars | controles | entrou? |
|---|---|---|---|---|---|
| `SlidingWindowForcaBruta.tsx` | sim | sim | sim | sim | **sim**, as três camadas |
| `SlidingWindowVisualizer.tsx` | sim | sim | sim | sim | **sim**, as três camadas |

Nenhum ficou de fora. O `SlidingWindowVisualizer` aparece duas vezes na página (`variant="fixed"` e `variant="dynamic"`), então são **três peças** medidas.

## Medições

Janela de **1512x900** (notebook de 16"), animação congelada, depois de `document.fonts.ready`.

### No fluxo do artigo — orçamento de 816px

| peça | antes | depois |
|---|---|---|
| força bruta contra janela | **874px** (58px a mais) | **588px** |
| janela fixa | **834px** (18px a mais) | **574px** |
| janela variável | **899px** (83px a mais) | **613px** |

As três estouravam. Depois, as três cabem com mais de 200px de folga, com o código recolhido e o botão dizendo "Mostrar código". Numa janela alta (1512x1400) o bloco já vem aberto — a decisão é medição, não breakpoint.

### No painel expandido — janela de 900px

Antes, `.viz-overlay .viz` rolava **inteiro**, então o cabeçalho e os controles iam embora junto com o conteúdo:

| peça | conteúdo × caixa | `▶ Rodar` ao abrir | cabeçalho depois de rolar até o fim |
|---|---|---|---|
| força bruta | 919px em 850px | base em **910px** (fora da tela) | topo em **-44px** |
| janela fixa | 888px em 850px | base em 879px | topo em **-13px** |
| janela variável | 919px em 850px | base em **910px** (fora da tela) | topo em **-44px** |

Ou seja: nas duas peças maiores não dava para ver o cabeçalho e o botão que faz o algoritmo andar ao mesmo tempo.

Depois: o miolo é a única área rolável, a figura cabe (835px de conteúdo em 835px de caixa), o `▶ Rodar` termina em **834px** dentro da janela de 900, e o código volta a aparecer porque agora cabe — comprimir antes de esconder.

## O que mudou no código

- A mecânica vem do `useVisualizer`, com `VizHeader` e `VizFooter`. Saem de cada arquivo o estado de reprodução, o `setInterval`, o `Esc`, o portal, o cabeçalho e a linha de controles. Ficam o miolo e o `.viz-code-slot` em volta do bloco de código (zerar a trilha da coluna tira a largura, não a altura). Líquido: **−553 linhas** nos dois componentes.
- `measureOn`: `[mode, n]` na janela fixa/variável (o código vai de 10 a 11 linhas e o array muda de tamanho) e `[n, steps.length]` na comparação — com `k > n` não sobra linha do tempo e o rodapé inteiro sai da peça, o que muda a altura.
- Identificadores em inglês. **Nenhum texto de tela mudou**: o `scripts/guarda-idioma.py` contra o `origin/main` acusa só `@/lib/visualizer`, `viz-code-slot`, `k && left` (fragmento de código que o regex de JSX pega) e `Visualizador · §` — o título saiu de um nó JSX e virou a prop `title` do hook, renderizando o mesmo texto. Conferido no navegador: `"Visualizador · janela fixa, a maior soma de k elementos seguidos"` e as outras duas, iguais às de antes, e o teste `Sliding Window reúne janela fixa e variável na mesma página` (que já existia) continua verde justamente porque procura esses textos.
- Nada de CSS novo: nenhuma linha do `globals.css` foi tocada.

## Como está provado

`tests/viz-sliding-window.spec.ts`, arquivo novo para não disputar o `navegacao.spec.ts` com os outros tópicos em andamento. Sete casos; os quatro primeiros são o mínimo do contrato §8, os três últimos são deste tópico — o `ForcaBruta` existe para contrastar dois contadores, então o rótulo ao lado do número é conteúdo didático.

Cada teste foi rodado **contra o código quebrado**, com o build visível e quebras que compilam:

| quebra | teste | resultado |
|---|---|---|
| `VizFooter` de volta para dentro do `.viz-body` | cabeçalho/rodapé parados | falha: cabeçalho desloca **46px** |
| `data-codigo="on"` fixo no `<figure>` | tela baixa recolhe | falha: fatia mede **306px** onde o rótulo promete recolhido |
| `data-codigo="off"` fixo no `<figure>` | tela alta abre | falha: **2px** onde deveria haver 306 |
| `manualChoice.current = null` no hook | escolha do aluno sobrevive | falha: fatia vai a **2px** |
| `input` fora da lista de campos em edição | teclado não rouba a tecla | falha: passo anda **5 → 6** com o cursor no campo |
| card da força bruta mostrando `windowOps` | rótulo certo, número certo | falha: **18 → 13** |
| conta da força bruta sem o fator `k` | leituras batem com a nota | falha: **18 → 6** |

**Um teste passou onde devia falhar, e o culpado era o experimento.** A primeira versão do caso "a escolha do aluno sobrevive" clicava no preset com a transição do bloco ainda **em voo** (164px dos 306px finais): a medição seguinte lia a peça a caminho e concluía "cabe", então o defeito não aparecia. É a armadilha de "congele a animação antes de medir" aparecendo do lado de quem escreve o teste. O conserto foi o helper `alturaEstavel`, que só devolve a altura depois que ela para de mudar, mais uma asserção que **mede a premissa** (com o código à mostra a peça de fato não cabe no orçamento) em vez de supô-la.

`npm run test:build`: build limpo, e os 8 casos novos passam. A suíte inteira fecha **98/98** com `--workers=2`. Com o paralelismo cheio aparecem falhas intermitentes em `navegacao.spec.ts:642` (`tópico X entrega artigo…`) para tópicos sorteados a cada rodada — todas passam isoladas, e são disputa pelo `python3 -m http.server`, que é single-thread, nesta máquina rodando sete agentes ao mesmo tempo.

## Revisão

**Rodada 1 — um achado, procede.** Na janela fixa o `k` é o tamanho da janela e não pode passar de `n`; a regra estava no comentário e no cálculo (`min(k, n)`), mas não no estado. Encurtar o array pelo campo deixava o `k` antigo no input enquanto o algoritmo já rodava com o valor limitado: com o preset "k = n" e o array reduzido a três elementos, o campo dizia **8** e a aula mostrava janelas de **3**. Corrigido no `e7c960d`, com clamp na forma funcional do `setState` (o handler dispara a cada tecla).

Tratado como amostra de classe: varri "valor exibido divergindo do valor usado" em todos os caminhos que mexem em `nums` ou `k`, nos dois arquivos. `applyPreset` troca os dois juntos, `onKChange` e `shuffle` já limitavam, no modo dinâmico o `k` é teto de soma sem limite superior, e o `ForcaBruta` **avisa** em vez de limitar (`"k = 12 não cabe num array de 8 posições"`) com o mesmo `k` do campo. `onInputChange` da janela fixa era a única divergência.

O teste novo foi rodado contra o código sem o fix, com o clamp virando um no-op que compila: reprova com `Expected: "3"` / `Received: "8"`.

**Rodadas 2 e 3 — limpas**, sem bloco de comentários suprimidos e com a thread resolvida.

## Contrato atualizado

O `docs(visualizers)` acrescenta ao `content/visualizers/README.md` §6 a regra que faltava e que este tópico expôs: **`measureOn` cobre o que liga ou desliga um pedaço da casca, não só o que muda o miolo.** O contrato tratava `total: 1` como escolha fixa do componente; aqui ele é derivado da entrada e atravessa 1 durante o uso (`k > n` devolve um passo só), fazendo o rodapé inteiro sumir — ~90px — sem que o tamanho da entrada mude.

## Fora do escopo desta PR, achado no caminho

Nada disto foi mexido aqui — decisão sua.

1. **A regra do "artigo autocontido" está quebrada em três lugares neste tópico**: o rótulo do preset `"Do encontro: soma ≤ 15"` (`SlidingWindowVisualizer.tsx`), e duas frases do `content/topics/sliding-window.mdx` — *"que veio de uma observação do Giovani no encontro"* (linha 151) e *"É a armadilha que o Eduardo levantou no encontro"* (linha 182). Como duas das três são texto do artigo, isto é uma PR de conteúdo, não da casca; corrigir só o preset deixaria o conjunto incoerente.
2. **Plural errado no caso de borda do `ForcaBruta`.** Com o preset "um elemento" (`nums=[9]`, `k=1`) as notas saem *"Custou 1 leituras para os dois"*, *"com 1 operações na força bruta contra 1 na janela, em 1 janelas"*. O `SlidingWindowVisualizer` já tem um helper `plural()` para isso; o `ForcaBruta` não.
3. **Com `k > n` o rodapé inteiro some**, porque o gerador devolve um passo só e `total: 1` desliga a linha do tempo pelo contrato. É o comportamento correto (não há o que animar) e os presets continuam clicáveis para sair de lá, mas o sumiço da barra de controles é brusco. Se incomodar, o lugar de resolver é o contrato, não este tópico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEdnPeF2dmxUHMUyW84scB
