### PR TITLE
feat(viz): casca adaptativa nos três visualizadores de two pointers

### DIFF
--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -262,6 +262,16 @@ seja o desse visualizador, porque ele vira o `aria-label` do diálogo.
   margem dos controles: dentro de uma área rolável ele também é a folga contra a
   borda, então o conteúdo não encosta na linha do rodapé quando a rolagem chega
   ao fim.
+- **Desenho com `width: 100%` e `height: auto` infla a ALTURA junto com a
+  largura, e o que infla é o vazio.** Um SVG com viewBox de 406x204 esticado
+  para os 800px do corpo passa a ocupar 402px de altura — 2x o tamanho natural,
+  e no visualizador de ciclo isso era 402 dos 939px da peça inteira. Recolher o
+  código não resolve, porque o problema não é o código. Um `max-height` no bloco
+  temático do visualizador, dentro de `@media (max-height: ...)`, devolve a
+  altura sem esconder nada: o `preserveAspectRatio` padrão encolhe e centraliza,
+  e o desenho continua inteiro. **No expandido o teto não vale** — lá o miolo
+  rola, e o painel existe justamente para ver o desenho maior; deixe a regra do
+  painel ganhar por especificidade, não por ordem de arquivo.
 
 ## 8. Como provar que funcionou
 
@@ -302,3 +312,19 @@ regras que custaram caro:
   foi o experimento. Escolha uma quebra que **compile** (inverter uma condição,
   não acrescentar um `return` que deixa código inalcançável).
 - Use `npm run test:build`. `npm test` sozinho exercita o build anterior.
+
+E dois jeitos de escrever um teste **vazio** desta casca, os dois medidos aqui,
+os dois passando contra a quebra antes de serem consertados:
+
+- **Rolar o `.viz-body` sem provar que é ele quem rola.** Se a quebra devolve a
+  rolagem para a figura inteira — que é exatamente o bug que a camada 1 conserta
+  —, `body.scrollTop` fica em zero, o cabeçalho não se mexe, e o teste aprova a
+  quebra. Exija as três coisas: que o miolo **estoure**
+  (`scrollHeight - clientHeight > SLACK`), que ele mesmo **role**
+  (`scrollTop > 0` depois de rolar) e que a figura **não** role.
+- **Trocar um estado que não está em `measureOn`.** O teste da escolha manual só
+  significa alguma coisa quando a medição discordaria do aluno. Um preset que
+  troca só o alvo não muda `measureOn`, não dispara medição nenhuma, e a escolha
+  "sobrevive" sem que nada a tenha ameaçado. Escolha um estado que muda mesmo a
+  entrada da medição, **confirme a troca na tela** antes de concluir, e deixe a
+  janela apertada o bastante para a medição querer recolher.

--- a/content/visualizers/TwoPointersCiclo.tsx
+++ b/content/visualizers/TwoPointersCiclo.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TwoPointersCiclo, o sabor rápido e lento (Floyd) numa lista ligada.
@@ -9,27 +10,27 @@ import { createPortal } from "react-dom";
 // Os outros dois visualizadores de Two Pointers andam sobre células de array.
 // Aqui a estrutura tem forma própria (o "rho": uma cauda reta que desemboca num
 // laço), então o desenho é um SVG com layout calculado, e não uma fileira de
-// células. O gerador de passos continua puro, igual aos demais.
+// células. O gerador de passos continua puro, e a casca vem do `useVisualizer`.
 //
 // A lista é descrita por dois números: quantos nós vêm antes do ciclo e quantos
 // nós formam o ciclo. Com ciclo = 0 a lista termina em None, que é o caso em
 // que o algoritmo precisa devolver False.
 // ---------------------------------------------------------------------------
 
-type Passo = {
-  lento: number | null;
-  rapido: number | null;
-  linha: number;
-  iteracao: number;
-  passosLento: number;
-  passosRapido: number;
-  encontrou?: boolean;
-  fim?: boolean;
-  nota: string;
+type Step = {
+  slow: number | null;
+  fast: number | null;
+  line: number;
+  iteration: number;
+  slowSteps: number;
+  fastSteps: number;
+  found?: boolean;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo.
-const CODIGO = [
+// As linhas mapeiam 1:1 com o campo `line` de cada passo.
+const CODE = [
   "def tem_ciclo(cabeca):",
   "    lento = rapido = cabeca",
   "    while rapido and rapido.prox:",
@@ -40,299 +41,263 @@ const CODIGO = [
   "    return False",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-const R_NO = 17; // raio do nó
+const R_NODE = 17; // raio do nó
 const GAP = 68; // distância entre nós da cauda
 
-function raioCiclo(ciclo: number): number {
-  return Math.max(48, ciclo * 9);
+function cycleRadius(cycle: number): number {
+  return Math.max(48, cycle * 9);
 }
 
-// prox(i): índice do próximo nó, ou null quando a lista acaba.
-function fazProx(cauda: number, ciclo: number) {
-  const total = cauda + ciclo;
+// next(i): índice do próximo nó, ou null quando a lista acaba.
+function makeNext(tail: number, cycle: number) {
+  const total = tail + cycle;
   return (i: number | null): number | null => {
     if (i === null) return null;
     if (i < total - 1) return i + 1;
-    return ciclo > 0 ? cauda : null;
+    return cycle > 0 ? tail : null;
   };
 }
 
-function gerarPassos(cauda: number, ciclo: number): Passo[] {
-  const total = cauda + ciclo;
-  const prox = fazProx(cauda, ciclo);
-  const out: Passo[] = [];
-  let lento: number | null = 0;
-  let rapido: number | null = 0;
-  let iteracao = 0;
-  let passosLento = 0;
-  let passosRapido = 0;
-  const base = () => ({ lento, rapido, iteracao, passosLento, passosRapido });
+function generateSteps(tail: number, cycle: number): Step[] {
+  const total = tail + cycle;
+  const next = makeNext(tail, cycle);
+  const out: Step[] = [];
+  let slow: number | null = 0;
+  let fast: number | null = 0;
+  let iteration = 0;
+  let slowSteps = 0;
+  let fastSteps = 0;
+  const base = () => ({ slow, fast, iteration, slowSteps, fastSteps });
   out.push({
     ...base(),
-    linha: 1,
-    nota: `lento e rápido começam os dois na cabeça, o nó 0. A lista tem ${total} ${total === 1 ? "nó" : "nós"}.`,
+    line: 1,
+    note: `lento e rápido começam os dois na cabeça, o nó 0. A lista tem ${total} ${total === 1 ? "nó" : "nós"}.`,
   });
-  let guarda = 0;
-  while (guarda++ < 200) {
-    if (rapido === null || prox(rapido) === null) {
+  let guard = 0;
+  while (guard++ < 200) {
+    if (fast === null || next(fast) === null) {
       out.push({
         ...base(),
-        linha: 7,
-        fim: true,
-        nota:
-          rapido === null
+        line: 7,
+        done: true,
+        note:
+          fast === null
             ? `o rápido caiu para fora da lista (None): quem tem ciclo nunca sai dele, então esta lista não tem ciclo.`
-            : `o rápido está no nó ${rapido}, que é o último e aponta para None: chegou ao fim, esta lista não tem ciclo.`,
+            : `o rápido está no nó ${fast}, que é o último e aponta para None: chegou ao fim, esta lista não tem ciclo.`,
       });
       break;
     }
-    iteracao++;
-    const lentoAntes = lento as number;
-    const rapidoAntes = rapido as number;
-    lento = prox(lento);
-    passosLento += 1;
+    iteration++;
+    const slowBefore = slow as number;
+    const fastBefore = fast as number;
+    slow = next(slow);
+    slowSteps += 1;
     // O rápido dá dois saltos, mas o segundo pode cair no None. Contar sempre
     // 2 inflaria o painel, então só conta salto que aterrissa num nó.
-    const meio = prox(rapido) as number;
-    rapido = prox(meio);
-    passosRapido += rapido === null ? 1 : 2;
-    const destinoRapido = rapido === null ? "para fora da lista (None)" : `para o nó ${rapido}`;
+    const middle = next(fast) as number;
+    fast = next(middle);
+    fastSteps += fast === null ? 1 : 2;
+    const fastTarget = fast === null ? "para fora da lista (None)" : `para o nó ${fast}`;
     out.push({
       ...base(),
-      linha: 4,
-      nota: `iteração ${iteracao}: o lento sai do nó ${lentoAntes} e anda 1, chega ao nó ${lento}. O rápido sai do nó ${rapidoAntes} e anda 2, vai ${destinoRapido}.`,
+      line: 4,
+      note: `iteração ${iteration}: o lento sai do nó ${slowBefore} e anda 1, chega ao nó ${slow}. O rápido sai do nó ${fastBefore} e anda 2, vai ${fastTarget}.`,
     });
-    if (rapido !== null && lento === rapido) {
+    if (fast !== null && slow === fast) {
       out.push({
         ...base(),
-        linha: 6,
-        encontrou: true,
-        fim: true,
-        nota: `lento e rápido pararam os dois no nó ${lento}: eles se encontraram, logo a lista tem ciclo. Foram ${iteracao} ${iteracao === 1 ? "iteração" : "iterações"}.`,
+        line: 6,
+        found: true,
+        done: true,
+        note: `lento e rápido pararam os dois no nó ${slow}: eles se encontraram, logo a lista tem ciclo. Foram ${iteration} ${iteration === 1 ? "iteração" : "iterações"}.`,
       });
       break;
     }
     out.push({
       ...base(),
-      linha: 5,
-      nota:
-        rapido === null
-          ? `o lento está no nó ${lento} e o rápido saiu da lista: ainda não se encontraram, volto para o topo do while.`
-          : `o lento está no nó ${lento} e o rápido no nó ${rapido}: ainda não se encontraram, volto para o topo do while.`,
+      line: 5,
+      note:
+        fast === null
+          ? `o lento está no nó ${slow} e o rápido saiu da lista: ainda não se encontraram, volto para o topo do while.`
+          : `o lento está no nó ${slow} e o rápido no nó ${fast}: ainda não se encontraram, volto para o topo do while.`,
     });
   }
   return out;
 }
 
-type Preset = { key: string; rotulo: string; cauda: number; ciclo: number };
+type Preset = { key: string; label: string; tail: number; cycle: number };
 const PRESETS: Preset[] = [
-  { key: "classico", rotulo: "Clássico: 3 antes + ciclo de 5", cauda: 3, ciclo: 5 },
-  { key: "sem", rotulo: "Sem ciclo: 6 nós em fila", cauda: 6, ciclo: 0 },
-  { key: "puro", rotulo: "Só ciclo: 6 nós em roda", cauda: 0, ciclo: 6 },
-  { key: "laco", rotulo: "Laço em si mesmo: 3 + ciclo de 1", cauda: 3, ciclo: 1 },
+  { key: "classico", label: "Clássico: 3 antes + ciclo de 5", tail: 3, cycle: 5 },
+  { key: "sem", label: "Sem ciclo: 6 nós em fila", tail: 6, cycle: 0 },
+  { key: "puro", label: "Só ciclo: 6 nós em roda", tail: 0, cycle: 6 },
+  { key: "laco", label: "Laço em si mesmo: 3 + ciclo de 1", tail: 3, cycle: 1 },
 ];
 
 export function TwoPointersCiclo() {
-  const [cauda, setCauda] = useState(3);
-  const [ciclo, setCiclo] = useState(5);
+  const [tail, setTail] = useState(3);
+  const [cycle, setCycle] = useState(5);
   const [preset, setPreset] = useState("classico");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   // Uma lista sem nenhum nó não teria o que desenhar nem o que percorrer.
-  const nCauda = cauda + ciclo === 0 ? 1 : cauda;
-  const total = nCauda + ciclo;
+  const nTail = tail + cycle === 0 ? 1 : tail;
+  const nodeCount = nTail + cycle;
 
-  const passos = useMemo(() => gerarPassos(nCauda, ciclo), [nCauda, ciclo]);
-  const qtd = passos.length;
-  const idx = Math.min(passo, qtd - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(nTail, cycle), [nTail, cycle]);
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const viz = useVisualizer({
+    title: "Visualizador · rápido e lento: existe ciclo na lista ligada?",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o desenho. O SVG tem largura 100% e altura
+    // automática, então a altura na tela sai da razão do viewBox — e os dois
+    // lados dessa razão dependem da cauda e do ciclo.
+    measureOn: [nTail, cycle],
+  });
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= qtd - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, qtd, parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    if (tocando && idx >= qtd - 1) setTocando(false);
-  }, [tocando, idx, qtd]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const aoMudarCauda = (v: number) => { reiniciar(); setPreset(""); setCauda(v); };
-  const aoMudarCiclo = (v: number) => { reiniciar(); setPreset(""); setCiclo(v); };
-  const aplicarPreset = (pr: Preset) => { reiniciar(); setPreset(pr.key); setCauda(pr.cauda); setCiclo(pr.ciclo); };
+  const onTailChange = (v: number) => { viz.reset(); setPreset(""); setTail(v); };
+  const onCycleChange = (v: number) => { viz.reset(); setPreset(""); setCycle(v); };
+  const applyPreset = (pr: Preset) => { viz.reset(); setPreset(pr.key); setTail(pr.tail); setCycle(pr.cycle); };
 
   // --- layout do desenho -----------------------------------------------
   // Com ciclo de 1 nó não existe circunferência: o raio vira 0 e o laço é um
   // arco desenhado por cima do próprio nó, então a altura precisa sobrar.
-  const Rc = ciclo >= 2 ? raioCiclo(ciclo) : 0;
-  const entradaX = 28 + nCauda * GAP; // x do primeiro nó do ciclo
-  const cx = entradaX + Rc;
-  const alturaSvg = ciclo >= 2 ? 2 * Rc + 92 : ciclo === 1 ? 156 : 128;
-  const cy = alturaSvg / 2;
-  const ultimoCaudaX = 28 + (nCauda - 1) * GAP;
-  const larguraSvg = ciclo >= 2 ? cx + Rc + 34 : ciclo === 1 ? entradaX + 40 : ultimoCaudaX + GAP + 58;
+  const Rc = cycle >= 2 ? cycleRadius(cycle) : 0;
+  const entryX = 28 + nTail * GAP; // x do primeiro nó do ciclo
+  const cx = entryX + Rc;
+  const svgHeight = cycle >= 2 ? 2 * Rc + 92 : cycle === 1 ? 156 : 128;
+  const cy = svgHeight / 2;
+  const lastTailX = 28 + (nTail - 1) * GAP;
+  const svgWidth = cycle >= 2 ? cx + Rc + 34 : cycle === 1 ? entryX + 40 : lastTailX + GAP + 58;
 
   const pos = (i: number) => {
-    if (i < nCauda) return { x: 28 + i * GAP, y: cy, ang: null as number | null };
-    const k = i - nCauda;
-    const a = Math.PI + (k * 2 * Math.PI) / Math.max(1, ciclo);
-    return { x: cx + Rc * Math.cos(a), y: cy + Rc * Math.sin(a), ang: a };
+    if (i < nTail) return { x: 28 + i * GAP, y: cy, angle: null as number | null };
+    const k = i - nTail;
+    const a = Math.PI + (k * 2 * Math.PI) / Math.max(1, cycle);
+    return { x: cx + Rc * Math.cos(a), y: cy + Rc * Math.sin(a), angle: a };
   };
 
   // Reta encurtada nas duas pontas, para não entrar por baixo dos nós.
-  const reta = (ax: number, ay: number, bx: number, by: number) => {
+  const segment = (ax: number, ay: number, bx: number, by: number) => {
     const dx = bx - ax;
     const dy = by - ay;
     const d = Math.max(1, Math.hypot(dx, dy));
     const ux = dx / d;
     const uy = dy / d;
     return {
-      x1: ax + ux * (R_NO + 3),
-      y1: ay + uy * (R_NO + 3),
-      x2: bx - ux * (R_NO + 10),
-      y2: by - uy * (R_NO + 10),
+      x1: ax + ux * (R_NODE + 3),
+      y1: ay + uy * (R_NODE + 3),
+      x2: bx - ux * (R_NODE + 10),
+      y2: by - uy * (R_NODE + 10),
     };
   };
 
-  const retas: { k: string; x1: number; y1: number; x2: number; y2: number }[] = [];
-  for (let i = 0; i < nCauda; i++) {
-    if (i + 1 < total) {
+  const segments: { k: string; x1: number; y1: number; x2: number; y2: number }[] = [];
+  for (let i = 0; i < nTail; i++) {
+    if (i + 1 < nodeCount) {
       const a = pos(i);
       const b = pos(i + 1);
-      retas.push({ k: `t${i}`, ...reta(a.x, a.y, b.x, b.y) });
+      segments.push({ k: `t${i}`, ...segment(a.x, a.y, b.x, b.y) });
     }
   }
   // Sem ciclo, o último nó aponta para o None escrito ao lado dele.
-  if (ciclo === 0) {
-    const a = pos(total - 1);
-    retas.push({ k: "none", x1: a.x + R_NO + 3, y1: cy, x2: ultimoCaudaX + GAP - 22, y2: cy });
+  if (cycle === 0) {
+    const a = pos(nodeCount - 1);
+    segments.push({ k: "none", x1: a.x + R_NODE + 3, y1: cy, x2: lastTailX + GAP - 22, y2: cy });
   }
 
   // Arcos do ciclo: seguem a própria circunferência, então nunca se sobrepõem.
-  const arcos: string[] = [];
-  if (ciclo >= 2) {
-    const da = (2 * Math.PI) / ciclo;
-    const off = Math.min(da * 0.34, (R_NO + 9) / Rc);
-    for (let k = 0; k < ciclo; k++) {
+  const arcs: string[] = [];
+  if (cycle >= 2) {
+    const da = (2 * Math.PI) / cycle;
+    const off = Math.min(da * 0.34, (R_NODE + 9) / Rc);
+    for (let k = 0; k < cycle; k++) {
       const a1 = Math.PI + k * da + off;
       const a2 = Math.PI + (k + 1) * da - off;
       const x1 = cx + Rc * Math.cos(a1);
       const y1 = cy + Rc * Math.sin(a1);
       const x2 = cx + Rc * Math.cos(a2);
       const y2 = cy + Rc * Math.sin(a2);
-      arcos.push(`M ${x1.toFixed(1)},${y1.toFixed(1)} A ${Rc},${Rc} 0 0,1 ${x2.toFixed(1)},${y2.toFixed(1)}`);
+      arcs.push(`M ${x1.toFixed(1)},${y1.toFixed(1)} A ${Rc},${Rc} 0 0,1 ${x2.toFixed(1)},${y2.toFixed(1)}`);
     }
-  } else if (ciclo === 1) {
-    const a = pos(nCauda);
-    arcos.push(
-      `M ${(a.x - 9).toFixed(1)},${(a.y - R_NO - 2).toFixed(1)} C ${(a.x - 52).toFixed(1)},${(a.y - R_NO - 62).toFixed(1)} ${(a.x + 52).toFixed(1)},${(a.y - R_NO - 62).toFixed(1)} ${(a.x + 11).toFixed(1)},${(a.y - R_NO - 4).toFixed(1)}`
+  } else if (cycle === 1) {
+    const a = pos(nTail);
+    arcs.push(
+      `M ${(a.x - 9).toFixed(1)},${(a.y - R_NODE - 2).toFixed(1)} C ${(a.x - 52).toFixed(1)},${(a.y - R_NODE - 62).toFixed(1)} ${(a.x + 52).toFixed(1)},${(a.y - R_NODE - 62).toFixed(1)} ${(a.x + 11).toFixed(1)},${(a.y - R_NODE - 4).toFixed(1)}`
     );
   }
 
-  const corNo = (i: number) => {
-    const eLento = p.lento === i;
-    const eRapido = p.rapido === i;
-    if (eLento && eRapido) return { fill: "rgba(52,211,153,0.24)", stroke: "#34d399", txt: "#eafff5" };
-    if (eLento) return { fill: "rgba(59,130,246,0.22)", stroke: "#3b82f6", txt: "#ffffff" };
-    if (eRapido) return { fill: "rgba(245,158,11,0.2)", stroke: "#f59e0b", txt: "#ffffff" };
-    return { fill: "#0f1826", stroke: "rgba(255,255,255,0.14)", txt: "#8ba0bb" };
+  const nodeColor = (i: number) => {
+    const isSlow = p.slow === i;
+    const isFast = p.fast === i;
+    if (isSlow && isFast) return { fill: "rgba(52,211,153,0.24)", stroke: "#34d399", textColor: "#eafff5" };
+    if (isSlow) return { fill: "rgba(59,130,246,0.22)", stroke: "#3b82f6", textColor: "#ffffff" };
+    if (isFast) return { fill: "rgba(245,158,11,0.2)", stroke: "#f59e0b", textColor: "#ffffff" };
+    return { fill: "#0f1826", stroke: "rgba(255,255,255,0.14)", textColor: "#8ba0bb" };
   };
 
-  const marcaNo = (i: number) => {
-    const eLento = p.lento === i;
-    const eRapido = p.rapido === i;
-    if (eLento && eRapido) return { txt: "L R", cor: "#6ee7b7" };
-    if (eLento) return { txt: "L", cor: "#93bbfd" };
-    if (eRapido) return { txt: "R", cor: "#fcd34d" };
+  const nodeMark = (i: number) => {
+    const isSlow = p.slow === i;
+    const isFast = p.fast === i;
+    if (isSlow && isFast) return { txt: "L R", color: "#6ee7b7" };
+    if (isSlow) return { txt: "L", color: "#93bbfd" };
+    if (isFast) return { txt: "R", color: "#fcd34d" };
     return null;
   };
 
-  const variaveis = [
-    { nome: "lento", valor: p.lento === null ? "None" : `nó ${p.lento}` },
-    { nome: "rapido", valor: p.rapido === null ? "None" : `nó ${p.rapido}` },
-    { nome: "iteração", valor: `${p.iteracao}` },
-    { nome: "ciclo?", valor: p.encontrou ? "sim" : p.fim ? "não" : "?", best: !!p.encontrou },
+  const vars = [
+    { name: "lento", value: p.slow === null ? "None" : `nó ${p.slow}` },
+    { name: "rapido", value: p.fast === null ? "None" : `nó ${p.fast}` },
+    { name: "iteração", value: `${p.iteration}` },
+    { name: "ciclo?", value: p.found ? "sim" : p.done ? "não" : "?", best: !!p.found },
   ];
 
-  const estatisticas = [
-    { k: "n", rot: "nós na lista", val: `${total}` },
-    { k: "it", rot: "iterações", val: `${p.iteracao}` },
-    { k: "l", rot: "nós que o lento andou", val: `${p.passosLento}` },
-    { k: "r", rot: "nós que o rápido andou", val: `${p.passosRapido}` },
+  const stats = [
+    { k: "n", label: "nós na lista", value: `${nodeCount}` },
+    { k: "it", label: "iterações", value: `${p.iteration}` },
+    { k: "l", label: "nós que o lento andou", value: `${p.slowSteps}` },
+    { k: "r", label: "nós que o rápido andou", value: `${p.fastSteps}` },
   ];
 
-  const notaCls = "viz-note" + (p.encontrou ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / qtd) * 100);
+  const noteClass = "viz-note" + (p.found ? " ok" : p.done ? " invalid" : "");
 
-  const descricao = `Lista com ${total} nós, ${ciclo > 0 ? `com ciclo de ${ciclo} nós` : "sem ciclo"}. Lento em ${p.lento === null ? "None" : `nó ${p.lento}`}, rápido em ${p.rapido === null ? "None" : `nó ${p.rapido}`}.`;
+  const description = `Lista com ${nodeCount} nós, ${cycle > 0 ? `com ciclo de ${cycle} nós` : "sem ciclo"}. Lento em ${p.slow === null ? "None" : `nó ${p.slow}`}, rápido em ${p.fast === null ? "None" : `nó ${p.fast}`}.`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · rápido e lento: existe ciclo na lista ligada?</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {qtd}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
         <div className="viz-inputs">
           <label className="viz-field grow">
-            <span>Nós antes do ciclo: {nCauda}{cauda + ciclo === 0 ? " (o mínimo)" : ""}</span>
+            <span>Nós antes do ciclo: {nTail}{tail + cycle === 0 ? " (o mínimo)" : ""}</span>
             <input
-              type="range" min={0} max={6} step={1} value={cauda}
-              onChange={(e) => aoMudarCauda(parseInt(e.target.value, 10))}
+              type="range" min={0} max={6} step={1} value={tail}
+              onChange={(e) => onTailChange(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </label>
           <label className="viz-field grow">
-            <span>Nós no ciclo: {ciclo === 0 ? "nenhum, a lista termina em None" : ciclo}</span>
+            <span>Nós no ciclo: {cycle === 0 ? "nenhum, a lista termina em None" : cycle}</span>
             <input
-              type="range" min={0} max={8} step={1} value={ciclo}
-              onChange={(e) => aoMudarCiclo(parseInt(e.target.value, 10))}
+              type="range" min={0} max={8} step={1} value={cycle}
+              onChange={(e) => onCycleChange(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </label>
@@ -341,9 +306,9 @@ export function TwoPointersCiclo() {
         <div className="tp-canvas-wrap">
           <svg
             className="tp-svg"
-            viewBox={`-22 -8 ${Math.round(larguraSvg + 44)} ${Math.round(alturaSvg + 16)}`}
+            viewBox={`-22 -8 ${Math.round(svgWidth + 44)} ${Math.round(svgHeight + 16)}`}
             role="img"
-            aria-label={descricao}
+            aria-label={description}
           >
             <defs>
               <marker id="tp-seta" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
@@ -351,19 +316,19 @@ export function TwoPointersCiclo() {
               </marker>
             </defs>
 
-            {retas.map((s) => (
+            {segments.map((s) => (
               <line
                 key={s.k} x1={s.x1} y1={s.y1} x2={s.x2} y2={s.y2}
                 stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#tp-seta)"
               />
             ))}
-            {arcos.map((d, i) => (
+            {arcs.map((d, i) => (
               <path key={`a${i}`} d={d} fill="none" stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#tp-seta)" />
             ))}
 
-            {ciclo === 0 ? (
+            {cycle === 0 ? (
               <text
-                x={ultimoCaudaX + GAP} y={cy} fill="#61748c"
+                x={lastTailX + GAP} y={cy} fill="#61748c"
                 fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={13}
                 textAnchor="middle" dominantBaseline="middle"
               >
@@ -371,30 +336,30 @@ export function TwoPointersCiclo() {
               </text>
             ) : null}
 
-            {Array.from({ length: total }, (_, i) => {
+            {Array.from({ length: nodeCount }, (_, i) => {
               const q = pos(i);
-              const c = corNo(i);
-              const m = marcaNo(i);
+              const c = nodeColor(i);
+              const m = nodeMark(i);
               // Rótulo: para fora da roda nos nós do ciclo, acima nos nós da
               // cauda. Duas exceções, senão ele colide com uma seta: o nó de
               // entrada do ciclo (a seta da cauda chega por ali) fica com o
               // rótulo acima, e o ciclo de um nó só o joga para baixo, porque
               // o laço ocupa a parte de cima.
-              const entradaComCauda = i === nCauda && nCauda > 0;
-              const radial = q.ang !== null && Rc > 0 && !entradaComCauda;
+              const entryWithTail = i === nTail && nTail > 0;
+              const radial = q.angle !== null && Rc > 0 && !entryWithTail;
               let lx = q.x;
-              let ly = q.y - R_NO - 12;
+              let ly = q.y - R_NODE - 12;
               if (radial) {
-                lx = cx + (Rc + R_NO + 14) * Math.cos(q.ang as number);
-                ly = cy + (Rc + R_NO + 14) * Math.sin(q.ang as number);
-              } else if (q.ang !== null && Rc === 0) {
-                ly = q.y + R_NO + 14;
+                lx = cx + (Rc + R_NODE + 14) * Math.cos(q.angle as number);
+                ly = cy + (Rc + R_NODE + 14) * Math.sin(q.angle as number);
+              } else if (q.angle !== null && Rc === 0) {
+                ly = q.y + R_NODE + 14;
               }
               return (
                 <g key={i}>
-                  <circle cx={q.x} cy={q.y} r={R_NO} fill={c.fill} stroke={c.stroke} strokeWidth={1.8} />
+                  <circle cx={q.x} cy={q.y} r={R_NODE} fill={c.fill} stroke={c.stroke} strokeWidth={1.8} />
                   <text
-                    x={q.x} y={q.y} fill={c.txt}
+                    x={q.x} y={q.y} fill={c.textColor}
                     fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={13} fontWeight={600}
                     textAnchor="middle" dominantBaseline="central"
                   >
@@ -402,7 +367,7 @@ export function TwoPointersCiclo() {
                   </text>
                   {m ? (
                     <text
-                      x={lx} y={ly} fill={m.cor}
+                      x={lx} y={ly} fill={m.color}
                       fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={12} fontWeight={700}
                       textAnchor="middle" dominantBaseline="central"
                     >
@@ -421,65 +386,51 @@ export function TwoPointersCiclo() {
           <span><i style={{ background: "#34d399" }} /> os dois no mesmo nó: achou o ciclo</span>
         </p>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">ciclo.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` recolhe a ALTURA (grid 1fr→0fr): zerar a trilha
+              da coluna só tira a largura, e a linha do grid continuaria com a
+              altura do código. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">ciclo.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= qtd - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === qtd - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, qtd - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/TwoPointersPalindromo.tsx
+++ b/content/visualizers/TwoPointersPalindromo.tsx
@@ -1,40 +1,40 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TwoPointersPalindromo, ponteiros convergentes que NÃO andam no mesmo ritmo.
 //
 // Mesmo esqueleto do TwoPointersVisualizer (gerador puro de passos + a casca
-// compartilhada), mas o que se aprende aqui é outro: quando o problema manda
-// ignorar pontuação e espaço, cada ponteiro anda no seu ritmo, e a string
-// original nunca é copiada nem limpa. É a versão que o pessoal chegou ao vivo
-// no encontro, depois de perceber que replace() cria uma string nova a cada
-// caractere descartado.
+// compartilhada do `useVisualizer`), mas o que se aprende aqui é outro: quando
+// o problema manda ignorar pontuação e espaço, cada ponteiro anda no seu ritmo,
+// e a string original nunca é copiada nem limpa — porque replace() cria uma
+// string nova a cada caractere descartado.
 //
 // O contador de "strings novas" fica sempre em 0 de propósito, e ao lado dele
 // aparece quantas a versão que limpa a string antes teria alocado. É o
 // argumento visual do O(1) contra o O(n) de espaço, com número concreto.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   l: number;
   r: number;
-  linha: number;
-  comparacoes: number;
-  saltos: number;
+  line: number;
+  comparisons: number;
+  skips: number;
   moveL?: boolean;
   moveR?: boolean;
-  comparando?: boolean;
-  falha?: boolean;
+  comparing?: boolean;
+  failed?: boolean;
   ok?: boolean;
-  fim?: boolean;
-  nota: string;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo.
-const CODIGO = [
+// As linhas mapeiam 1:1 com o campo `line` de cada passo.
+const CODE = [
   "def e_palindromo(s):",
   "    esq, dir = 0, len(s) - 1",
   "    while esq < dir:",
@@ -50,127 +50,105 @@ const CODIGO = [
   "    return True",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
 function alnum(c: string): boolean {
   return /[a-zA-Z0-9]/.test(c);
 }
 
 // Espaço vira um glifo visível, senão a célula fica vazia e parece bug.
-function mostrar(c: string): string {
+function show(c: string): string {
   return c === " " ? "␣" : c;
 }
 
-function gerarPassos(s: string): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(s: string): Step[] {
+  const out: Step[] = [];
   let l = 0;
   let r = s.length - 1;
-  let comparacoes = 0;
-  let saltos = 0;
-  const base = () => ({ l, r, comparacoes, saltos });
+  let comparisons = 0;
+  let skips = 0;
+  const base = () => ({ l, r, comparisons, skips });
   // Caso de borda que o LeetCode cobra: string vazia é palíndromo por vacuidade,
   // e o while nem chega a rodar.
   if (s.length === 0) {
-    return [{ ...base(), linha: 12, ok: true, fim: true, nota: "string vazia: o while nem começa, porque esq (0) já não é menor que dir (-1). Sem nenhuma comparação, a resposta é sim, é palíndromo." }];
+    return [{ ...base(), line: 12, ok: true, done: true, note: "string vazia: o while nem começa, porque esq (0) já não é menor que dir (-1). Sem nenhuma comparação, a resposta é sim, é palíndromo." }];
   }
-  out.push({ ...base(), linha: 1, nota: `esq no caractere 0 e dir no caractere ${s.length - 1}. Vou fechando os dois até eles se encontrarem.` });
-  let guarda = 0;
-  while (l < r && guarda++ < 300) {
+  out.push({ ...base(), line: 1, note: `esq no caractere 0 e dir no caractere ${s.length - 1}. Vou fechando os dois até eles se encontrarem.` });
+  let guard = 0;
+  while (l < r && guard++ < 300) {
     if (!alnum(s[l])) {
-      saltos++;
-      out.push({ ...base(), linha: 4, moveL: true, nota: `s[${l}] = "${mostrar(s[l])}" não é letra nem dígito: avanço só a esquerda, a direita fica parada.` });
+      skips++;
+      out.push({ ...base(), line: 4, moveL: true, note: `s[${l}] = "${show(s[l])}" não é letra nem dígito: avanço só a esquerda, a direita fica parada.` });
       l++;
       continue;
     }
     if (!alnum(s[r])) {
-      saltos++;
-      out.push({ ...base(), linha: 6, moveR: true, nota: `s[${r}] = "${mostrar(s[r])}" não é letra nem dígito: recuo só a direita, a esquerda fica parada.` });
+      skips++;
+      out.push({ ...base(), line: 6, moveR: true, note: `s[${r}] = "${show(s[r])}" não é letra nem dígito: recuo só a direita, a esquerda fica parada.` });
       r--;
       continue;
     }
     const a = s[l].toLowerCase();
     const b = s[r].toLowerCase();
-    comparacoes++;
+    comparisons++;
     if (a !== b) {
-      out.push({ ...base(), linha: 8, comparando: true, falha: true, fim: true, nota: `s[${l}] = "${s[l]}" e s[${r}] = "${s[r]}": diferentes mesmo ignorando maiúscula. Não é palíndromo, e eu já posso parar aqui.` });
+      out.push({ ...base(), line: 8, comparing: true, failed: true, done: true, note: `s[${l}] = "${s[l]}" e s[${r}] = "${s[r]}": diferentes mesmo ignorando maiúscula. Não é palíndromo, e eu já posso parar aqui.` });
       return out;
     }
-    out.push({ ...base(), linha: 7, comparando: true, nota: `s[${l}] = "${s[l]}" e s[${r}] = "${s[r]}": iguais quando ignoro maiúscula. Comparação ${comparacoes}.` });
-    out.push({ ...base(), linha: 10, moveL: true, moveR: true, nota: `bateu: fecho os dois de uma vez, esquerda vai para ${l + 1} e direita para ${r - 1}.` });
+    out.push({ ...base(), line: 7, comparing: true, note: `s[${l}] = "${s[l]}" e s[${r}] = "${s[r]}": iguais quando ignoro maiúscula. Comparação ${comparisons}.` });
+    out.push({ ...base(), line: 10, moveL: true, moveR: true, note: `bateu: fecho os dois de uma vez, esquerda vai para ${l + 1} e direita para ${r - 1}.` });
     l++;
     r--;
   }
   // Com tamanho ímpar os ponteiros param no mesmo caractere; com tamanho par
   // eles se cruzam. A condição `esq < dir` cobre os dois sem `if` extra.
-  const fecho =
+  const closing =
     l === r
       ? `esq e dir pararam os dois no índice ${l}: é o caractere do meio, e ele é palíndromo de si mesmo, não precisa de comparação nenhuma.`
       : `esq (${l}) passou dir (${r}): sobrou parte nenhuma no meio, todos os pares já foram conferidos.`;
-  out.push({ ...base(), linha: 12, ok: true, fim: true, nota: `${fecho} É palíndromo, com ${comparacoes} ${comparacoes === 1 ? "comparação" : "comparações"} e ${saltos} ${saltos === 1 ? "salto" : "saltos"}.` });
+  out.push({ ...base(), line: 12, ok: true, done: true, note: `${closing} É palíndromo, com ${comparisons} ${comparisons === 1 ? "comparação" : "comparações"} e ${skips} ${skips === 1 ? "salto" : "saltos"}.` });
   return out;
 }
 
 const DEFAULT_S = "A man, a plan, a canal: Panama";
 
-type Preset = { key: string; rotulo: string; s: string };
+type Preset = { key: string; label: string; s: string };
 const PRESETS: Preset[] = [
-  { key: "arara", rotulo: "arara", s: "arara" },
-  { key: "banana", rotulo: "banana (falha no passo 1)", s: "banana" },
-  { key: "raceacar", rotulo: "race a car (falha no fim)", s: "race a car" },
-  { key: "panama", rotulo: "A man, a plan, a canal: Panama", s: DEFAULT_S },
-  { key: "zeroP", rotulo: "0P (a pegadinha do %32)", s: "0P" },
-  { key: "vazio", rotulo: "vazio (caso de borda)", s: "" },
+  { key: "arara", label: "arara", s: "arara" },
+  { key: "banana", label: "banana (falha no passo 1)", s: "banana" },
+  { key: "raceacar", label: "race a car (falha no fim)", s: "race a car" },
+  { key: "panama", label: "A man, a plan, a canal: Panama", s: DEFAULT_S },
+  { key: "zeroP", label: "0P (a pegadinha do %32)", s: "0P" },
+  { key: "vazio", label: "vazio (caso de borda)", s: "" },
 ];
 
 export function TwoPointersPalindromo() {
-  const [texto, setTexto] = useState(DEFAULT_S);
+  const [text, setText] = useState(DEFAULT_S);
   const [preset, setPreset] = useState("panama");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const s = text;
+  const steps = useMemo(() => generateSteps(s), [s]);
 
-  const s = texto;
-  const passos = useMemo(() => gerarPassos(s), [s]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · palíndromo com ponteiros em ritmos diferentes",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O que muda a altura da peça: a fita de caracteres some quando a string é
+    // vazia e dá lugar ao aviso, que tem outra altura. O comprimento não muda a
+    // altura (a fita é `nowrap` e rola na horizontal), mas o zero muda.
+    measureOn: [s.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((st) => (st >= total - 1 ? st : st + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const aoMudarTexto = (v: string) => {
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setTexto(v.slice(0, 40));
+  const onTextChange = (v: string) => {
+    viz.reset(); setPreset("");
+    setText(v.slice(0, 40));
   };
-  const aplicarPreset = (pr: Preset) => {
-    parar(); setTocando(false); setPasso(0); setPreset(pr.key);
-    setTexto(pr.s);
+  const applyPreset = (pr: Preset) => {
+    viz.reset(); setPreset(pr.key);
+    setText(pr.s);
   };
 
   const cells = s.split("").map((c, i) => {
@@ -178,63 +156,51 @@ export function TwoPointersPalindromo() {
     if (!alnum(c)) cls += " pula";
     if (i === p.l || i === p.r) cls += " in";
     if (i < p.l || i > p.r) cls += " drop";
-    if (p.falha && (i === p.l || i === p.r)) cls += " sai";
-    else if ((p.comparando || p.moveL || p.moveR) && (i === p.l || i === p.r)) cls += " entra";
-    let marca = "";
-    if (i === p.l) marca = "E";
-    if (i === p.r) marca = marca ? "E D" : "D";
-    return { i, c: mostrar(c), cls, marca };
+    if (p.failed && (i === p.l || i === p.r)) cls += " sai";
+    else if ((p.comparing || p.moveL || p.moveR) && (i === p.l || i === p.r)) cls += " entra";
+    let mark = "";
+    if (i === p.l) mark = "E";
+    if (i === p.r) mark = mark ? "E D" : "D";
+    return { i, c: show(c), cls, mark };
   });
 
-  const variaveis = [
-    { nome: "esq", valor: `${p.l}` },
-    { nome: "dir", valor: `${p.r}` },
-    { nome: "s[esq]", valor: p.l < s.length ? `"${mostrar(s[p.l])}"` : "-" },
-    { nome: "s[dir]", valor: p.r >= 0 ? `"${mostrar(s[p.r])}"` : "-", best: true },
+  const vars = [
+    { name: "esq", value: `${p.l}` },
+    { name: "dir", value: `${p.r}` },
+    { name: "s[esq]", value: p.l < s.length ? `"${show(s[p.l])}"` : "-" },
+    { name: "s[dir]", value: p.r >= 0 ? `"${show(s[p.r])}"` : "-", best: true },
   ];
 
   // A solução que limpa a string antes aloca uma string nova por caractere
   // aproveitado (string é imutável, cada `limpa += c` cria outra) mais uma para
   // o `limpa[::-1]`. É o O(n) de espaço que os dois ponteiros não pagam.
-  const uteis = s.split("").filter(alnum).length;
-  const copiasIngenuas = uteis + 1;
+  const useful = s.split("").filter(alnum).length;
+  const naiveCopies = useful + 1;
 
-  const estatisticas = [
-    { k: "n", rot: "caracteres (n)", val: `${s.length}` },
-    { k: "comp", rot: "comparações", val: `${p.comparacoes}` },
-    { k: "salto", rot: "saltos de pontuação", val: `${p.saltos}` },
-    { k: "mem", rot: "strings novas aqui", val: "0" },
-    { k: "mem2", rot: "strings novas limpando antes", val: `${copiasIngenuas}` },
+  const stats = [
+    { k: "n", label: "caracteres (n)", value: `${s.length}` },
+    { k: "comp", label: "comparações", value: `${p.comparisons}` },
+    { k: "salto", label: "saltos de pontuação", value: `${p.skips}` },
+    { k: "mem", label: "strings novas aqui", value: "0" },
+    { k: "mem2", label: "strings novas limpando antes", value: `${naiveCopies}` },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.falha ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.failed ? " invalid" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · palíndromo com ponteiros em ritmos diferentes</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -242,7 +208,7 @@ export function TwoPointersPalindromo() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Texto (até 40 caracteres)</span>
-            <input className="viz-input" value={texto} onChange={(e) => aoMudarTexto(e.target.value)} />
+            <input className="viz-input" value={text} onChange={(e) => onTextChange(e.target.value)} />
           </label>
         </div>
 
@@ -252,7 +218,7 @@ export function TwoPointersPalindromo() {
               <div className="viz-cell-wrap" key={c.i}>
                 <span className="viz-cell-idx">{c.i}</span>
                 <div className={c.cls}>{c.c}</div>
-                <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+                <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
               </div>
             ))}
           </div>
@@ -265,65 +231,51 @@ export function TwoPointersPalindromo() {
           <span><i style={{ background: "var(--ccc-accent)" }} /> posição atual de esq e dir</span>
         </p>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">palindromo.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` recolhe a ALTURA (grid 1fr→0fr): zerar a trilha
+              da coluna só tira a largura, e a linha do grid continuaria com a
+              altura do código. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">palindromo.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((st) => (
+          {stats.map((st) => (
             <div className="bigo-stat" key={st.k}>
-              <span>{st.rot}</span>
-              <strong>{st.val}</strong>
+              <span>{st.label}</span>
+              <strong>{st.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={() => { parar(); setTocando(false); setPasso(0); }}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/TwoPointersVisualizer.tsx
+++ b/content/visualizers/TwoPointersVisualizer.tsx
@@ -1,40 +1,39 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TwoPointersVisualizer, ponteiros convergentes (Two Sum em array ordenado).
 //
-// Mesmo padrão do SlidingWindowVisualizer: um gerador puro de passos + a mesma casca
-// (células, código sincronizado, variáveis, controles, Expandir). É a receita
-// para novos visualizadores, copie, troque `gerarPassos` e `CODIGO`.
+// Gerador puro de passos + a casca compartilhada do `useVisualizer`: medição de
+// altura, painel com cabeçalho e controles parados, código recolhível e os
+// controles de reprodução. Aqui fica só o que é DESTE visualizador. Contrato em
+// `content/visualizers/README.md`.
 //
 // Além do passo a passo, o painel de estatísticas conta as SOMAS AVALIADAS e
 // mostra, ao lado, quantos pares a força bruta testaria no pior caso
 // (n(n-1)/2). É esse par de números que transforma "O(n) é melhor que O(n²)"
 // em algo que o aluno vê acontecendo.
-//
-// O array padrão [1, 2, 3, 6, 8, 10, 20, 21] com alvo 16 é o mesmo que a
-// galera usou no encontro: as somas saem 22, 21, 11, 12, 13 e 16.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   l: number;
   r: number;
-  soma: number | null;
-  somas: number; // quantas somas já foram avaliadas até este passo
-  linha: number;
+  sum: number | null;
+  sums: number; // quantas somas já foram avaliadas até este passo
+  line: number;
   moveL?: boolean;
   moveR?: boolean;
   found?: boolean;
-  fim?: boolean;
-  nota: string;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com os passos (campo `linha` em gerarPassos), então a
+// As linhas mapeiam 1:1 com os passos (campo `line` em generateSteps), então a
 // ordem e a quantidade de linhas não podem mudar.
-const CODIGO = [
+const CODE = [
   "def dois_ponteiros(nums, alvo):",
   "    esquerda = 0",
   "    direita = len(nums) - 1",
@@ -49,114 +48,91 @@ const CODIGO = [
   "    return []",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-function gerarPassos(nums: number[], alvo: number): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(nums: number[], target: number): Step[] {
+  const out: Step[] = [];
   let l = 0;
   let r = nums.length - 1;
-  let somas = 0;
-  out.push({ l, r, soma: null, somas, linha: 2, nota: "esquerda no início, direita no fim do array ordenado." });
-  let guarda = 0;
-  while (l < r && guarda++ < 100) {
-    const soma = nums[l] + nums[r];
-    somas++;
-    out.push({ l, r, soma, somas, linha: 4, nota: `soma = nums[${l}] + nums[${r}] = ${nums[l]} + ${nums[r]} = ${soma}.` });
-    if (soma === alvo) {
-      out.push({ l, r, soma, somas, linha: 6, found: true, fim: true, nota: `soma = alvo (${alvo})! Par encontrado nos índices ${l} e ${r}, com ${somas} ${somas === 1 ? "soma avaliada" : "somas avaliadas"}.` });
+  let sums = 0;
+  out.push({ l, r, sum: null, sums, line: 2, note: "esquerda no início, direita no fim do array ordenado." });
+  let guard = 0;
+  while (l < r && guard++ < 100) {
+    const sum = nums[l] + nums[r];
+    sums++;
+    out.push({ l, r, sum, sums, line: 4, note: `soma = nums[${l}] + nums[${r}] = ${nums[l]} + ${nums[r]} = ${sum}.` });
+    if (sum === target) {
+      out.push({ l, r, sum, sums, line: 6, found: true, done: true, note: `soma = alvo (${target})! Par encontrado nos índices ${l} e ${r}, com ${sums} ${sums === 1 ? "soma avaliada" : "somas avaliadas"}.` });
       return out;
     }
-    if (soma < alvo) {
-      out.push({ l, r, soma, somas, linha: 8, moveL: true, nota: `${soma} < ${alvo}: preciso de uma soma maior, então avanço a esquerda e descarto o índice ${l} de vez.` });
+    if (sum < target) {
+      out.push({ l, r, sum, sums, line: 8, moveL: true, note: `${sum} < ${target}: preciso de uma soma maior, então avanço a esquerda e descarto o índice ${l} de vez.` });
       l++;
     } else {
-      out.push({ l, r, soma, somas, linha: 10, moveR: true, nota: `${soma} > ${alvo}: preciso de uma soma menor, então recuo a direita e descarto o índice ${r} de vez.` });
+      out.push({ l, r, sum, sums, line: 10, moveR: true, note: `${sum} > ${target}: preciso de uma soma menor, então recuo a direita e descarto o índice ${r} de vez.` });
       r--;
     }
   }
-  out.push({ l, r, soma: null, somas, linha: 11, fim: true, nota: `Os ponteiros se encontraram no índice ${l}: não existe par com essa soma, e para descobrir isso bastaram ${somas} ${somas === 1 ? "soma" : "somas"}.` });
+  out.push({ l, r, sum: null, sums, line: 11, done: true, note: `Os ponteiros se encontraram no índice ${l}: não existe par com essa soma, e para descobrir isso bastaram ${sums} ${sums === 1 ? "soma" : "somas"}.` });
   return out;
 }
 
 const DEFAULT_NUMS = [1, 2, 3, 6, 8, 10, 20, 21];
-const DEFAULT_ALVO = 16;
+const DEFAULT_TARGET = 16;
 
-// Casos escolhidos a dedo: o do encontro, o melhor caso, o pior caso (nenhum
+// Casos escolhidos a dedo: o principal, o melhor caso, o pior caso (nenhum
 // par, n-1 somas) e uma borda em que todo elemento é igual.
-type Preset = { key: string; rotulo: string; nums: number[]; alvo: number };
+type Preset = { key: string; label: string; nums: number[]; target: number };
 const PRESETS: Preset[] = [
-  { key: "encontro", rotulo: "Do encontro: alvo 16", nums: DEFAULT_NUMS, alvo: DEFAULT_ALVO },
-  { key: "pontas", rotulo: "Acerta de cara: alvo 22", nums: DEFAULT_NUMS, alvo: 22 },
-  { key: "sem", rotulo: "Sem solução: alvo 100", nums: DEFAULT_NUMS, alvo: 100 },
-  { key: "iguais", rotulo: "Tudo igual: alvo 11", nums: [5, 5, 5, 5], alvo: 11 },
+  { key: "encontro", label: "Do encontro: alvo 16", nums: DEFAULT_NUMS, target: DEFAULT_TARGET },
+  { key: "pontas", label: "Acerta de cara: alvo 22", nums: DEFAULT_NUMS, target: 22 },
+  { key: "sem", label: "Sem solução: alvo 100", nums: DEFAULT_NUMS, target: 100 },
+  { key: "iguais", label: "Tudo igual: alvo 11", nums: [5, 5, 5, 5], target: 11 },
 ];
 
-function ordenar(v: number[]) {
+function sortAsc(v: number[]) {
   return [...v].sort((a, b) => a - b);
 }
 
 export function TwoPointersVisualizer() {
   const [nums, setNums] = useState<number[]>(DEFAULT_NUMS);
-  const [entrada, setEntrada] = useState(DEFAULT_NUMS.join(", "));
-  const [alvo, setAlvo] = useState(DEFAULT_ALVO);
+  const [input, setInput] = useState(DEFAULT_NUMS.join(", "));
+  const [target, setTarget] = useState(DEFAULT_TARGET);
   const [preset, setPreset] = useState("encontro");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(nums.length ? nums : [1], target), [nums, target]);
+  const n = nums.length;
 
-  const passos = useMemo(() => gerarPassos(nums.length ? nums : [1], alvo), [nums, alvo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · ponteiros convergentes: dois números que somam o alvo",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o tamanho do array (as células quebram
+    // linha). O código tem 12 linhas fixas e o alvo não mexe no layout.
+    measureOn: [n],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const aoMudarEntrada = (v: string) => {
-    const arr = ordenar(v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 14));
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setEntrada(v); setNums(arr.length ? arr : [1]);
+  const onInputChange = (v: string) => {
+    const arr = sortAsc(v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 14));
+    viz.reset(); setPreset("");
+    setInput(v); setNums(arr.length ? arr : [1]);
   };
-  const aoMudarAlvo = (v: string) => {
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setAlvo(parseInt(v, 10) || 0);
+  const onTargetChange = (v: string) => {
+    viz.reset(); setPreset("");
+    setTarget(parseInt(v, 10) || 0);
   };
-  const aplicarPreset = (pr: Preset) => {
-    parar(); setTocando(false); setPasso(0); setPreset(pr.key);
-    setNums(pr.nums); setEntrada(pr.nums.join(", ")); setAlvo(pr.alvo);
+  const applyPreset = (pr: Preset) => {
+    viz.reset(); setPreset(pr.key);
+    setNums(pr.nums); setInput(pr.nums.join(", ")); setTarget(pr.target);
   };
-  const sortear = () => {
-    const n = 6 + Math.floor(Math.random() * 3);
-    const arr = ordenar(Array.from({ length: n }, () => 1 + Math.floor(Math.random() * 14)));
-    const alvoNovo = arr[Math.floor(Math.random() * n)] + arr[Math.floor(Math.random() * n)];
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setNums(arr); setEntrada(arr.join(", ")); setAlvo(alvoNovo);
+  const shuffle = () => {
+    const size = 6 + Math.floor(Math.random() * 3);
+    const arr = sortAsc(Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 14)));
+    const newTarget = arr[Math.floor(Math.random() * size)] + arr[Math.floor(Math.random() * size)];
+    viz.reset(); setPreset("");
+    setNums(arr); setInput(arr.join(", ")); setTarget(newTarget);
   };
 
   const cells = nums.map((v, i) => {
@@ -166,56 +142,43 @@ export function TwoPointersVisualizer() {
     if (p.found && (i === p.l || i === p.r)) cls += " entra";
     if (p.moveL && i === p.l) cls += " entra";
     if (p.moveR && i === p.r) cls += " entra";
-    let marca = "";
-    if (i === p.l) marca = "E";
-    if (i === p.r) marca = marca ? "E D" : "D";
-    return { i, v, cls, marca };
+    let mark = "";
+    if (i === p.l) mark = "E";
+    if (i === p.r) mark = mark ? "E D" : "D";
+    return { i, v, cls, mark };
   });
 
-  const variaveis = [
-    { nome: "esquerda", valor: `${p.l}` },
-    { nome: "direita", valor: `${p.r}` },
-    { nome: "soma", valor: p.soma == null ? "-" : `${p.soma}` },
-    { nome: "alvo", valor: `${alvo}`, best: true },
+  const vars = [
+    { name: "esquerda", value: `${p.l}` },
+    { name: "direita", value: `${p.r}` },
+    { name: "soma", value: p.sum == null ? "-" : `${p.sum}` },
+    { name: "alvo", value: `${target}`, best: true },
   ];
 
-  const n = nums.length;
-  const paresForcaBruta = (n * (n - 1)) / 2;
-  const estatisticas = [
-    { k: "n", rot: "tamanho (n)", val: `${n}` },
-    { k: "somas", rot: "somas avaliadas", val: `${p.somas}` },
-    { k: "bruta", rot: "pares na força bruta", val: `${paresForcaBruta}` },
-    { k: "espaco", rot: "memória extra", val: "O(1)" },
+  const bruteForcePairs = (n * (n - 1)) / 2;
+  const stats = [
+    { k: "n", label: "tamanho (n)", value: `${n}` },
+    { k: "somas", label: "somas avaliadas", value: `${p.sums}` },
+    { k: "bruta", label: "pares na força bruta", value: `${bruteForcePairs}` },
+    { k: "espaco", label: "memória extra", value: "O(1)" },
   ];
 
-  const notaCls = "viz-note" + (p.found ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.found ? " ok" : p.done ? " invalid" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · ponteiros convergentes: dois números que somam o alvo</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -223,13 +186,13 @@ export function TwoPointersVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Array (é ordenado sozinho)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>alvo</span>
-            <input className="viz-input k" type="number" value={alvo} onChange={(e) => aoMudarAlvo(e.target.value)} />
+            <input className="viz-input k" type="number" value={target} onChange={(e) => onTargetChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="viz-cells">
@@ -237,70 +200,56 @@ export function TwoPointersVisualizer() {
             <div className="viz-cell-wrap" key={c.i}>
               <span className="viz-cell-idx">{c.i}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">solucao.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` recolhe a ALTURA (grid 1fr→0fr): zerar a trilha
+              da coluna só tira a largura, e a linha do grid continuaria com a
+              altura do código. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">solucao.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={() => { parar(); setTocando(false); setPasso(0); }}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -595,6 +595,19 @@ html { scroll-behavior: smooth; }
 .tp-canvas-wrap { border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-panel); overflow-x: auto; }
 .tp-svg { display: block; width: 100%; min-width: 440px; height: auto; }
 
+/* Camada 2 da casca adaptativa, para ESTE desenho: com `width: 100%` o rho é
+   esticado até a largura do corpo, e o que cresce junto é o vazio entre os nós.
+   Medido em 1512x900, no fluxo do artigo: viewBox de 406x204 renderizando a
+   800x402px, ou seja 402 dos 939px da peça, contra um orçamento de 816.
+   O teto devolve 138px sem esconder nada — o `preserveAspectRatio` padrão
+   encolhe e centraliza o desenho, que continua inteiro na tela.
+   No expandido o teto sai: lá o miolo rola, e o painel existe justamente para
+   ver o desenho maior. Vence por especificidade, não por ordem de arquivo. */
+@media (max-height: 950px) {
+  .tp-svg { max-height: 264px; }
+  .viz-overlay-fit .tp-svg { max-height: none; }
+}
+
 /* ------ Strings: heap de alocações, fita de bytes e as duas fitas do rotate ---
    Prefixo .str-* para não colidir com os próximos temas. Usado por
    StringsVisualizer, StringsBytesVisualizer e StringsRotateVisualizer. */

--- a/tests/viz-two-pointers.spec.ts
+++ b/tests/viz-two-pointers.spec.ts
@@ -1,0 +1,291 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa nos três visualizadores de Two Pointers.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura. Então aqui a régua é sempre um número medido no
+// navegador (altura, posição, deslocamento) ou o texto que o aluno lê.
+//
+// O tópico de Two Pointers é o caso canônico da armadilha de idioma: os
+// rótulos `esq`/`dir` e o Python da tela são conteúdo didático em PORTUGUÊS
+// morando dentro de string. O último teste existe para que um rename de
+// identificador nunca mais os arraste junto.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/two-pointers/";
+
+// Janela de notebook de 16", que é o caso que motivou a casca.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para as três peças caberem com o código à mostra.
+const ALTA = { width: 1512, height: 1500 };
+// Apertada de propósito: garante que o miolo do painel tem o que rolar nos
+// três visualizadores, inclusive no palíndromo, que em 900px cabia inteiro.
+const APERTADA = { width: 1512, height: 700 };
+
+// `preset` é o índice de um preset que muda de verdade o que está em
+// `measureOn` — e `pecas`/`quantas` provam essa mudança na tela antes do teste
+// concluir qualquer coisa. Sem isso o teste da escolha manual passa vazio: um
+// preset que só troca o alvo não pede medição nova, então não há medição
+// alguma para a escolha do aluno vencer.
+const VISUALIZADORES = [
+  { i: 0, nome: "ponteiros convergentes", arquivo: "solucao.py", preset: 3, pecas: ".viz-cell", quantas: 4 },
+  { i: 1, nome: "palíndromo", arquivo: "palindromo.py", preset: 1, pecas: ".viz-cell", quantas: 6 },
+  { i: 2, nome: "rápido e lento", arquivo: "ciclo.py", preset: 1, pecas: ".tp-svg circle", quantas: 6 },
+];
+
+/** A peça no fluxo do artigo. */
+function noArtigo(page: Page, i: number): Locator {
+  return page.locator("article figure.viz").nth(i);
+}
+
+/** A peça depois de expandida: ela é portada para fora do artigo. */
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto(URL);
+  // As fontes chegam com `display: swap`: medir antes é medir o fallback, e a
+  // casca só decide depois delas.
+  await page.evaluate(() => document.fonts.ready);
+  await expect(page.locator("article figure.viz-fit").first()).toBeVisible();
+}
+
+async function expandir(page: Page, i: number): Promise<Locator> {
+  await noArtigo(page, i).getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = noPainel(page);
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+/** Altura renderizada de um elemento, já esperando a transição de 0,32s parar. */
+async function altura(loc: Locator): Promise<number> {
+  return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+for (const v of VISUALIZADORES) {
+  test.describe(`two-pointers · ${v.nome}`, () => {
+    // §8.1 do contrato: no expandido o cabeçalho e o rodapé ficam parados, e o
+    // botão que faz o algoritmo andar nunca sai da tela. Antes da casca a
+    // figura inteira rolava e o cabeçalho subia 99, 163 e 476px (medido).
+    //
+    // A janela é apertada de propósito e o código é aberto antes de rolar: sem
+    // garantir que o miolo TEM o que rolar, o teste vira uma pergunta vazia —
+    // ele passaria igual num painel onde a rolagem mudou de lugar. Por isso a
+    // primeira asserção é que o miolo estoura, e a segunda é que ele mesmo
+    // rolou.
+    test("expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({ page }) => {
+      await abrir(page, APERTADA);
+      const painel = await expandir(page, v.i);
+
+      const mostrar = painel.locator("button.viz-toggle-codigo");
+      if ((await mostrar.textContent()) === "Mostrar código") await mostrar.click();
+      await expect(mostrar).toHaveText("Ocultar código");
+
+      const miolo = painel.locator(".viz-body");
+      const cabeca = painel.locator(".viz-head");
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+      // 1. o miolo é o que estoura...
+      await expect
+        .poll(() => miolo.evaluate((el) => el.scrollHeight - el.clientHeight))
+        .toBeGreaterThan(8);
+
+      const topoAntes = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+      // O rótulo importa tanto quanto a posição: um botão no lugar certo
+      // dizendo a coisa errada ensina errado do mesmo jeito.
+      await expect(rodar).toHaveText("▶ Rodar");
+      await expect(rodar).toBeInViewport();
+
+      // 2. ...e é ele que rola, não a figura inteira.
+      await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+      await expect.poll(() => miolo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(8);
+      expect(await painel.evaluate((f) => Math.round(f.scrollTop))).toBe(0);
+
+      // 3. e o cabeçalho não saiu do lugar.
+      const topoDepois = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+      expect(Math.abs(topoDepois - topoAntes)).toBeLessThanOrEqual(1);
+      await expect(rodar).toBeInViewport();
+      await expect(rodar).toHaveText("▶ Rodar");
+
+      // E o rodapé está colado no pé da figura, não empurrado para fora dela.
+      const folga = await painel.evaluate((f) => {
+        const foot = f.querySelector(".viz-foot") as HTMLElement;
+        return Math.round(f.getBoundingClientRect().bottom - foot.getBoundingClientRect().bottom);
+      });
+      expect(folga).toBeLessThanOrEqual(2);
+    });
+
+    // §8.2: em tela baixa a peça não cabe com o código à mostra, então ele
+    // recolhe — e o botão passa a dizer o que faria aparecer.
+    test("tela baixa: o botão diz 'Mostrar código' e o bloco está recolhido", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Mostrar código");
+      await expect(botao).toHaveAttribute("aria-expanded", "false");
+      // Recolhido de verdade: o slot perde a ALTURA, não só a largura. Zerar a
+      // trilha da coluna deixava a linha do grid com a altura do código.
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeLessThanOrEqual(4);
+
+      // E a peça inteira passa a caber na janela, que é o ponto de tudo isto.
+      const orcamento = await page.evaluate(() => {
+        const h = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+        return window.innerHeight - h - 24;
+      });
+      expect(await altura(fig)).toBeLessThanOrEqual(orcamento);
+    });
+
+    // §8.3: onde cabe, o código já vem à mostra — a medição decide, não um
+    // breakpoint de largura.
+    test("tela alta: o código já vem aberto e o botão diz 'Ocultar código'", async ({ page }) => {
+      await abrir(page, ALTA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Ocultar código");
+      await expect(botao).toHaveAttribute("aria-expanded", "true");
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+      // O bloco é mesmo o código deste visualizador, não um bloco qualquer.
+      await expect(fig.locator(".viz-code-head")).toHaveText(v.arquivo);
+    });
+
+    // §8.4: a escolha explícita do aluno vence a medição e não é desfeita por
+    // uma troca de estado que pediria medição nova (`measureOn`).
+    // A janela é a apertada de propósito: em 900px sobrava pouco, e num
+    // visualizador a peça com o código aberto cabia por pouco — aí a medição
+    // não queria recolher nada e o teste passava mesmo com a trava removida.
+    // Prova de quebra só vale quando a medição REALMENTE discordaria do aluno.
+    test("a escolha do aluno sobrevive a uma troca de estado que pede medição nova", async ({ page }) => {
+      await abrir(page, APERTADA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Mostrar código");
+      await botao.click();
+      await expect(botao).toHaveText("Ocultar código");
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+
+      // Troca um preset que muda o que está em `measureOn` e dispara nova
+      // medição. Sem a trava da escolha manual, ela recolheria o código.
+      await fig.locator("button.bigo-chip").nth(v.preset).click();
+      // A entrada da medição mudou MESMO: sem esta prova o teste passaria
+      // celebrando uma medição que nunca aconteceu.
+      await expect(fig.locator(v.pecas)).toHaveCount(v.quantas);
+      await page.waitForTimeout(500); // deixa a medição e a transição rodarem
+
+      await expect(botao).toHaveText("Ocultar código");
+      expect(await altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+    });
+
+    // §8.5: as teclas dirigem a animação dentro do painel.
+    test("expandido: as setas andam o passo e o espaço roda", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const painel = await expandir(page, v.i);
+      const passo = painel.locator(".viz-step");
+
+      const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+      await expect(passo).toHaveText(`passo 1 de ${total}`);
+
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 2 de ${total}`);
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 3 de ${total}`);
+      await page.keyboard.press("ArrowLeft");
+      await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+      // Espaço roda: o rótulo do botão é o que diz se rodou.
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("❚❚ Pausar");
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("▶ Rodar");
+    });
+  });
+}
+
+// A regra mais importante dos atalhos é o inverso deles: com o cursor num
+// campo, espaço é espaço e seta é cursor. Sequestrar isso deixa a entrada
+// impossível de editar, que é pior que não ter atalho.
+for (const v of [
+  { i: 0, nome: "ponteiros convergentes" },
+  { i: 1, nome: "palíndromo" },
+]) {
+  test(`two-pointers · ${v.nome}: o campo em edição manda no espaço`, async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page, v.i);
+    const campo = painel.locator("input.viz-input").first();
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+    await campo.click();
+    // `End` não leva o cursor ao fim de um input no macOS, então a régua é o
+    // valor comparado consigo mesmo, não a posição do cursor.
+    const antes = await campo.inputValue();
+    await page.keyboard.press("Space");
+
+    await expect(campo).not.toHaveValue(antes);
+    expect((await campo.inputValue()).length).toBe(antes.length + 1);
+    // E a animação NÃO começou.
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+}
+
+// ---------------------------------------------------------------------------
+// O teto de altura do desenho do rho (camada 2, específica deste visualizador).
+// Medido em 1512x900: o SVG ia a 402px dos 939px da peça, contra 816 de
+// orçamento. O teto devolve a peça para dentro da janela sem esconder nada, e
+// NÃO vale no expandido, que existe para ver o desenho maior.
+// ---------------------------------------------------------------------------
+test("two-pointers · o desenho do rho tem teto no artigo e não tem no expandido", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const fig = noArtigo(page, 2);
+  const svgNoArtigo = await altura(fig.locator(".tp-svg"));
+  expect(svgNoArtigo).toBeLessThanOrEqual(264);
+
+  // O desenho continua inteiro: nenhum nó foi cortado pelo teto.
+  const cabeInteiro = await fig.locator(".tp-svg").evaluate((svg) => {
+    const caixa = svg.getBoundingClientRect();
+    return [...svg.querySelectorAll("circle")].every((c) => {
+      const r = c.getBoundingClientRect();
+      return r.top >= caixa.top - 1 && r.bottom <= caixa.bottom + 1;
+    });
+  });
+  expect(cabeInteiro).toBe(true);
+
+  const painel = await expandir(page, 2);
+  await expect.poll(() => altura(painel.locator(".tp-svg"))).toBeGreaterThan(264);
+});
+
+// ---------------------------------------------------------------------------
+// O guarda de idioma, agora como teste: identificador em inglês, tela em
+// português (contrato §0). Um `find & replace` de `esq` → `left` traduz o
+// identificador e estraga a aula junto — e o `tsc` não reclama de nada.
+// ---------------------------------------------------------------------------
+test("two-pointers · o Python da tela e os rótulos seguem em português", async ({ page }) => {
+  await abrir(page, ALTA);
+
+  // O gerador de passos e o código andam juntos: se o rename tivesse pegado a
+  // string, estas linhas viriam em inglês.
+  await expect(noArtigo(page, 0).locator(".viz-code-body")).toContainText("esquerda = 0");
+  await expect(noArtigo(page, 0).locator(".viz-code-body")).toContainText("soma = nums[esquerda] + nums[direita]");
+  await expect(noArtigo(page, 1).locator(".viz-code-body")).toContainText("esq, dir = 0, len(s) - 1");
+  await expect(noArtigo(page, 2).locator(".viz-code-body")).toContainText("lento = rapido = cabeca");
+
+  // Os rótulos do painel de variáveis explicam justamente aquelas linhas: se um
+  // lado vira inglês e o outro não, o aluno perde a correspondência.
+  const rotulos = async (i: number) =>
+    noArtigo(page, i).locator(".viz-var-name").allTextContents();
+  expect(await rotulos(0)).toEqual(["esquerda", "direita", "soma", "alvo"]);
+  expect(await rotulos(1)).toEqual(["esq", "dir", "s[esq]", "s[dir]"]);
+  expect(await rotulos(2)).toEqual(["lento", "rapido", "iteração", "ciclo?"]);
+
+  // E a nota do passo a passo, que é onde a frase "o array precisa estar
+  // sorted" apareceria.
+  await expect(noArtigo(page, 0).locator(".viz-note")).toHaveText(
+    "esquerda no início, direita no fim do array ordenado."
+  );
+});

--- a/tests/viz-two-pointers.spec.ts
+++ b/tests/viz-two-pointers.spec.ts
@@ -66,6 +66,35 @@ async function altura(loc: Locator): Promise<number> {
   return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
 }
 
+/**
+ * Amostra o estado do bloco recolhível N vezes ao longo de `ms` e devolve as
+ * amostras que falharam.
+ *
+ * Quando a promessa é PERMANÊNCIA ("a escolha do aluno sobrevive"), uma espera
+ * fixa seguida de uma leitura olha um instante só — o instante depois da
+ * espera. Um `expect.poll` cobre mais, mas passa na primeira amostra que der
+ * certo, então ele responde "esteve aberto em algum momento", não "continuou
+ * aberto". Amostrar responde a pergunta certa: nenhum instante da janela pode
+ * ter falhado.
+ *
+ * (Medido, para não virar folclore: contra a quebra que remove a trava da
+ * escolha manual, as duas formas reprovam nos três visualizadores. A
+ * amostragem é a mais forte das duas por construção, não porque a outra não
+ * pegue este bug específico.)
+ */
+async function amostrarAberto(page: Page, fig: Locator, ms = 900, n = 9): Promise<string[]> {
+  const falhas: string[] = [];
+  for (let i = 0; i < n; i++) {
+    const alturaSlot = await altura(fig.locator(".viz-code-slot"));
+    const rotulo = (await fig.locator("button.viz-toggle-codigo").textContent()) ?? "";
+    if (alturaSlot <= 100 || rotulo !== "Ocultar código") {
+      falhas.push(`aos ${Math.round((i * ms) / n)}ms: slot=${alturaSlot}px, rótulo=${JSON.stringify(rotulo)}`);
+    }
+    await page.waitForTimeout(ms / n);
+  }
+  return falhas;
+}
+
 for (const v of VISUALIZADORES) {
   test.describe(`two-pointers · ${v.nome}`, () => {
     // §8.1 do contrato: no expandido o cabeçalho e o rodapé ficam parados, e o
@@ -176,10 +205,11 @@ for (const v of VISUALIZADORES) {
       // A entrada da medição mudou MESMO: sem esta prova o teste passaria
       // celebrando uma medição que nunca aconteceu.
       await expect(fig.locator(v.pecas)).toHaveCount(v.quantas);
-      await page.waitForTimeout(500); // deixa a medição e a transição rodarem
 
-      await expect(botao).toHaveText("Ocultar código");
-      expect(await altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+      // A janela amostrada cobre a medição E a transição de 0,32s que viria
+      // depois dela. Exigir que NENHUMA amostra tenha falhado é o que separa
+      // "está aberto" de "continua aberto".
+      expect(await amostrarAberto(page, fig)).toEqual([]);
     });
 
     // §8.5: as teclas dirigem a animação dentro do painel.

--- a/tests/viz-two-pointers.spec.ts
+++ b/tests/viz-two-pointers.spec.ts
@@ -243,10 +243,16 @@ for (const v of [
 test("two-pointers · o desenho do rho tem teto no artigo e não tem no expandido", async ({ page }) => {
   await abrir(page, BAIXA);
   const fig = noArtigo(page, 2);
-  const svgNoArtigo = await altura(fig.locator(".tp-svg"));
-  expect(svgNoArtigo).toBeLessThanOrEqual(264);
 
-  // O desenho continua inteiro: nenhum nó foi cortado pelo teto.
+  // A régua não é o valor do `max-height` (isso só repetiria o CSS aqui e
+  // quebraria o teste a cada ajuste fino): é a altura SEM teto, medida em
+  // 1512x900 antes deste conserto, que era 402px. O desenho tem que ter
+  // encolhido de verdade em relação a ela.
+  const SEM_TETO = 402;
+  const svgNoArtigo = await altura(fig.locator(".tp-svg"));
+  expect(svgNoArtigo).toBeLessThan(SEM_TETO * 0.8);
+
+  // E o desenho continua inteiro: nenhum nó foi cortado pelo teto.
   const cabeInteiro = await fig.locator(".tp-svg").evaluate((svg) => {
     const caixa = svg.getBoundingClientRect();
     return [...svg.querySelectorAll("circle")].every((c) => {
@@ -256,8 +262,11 @@ test("two-pointers · o desenho do rho tem teto no artigo e não tem no expandid
   });
   expect(cabeInteiro).toBe(true);
 
+  // No painel o teto sai: lá o miolo rola e o desenho pode crescer. A régua é
+  // o próprio desenho do artigo, não um número solto.
   const painel = await expandir(page, 2);
-  await expect.poll(() => altura(painel.locator(".tp-svg"))).toBeGreaterThan(264);
+  await expect.poll(() => altura(painel.locator(".tp-svg"))).toBeGreaterThan(svgNoArtigo);
+  expect(await painel.locator(".tp-svg").evaluate((el) => getComputedStyle(el).maxHeight)).toBe("none");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos **três** visualizadores de Two
Pointers, via `useVisualizer` + `VizHeader` + `VizFooter`. Nenhum ficou de
fora: o inventário deu overlay, bloco de código, painel de variáveis e
controles nos três, então os três receberam as três camadas.

| arquivo | overlay | código | vars | ctrl | entrou |
|---|---|---|---|---|---|
| `TwoPointersVisualizer.tsx` | sim | sim | sim | sim | ✅ |
| `TwoPointersPalindromo.tsx` | sim | sim | sim | sim | ✅ |
| `TwoPointersCiclo.tsx` | sim | sim | sim | sim | ✅ |

Adaptar foi majoritariamente **remover**: 1.120 linhas viraram 780.

## Os números, medidos

Janela de 1512x900 (notebook de 16"), depois de `document.fonts.ready`, com a
animação congelada. Orçamento no fluxo do artigo: 816px.

### No artigo

| peça | antes | depois | orçamento |
|---|---|---|---|
| ponteiros convergentes | 885px (+69) | **574px** (-242) | 816px |
| palíndromo | 983px (+167) | **646px** (-170) | 816px |
| rápido e lento | 1148px (+332) | **801px** (-15) | 816px |

Os três estouravam; os três cabem.

### No painel expandido

Antes, a figura **inteira** rolava, então o cabeçalho e o `▶ Rodar` iam embora
junto com o conteúdo — que é exatamente o bug que a casca existe para
consertar.

| peça | cabeçalho ao rolar até o fim | `▶ Rodar` no topo da rolagem |
|---|---|---|
| ponteiros convergentes | -99px → **0px** | fora (bottom 940) → **na viewport** |
| palíndromo | -163px → **0px** | fora (bottom 1004) → **na viewport** |
| rápido e lento | -476px → **0px** | fora (bottom 1317) → **na viewport** |

Agora só o `.viz-body` rola, e o rodapé fica colado no pé da figura (1px nos
três).

## O teto do desenho do rho

Com a casca aplicada, o visualizador de ciclo **ainda** pedia 939px com o
código já recolhido. A quebra por bloco mostrou onde: o SVG sozinho ocupava
**402px dos 939**. Ele tem viewBox de 406x204 e `width: 100%`, então era
esticado até os 800px do corpo e a altura ia junto — 2x o natural, e o que
cresce nesse esticão é o vazio entre os nós.

Um `max-height` em `@media (max-height: 950px)`, no bloco temático `.tp-*`,
devolve 138px sem esconder nada: o `preserveAspectRatio` padrão encolhe e
centraliza, e o desenho continua inteiro (o teste confere que nenhum nó ficou
fora da caixa). No expandido o teto **não** vale, porque lá o miolo rola e o
painel existe para ver o desenho maior.

O bloco `viz-fit` compartilhado do `globals.css` **não foi tocado**, nem
`content/roadmap.ts`, nem `mdx-components.tsx`, nem `tests/navegacao.spec.ts`.

## Idioma: identificador em inglês, tela em português

Este tópico é o caso canônico da armadilha: `esq`/`dir`, o Python da tela
(`esq, dir = 0, len(s) - 1`) e as notas do passo a passo são conteúdo
didático **em português** morando dentro de string. Conferido de duas formas
independentes:

1. `scripts/guarda-idioma.py` nos três arquivos — só sobraram nome de classe
   CSS, de import e o texto do cabeçalho/rodapé que passou a ser renderizado
   pelo hook;
2. uma captura do texto **renderizado** dos **55 passos** dos três
   visualizadores, antes e depois, incluindo o texto dentro do SVG e os
   `aria-label`. Resultado: **nada saiu da tela**, e a única coisa que entrou
   foi o botão "Ocultar código" da própria casca.

## Testes

`tests/viz-two-pointers.spec.ts`, arquivo novo (19 testes) para não disputar
`navegacao.spec.ts` com os outros agentes. Medem comportamento e leem rótulo.

Cada teste rodou **contra o código quebrado**, com o build visível, quebras
que compilam e restauração por `cp`:

| quebra | testes que falharam |
|---|---|
| A — a figura inteira volta a rolar (desfaz a camada 1) | 3 |
| B — `if (!overflows)`: a medição decide ao contrário | 6 |
| D — a medição ignora a escolha manual do aluno | 3 |
| E — `stepBy(0)`: a seta é ouvida e não anda nada | 3 |
| F — o espaço é sequestrado com o cursor dentro do campo | 2 |
| G — o teto do desenho do rho some | 1 |
| H — `esq` vira `left` no rótulo da variável | 1 |

19 falhas para 19 testes: todo teste do arquivo foi provado.

**Duas versões destes testes passaram onde deviam falhar, e nos dois casos o
errado era o teste**, não o experimento:

- o de cabeçalho parado rolava o `.viz-body` sem nunca provar que o
  `.viz-body` é quem rola. Com a rolagem devolvida à figura, `scrollTop` não
  saía do zero, o cabeçalho não se mexia, e o teste **aprovava a quebra**;
- o da escolha manual trocava um preset que não mexe em `measureOn` (só o
  alvo), então não havia medição nova para a escolha do aluno vencer.

Os dois estão consertados e agora falham contra a quebra. As duas lições
subiram para o §8 do contrato.

## Contrato

`content/visualizers/README.md` ganhou o desenho que infla (§7) e os dois
jeitos de escrever um teste vazio desta casca (§8).

## Nota sobre o CI local

`npm run test:build` passou com os 19 testes novos verdes em todas as
rodadas. A suíte `navegacao.spec.ts` oscilou nesta máquina (0, 1, 3, 5 e 8
falhas em rodadas seguidas, em tópicos sem relação nenhuma com este PR —
home, Discord, introdução, quick-sort, big-o), com `BrokenPipeError` no
`python3 -m http.server`. É contenção: seis agentes rodando build e Playwright
em paralelo aqui. `src/lib/visualizer.tsx` está **byte a byte igual à main**
(diff vazio), e todos os testes que oscilaram passam em isolamento. Vale
conferir o CI limpo do GitHub.

## Rodada de revisão do Copilot

Uma thread, e o bloco de comentários suprimidos veio **vazio** (conferido pela
API, não pelo resumo).

O achado: o `waitForTimeout(500)` no teste da escolha manual é frágil. Procede,
e o problema era pior que a fragilidade apontada — aquele teste promete
**permanência**, e uma espera fixa olha um instante só. Virou amostragem: 9
leituras em 900ms, exigindo que nenhuma falhe, lendo altura **e** rótulo.

Antes de responder, rodei a sugestão da revisão (`expect.poll`) contra a quebra:
ela **também** reprova nos três visualizadores. Eu ia escrever que era mais
fraca e o experimento me corrigiu — a medição roda em `useLayoutEffect`, antes
da pintura, então o `poll` não pega o estado bom no primeiro tiro. Está na
thread com a tabela das três formas.

Tratado como classe: varri o arquivo atrás de outras esperas fixas e outras
asserções de permanência. Era a única de cada.
