### PR TITLE
feat(viz): casca adaptativa nos visualizadores de strings

### DIFF
--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -234,6 +234,7 @@ Reprodução, quando você precisa mexer nela de fora: `viz.step` (já limitado 
 | sem bloco dispensável (SVG de árvore, canvas) | `collapsible: false` — ganha o painel parado e nada mais. Não invente um bloco só para ter o botão |
 | o recolhível não é código | `blockName: "tabela"` — o rótulo passa a dizer o que some, porque **rótulo que mente ensina errado** |
 | sem linha do tempo (classificador, tabela) | `total: 1` — some o contador de passo, o rodapé e os atalhos |
+| sem passo, mas com um número que resume o estado | passe o número como `children` do `VizHeader`: ele entra onde ficaria o "passo N de M". Mande o **rótulo junto** (`3 bytes em UTF-8`, não `3`), porque sem o passo ao lado o número perde o contexto que o explicava |
 | ritmo próprio | `speeds: [...]` — um passo de sudoku e uma troca de array não pedem o mesmo tempo |
 | só passo a passo, sem animação contínua | `<VizFooter noSpeed />` |
 | botões extras nos controles | `<VizFooter>{seus botões}</VizFooter>` |
@@ -252,6 +253,15 @@ seja o desse visualizador, porque ele vira o `aria-label` do diálogo.
 - **Lista de trilhas de grid só interpola quando todas são da mesma natureza.**
   `1fr 300px → 1fr` não anima. `minmax(0,2fr) minmax(0,1fr) → minmax(0,0fr)
   minmax(0,1fr)` anima.
+- **Quem deixa a trilha fechar é o `overflow` do filho, não um `min-height`
+  escrito à mão.** Um item de grid só ganha tamanho mínimo automático quando o
+  overflow dele é `visible`; qualquer outro valor já zera esse mínimo. É por isso
+  que o `.viz-code`, que é `overflow: hidden`, fecha sem mais nada. Ao recolher
+  um bloco que **não** é `.viz-code`, olhe o `overflow` dele antes de escrever
+  CSS: uma tabela dentro de um container com `overflow-x: auto` já fecha sozinha,
+  e o par de regras "de apoio" que parece obrigatório é inerte. Prove antes de
+  ficar com ele — se o teste de altura passa com a regra removida, a regra não é
+  a razão de nada.
 - **A sombra do rodapé não é simétrica à do cabeçalho por acidente.** O
   cabeçalho tem fundo próprio e dilui a sombra nesse degrau de cor; o rodapé
   divide o fundo com o miolo e ainda soma com o `border-top` dos controles. Com

--- a/content/visualizers/StringsBytesVisualizer.tsx
+++ b/content/visualizers/StringsBytesVisualizer.tsx
@@ -21,9 +21,9 @@ type EncKey = "ascii" | "utf8" | "utf16" | "utf32";
 
 type Enc = {
   key: EncKey;
-  nome: string;
+  name: string;
   sub: string;
-  bytesDe: (cp: number) => number[];
+  bytesOf: (cp: number) => number[];
 };
 
 // UTF-8: 1 byte até U+007F, 2 até U+07FF, 3 até U+FFFF, 4 acima disso.
@@ -44,9 +44,9 @@ function utf8(cp: number): number[] {
 function utf16(cp: number): number[] {
   if (cp < 0x10000) return [cp & 0xff, cp >> 8];
   const v = cp - 0x10000;
-  const alto = 0xd800 + (v >> 10);
-  const baixo = 0xdc00 + (v & 0x3ff);
-  return [alto & 0xff, alto >> 8, baixo & 0xff, baixo >> 8];
+  const high = 0xd800 + (v >> 10);
+  const low = 0xdc00 + (v & 0x3ff);
+  return [high & 0xff, high >> 8, low & 0xff, low >> 8];
 }
 
 function utf32(cp: number): number[] {
@@ -60,30 +60,30 @@ function ascii(cp: number): number[] {
 }
 
 const ENCS: Enc[] = [
-  { key: "ascii", nome: "ASCII", sub: "1 byte, só até U+007F", bytesDe: ascii },
-  { key: "utf8", nome: "UTF-8", sub: "1 a 4 bytes por caractere", bytesDe: utf8 },
-  { key: "utf16", nome: "UTF-16", sub: "2 ou 4 bytes (padrão do C# e do Java)", bytesDe: utf16 },
-  { key: "utf32", nome: "UTF-32", sub: "4 bytes sempre", bytesDe: utf32 },
+  { key: "ascii", name: "ASCII", sub: "1 byte, só até U+007F", bytesOf: ascii },
+  { key: "utf8", name: "UTF-8", sub: "1 a 4 bytes por caractere", bytesOf: utf8 },
+  { key: "utf16", name: "UTF-16", sub: "2 ou 4 bytes (padrão do C# e do Java)", bytesOf: utf16 },
+  { key: "utf32", name: "UTF-32", sub: "4 bytes sempre", bytesOf: utf32 },
 ];
 
 const ZWJ = 0x200d;
-const FAMILIA = String.fromCodePoint(0x1f468, ZWJ, 0x1f469, ZWJ, 0x1f467, ZWJ, 0x1f466);
-const JOIA = String.fromCodePoint(0x1f44d);
-const BANDEIRA = String.fromCodePoint(0x1f1e7, 0x1f1f7);
+const FAMILY = String.fromCodePoint(0x1f468, ZWJ, 0x1f469, ZWJ, 0x1f467, ZWJ, 0x1f466);
+const THUMBS_UP = String.fromCodePoint(0x1f44d);
+const FLAG = String.fromCodePoint(0x1f1e7, 0x1f1f7);
 
-const PRESETS: { rotulo: string; texto: string }[] = [
-  { rotulo: "CCC", texto: "CCC" },
-  { rotulo: "ção", texto: "ção" },
-  { rotulo: "日本語", texto: "日本語" },
-  { rotulo: "joia", texto: JOIA },
-  { rotulo: "família", texto: FAMILIA },
-  { rotulo: "bandeira", texto: BANDEIRA },
+const PRESETS: { label: string; text: string }[] = [
+  { label: "CCC", text: "CCC" },
+  { label: "ção", text: "ção" },
+  { label: "日本語", text: "日本語" },
+  { label: "joia", text: THUMBS_UP },
+  { label: "família", text: FAMILY },
+  { label: "bandeira", text: FLAG },
 ];
 
-const PADRAO = "CCC";
+const DEFAULT_TEXT = "CCC";
 const MAX_CP = 20;
 
-const CORES = ["#60a5fa", "#34d399", "#fbbf24", "#f472b6", "#a78bfa", "#22d3ee"];
+const COLORS = ["#60a5fa", "#34d399", "#fbbf24", "#f472b6", "#a78bfa", "#22d3ee"];
 
 function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
@@ -94,14 +94,14 @@ function hex2(b: number): string {
   return s.length === 1 ? `0${s}` : s;
 }
 
-function pontoCodigo(cp: number): string {
+function codePointLabel(cp: number): string {
   const s = cp.toString(16).toUpperCase();
   return `U+${s.padStart(4, "0")}`;
 }
 
 // Rótulo para os code points que não desenham nada na tela. Sem isso, a linha
 // do ZWJ (o "cola" dos emojis compostos) apareceria vazia e pareceria bug.
-function invisivel(cp: number): string | null {
+function invisibleLabel(cp: number): string | null {
   if (cp === ZWJ) return "ZWJ (cola)";
   if (cp === 0x20) return "espaço";
   if (cp >= 0xfe00 && cp <= 0xfe0f) return "seletor de variação";
@@ -114,28 +114,28 @@ function invisivel(cp: number): string | null {
 // combinantes, o keycap e o segundo indicador regional (bandeiras). Cobre os
 // casos do artigo sem depender de Intl.Segmenter, que não existe em todo
 // ambiente e traria risco de divergência entre servidor e cliente.
-function contarGrafemas(cps: number[]): number {
+function countGraphemes(cps: number[]): number {
   let n = 0;
-  let aposZWJ = false;
-  let regionalAberto = false;
+  let afterZWJ = false;
+  let regionalOpen = false;
   for (const cp of cps) {
-    const combina =
-      aposZWJ ||
+    const combines =
+      afterZWJ ||
       cp === ZWJ ||
       (cp >= 0xfe00 && cp <= 0xfe0f) ||
       (cp >= 0x1f3fb && cp <= 0x1f3ff) ||
       (cp >= 0x0300 && cp <= 0x036f) ||
       cp === 0x20e3 ||
-      (regionalAberto && cp >= 0x1f1e6 && cp <= 0x1f1ff);
-    if (!combina) n++;
-    aposZWJ = cp === ZWJ;
-    regionalAberto = !regionalAberto && cp >= 0x1f1e6 && cp <= 0x1f1ff;
+      (regionalOpen && cp >= 0x1f1e6 && cp <= 0x1f1ff);
+    if (!combines) n++;
+    afterZWJ = cp === ZWJ;
+    regionalOpen = !regionalOpen && cp >= 0x1f1e6 && cp <= 0x1f1ff;
   }
   return n;
 }
 
 export function StringsBytesVisualizer() {
-  const [texto, setTexto] = useState(PADRAO);
+  const [text, setText] = useState(DEFAULT_TEXT);
   const [enc, setEnc] = useState<EncKey>("utf8");
   const [expanded, setExpanded] = useState(false);
   const [mounted, setMounted] = useState(false);
@@ -152,32 +152,32 @@ export function StringsBytesVisualizer() {
   }, [expanded]);
 
   const cps = useMemo(
-    () => Array.from(texto).slice(0, MAX_CP).map((c) => c.codePointAt(0) ?? 0),
-    [texto]
+    () => Array.from(text).slice(0, MAX_CP).map((c) => c.codePointAt(0) ?? 0),
+    [text]
   );
 
-  const totais = useMemo(() => {
+  const totals = useMemo(() => {
     const out: Record<EncKey, number> = { ascii: 0, utf8: 0, utf16: 0, utf32: 0 };
-    for (const e of ENCS) for (const cp of cps) out[e.key] += e.bytesDe(cp).length;
+    for (const e of ENCS) for (const cp of cps) out[e.key] += e.bytesOf(cp).length;
     return out;
   }, [cps]);
 
-  const perdidos = cps.filter((cp) => cp >= 0x80).length;
-  const grafemas = contarGrafemas(cps);
-  const unidades16 = cps.reduce((acc, cp) => acc + (cp < 0x10000 ? 1 : 2), 0);
-  const encAtual = ENCS.find((e) => e.key === enc) ?? ENCS[1];
+  const lost = cps.filter((cp) => cp >= 0x80).length;
+  const graphemes = countGraphemes(cps);
+  const utf16Units = cps.reduce((acc, cp) => acc + (cp < 0x10000 ? 1 : 2), 0);
+  const currentEnc = ENCS.find((e) => e.key === enc) ?? ENCS[1];
 
-  const linhas = cps.map((cp, i) => ({
+  const rows = cps.map((cp, i) => ({
     i,
     cp,
-    glifo: String.fromCodePoint(cp),
-    rotulo: invisivel(cp),
-    bytes: encAtual.bytesDe(cp),
-    cor: CORES[i % CORES.length],
+    glyph: String.fromCodePoint(cp),
+    label: invisibleLabel(cp),
+    bytes: currentEnc.bytesOf(cp),
+    color: COLORS[i % COLORS.length],
   }));
 
-  const fita = linhas.flatMap((l) =>
-    l.bytes.map((b, j) => ({ chave: `${l.i}-${j}`, b, cor: l.cor, ini: j === 0 }))
+  const tape = rows.flatMap((l) =>
+    l.bytes.map((b, j) => ({ key: `${l.i}-${j}`, b, color: l.color, first: j === 0 }))
   );
 
   const viz = (
@@ -189,7 +189,7 @@ export function StringsBytesVisualizer() {
         </div>
         <div className="viz-head-right">
           <span className="viz-step">
-            {num(totais[enc])} bytes em {encAtual.nome}
+            {num(totals[enc])} bytes em {currentEnc.name}
           </span>
           <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
             {expanded ? "✕ Fechar" : "⤢ Expandir"}
@@ -203,11 +203,11 @@ export function StringsBytesVisualizer() {
             <span>Texto (até {MAX_CP} code points)</span>
             <input
               className="viz-input"
-              value={texto}
-              onChange={(e) => setTexto(Array.from(e.target.value).slice(0, MAX_CP).join(""))}
+              value={text}
+              onChange={(e) => setText(Array.from(e.target.value).slice(0, MAX_CP).join(""))}
             />
           </label>
-          <button className="viz-btn" onClick={() => setTexto(PADRAO)}>
+          <button className="viz-btn" onClick={() => setText(DEFAULT_TEXT)}>
             ↺ Reiniciar
           </button>
         </div>
@@ -215,12 +215,12 @@ export function StringsBytesVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
-              key={pr.rotulo}
-              className={`bigo-chip${texto === pr.texto ? " on" : ""}`}
-              onClick={() => setTexto(pr.texto)}
-              aria-pressed={texto === pr.texto}
+              key={pr.label}
+              className={`bigo-chip${text === pr.text ? " on" : ""}`}
+              onClick={() => setText(pr.text)}
+              aria-pressed={text === pr.text}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -228,19 +228,19 @@ export function StringsBytesVisualizer() {
         <div className="str-encs">
           {ENCS.map((e) => {
             const on = e.key === enc;
-            const perde = e.key === "ascii" && perdidos > 0;
+            const loses = e.key === "ascii" && lost > 0;
             return (
               <button
                 key={e.key}
-                className={`str-enc${on ? " on" : ""}${perde ? " perde" : ""}`}
+                className={`str-enc${on ? " on" : ""}${loses ? " perde" : ""}`}
                 onClick={() => setEnc(e.key)}
                 aria-pressed={on}
               >
-                <span className="str-enc-nome">{e.nome}</span>
-                <span className="str-enc-val">{num(totais[e.key])} bytes</span>
+                <span className="str-enc-nome">{e.name}</span>
+                <span className="str-enc-val">{num(totals[e.key])} bytes</span>
                 <span className="str-enc-sub">
-                  {perde
-                    ? `perde ${perdidos} ${perdidos === 1 ? "caractere" : "caracteres"}, viram "?"`
+                  {loses
+                    ? `perde ${lost} ${lost === 1 ? "caractere" : "caracteres"}, viram "?"`
                     : e.sub}
                 </span>
               </button>
@@ -251,7 +251,7 @@ export function StringsBytesVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>o que você vê (grafemas)</span>
-            <strong style={{ color: "#34d399" }}>{num(grafemas)}</strong>
+            <strong style={{ color: "#34d399" }}>{num(graphemes)}</strong>
           </div>
           <div className="bigo-stat">
             <span>code points (len no Python)</span>
@@ -259,24 +259,24 @@ export function StringsBytesVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>unidades UTF-16 (Length no C#)</span>
-            <strong>{num(unidades16)}</strong>
+            <strong>{num(utf16Units)}</strong>
           </div>
           <div className="bigo-stat">
-            <span>bytes em {encAtual.nome}</span>
-            <strong style={{ color: "#93bbfd" }}>{num(totais[enc])}</strong>
+            <span>bytes em {currentEnc.name}</span>
+            <strong style={{ color: "#93bbfd" }}>{num(totals[enc])}</strong>
           </div>
         </div>
 
         <div className="str-bytes-fita">
           <span className="str-lbl">
-            Memória em {encAtual.nome}: cada quadradinho é 1 byte
+            Memória em {currentEnc.name}: cada quadradinho é 1 byte
           </span>
-          {fita.length ? (
-            fita.map((f) => (
+          {tape.length ? (
+            tape.map((f) => (
               <span
-                key={f.chave}
-                className={`str-byte-cell${f.ini ? " ini" : ""}`}
-                style={{ background: f.cor }}
+                key={f.key}
+                className={`str-byte-cell${f.first ? " ini" : ""}`}
+                style={{ background: f.color }}
               >
                 {hex2(f.b)}
               </span>
@@ -292,20 +292,20 @@ export function StringsBytesVisualizer() {
               <tr>
                 <th>Caractere</th>
                 <th>Code point</th>
-                <th>Bytes em {encAtual.nome}</th>
+                <th>Bytes em {currentEnc.name}</th>
                 <th className="nums">Tamanho</th>
               </tr>
             </thead>
             <tbody>
-              {linhas.map((l) => (
+              {rows.map((l) => (
                 <tr key={l.i}>
                   <td>
-                    <span className="str-glifo" style={{ color: l.cor }}>
-                      {l.rotulo ? "·" : l.glifo}
+                    <span className="str-glifo" style={{ color: l.color }}>
+                      {l.label ? "·" : l.glyph}
                     </span>
-                    {l.rotulo ? <span className="str-inviz">{l.rotulo}</span> : null}
+                    {l.label ? <span className="str-inviz">{l.label}</span> : null}
                   </td>
-                  <td className="str-cp">{pontoCodigo(l.cp)}</td>
+                  <td className="str-cp">{codePointLabel(l.cp)}</td>
                   <td>
                     <span className="str-bytes">
                       {l.bytes.map((b, j) => (
@@ -318,7 +318,7 @@ export function StringsBytesVisualizer() {
                   <td className="nums">{l.bytes.length}</td>
                 </tr>
               ))}
-              {linhas.length === 0 ? (
+              {rows.length === 0 ? (
                 <tr>
                   <td colSpan={4}>Digite alguma coisa, ou escolha um dos exemplos acima.</td>
                 </tr>
@@ -328,9 +328,9 @@ export function StringsBytesVisualizer() {
         </div>
 
         <p className="viz-note">
-          {grafemas === cps.length && cps.length === unidades16
-            ? `Aqui os três números batem: ${num(grafemas)} ${grafemas === 1 ? "caractere" : "caracteres"} na tela, ${num(cps.length)} code ${cps.length === 1 ? "point" : "points"} e ${num(unidades16)} ${unidades16 === 1 ? "unidade" : "unidades"} UTF-16. É o caso fácil, e é o único que a intuição acerta.`
-            : `Repare no desencontro: são ${num(grafemas)} ${grafemas === 1 ? "caractere" : "caracteres"} na tela, ${num(cps.length)} code points e ${num(unidades16)} unidades UTF-16. Um contador de caracteres feito com o length errado corta o texto no lugar errado.`}
+          {graphemes === cps.length && cps.length === utf16Units
+            ? `Aqui os três números batem: ${num(graphemes)} ${graphemes === 1 ? "caractere" : "caracteres"} na tela, ${num(cps.length)} code ${cps.length === 1 ? "point" : "points"} e ${num(utf16Units)} ${utf16Units === 1 ? "unidade" : "unidades"} UTF-16. É o caso fácil, e é o único que a intuição acerta.`
+            : `Repare no desencontro: são ${num(graphemes)} ${graphemes === 1 ? "caractere" : "caracteres"} na tela, ${num(cps.length)} code points e ${num(utf16Units)} unidades UTF-16. Um contador de caracteres feito com o length errado corta o texto no lugar errado.`}
         </p>
       </div>
     </figure>

--- a/content/visualizers/StringsBytesVisualizer.tsx
+++ b/content/visualizers/StringsBytesVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // StringsBytesVisualizer, "caractere" não é "byte".
@@ -15,6 +16,12 @@ import { createPortal } from "react-dom";
 // produção: grafemas (o que a pessoa vê), code points (o len do Python),
 // unidades UTF-16 (o Length do C# e do Java) e bytes (o que vai para o disco,
 // para o banco e para a rede).
+//
+// Da casca (`content/visualizers/README.md`) ele usa `total: 1`, porque não há
+// linha do tempo para percorrer, e o bloco recolhível é a TABELA, não código:
+// medido em 1512x900, ir de 3 para 20 code points sobe a peça de 730px para
+// 1.410px, e os 680px de diferença são todos linha de tabela. Os quatro
+// contadores e a fita de bytes, que é o que o artigo manda olhar, cabem sempre.
 // ---------------------------------------------------------------------------
 
 type EncKey = "ascii" | "utf8" | "utf16" | "utf32";
@@ -137,19 +144,6 @@ function countGraphemes(cps: number[]): number {
 export function StringsBytesVisualizer() {
   const [text, setText] = useState(DEFAULT_TEXT);
   const [enc, setEnc] = useState<EncKey>("utf8");
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-
-  useEffect(() => setMounted(true), []);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
 
   const cps = useMemo(
     () => Array.from(text).slice(0, MAX_CP).map((c) => c.codePointAt(0) ?? 0),
@@ -180,24 +174,29 @@ export function StringsBytesVisualizer() {
     l.bytes.map((b, j) => ({ key: `${l.i}-${j}`, b, color: l.color, first: j === 0 }))
   );
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · caractere, code point e byte</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {num(totals[enc])} bytes em {currentEnc.name}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const viz = useVisualizer({
+    title: "Visualizador · caractere, code point e byte",
+    // Não há linha do tempo: some o contador de passo, o rodapé e os atalhos.
+    total: 1,
+    // O rótulo do botão tem que dizer o que some, e aqui o que some é a tabela.
+    blockName: "tabela",
+    // O que muda a altura: quantos code points (uma linha de tabela cada), qual
+    // encoding (o número de chips de byte por linha) e o total de bytes (a fita
+    // quebra linha a cada ~30 quadradinhos).
+    measureOn: [cps.length, enc, totals[enc]],
+  });
 
-      <div className="viz-body">
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* O contador de bytes ocupa o lugar do "passo N de M", que não existe
+          aqui: é o número que resume o estado desta peça. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {num(totals[enc])} bytes em {currentEnc.name}
+        </span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Texto (até {MAX_CP} code points)</span>
@@ -286,7 +285,12 @@ export function StringsBytesVisualizer() {
           )}
         </div>
 
-        <div className="str-scroll">
+        {/* O slot recolhe a ALTURA da tabela (`grid-template-rows: 1fr → 0fr`).
+            A tabela fica no DOM mesmo recolhida, e é isso que permite medir o
+            pior caso de altura; `inert` tira ela do teclado e dos leitores de
+            tela enquanto está fora de vista. */}
+        <div className="viz-code-slot">
+        <div className="str-scroll" {...viz.blockProps}>
           <table className="str-tab">
             <thead>
               <tr>
@@ -326,6 +330,7 @@ export function StringsBytesVisualizer() {
             </tbody>
           </table>
         </div>
+        </div>
 
         <p className="viz-note">
           {graphemes === cps.length && cps.length === utf16Units
@@ -336,18 +341,5 @@ export function StringsBytesVisualizer() {
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/StringsRotateVisualizer.tsx
+++ b/content/visualizers/StringsRotateVisualizer.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // StringsRotateVisualizer, o LeetCode 796 (Rotate String) nos dois caminhos.
 //
-// Gerador puro de passos + a casca compartilhada, igual ao TwoPointersVisualizer.
+// Gerador puro de passos + a casca adaptativa do `useVisualizer` (contrato em
+// `content/visualizers/README.md`).
 // A diferença é que aqui existem DUAS fitas de células alinhadas: a string de
 // trabalho em cima e o goal embaixo. O alinhamento sai de graça porque as duas
 // fitas têm o mesmo número de células do mesmo tamanho (as posições fora da
@@ -71,7 +73,6 @@ const WORDS = ["abcde", "craft", "codigo", "rotate", "banana"];
 
 const MAX = 10;
 const SPEEDS = [0, 1400, 950, 650, 420, 250];
-const SPEED_LABELS = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
@@ -287,58 +288,25 @@ export function StringsRotateVisualizer() {
   const [mode, setMode] = useState<Mode>("loop");
   const [s, setS] = useState(PRESETS[0].s);
   const [goal, setGoal] = useState(PRESETS[0].goal);
-  const [step, setStep] = useState(0);
-  const [playing, setPlaying] = useState(false);
-  const [speed, setSpeed] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   const steps = useMemo(() => generateSteps(s, goal, mode), [s, goal, mode]);
-  const total = steps.length;
-  const idx = Math.min(step, total - 1);
-  const p = steps[idx];
   const cfg = MODES.find((m) => m.key === mode) ?? MODES[0];
   const n = Math.min(Array.from(s).length, MAX);
 
-  const stop = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => stop(), [stop]);
+  const viz = useVisualizer({
+    title: "Visualizador · Rotate String, força bruta contra o truque",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o modo (no truque a fita passa de n para 2n
+    // células e quebra linha antes), o tamanho de s e o de goal — quando os dois
+    // diferem o gerador para em dois passos e a peça encolhe.
+    measureOn: [mode, n, Array.from(goal).length],
+  });
 
-  useEffect(() => {
-    stop();
-    if (!playing) return;
-    timer.current = setInterval(() => setStep((v) => (v >= total - 1 ? v : v + 1)), SPEEDS[speed]);
-    return stop;
-  }, [playing, speed, total, stop]);
-
-  useEffect(() => {
-    if (playing && idx >= total - 1) setPlaying(false);
-  }, [playing, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reset = () => {
-    stop();
-    setPlaying(false);
-    setStep(0);
-  };
+  const p = steps[viz.step];
 
   const apply = (nextS: string, nextGoal: string) => {
-    reset();
+    viz.reset();
     setS(Array.from(nextS).slice(0, MAX).join(""));
     setGoal(Array.from(nextGoal).slice(0, MAX).join(""));
   };
@@ -360,7 +328,6 @@ export function StringsRotateVisualizer() {
 
   const worstLoop = n * (2 * n - 1);
   const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
-  const stepPct = Math.round(((idx + 1) / total) * 100);
   const code = mode === "loop" ? LOOP_CODE : TRICK_CODE;
 
   const vars = [
@@ -370,24 +337,11 @@ export function StringsRotateVisualizer() {
     { name: "comparações", value: num(p.comparisons), best: true },
   ];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" style={{ background: cfg.color }} />
-          <span>Visualizador · Rotate String, força bruta contra o truque</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} color={cfg.color} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {MODES.map((m) => {
             const on = m.key === mode;
@@ -397,7 +351,7 @@ export function StringsRotateVisualizer() {
                 className={`bigo-chip${on ? " on" : ""}`}
                 style={on ? { borderColor: m.color, color: m.color } : undefined}
                 onClick={() => {
-                  reset();
+                  viz.reset();
                   setMode(m.key);
                 }}
                 aria-pressed={on}
@@ -484,20 +438,24 @@ export function StringsRotateVisualizer() {
         <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">
-              {cfg.file} · {cfg.family}
-            </div>
-            <div className="viz-code-body">
-              {code.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O slot recolhe a ALTURA do código: zerar só a trilha da coluna
+              tiraria a largura e deixaria a linha do grid do mesmo tamanho. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">
+                {cfg.file} · {cfg.family}
+              </div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {vars.map((v) => (
               <div className="viz-var" key={v.name}>
@@ -507,78 +465,13 @@ export function StringsRotateVisualizer() {
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reset}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              stop();
-              setPlaying(false);
-              setStep(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (playing) {
-                setPlaying(false);
-                return;
-              }
-              setStep(idx >= total - 1 ? 0 : idx);
-              setPlaying(true);
-            }}
-          >
-            {playing ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              stop();
-              setPlaying(false);
-              setStep(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={speed}
-              onChange={(e) => setSpeed(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{SPEED_LABELS[speed]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${stepPct}%`, background: cfg.color }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} color={cfg.color} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/StringsRotateVisualizer.tsx
+++ b/content/visualizers/StringsRotateVisualizer.tsx
@@ -18,25 +18,25 @@ import { createPortal } from "react-dom";
 // o goal ali dentro, porque s + s contém todas as rotações de s.
 // ---------------------------------------------------------------------------
 
-type Modo = "laco" | "truque";
+type Mode = "loop" | "trick";
 
-type Passo = {
-  linha: number;
-  fita: string[];
-  fitaLbl: string;
-  alvo: (string | null)[];
-  janela: { ini: number; fim: number } | null;
-  iguais: number[];
-  difere: number | null;
-  copias: number;
+type Step = {
+  line: number;
+  tape: string[];
+  tapeLabel: string;
+  target: (string | null)[];
+  window: { start: number; end: number } | null;
+  matched: number[];
+  differs: number | null;
+  copies: number;
   strings: number;
-  comparacoes: number;
-  nota: string;
+  comparisons: number;
+  note: string;
   ok?: boolean;
-  fim?: boolean;
+  done?: boolean;
 };
 
-const CODIGO_LACO = [
+const LOOP_CODE = [
   "def rotate_string(s, goal):",
   "    if len(s) != len(goal):",
   "        return False",
@@ -47,7 +47,7 @@ const CODIGO_LACO = [
   "    return False",
 ];
 
-const CODIGO_TRUQUE = [
+const TRICK_CODE = [
   "def rotate_string(s, goal):",
   "    if len(s) != len(goal):",
   "        return False",
@@ -55,78 +55,78 @@ const CODIGO_TRUQUE = [
   "    return goal in dobrado",
 ];
 
-const MODOS: { key: Modo; rotulo: string; familia: string; cor: string; arquivo: string }[] = [
-  { key: "laco", rotulo: "rotaciona e compara", familia: "O(n²)", cor: "#fbbf24", arquivo: "ingenuo.py" },
-  { key: "truque", rotulo: "goal in s + s", familia: "O(n)", cor: "#34d399", arquivo: "truque.py" },
+const MODES: { key: Mode; label: string; family: string; color: string; file: string }[] = [
+  { key: "loop", label: "rotaciona e compara", family: "O(n²)", color: "#fbbf24", file: "ingenuo.py" },
+  { key: "trick", label: "goal in s + s", family: "O(n)", color: "#34d399", file: "truque.py" },
 ];
 
-const PRESETS: { rotulo: string; s: string; goal: string }[] = [
-  { rotulo: "caso feliz", s: "abcde", goal: "cdeab" },
-  { rotulo: "não rotaciona", s: "abcde", goal: "abced" },
-  { rotulo: "tamanhos diferentes", s: "abc", goal: "abcd" },
-  { rotulo: "volta completa", s: "abcd", goal: "abcd" },
+const PRESETS: { label: string; s: string; goal: string }[] = [
+  { label: "caso feliz", s: "abcde", goal: "cdeab" },
+  { label: "não rotaciona", s: "abcde", goal: "abced" },
+  { label: "tamanhos diferentes", s: "abc", goal: "abcd" },
+  { label: "volta completa", s: "abcd", goal: "abcd" },
 ];
 
-const PALAVRAS = ["abcde", "craft", "codigo", "rotate", "banana"];
+const WORDS = ["abcde", "craft", "codigo", "rotate", "banana"];
 
 const MAX = 10;
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
+const SPEED_LABELS = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function plural(n: number, um: string, muitos: string): string {
-  return n === 1 ? um : muitos;
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
 }
 
 // Quantos caracteres batem antes de divergir. Serve para o contador de
 // comparações não mentir: comparar duas strings NÃO é uma operação só.
-function prefixo(a: string[], b: string[]): number {
+function commonPrefix(a: string[], b: string[]): number {
   let k = 0;
   while (k < a.length && k < b.length && a[k] === b[k]) k++;
   return k;
 }
 
-function janelaAlvo(goal: string[], largura: number, offset: number): (string | null)[] {
-  const out: (string | null)[] = new Array(largura).fill(null);
-  for (let k = 0; k < goal.length && offset + k < largura; k++) out[offset + k] = goal[k];
+function targetWindow(goal: string[], width: number, offset: number): (string | null)[] {
+  const out: (string | null)[] = new Array(width).fill(null);
+  for (let k = 0; k < goal.length && offset + k < width; k++) out[offset + k] = goal[k];
   return out;
 }
 
-function gerarPassos(sEntrada: string, goalEntrada: string, modo: Modo): Passo[] {
-  const s0 = Array.from(sEntrada).slice(0, MAX);
-  const goal = Array.from(goalEntrada).slice(0, MAX);
+function generateSteps(sInput: string, goalInput: string, mode: Mode): Step[] {
+  const s0 = Array.from(sInput).slice(0, MAX);
+  const goal = Array.from(goalInput).slice(0, MAX);
   const n = s0.length;
-  const out: Passo[] = [];
+  const out: Step[] = [];
 
   const base = {
-    copias: 0,
+    copies: 0,
     strings: 0,
-    comparacoes: 0,
-    janela: null,
-    iguais: [],
-    difere: null,
+    comparisons: 0,
+    window: null,
+    matched: [],
+    differs: null,
   };
 
   if (n !== goal.length) {
     out.push({
       ...base,
-      linha: 1,
-      fita: s0,
-      fitaLbl: "s",
-      alvo: janelaAlvo(goal, Math.max(n, goal.length), 0),
-      nota: `len(s) = ${n} e len(goal) = ${goal.length}. Tamanhos diferentes: nenhuma rotação vai transformar um no outro.`,
+      line: 1,
+      tape: s0,
+      tapeLabel: "s",
+      target: targetWindow(goal, Math.max(n, goal.length), 0),
+      note: `len(s) = ${n} e len(goal) = ${goal.length}. Tamanhos diferentes: nenhuma rotação vai transformar um no outro.`,
     });
     out.push({
       ...base,
-      linha: 2,
-      fita: s0,
-      fitaLbl: "s",
-      alvo: janelaAlvo(goal, Math.max(n, goal.length), 0),
-      fim: true,
-      nota: "Devolvo False sem copiar um único caractere. Este teste de uma linha é o que salva o pior caso.",
+      line: 2,
+      tape: s0,
+      tapeLabel: "s",
+      target: targetWindow(goal, Math.max(n, goal.length), 0),
+      done: true,
+      note: "Devolvo False sem copiar um único caractere. Este teste de uma linha é o que salva o pior caso.",
     });
     return out;
   }
@@ -134,193 +134,193 @@ function gerarPassos(sEntrada: string, goalEntrada: string, modo: Modo): Passo[]
   if (n === 0) {
     out.push({
       ...base,
-      linha: 1,
-      fita: [],
-      fitaLbl: "s",
-      alvo: [],
+      line: 1,
+      tape: [],
+      tapeLabel: "s",
+      target: [],
       ok: true,
-      fim: true,
-      nota: "Duas strings vazias: mesmo tamanho e mesmo conteúdo, então a resposta é True sem nenhum trabalho.",
+      done: true,
+      note: "Duas strings vazias: mesmo tamanho e mesmo conteúdo, então a resposta é True sem nenhum trabalho.",
     });
     return out;
   }
 
-  if (modo === "laco") {
+  if (mode === "loop") {
     let s = [...s0];
-    let copias = 0;
+    let copies = 0;
     let strings = 0;
-    let comparacoes = 0;
+    let comparisons = 0;
     out.push({
       ...base,
-      linha: 1,
-      fita: [...s],
-      fitaLbl: "s",
-      alvo: janelaAlvo(goal, n, 0),
-      nota: `len(s) = len(goal) = ${n}, então vale tentar. Vou girar s uma posição por vez e comparar com goal a cada volta.`,
+      line: 1,
+      tape: [...s],
+      tapeLabel: "s",
+      target: targetWindow(goal, n, 0),
+      note: `len(s) = len(goal) = ${n}, então vale tentar. Vou girar s uma posição por vez e comparar com goal a cada volta.`,
     });
     for (let i = 0; i < n; i++) {
-      const primeiro = s[0];
-      s = [...s.slice(1), primeiro];
-      copias += n - 1 + n;
+      const first = s[0];
+      s = [...s.slice(1), first];
+      copies += n - 1 + n;
       strings += 2;
       out.push({
-        linha: 4,
-        fita: [...s],
-        fitaLbl: "s",
-        alvo: janelaAlvo(goal, n, 0),
-        janela: null,
-        iguais: [],
-        difere: null,
-        copias,
+        line: 4,
+        tape: [...s],
+        tapeLabel: "s",
+        target: targetWindow(goal, n, 0),
+        window: null,
+        matched: [],
+        differs: null,
+        copies,
         strings,
-        comparacoes,
-        nota: `Rotação ${i + 1}: s[1:] já é uma string nova com ${n - 1} ${plural(n - 1, "caractere", "caracteres")} copiados, e a concatenação com "${primeiro}" aloca outra de ${n} e copia ${n}. Duas strings novas e ${2 * n - 1} cópias só para testar um deslocamento.`,
+        comparisons,
+        note: `Rotação ${i + 1}: s[1:] já é uma string nova com ${n - 1} ${plural(n - 1, "caractere", "caracteres")} copiados, e a concatenação com "${first}" aloca outra de ${n} e copia ${n}. Duas strings novas e ${2 * n - 1} cópias só para testar um deslocamento.`,
       });
-      const k = prefixo(s, goal);
-      const igual = k === n;
-      comparacoes += igual ? n : k + 1;
+      const k = commonPrefix(s, goal);
+      const same = k === n;
+      comparisons += same ? n : k + 1;
       out.push({
-        linha: igual ? 6 : 5,
-        fita: [...s],
-        fitaLbl: "s",
-        alvo: janelaAlvo(goal, n, 0),
-        janela: { ini: 0, fim: n - 1 },
-        iguais: Array.from({ length: k }, (_, j) => j),
-        difere: igual ? null : k,
-        copias,
+        line: same ? 6 : 5,
+        tape: [...s],
+        tapeLabel: "s",
+        target: targetWindow(goal, n, 0),
+        window: { start: 0, end: n - 1 },
+        matched: Array.from({ length: k }, (_, j) => j),
+        differs: same ? null : k,
+        copies,
         strings,
-        comparacoes,
-        ok: igual,
-        fim: igual,
-        nota: igual
-          ? `"${s.join("")}" é igual a goal. Achei na rotação ${i + 1}, depois de ${copias} ${plural(copias, "caractere copiado", "caracteres copiados")} e ${strings} strings novas.`
+        comparisons,
+        ok: same,
+        done: same,
+        note: same
+          ? `"${s.join("")}" é igual a goal. Achei na rotação ${i + 1}, depois de ${copies} ${plural(copies, "caractere copiado", "caracteres copiados")} e ${strings} strings novas.`
           : `Comparo "${s.join("")}" com "${goal.join("")}": ${k === 0 ? "já diverge no índice 0" : `batem os ${k} ${plural(k, "primeiro", "primeiros")} e divergem no índice ${k}`} ("${s[k]}" contra "${goal[k]}"). Sigo girando, e as duas strings desta volta viram lixo.`,
       });
-      if (igual) return out;
+      if (same) return out;
     }
     out.push({
-      linha: 7,
-      fita: [...s],
-      fitaLbl: "s",
-      alvo: janelaAlvo(goal, n, 0),
-      janela: null,
-      iguais: [],
-      difere: null,
-      copias,
+      line: 7,
+      tape: [...s],
+      tapeLabel: "s",
+      target: targetWindow(goal, n, 0),
+      window: null,
+      matched: [],
+      differs: null,
+      copies,
       strings,
-      comparacoes,
-      fim: true,
-      nota: `Dei a volta completa (${n} rotações) e nunca bati com goal: False. Custou ${copias} caracteres copiados e ${strings} strings alocadas para descobrir isso.`,
+      comparisons,
+      done: true,
+      note: `Dei a volta completa (${n} rotações) e nunca bati com goal: False. Custou ${copies} caracteres copiados e ${strings} strings alocadas para descobrir isso.`,
     });
     return out;
   }
 
-  const dobrado = [...s0, ...s0];
-  let copias = 0;
+  const doubled = [...s0, ...s0];
+  let copies = 0;
   let strings = 0;
-  let comparacoes = 0;
+  let comparisons = 0;
   out.push({
     ...base,
-    linha: 1,
-    fita: [...s0],
-    fitaLbl: "s",
-    alvo: janelaAlvo(goal, n, 0),
-    nota: `len(s) = len(goal) = ${n}. Mesmo tamanho, então o teste continua.`,
+    line: 1,
+    tape: [...s0],
+    tapeLabel: "s",
+    target: targetWindow(goal, n, 0),
+    note: `len(s) = len(goal) = ${n}. Mesmo tamanho, então o teste continua.`,
   });
-  copias = 2 * n;
+  copies = 2 * n;
   strings = 1;
   out.push({
-    linha: 3,
-    fita: dobrado,
-    fitaLbl: "dobrado = s + s",
-    alvo: janelaAlvo(goal, 2 * n, 0),
-    janela: null,
-    iguais: [],
-    difere: null,
-    copias,
+    line: 3,
+    tape: doubled,
+    tapeLabel: "dobrado = s + s",
+    target: targetWindow(goal, 2 * n, 0),
+    window: null,
+    matched: [],
+    differs: null,
+    copies,
     strings,
-    comparacoes,
-    nota: `Concateno s comigo mesmo UMA vez: ${copias} cópias, uma string nova. Dentro de "${dobrado.join("")}" moram todas as ${n} rotações de s, cada uma começando numa posição.`,
+    comparisons,
+    note: `Concateno s comigo mesmo UMA vez: ${copies} cópias, uma string nova. Dentro de "${doubled.join("")}" moram todas as ${n} rotações de s, cada uma começando numa posição.`,
   });
   for (let j = 0; j <= n; j++) {
-    const janela = dobrado.slice(j, j + n);
-    const k = prefixo(janela, goal);
-    const igual = k === n;
-    comparacoes += igual ? n : k + 1;
+    const chunk = doubled.slice(j, j + n);
+    const k = commonPrefix(chunk, goal);
+    const same = k === n;
+    comparisons += same ? n : k + 1;
     out.push({
-      linha: 4,
-      fita: dobrado,
-      fitaLbl: "dobrado = s + s",
-      alvo: janelaAlvo(goal, 2 * n, j),
-      janela: { ini: j, fim: j + n - 1 },
-      iguais: Array.from({ length: k }, (_, t) => j + t),
-      difere: igual ? null : j + k,
-      copias,
+      line: 4,
+      tape: doubled,
+      tapeLabel: "dobrado = s + s",
+      target: targetWindow(goal, 2 * n, j),
+      window: { start: j, end: j + n - 1 },
+      matched: Array.from({ length: k }, (_, t) => j + t),
+      differs: same ? null : j + k,
+      copies,
       strings,
-      comparacoes,
-      ok: igual,
-      fim: igual,
-      nota: igual
-        ? `Posição ${j}: "${janela.join("")}" é exatamente o goal. True, e sem alocar mais nada: a busca só leu a memória que já existia.`
-        : `Posição ${j}: "${janela.join("")}" ${k === 0 ? "já diverge no primeiro caractere" : `bate ${k} ${plural(k, "caractere", "caracteres")} e diverge`}. Ando uma casa, sem alocar nada.`,
+      comparisons,
+      ok: same,
+      done: same,
+      note: same
+        ? `Posição ${j}: "${chunk.join("")}" é exatamente o goal. True, e sem alocar mais nada: a busca só leu a memória que já existia.`
+        : `Posição ${j}: "${chunk.join("")}" ${k === 0 ? "já diverge no primeiro caractere" : `bate ${k} ${plural(k, "caractere", "caracteres")} e diverge`}. Ando uma casa, sem alocar nada.`,
     });
-    if (igual) return out;
+    if (same) return out;
   }
   out.push({
-    linha: 4,
-    fita: dobrado,
-    fitaLbl: "dobrado = s + s",
-    alvo: janelaAlvo(goal, 2 * n, 0),
-    janela: null,
-    iguais: [],
-    difere: null,
-    copias,
+    line: 4,
+    tape: doubled,
+    tapeLabel: "dobrado = s + s",
+    target: targetWindow(goal, 2 * n, 0),
+    window: null,
+    matched: [],
+    differs: null,
+    copies,
     strings,
-    comparacoes,
-    fim: true,
-    nota: `Nenhuma posição de "${dobrado.join("")}" contém "${goal.join("")}": False. Foram ${copias} cópias no total, contra as ${n * (2 * n - 1)} que o laço gastaria com esta entrada.`,
+    comparisons,
+    done: true,
+    note: `Nenhuma posição de "${doubled.join("")}" contém "${goal.join("")}": False. Foram ${copies} cópias no total, contra as ${n * (2 * n - 1)} que o laço gastaria com esta entrada.`,
   });
   return out;
 }
 
 export function StringsRotateVisualizer() {
-  const [modo, setModo] = useState<Modo>("laco");
+  const [mode, setMode] = useState<Mode>("loop");
   const [s, setS] = useState(PRESETS[0].s);
   const [goal, setGoal] = useState(PRESETS[0].goal);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(3);
   const [expanded, setExpanded] = useState(false);
   const [mounted, setMounted] = useState(false);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => setMounted(true), []);
 
-  const passos = useMemo(() => gerarPassos(s, goal, modo), [s, goal, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const cfg = MODOS.find((m) => m.key === modo) ?? MODOS[0];
+  const steps = useMemo(() => generateSteps(s, goal, mode), [s, goal, mode]);
+  const total = steps.length;
+  const idx = Math.min(step, total - 1);
+  const p = steps[idx];
+  const cfg = MODES.find((m) => m.key === mode) ?? MODES[0];
   const n = Math.min(Array.from(s).length, MAX);
 
-  const parar = useCallback(() => {
+  const stop = useCallback(() => {
     if (timer.current) {
       clearInterval(timer.current);
       timer.current = null;
     }
   }, []);
-  useEffect(() => () => parar(), [parar]);
+  useEffect(() => () => stop(), [stop]);
 
   useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((v) => (v >= total - 1 ? v : v + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+    stop();
+    if (!playing) return;
+    timer.current = setInterval(() => setStep((v) => (v >= total - 1 ? v : v + 1)), SPEEDS[speed]);
+    return stop;
+  }, [playing, speed, total, stop]);
 
   useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
+    if (playing && idx >= total - 1) setPlaying(false);
+  }, [playing, idx, total]);
 
   useEffect(() => {
     if (!expanded) return;
@@ -331,50 +331,50 @@ export function StringsRotateVisualizer() {
     return () => window.removeEventListener("keydown", onKey);
   }, [expanded]);
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
+  const reset = () => {
+    stop();
+    setPlaying(false);
+    setStep(0);
   };
 
-  const aplicar = (novoS: string, novoGoal: string) => {
-    reiniciar();
-    setS(Array.from(novoS).slice(0, MAX).join(""));
-    setGoal(Array.from(novoGoal).slice(0, MAX).join(""));
+  const apply = (nextS: string, nextGoal: string) => {
+    reset();
+    setS(Array.from(nextS).slice(0, MAX).join(""));
+    setGoal(Array.from(nextGoal).slice(0, MAX).join(""));
   };
 
-  const sortear = () => {
-    const palavra = PALAVRAS[Math.floor(Math.random() * PALAVRAS.length)];
-    const k = 1 + Math.floor(Math.random() * (palavra.length - 1));
-    aplicar(palavra, palavra.slice(k) + palavra.slice(0, k));
+  const pickRandom = () => {
+    const word = WORDS[Math.floor(Math.random() * WORDS.length)];
+    const k = 1 + Math.floor(Math.random() * (word.length - 1));
+    apply(word, word.slice(k) + word.slice(0, k));
   };
 
-  const classeCelula = (i: number, dentro: boolean) => {
+  const cellClass = (i: number, inside: boolean) => {
     let cls = "viz-cell";
-    if (p.difere === i) cls += " str-cell-no";
-    else if (p.iguais.includes(i)) cls += " str-cell-ok";
-    else if (p.janela && dentro) cls += " in";
-    else if (p.janela) cls += " drop";
+    if (p.differs === i) cls += " str-cell-no";
+    else if (p.matched.includes(i)) cls += " str-cell-ok";
+    else if (p.window && inside) cls += " in";
+    else if (p.window) cls += " drop";
     return cls;
   };
 
-  const piorLaco = n * (2 * n - 1);
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const codigo = modo === "laco" ? CODIGO_LACO : CODIGO_TRUQUE;
+  const worstLoop = n * (2 * n - 1);
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
+  const stepPct = Math.round(((idx + 1) / total) * 100);
+  const code = mode === "loop" ? LOOP_CODE : TRICK_CODE;
 
-  const variaveis = [
-    { nome: "n", valor: `${n}` },
-    { nome: "strings novas", valor: num(p.strings) },
-    { nome: "cópias", valor: num(p.copias) },
-    { nome: "comparações", valor: num(p.comparacoes), best: true },
+  const vars = [
+    { name: "n", value: `${n}` },
+    { name: "strings novas", value: num(p.strings) },
+    { name: "cópias", value: num(p.copies) },
+    { name: "comparações", value: num(p.comparisons), best: true },
   ];
 
   const viz = (
     <figure className="viz" style={{ margin: 0 }}>
       <div className="viz-head">
         <div className="viz-head-title">
-          <span className="dot" style={{ background: cfg.cor }} />
+          <span className="dot" style={{ background: cfg.color }} />
           <span>Visualizador · Rotate String, força bruta contra o truque</span>
         </div>
         <div className="viz-head-right">
@@ -389,21 +389,21 @@ export function StringsRotateVisualizer() {
 
       <div className="viz-body">
         <div className="bigo-chips">
-          {MODOS.map((m) => {
-            const on = m.key === modo;
+          {MODES.map((m) => {
+            const on = m.key === mode;
             return (
               <button
                 key={m.key}
                 className={`bigo-chip${on ? " on" : ""}`}
-                style={on ? { borderColor: m.cor, color: m.cor } : undefined}
+                style={on ? { borderColor: m.color, color: m.color } : undefined}
                 onClick={() => {
-                  reiniciar();
-                  setModo(m.key);
+                  reset();
+                  setMode(m.key);
                 }}
                 aria-pressed={on}
               >
-                <span className="sw" style={{ background: on ? m.cor : "#3a4a60" }} />
-                {m.familia} · {m.rotulo}
+                <span className="sw" style={{ background: on ? m.color : "#3a4a60" }} />
+                {m.family} · {m.label}
               </button>
             );
           })}
@@ -412,13 +412,13 @@ export function StringsRotateVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>s</span>
-            <input className="viz-input" value={s} onChange={(e) => aplicar(e.target.value, goal)} />
+            <input className="viz-input" value={s} onChange={(e) => apply(e.target.value, goal)} />
           </label>
           <label className="viz-field grow">
             <span>goal</span>
-            <input className="viz-input" value={goal} onChange={(e) => aplicar(s, e.target.value)} />
+            <input className="viz-input" value={goal} onChange={(e) => apply(s, e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={pickRandom}>
             Sortear
           </button>
         </div>
@@ -426,36 +426,36 @@ export function StringsRotateVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
-              key={pr.rotulo}
+              key={pr.label}
               className={`bigo-chip${s === pr.s && goal === pr.goal ? " on" : ""}`}
-              onClick={() => aplicar(pr.s, pr.goal)}
+              onClick={() => apply(pr.s, pr.goal)}
               aria-pressed={s === pr.s && goal === pr.goal}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
         <div className="str-fitas">
-          <span className="str-lbl">{p.fitaLbl}</span>
+          <span className="str-lbl">{p.tapeLabel}</span>
           <div className="viz-cells">
-            {p.fita.map((c, i) => {
-              const dentro = p.janela ? i >= p.janela.ini && i <= p.janela.fim : false;
+            {p.tape.map((c, i) => {
+              const inside = p.window ? i >= p.window.start && i <= p.window.end : false;
               return (
                 <div className="viz-cell-wrap" key={`f-${i}`}>
                   <span className="viz-cell-idx">{i}</span>
-                  <div className={classeCelula(i, dentro)}>{c}</div>
+                  <div className={cellClass(i, inside)}>{c}</div>
                 </div>
               );
             })}
           </div>
           <span className="str-lbl">goal</span>
           <div className="viz-cells">
-            {p.alvo.map((c, i) => {
-              const dentro = c !== null;
+            {p.target.map((c, i) => {
+              const inside = c !== null;
               return (
                 <div className="viz-cell-wrap" key={`a-${i}`}>
-                  <div className={c === null ? "viz-cell str-fantasma" : classeCelula(i, dentro)}>{c ?? "·"}</div>
+                  <div className={c === null ? "viz-cell str-fantasma" : cellClass(i, inside)}>{c ?? "·"}</div>
                 </div>
               );
             })}
@@ -465,15 +465,15 @@ export function StringsRotateVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>caracteres copiados</span>
-            <strong style={{ color: cfg.cor }}>{num(p.copias)}</strong>
+            <strong style={{ color: cfg.color }}>{num(p.copies)}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações de caractere</span>
-            <strong>{num(p.comparacoes)}</strong>
+            <strong>{num(p.comparisons)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso com o laço</span>
-            <strong style={{ color: "#fbbf24" }}>{num(piorLaco)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{num(worstLoop)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso com o truque</span>
@@ -481,16 +481,16 @@ export function StringsRotateVisualizer() {
           </div>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
           <div className="viz-code">
             <div className="viz-code-head">
-              {cfg.arquivo} · {cfg.familia}
+              {cfg.file} · {cfg.family}
             </div>
             <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+              {code.map((txt, i) => (
+                <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
                   <span className="ln">{i + 1}</span>
                   {txt}
                 </div>
@@ -499,26 +499,26 @@ export function StringsRotateVisualizer() {
           </div>
           <div className="viz-vars">
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
+          <button className="viz-btn" title="Reiniciar" onClick={reset}>
             ↺
           </button>
           <button
             className="viz-btn"
             disabled={idx === 0}
             onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
+              stop();
+              setPlaying(false);
+              setStep(Math.max(0, idx - 1));
             }}
           >
             ‹ Anterior
@@ -526,23 +526,23 @@ export function StringsRotateVisualizer() {
           <button
             className="viz-play"
             onClick={() => {
-              if (tocando) {
-                setTocando(false);
+              if (playing) {
+                setPlaying(false);
                 return;
               }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
+              setStep(idx >= total - 1 ? 0 : idx);
+              setPlaying(true);
             }}
           >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+            {playing ? "❚❚ Pausar" : "▶ Rodar"}
           </button>
           <button
             className="viz-btn"
             disabled={idx === total - 1}
             onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
+              stop();
+              setPlaying(false);
+              setStep(Math.min(idx + 1, total - 1));
             }}
           >
             Próximo ›
@@ -554,14 +554,14 @@ export function StringsRotateVisualizer() {
               min={1}
               max={5}
               step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
+              value={speed}
+              onChange={(e) => setSpeed(parseInt(e.target.value, 10))}
             />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+            <span className="val">{SPEED_LABELS[speed]}</span>
           </div>
         </div>
         <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%`, background: cfg.cor }} />
+          <div className="viz-progress-fill" style={{ width: `${stepPct}%`, background: cfg.color }} />
         </div>
       </div>
     </figure>

--- a/content/visualizers/StringsVisualizer.tsx
+++ b/content/visualizers/StringsVisualizer.tsx
@@ -1,13 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // StringsVisualizer, o custo de montar uma string caractere a caractere.
 //
-// Mesmo padrão do TwoPointersVisualizer: gerador PURO de passos + a casca
-// compartilhada (células, código sincronizado, variáveis, controles, Expandir).
+// Gerador PURO de passos + a casca adaptativa do `useVisualizer`: medição de
+// altura, painel com cabeçalho e controles parados, código recolhível e os
+// controles de reprodução. Aqui fica só o que é DESTE visualizador. Contrato em
+// `content/visualizers/README.md`.
 //
 // O que este visualizador ensina: com string imutável, `s = s + c` dentro de um
 // laço aloca uma string NOVA a cada volta e recopia tudo que já estava lá. O
@@ -71,7 +74,6 @@ const DEFAULT_WORD = "CRAFTCODE";
 const MAX = 16;
 
 const SPEEDS = [0, 1400, 950, 650, 420, 250];
-const SPEED_LABELS = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 // Formatação determinística (nada de Intl, para o HTML do servidor bater com o
 // do cliente na hidratação).
@@ -194,70 +196,36 @@ function generateSteps(word: string, mode: Mode): Step[] {
 export function StringsVisualizer() {
   const [mode, setMode] = useState<Mode>("concat");
   const [word, setWord] = useState(DEFAULT_WORD);
-  const [step, setStep] = useState(0);
-  const [playing, setPlaying] = useState(false);
-  const [speed, setSpeed] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   const chars = useMemo(() => Array.from(word).slice(0, MAX), [word]);
   const n = chars.length;
   const steps = useMemo(() => generateSteps(word, mode), [word, mode]);
-  const total = steps.length;
-  const idx = Math.min(step, total - 1);
-  const p = steps[idx];
   const cfg = MODES.find((m) => m.key === mode) ?? MODES[0];
 
-  const stop = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => stop(), [stop]);
+  const viz = useVisualizer({
+    title: "Visualizador · o custo de montar uma string",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o modo (o join ganha a lista de pedaços, um
+    // bloco inteiro a mais) e o tamanho da palavra (as células quebram linha).
+    measureOn: [mode, n],
+  });
 
-  useEffect(() => {
-    stop();
-    if (!playing) return;
-    timer.current = setInterval(() => setStep((s) => (s >= total - 1 ? s : s + 1)), SPEEDS[speed]);
-    return stop;
-  }, [playing, speed, total, stop]);
-
-  useEffect(() => {
-    if (playing && idx >= total - 1) setPlaying(false);
-  }, [playing, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reset = () => {
-    stop();
-    setPlaying(false);
-    setStep(0);
-  };
+  const p = steps[viz.step];
 
   const onWordChange = (v: string) => {
-    reset();
+    viz.reset();
     setWord(Array.from(v).slice(0, MAX).join(""));
   };
 
   const pickRandom = () => {
     const next = WORDS[Math.floor(Math.random() * WORDS.length)];
-    reset();
+    viz.reset();
     setWord(next);
   };
 
   const pickMode = (m: Mode) => {
-    reset();
+    viz.reset();
     setMode(m);
   };
 
@@ -291,27 +259,13 @@ export function StringsVisualizer() {
         ];
 
   const noteClass = "viz-note" + (p.ok ? " ok" : "");
-  const stepPct = Math.round(((idx + 1) / total) * 100);
   const code = mode === "concat" ? CONCAT_CODE : JOIN_CODE;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" style={{ background: cfg.color }} />
-          <span>Visualizador · o custo de montar uma string</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} color={cfg.color} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {MODES.map((m) => {
             const on = m.key === mode;
@@ -420,20 +374,27 @@ export function StringsVisualizer() {
         <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">
-              {cfg.file} · {cfg.family}
-            </div>
-            <div className="viz-code-body">
-              {code.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura existe para a ALTURA: zerar a trilha da coluna só tira a
+              largura, e a linha do grid continuaria com a altura do código. O
+              `.viz-code-slot` é o truque de `grid-template-rows: 1fr → 0fr`. O
+              código fica no DOM mesmo recolhido, que é o que permite medir o
+              pior caso; `inert` tira ele do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">
+                {cfg.file} · {cfg.family}
+              </div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {vars.map((v) => (
               <div className="viz-var" key={v.name}>
@@ -443,78 +404,13 @@ export function StringsVisualizer() {
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reset}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              stop();
-              setPlaying(false);
-              setStep(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (playing) {
-                setPlaying(false);
-                return;
-              }
-              setStep(idx >= total - 1 ? 0 : idx);
-              setPlaying(true);
-            }}
-          >
-            {playing ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              stop();
-              setPlaying(false);
-              setStep(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={speed}
-              onChange={(e) => setSpeed(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{SPEED_LABELS[speed]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${stepPct}%`, background: cfg.color }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} color={cfg.color} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/StringsVisualizer.tsx
+++ b/content/visualizers/StringsVisualizer.tsx
@@ -16,26 +16,26 @@ import { createPortal } from "react-dom";
 // diferença entre O(n²) e O(n) aparecer em número e não só em teoria.
 // ---------------------------------------------------------------------------
 
-type Modo = "concat" | "join";
+type Mode = "concat" | "join";
 
-type Bloco = { id: number; txt: string; viva: boolean; nova: boolean };
+type Block = { id: number; text: string; alive: boolean; fresh: boolean };
 
-type Passo = {
-  linha: number;
+type Step = {
+  line: number;
   i: number; // índice do caractere corrente (-1 antes de começar)
-  usados: number; // quantos caracteres já entraram no resultado
-  blocos: Bloco[]; // strings alocadas na memória
-  partes: string[]; // a lista do modo join
-  copias: number;
+  used: number; // quantos caracteres já entraram no resultado
+  blocks: Block[]; // strings alocadas na memória
+  parts: string[]; // a lista do modo join
+  copies: number;
   strings: number;
-  nota: string;
+  note: string;
   ok?: boolean;
-  fim?: boolean;
+  done?: boolean;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` dos passos, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` dos passos, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO_CONCAT = [
+const CONCAT_CODE = [
   "def juntar(palavra):",
   '    s = ""',
   "    for c in palavra:",
@@ -43,7 +43,7 @@ const CODIGO_CONCAT = [
   "    return s",
 ];
 
-const CODIGO_JOIN = [
+const JOIN_CODE = [
   "def juntar(palavra):",
   "    partes = []",
   "    for c in palavra:",
@@ -51,27 +51,27 @@ const CODIGO_JOIN = [
   '    return "".join(partes)',
 ];
 
-const MODOS: { key: Modo; rotulo: string; familia: string; cor: string; arquivo: string }[] = [
-  { key: "concat", rotulo: "s = s + c no laço", familia: "O(n²)", cor: "#fbbf24", arquivo: "concat.py" },
-  { key: "join", rotulo: "lista + join", familia: "O(n)", cor: "#34d399", arquivo: "join.py" },
+const MODES: { key: Mode; label: string; family: string; color: string; file: string }[] = [
+  { key: "concat", label: "s = s + c no laço", family: "O(n²)", color: "#fbbf24", file: "concat.py" },
+  { key: "join", label: "lista + join", family: "O(n)", color: "#34d399", file: "join.py" },
 ];
 
-const PALAVRAS = ["CCC", "CRAFT", "CODECLUB", "ALGORITMO", "ESTRUTURA", "CRAFTCODECLUB", "IMUTAVEL", "STRING"];
+const WORDS = ["CCC", "CRAFT", "CODECLUB", "ALGORITMO", "ESTRUTURA", "CRAFTCODECLUB", "IMUTAVEL", "STRING"];
 
 // Os mesmos exemplos que o artigo manda prever antes de rodar, para o aluno não
 // precisar digitar (inclusive a entrada vazia, que é o caso de borda).
-const PRESETS: { rotulo: string; texto: string }[] = [
-  { rotulo: "CCC", texto: "CCC" },
-  { rotulo: "CRAFTCODE", texto: "CRAFTCODE" },
-  { rotulo: "CRAFTCODECLUB", texto: "CRAFTCODECLUB" },
-  { rotulo: "entrada vazia", texto: "" },
+const PRESETS: { label: string; text: string }[] = [
+  { label: "CCC", text: "CCC" },
+  { label: "CRAFTCODE", text: "CRAFTCODE" },
+  { label: "CRAFTCODECLUB", text: "CRAFTCODECLUB" },
+  { label: "entrada vazia", text: "" },
 ];
 
-const PADRAO = "CRAFTCODE";
+const DEFAULT_WORD = "CRAFTCODE";
 const MAX = 16;
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
+const SPEED_LABELS = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 // Formatação determinística (nada de Intl, para o HTML do servidor bater com o
 // do cliente na hidratação).
@@ -79,156 +79,156 @@ function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function plural(n: number, um: string, muitos: string): string {
-  return n === 1 ? um : muitos;
+function plural(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
 }
 
-function gerarPassos(palavra: string, modo: Modo): Passo[] {
-  const chars = Array.from(palavra).slice(0, MAX);
+function generateSteps(word: string, mode: Mode): Step[] {
+  const chars = Array.from(word).slice(0, MAX);
   const n = chars.length;
-  const out: Passo[] = [];
+  const out: Step[] = [];
 
-  if (modo === "concat") {
-    const blocos: Bloco[] = [];
-    let copias = 0;
+  if (mode === "concat") {
+    const blocks: Block[] = [];
+    let copies = 0;
     let strings = 0;
     out.push({
-      linha: 1,
+      line: 1,
       i: -1,
-      usados: 0,
-      blocos: [],
-      partes: [],
-      copias,
+      used: 0,
+      blocks: [],
+      parts: [],
+      copies,
       strings,
-      nota: n
+      note: n
         ? "Começo com a string vazia. Como a string é imutável, cada volta do laço vai ter que criar uma string NOVA: não existe escrever um caractere no fim da que já está lá."
         : "A entrada está vazia: o laço não roda nenhuma vez e o resultado é a própria string vazia. Zero cópias, zero alocações.",
     });
     for (let i = 0; i < n; i++) {
-      copias += i + 1;
+      copies += i + 1;
       strings += 1;
-      for (const b of blocos) {
-        b.viva = false;
-        b.nova = false;
+      for (const b of blocks) {
+        b.alive = false;
+        b.fresh = false;
       }
-      blocos.push({ id: i + 1, txt: chars.slice(0, i + 1).join(""), viva: true, nova: true });
+      blocks.push({ id: i + 1, text: chars.slice(0, i + 1).join(""), alive: true, fresh: true });
       out.push({
-        linha: 3,
+        line: 3,
         i,
-        usados: i + 1,
-        blocos: blocos.map((b) => ({ ...b })),
-        partes: [],
-        copias,
+        used: i + 1,
+        blocks: blocks.map((b) => ({ ...b })),
+        parts: [],
+        copies,
         strings,
-        nota:
+        note:
           `Volta ${i + 1}: aloco uma string nova de ${i + 1} ${plural(i + 1, "caractere", "caracteres")}, ` +
           `copio ${i === 0 ? "nada de antes" : i === 1 ? "o caractere que já estava lá" : `os ${i} caracteres de antes`} e escrevo o "${chars[i]}". ` +
-          `${i + 1} ${plural(i + 1, "cópia", "cópias")} nesta volta, ${copias} no total. ` +
+          `${i + 1} ${plural(i + 1, "cópia", "cópias")} nesta volta, ${copies} no total. ` +
           (i === 0 ? "A string vazia fica para trás." : "A string da volta anterior virou lixo para o coletor."),
       });
     }
     out.push({
-      linha: 4,
+      line: 4,
       i: -1,
-      usados: n,
-      blocos: blocos.map((b) => ({ ...b, nova: false })),
-      partes: [],
-      copias,
+      used: n,
+      blocks: blocks.map((b) => ({ ...b, fresh: false })),
+      parts: [],
+      copies,
       strings,
       ok: true,
-      fim: true,
-      nota: n
-        ? `Resultado "${chars.join("")}" com ${copias} ${plural(copias, "caractere copiado", "caracteres copiados")} e ${strings} ${plural(strings, "string alocada", "strings alocadas")}, das quais ${n - 1} viraram lixo. A conta é 1+2+...+${n} = ${copias}, ou seja n(n+1)/2, que é O(n²).`
+      done: true,
+      note: n
+        ? `Resultado "${chars.join("")}" com ${copies} ${plural(copies, "caractere copiado", "caracteres copiados")} e ${strings} ${plural(strings, "string alocada", "strings alocadas")}, das quais ${n - 1} viraram lixo. A conta é 1+2+...+${n} = ${copies}, ou seja n(n+1)/2, que é O(n²).`
         : "Nada a montar. Repare que este é o caso de borda que costuma quebrar implementação apressada.",
     });
     return out;
   }
 
-  const partes: string[] = [];
-  let copias = 0;
+  const parts: string[] = [];
+  let copies = 0;
   let strings = 0;
   out.push({
-    linha: 1,
+    line: 1,
     i: -1,
-    usados: 0,
-    blocos: [],
-    partes: [],
-    copias,
+    used: 0,
+    blocks: [],
+    parts: [],
+    copies,
     strings,
-    nota: n
+    note: n
       ? "Começo com uma lista vazia. A ideia é adiar a cópia: guardo os pedaços e junto tudo de uma vez só no fim."
       : "A entrada está vazia: a lista fica vazia e o join devolve a string vazia sem copiar nada.",
   });
   for (let i = 0; i < n; i++) {
-    partes.push(chars[i]);
+    parts.push(chars[i]);
     out.push({
-      linha: 3,
+      line: 3,
       i,
-      usados: i + 1,
-      blocos: [],
-      partes: [...partes],
-      copias,
+      used: i + 1,
+      blocks: [],
+      parts: [...parts],
+      copies,
       strings,
-      nota: `Volta ${i + 1}: guardo "${chars[i]}" na lista. A lista só anota onde o caractere está, não copia caractere nenhum, então o contador de cópias continua em ${copias}.`,
+      note: `Volta ${i + 1}: guardo "${chars[i]}" na lista. A lista só anota onde o caractere está, não copia caractere nenhum, então o contador de cópias continua em ${copies}.`,
     });
   }
-  copias += n;
+  copies += n;
   strings = n ? 1 : 0;
   out.push({
-    linha: 4,
+    line: 4,
     i: -1,
-    usados: n,
-    blocos: n ? [{ id: 1, txt: chars.join(""), viva: true, nova: true }] : [],
-    partes: [...partes],
-    copias,
+    used: n,
+    blocks: n ? [{ id: 1, text: chars.join(""), alive: true, fresh: true }] : [],
+    parts: [...parts],
+    copies,
     strings,
     ok: true,
-    fim: true,
-    nota: n
-      ? `join: agora sim. Somo os ${n} tamanhos, aloco UMA string de ${n} ${plural(n, "caractere", "caracteres")} e copio tudo numa passada. Total: ${copias} ${plural(copias, "cópia", "cópias")} contra ${(n * (n + 1)) / 2} do "+=" no laço.`
+    done: true,
+    note: n
+      ? `join: agora sim. Somo os ${n} tamanhos, aloco UMA string de ${n} ${plural(n, "caractere", "caracteres")} e copio tudo numa passada. Total: ${copies} ${plural(copies, "cópia", "cópias")} contra ${(n * (n + 1)) / 2} do "+=" no laço.`
       : "join de uma lista vazia: devolve a string vazia, sem alocar nada.",
   });
   return out;
 }
 
 export function StringsVisualizer() {
-  const [modo, setModo] = useState<Modo>("concat");
-  const [palavra, setPalavra] = useState(PADRAO);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
+  const [mode, setMode] = useState<Mode>("concat");
+  const [word, setWord] = useState(DEFAULT_WORD);
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(3);
   const [expanded, setExpanded] = useState(false);
   const [mounted, setMounted] = useState(false);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => setMounted(true), []);
 
-  const chars = useMemo(() => Array.from(palavra).slice(0, MAX), [palavra]);
+  const chars = useMemo(() => Array.from(word).slice(0, MAX), [word]);
   const n = chars.length;
-  const passos = useMemo(() => gerarPassos(palavra, modo), [palavra, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const cfg = MODOS.find((m) => m.key === modo) ?? MODOS[0];
+  const steps = useMemo(() => generateSteps(word, mode), [word, mode]);
+  const total = steps.length;
+  const idx = Math.min(step, total - 1);
+  const p = steps[idx];
+  const cfg = MODES.find((m) => m.key === mode) ?? MODES[0];
 
-  const parar = useCallback(() => {
+  const stop = useCallback(() => {
     if (timer.current) {
       clearInterval(timer.current);
       timer.current = null;
     }
   }, []);
-  useEffect(() => () => parar(), [parar]);
+  useEffect(() => () => stop(), [stop]);
 
   useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+    stop();
+    if (!playing) return;
+    timer.current = setInterval(() => setStep((s) => (s >= total - 1 ? s : s + 1)), SPEEDS[speed]);
+    return stop;
+  }, [playing, speed, total, stop]);
 
   useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
+    if (playing && idx >= total - 1) setPlaying(false);
+  }, [playing, idx, total]);
 
   useEffect(() => {
     if (!expanded) return;
@@ -239,66 +239,66 @@ export function StringsVisualizer() {
     return () => window.removeEventListener("keydown", onKey);
   }, [expanded]);
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
+  const reset = () => {
+    stop();
+    setPlaying(false);
+    setStep(0);
   };
 
-  const aoMudarPalavra = (v: string) => {
-    reiniciar();
-    setPalavra(Array.from(v).slice(0, MAX).join(""));
+  const onWordChange = (v: string) => {
+    reset();
+    setWord(Array.from(v).slice(0, MAX).join(""));
   };
 
-  const sortear = () => {
-    const nova = PALAVRAS[Math.floor(Math.random() * PALAVRAS.length)];
-    reiniciar();
-    setPalavra(nova);
+  const pickRandom = () => {
+    const next = WORDS[Math.floor(Math.random() * WORDS.length)];
+    reset();
+    setWord(next);
   };
 
-  const trocarModo = (m: Modo) => {
-    reiniciar();
-    setModo(m);
+  const pickMode = (m: Mode) => {
+    reset();
+    setMode(m);
   };
 
   // Já consumido fica aceso (o caractere JÁ está dentro de s), o da volta atual
   // pulsa, e o que ainda não entrou fica apagado. É o resultado crescendo.
   const cells = chars.map((c, i) => {
     let cls = "viz-cell";
-    if (p.fim) cls += " in";
+    if (p.done) cls += " in";
     else if (i === p.i) cls += " in entra";
-    else if (i < p.usados) cls += " in";
+    else if (i < p.used) cls += " in";
     else cls += " drop";
-    return { i, c, cls, marca: i === p.i ? "c" : "" };
+    return { i, c, cls, mark: i === p.i ? "c" : "" };
   });
 
-  const totalConcat = (n * (n + 1)) / 2;
-  const mortas = p.blocos.filter((b) => !b.viva).length;
+  const concatTotal = (n * (n + 1)) / 2;
+  const dead = p.blocks.filter((b) => !b.alive).length;
 
-  const variaveis =
-    modo === "concat"
+  const vars =
+    mode === "concat"
       ? [
-          { nome: "s", valor: `"${chars.slice(0, p.usados).join("")}"` },
-          { nome: "len(s)", valor: `${p.usados}` },
-          { nome: "c", valor: p.i >= 0 ? `"${chars[p.i]}"` : "-" },
-          { nome: "cópias", valor: num(p.copias), best: true },
+          { name: "s", value: `"${chars.slice(0, p.used).join("")}"` },
+          { name: "len(s)", value: `${p.used}` },
+          { name: "c", value: p.i >= 0 ? `"${chars[p.i]}"` : "-" },
+          { name: "cópias", value: num(p.copies), best: true },
         ]
       : [
-          { nome: "len(partes)", valor: `${p.partes.length}` },
-          { nome: "c", valor: p.i >= 0 ? `"${chars[p.i]}"` : "-" },
-          { nome: "strings novas", valor: `${p.strings}` },
-          { nome: "cópias", valor: num(p.copias), best: true },
+          { name: "len(partes)", value: `${p.parts.length}` },
+          { name: "c", value: p.i >= 0 ? `"${chars[p.i]}"` : "-" },
+          { name: "strings novas", value: `${p.strings}` },
+          { name: "cópias", value: num(p.copies), best: true },
         ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const codigo = modo === "concat" ? CODIGO_CONCAT : CODIGO_JOIN;
+  const noteClass = "viz-note" + (p.ok ? " ok" : "");
+  const stepPct = Math.round(((idx + 1) / total) * 100);
+  const code = mode === "concat" ? CONCAT_CODE : JOIN_CODE;
 
   const viz = (
     <figure className="viz" style={{ margin: 0 }}>
       <div className="viz-head">
         <div className="viz-head-title">
-          <span className="dot" style={{ background: cfg.cor }} />
+          <span className="dot" style={{ background: cfg.color }} />
           <span>Visualizador · o custo de montar uma string</span>
         </div>
         <div className="viz-head-right">
@@ -313,18 +313,18 @@ export function StringsVisualizer() {
 
       <div className="viz-body">
         <div className="bigo-chips">
-          {MODOS.map((m) => {
-            const on = m.key === modo;
+          {MODES.map((m) => {
+            const on = m.key === mode;
             return (
               <button
                 key={m.key}
                 className={`bigo-chip${on ? " on" : ""}`}
-                style={on ? { borderColor: m.cor, color: m.cor } : undefined}
-                onClick={() => trocarModo(m.key)}
+                style={on ? { borderColor: m.color, color: m.color } : undefined}
+                onClick={() => pickMode(m.key)}
                 aria-pressed={on}
               >
-                <span className="sw" style={{ background: on ? m.cor : "#3a4a60" }} />
-                {m.familia} · {m.rotulo}
+                <span className="sw" style={{ background: on ? m.color : "#3a4a60" }} />
+                {m.family} · {m.label}
               </button>
             );
           })}
@@ -333,9 +333,9 @@ export function StringsVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Palavra a montar, um caractere por volta</span>
-            <input className="viz-input" value={palavra} onChange={(e) => aoMudarPalavra(e.target.value)} />
+            <input className="viz-input" value={word} onChange={(e) => onWordChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={pickRandom}>
             Sortear
           </button>
         </div>
@@ -343,12 +343,12 @@ export function StringsVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
-              key={pr.rotulo}
-              className={`bigo-chip${palavra === pr.texto ? " on" : ""}`}
-              onClick={() => aoMudarPalavra(pr.texto)}
-              aria-pressed={palavra === pr.texto}
+              key={pr.label}
+              className={`bigo-chip${word === pr.text ? " on" : ""}`}
+              onClick={() => onWordChange(pr.text)}
+              aria-pressed={word === pr.text}
             >
-              {pr.rotulo} · n = {Array.from(pr.texto).length}
+              {pr.label} · n = {Array.from(pr.text).length}
             </button>
           ))}
         </div>
@@ -359,7 +359,7 @@ export function StringsVisualizer() {
               <div className="viz-cell-wrap" key={c.i}>
                 <span className="viz-cell-idx">{c.i}</span>
                 <div className={c.cls}>{c.c}</div>
-                <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+                <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
               </div>
             ))
           ) : (
@@ -370,12 +370,12 @@ export function StringsVisualizer() {
         <div className="str-heap">
           <span className="str-lbl">
             Memória: strings alocadas
-            {mortas > 0 ? <em className="str-lixo"> {mortas} para o coletor de lixo</em> : null}
+            {dead > 0 ? <em className="str-lixo"> {dead} para o coletor de lixo</em> : null}
           </span>
-          {p.blocos.length ? (
-            p.blocos.map((b) => (
-              <span key={b.id} className={`str-bloco${b.viva ? " viva" : " morta"}${b.nova ? " nova" : ""}`}>
-                {b.txt}
+          {p.blocks.length ? (
+            p.blocks.map((b) => (
+              <span key={b.id} className={`str-bloco${b.alive ? " viva" : " morta"}${b.fresh ? " nova" : ""}`}>
+                {b.text}
               </span>
             ))
           ) : (
@@ -383,11 +383,11 @@ export function StringsVisualizer() {
           )}
         </div>
 
-        {modo === "join" ? (
+        {mode === "join" ? (
           <div className="str-heap">
             <span className="str-lbl">Lista de pedaços: guarda a referência, não copia caractere</span>
-            {p.partes.length ? (
-              p.partes.map((c, i) => (
+            {p.parts.length ? (
+              p.parts.map((c, i) => (
                 <span key={i} className="str-bloco viva">
                   {c}
                 </span>
@@ -401,7 +401,7 @@ export function StringsVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>caracteres copiados</span>
-            <strong style={{ color: cfg.cor }}>{num(p.copias)}</strong>
+            <strong style={{ color: cfg.color }}>{num(p.copies)}</strong>
           </div>
           <div className="bigo-stat">
             <span>strings alocadas</span>
@@ -409,7 +409,7 @@ export function StringsVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>total com s = s + c</span>
-            <strong style={{ color: "#fbbf24" }}>{num(totalConcat)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{num(concatTotal)}</strong>
           </div>
           <div className="bigo-stat">
             <span>total com join</span>
@@ -417,16 +417,16 @@ export function StringsVisualizer() {
           </div>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
           <div className="viz-code">
             <div className="viz-code-head">
-              {cfg.arquivo} · {cfg.familia}
+              {cfg.file} · {cfg.family}
             </div>
             <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+              {code.map((txt, i) => (
+                <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
                   <span className="ln">{i + 1}</span>
                   {txt}
                 </div>
@@ -435,26 +435,26 @@ export function StringsVisualizer() {
           </div>
           <div className="viz-vars">
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
+          <button className="viz-btn" title="Reiniciar" onClick={reset}>
             ↺
           </button>
           <button
             className="viz-btn"
             disabled={idx === 0}
             onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
+              stop();
+              setPlaying(false);
+              setStep(Math.max(0, idx - 1));
             }}
           >
             ‹ Anterior
@@ -462,23 +462,23 @@ export function StringsVisualizer() {
           <button
             className="viz-play"
             onClick={() => {
-              if (tocando) {
-                setTocando(false);
+              if (playing) {
+                setPlaying(false);
                 return;
               }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
+              setStep(idx >= total - 1 ? 0 : idx);
+              setPlaying(true);
             }}
           >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+            {playing ? "❚❚ Pausar" : "▶ Rodar"}
           </button>
           <button
             className="viz-btn"
             disabled={idx === total - 1}
             onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
+              stop();
+              setPlaying(false);
+              setStep(Math.min(idx + 1, total - 1));
             }}
           >
             Próximo ›
@@ -490,14 +490,14 @@ export function StringsVisualizer() {
               min={1}
               max={5}
               step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
+              value={speed}
+              onChange={(e) => setSpeed(parseInt(e.target.value, 10))}
             />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+            <span className="val">{SPEED_LABELS[speed]}</span>
           </div>
         </div>
         <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%`, background: cfg.cor }} />
+          <div className="viz-progress-fill" style={{ width: `${stepPct}%`, background: cfg.color }} />
         </div>
       </div>
     </figure>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -627,7 +627,16 @@ html { scroll-behavior: smooth; }
 .str-byte-cell { display: inline-grid; place-items: center; min-width: 34px; height: 30px; padding: 0 5px; border-radius: 6px; font-family: var(--mono); font-size: 12px; font-weight: 700; color: #071019; }
 .str-byte-cell.ini { box-shadow: inset 0 0 0 2px rgba(7, 16, 25, 0.55); }
 
-/* tabela caractere → code point → bytes */
+/* tabela caractere → code point → bytes.
+   O `overflow-x: auto` daqui não é só a barra horizontal da tabela larga: ele é
+   o que deixa esta tabela servir de bloco recolhível da casca adaptativa sem uma
+   linha de CSS a mais. Um item de grid só ganha o tamanho mínimo automático
+   quando o overflow dele é `visible`; com o eixo X em `auto`, o Y sai de
+   `visible` junto, o mínimo automático vira 0 e a trilha do `.viz-code-slot`
+   consegue fechar de `1fr` para `0fr`. É por isso que o `.viz-code`, que é
+   `overflow: hidden`, também dispensa `min-height` — e por isso o par de regras
+   que eu tinha escrito aqui para "ajudar" não fazia nada (o teste passava
+   inteiro com elas removidas). */
 .str-scroll { overflow-x: auto; margin-bottom: 4px; }
 .str-tab { width: 100%; min-width: 420px; border-collapse: collapse; font-size: 13.5px; }
 .str-tab th { padding: 8px 12px; text-align: left; font-size: 11px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ccc-muted); border-bottom: 1px solid var(--ccc-line); }

--- a/tests/viz-strings.spec.ts
+++ b/tests/viz-strings.spec.ts
@@ -49,6 +49,26 @@ async function medicaoTerminou(alvo: Locator) {
   await expect(alvo).toHaveAttribute("data-anim", "on");
 }
 
+/**
+ * Rola o miolo até uma fração da sobra e só volta quando o navegador aplicou a
+ * rolagem e pintou o quadro seguinte. Espera fixa aqui erra dos dois lados: é
+ * lenta quando a máquina está livre e insuficiente quando ela está carregada.
+ *
+ * O retorno é o `scrollTop` REAL, e conferi-lo não é preciosismo: se a rolagem
+ * não acontecer, "o cabeçalho não se mexeu" vira verdade à toa e o teste passa
+ * sem ter testado nada.
+ */
+async function rolarMiolo(miolo: Locator, fracao: number): Promise<number> {
+  return miolo.evaluate(
+    (el, f) =>
+      new Promise<number>((resolve) => {
+        el.scrollTop = (el.scrollHeight - el.clientHeight) * f;
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve(el.scrollTop)));
+      }),
+    fracao
+  );
+}
+
 async function expandir(page: Page, n: number) {
   await figura(page, n).getByRole("button", { name: "⤢ Expandir" }).click();
   await expect(painel(page)).toBeVisible();
@@ -92,10 +112,8 @@ test("rotate expandido: cabeçalho e rodapé não se mexem quando o miolo rola a
   // em vez de olhar só o instante depois de uma espera fixa.
   const desvios: number[] = [];
   for (const destino of [0.25, 0.5, 0.75, 1]) {
-    await miolo.evaluate((el, f) => {
-      el.scrollTop = (el.scrollHeight - el.clientHeight) * f;
-    }, destino);
-    await page.waitForTimeout(120);
+    const real = await rolarMiolo(miolo, destino);
+    expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
     desvios.push(
       Math.abs((await cabeca.boundingBox())!.y - antes.cabeca),
       Math.abs((await rodape.boundingBox())!.y - antes.rodape),
@@ -171,6 +189,11 @@ test("strings: abrir o código na mão sobrevive a trocar de modo, que pediria m
   // A promessa aqui é de PERMANÊNCIA, então uma leitura só depois de uma espera
   // não serve: ela olha um instante. Amostra ao longo do intervalo em que a
   // medição nova teria tempo de desfazer a escolha.
+  //
+  // Este `waitForTimeout` não é o mesmo bicho do que se usa para "esperar
+  // assentar": ali o sono é remendo (e virou `rolarMiolo`, com rAF), aqui o
+  // tempo decorrido É o objeto do teste — a medição roda em `requestAnimation-
+  // Frame`, então 600ms de amostragem dão a ela várias chances de reprovar.
   for (let i = 0; i < 4; i++) {
     await expect(alternar).toHaveText("Ocultar código");
     await expect(f).toHaveAttribute("data-codigo", "on");
@@ -231,10 +254,12 @@ test("rotate expandido: setas andam o passo e o espaço roda, sem roubar a tecla
   await expect.poll(() => campoS.inputValue()).toHaveLength(valorAntes.length + 1);
   expect((await campoS.inputValue()).replace(" ", "")).toBe(valorAntes);
   // Trocar a entrada reinicia a animação, e ela fica PARADA no primeiro passo.
+  // O segundo aqui também é objeto do teste, e não remendo de sincronização: a
+  // marcha padrão anda a cada 650ms, então se o espaço tivesse ligado a
+  // reprodução o passo teria andado pelo menos uma vez dentro da janela.
   await expect(passo).toHaveText(/^passo 1 de \d+$/);
-  const depoisDeUmSegundo = passo;
   await page.waitForTimeout(1000);
-  await expect(depoisDeUmSegundo).toHaveText(/^passo 1 de \d+$/);
+  await expect(passo).toHaveText(/^passo 1 de \d+$/);
 });
 
 // ---------------------------------------------------------------------------
@@ -319,10 +344,8 @@ test("bytes expandido: o cabeçalho fica parado enquanto a tabela aberta rola", 
   const antes = (await cabeca.boundingBox())!.y;
   const desvios: number[] = [];
   for (const destino of [0.34, 0.67, 1]) {
-    await miolo.evaluate((el, ff) => {
-      el.scrollTop = (el.scrollHeight - el.clientHeight) * ff;
-    }, destino);
-    await page.waitForTimeout(120);
+    const real = await rolarMiolo(miolo, destino);
+    expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
     desvios.push(Math.abs((await cabeca.boundingBox())!.y - antes));
   }
   expect(Math.max(...desvios)).toBeLessThanOrEqual(1);

--- a/tests/viz-strings.spec.ts
+++ b/tests/viz-strings.spec.ts
@@ -1,0 +1,331 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa nos três visualizadores do tópico `strings`.
+//
+// Cada teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada — já passaram por uma suíte verde um visualizador sem botão nenhum e um
+// painel de 0px de largura —, e comportamento certo com rótulo errado ensina
+// errado do mesmo jeito. Por isso, sempre que um número é verificado, o texto
+// ao lado dele entra na mesma asserção.
+//
+// A janela é 1512x900 (notebook de 16"), que é o caso que motivou a casca: com
+// ela o Rotate pedia 931px no artigo contra 816 de orçamento, e no expandido o
+// "▶ Rodar" caía 22px abaixo da borda da janela.
+// ---------------------------------------------------------------------------
+
+const BYTES = 0;
+const STRINGS = 1;
+const ROTATE = 2;
+
+function figura(page: Page, n: number): Locator {
+  return page.locator("article figure.viz").nth(n);
+}
+
+function painel(page: Page): Locator {
+  return page.locator(".viz-overlay-fit figure.viz-fit");
+}
+
+async function abrirTopico(page: Page, largura = 1512, altura = 900) {
+  await page.setViewportSize({ width: largura, height: altura });
+  await page.goto("/topico/strings/");
+  // As fontes chegam com `display: swap`: medir antes mede a de fallback.
+  await page.evaluate(() => document.fonts.ready);
+}
+
+/** Altura da caixa de um elemento, arredondada. Zero quando ele não tem caixa. */
+async function altura(alvo: Locator): Promise<number> {
+  const caixa = await alvo.boundingBox();
+  return caixa ? Math.round(caixa.height) : 0;
+}
+
+/**
+ * Espera a medição TERMINAR, em vez de dormir um tanto e torcer. O `data-anim`
+ * é o sinal que a própria casca publica: ele fica em "off" enquanto a medição
+ * acontece com a transição congelada, e só volta para "on" depois da decisão.
+ * Ler altura antes disso pega o layout do meio do caminho.
+ */
+async function medicaoTerminou(alvo: Locator) {
+  await expect(alvo).toHaveAttribute("data-anim", "on");
+}
+
+async function expandir(page: Page, n: number) {
+  await figura(page, n).getByRole("button", { name: "⤢ Expandir" }).click();
+  await expect(painel(page)).toBeVisible();
+  await medicaoTerminou(painel(page));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Cabeçalho e rodapé parados, e o botão que faz o algoritmo andar na tela.
+// ---------------------------------------------------------------------------
+
+test("rotate expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({
+  page,
+}) => {
+  await abrirTopico(page);
+  await expandir(page, ROTATE);
+  const p = painel(page);
+
+  // O bloco de código aberto é o pior caso de altura, e é o que garante que
+  // existe rolagem para testar. A escolha é do aluno e tem que valer.
+  const alternar = p.getByRole("button", { name: /código$/ });
+  if ((await alternar.textContent())?.includes("Mostrar")) await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect.poll(() => altura(p.locator(".viz-code"))).toBeGreaterThan(100);
+
+  const miolo = p.locator(".viz-body");
+  const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
+  // Sem sobra o teste não prova nada: ele precisa de conteúdo para rolar.
+  expect(sobra).toBeGreaterThan(0);
+
+  const cabeca = p.locator(".viz-head");
+  const rodape = p.locator(".viz-foot");
+  const rodar = p.getByRole("button", { name: "▶ Rodar" });
+
+  const antes = {
+    cabeca: (await cabeca.boundingBox())!.y,
+    rodape: (await rodape.boundingBox())!.y,
+    rodar: (await rodar.boundingBox())!.y,
+  };
+
+  // "Está parado agora" não é "continua parado": amostra ao longo da rolagem,
+  // em vez de olhar só o instante depois de uma espera fixa.
+  const desvios: number[] = [];
+  for (const destino of [0.25, 0.5, 0.75, 1]) {
+    await miolo.evaluate((el, f) => {
+      el.scrollTop = (el.scrollHeight - el.clientHeight) * f;
+    }, destino);
+    await page.waitForTimeout(120);
+    desvios.push(
+      Math.abs((await cabeca.boundingBox())!.y - antes.cabeca),
+      Math.abs((await rodape.boundingBox())!.y - antes.rodape),
+      Math.abs((await rodar.boundingBox())!.y - antes.rodar)
+    );
+  }
+  expect(Math.max(...desvios)).toBeLessThanOrEqual(1);
+
+  // E o botão que move o algoritmo continua inteiro dentro da janela — que é o
+  // que ele NÃO fazia antes da casca (medido: topo em 922px numa janela de 900).
+  const caixa = (await rodar.boundingBox())!;
+  const janela = page.viewportSize()!.height;
+  expect(caixa.y).toBeGreaterThanOrEqual(0);
+  expect(caixa.y + caixa.height).toBeLessThanOrEqual(janela);
+  // O rótulo, e não só a posição: um botão no lugar certo dizendo outra coisa
+  // manda o aluno clicar no que ele não quer.
+  await expect(rodar).toHaveText("▶ Rodar");
+});
+
+// ---------------------------------------------------------------------------
+// 2 e 3. Quem decide é a medição: recolhido na tela baixa, aberto na tela alta.
+// ---------------------------------------------------------------------------
+
+test("strings no artigo: tela baixa recolhe o código e diz Mostrar código", async ({ page }) => {
+  await abrirTopico(page, 1512, 700);
+  const f = figura(page, STRINGS);
+  const alternar = f.getByRole("button", { name: /código$/ });
+
+  await expect(alternar).toHaveText("Mostrar código");
+  await expect(f).toHaveAttribute("data-codigo", "off");
+  // Recolhido é ALTURA zerada, não só coluna estreita: zerar a trilha da coluna
+  // deixava a linha do grid com a altura inteira do bloco (armadilha medida).
+  await expect.poll(() => altura(f.locator(".viz-code"))).toBeLessThanOrEqual(4);
+  // E ele continua no DOM, fora do teclado e dos leitores de tela.
+  await expect(f.locator(".viz-code")).toHaveAttribute("aria-hidden", "true");
+});
+
+test("strings no artigo: tela alta já vem com o código aberto e legível", async ({ page }) => {
+  await abrirTopico(page, 1512, 1500);
+  const f = figura(page, STRINGS);
+  const alternar = f.getByRole("button", { name: /código$/ });
+
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect(f).toHaveAttribute("data-codigo", "on");
+  await expect.poll(() => altura(f.locator(".viz-code"))).toBeGreaterThan(100);
+  // O código certo do modo certo: rótulo junto do número, sempre.
+  await expect(f.locator(".viz-code-head")).toHaveText("concat.py · O(n²)");
+  await expect(f.locator(".viz-code-body")).toContainText("s = s + c");
+});
+
+// ---------------------------------------------------------------------------
+// 4. A escolha do aluno vence a medição, e não é desfeita por troca de estado.
+// ---------------------------------------------------------------------------
+
+test("strings: abrir o código na mão sobrevive a trocar de modo, que pediria medição nova", async ({
+  page,
+}) => {
+  await abrirTopico(page, 1512, 700);
+  const f = figura(page, STRINGS);
+  const alternar = f.getByRole("button", { name: /código$/ });
+
+  await expect(alternar).toHaveText("Mostrar código");
+  await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect.poll(() => altura(f.locator(".viz-code"))).toBeGreaterThan(100);
+
+  // Trocar de modo muda o `measureOn` e dispara medição nova. Numa tela de
+  // 700px o join não cabe de jeito nenhum — e mesmo assim a escolha manda.
+  await f.getByRole("button", { name: /lista \+ join/ }).click();
+  await expect(f.locator(".viz-code-head")).toHaveText("join.py · O(n)");
+  await medicaoTerminou(f);
+
+  // A promessa aqui é de PERMANÊNCIA, então uma leitura só depois de uma espera
+  // não serve: ela olha um instante. Amostra ao longo do intervalo em que a
+  // medição nova teria tempo de desfazer a escolha.
+  for (let i = 0; i < 4; i++) {
+    await expect(alternar).toHaveText("Ocultar código");
+    await expect(f).toHaveAttribute("data-codigo", "on");
+    expect(await altura(f.locator(".viz-code"))).toBeGreaterThan(100);
+    await page.waitForTimeout(150);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. Teclado: as setas e o espaço dirigem a animação, e o campo em edição manda.
+// ---------------------------------------------------------------------------
+
+test("rotate expandido: setas andam o passo e o espaço roda, sem roubar a tecla de quem digita", async ({
+  page,
+}) => {
+  await abrirTopico(page);
+  await expandir(page, ROTATE);
+  const p = painel(page);
+  const passo = p.locator(".viz-step");
+
+  await expect(passo).toHaveText(/^passo 1 de \d+$/);
+  const total = Number((await passo.textContent())!.match(/de (\d+)/)![1]);
+  expect(total).toBeGreaterThan(2);
+
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo 3 de ${total}`);
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+  // Espaço roda: o passo tem que ANDAR sozinho até o fim, não só o rótulo mudar.
+  await page.keyboard.press("Space");
+  await expect(passo).toHaveText(`passo ${total} de ${total}`);
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo ${total - 1} de ${total}`);
+
+  // Com o cursor num campo, seta é cursor e espaço é espaço. Sequestrar isso
+  // deixa a entrada impossível de editar, que é pior que não ter atalho.
+  const campoS = p.locator("input.viz-input").first();
+  await campoS.click();
+  const valorAntes = await campoS.inputValue();
+
+  // As setas ficam com o cursor do campo: nem o passo anda, nem o valor muda.
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo ${total - 1} de ${total}`);
+  await expect(campoS).toHaveValue(valorAntes);
+
+  // E o espaço é um espaço digitado. Se ele tivesse sido sequestrado para
+  // rodar/pausar, o `preventDefault` engoliria o caractere e o valor ficaria
+  // igual — é essa diferença que a asserção pega.
+  //
+  // A comparação é com o valor contra ele mesmo, e não com o fim da string: as
+  // setas acabaram de mexer o cursor, e onde o clique o deixou depende do
+  // sistema. O que importa é ter entrado UM espaço e nada mais ter mudado.
+  await page.keyboard.press("Space");
+  await expect.poll(() => campoS.inputValue()).toHaveLength(valorAntes.length + 1);
+  expect((await campoS.inputValue()).replace(" ", "")).toBe(valorAntes);
+  // Trocar a entrada reinicia a animação, e ela fica PARADA no primeiro passo.
+  await expect(passo).toHaveText(/^passo 1 de \d+$/);
+  const depoisDeUmSegundo = passo;
+  await page.waitForTimeout(1000);
+  await expect(depoisDeUmSegundo).toHaveText(/^passo 1 de \d+$/);
+});
+
+// ---------------------------------------------------------------------------
+// 6 e 7. O visualizador de bytes: sem linha do tempo, e o recolhível é a TABELA.
+// ---------------------------------------------------------------------------
+
+test("bytes: o botão fala em tabela, e recolher tira ALTURA da peça", async ({ page }) => {
+  await abrirTopico(page);
+  const f = figura(page, BYTES);
+  const campo = f.locator("input.viz-input");
+  const alternar = f.getByRole("button", { name: /tabela$/ });
+  const tabela = f.locator(".str-scroll");
+
+  // Com o padrão de 3 code points a peça cabe, e a medição deixa tudo à mostra.
+  await expect(alternar).toHaveText("Ocultar tabela");
+
+  // 20 code points é o limite da entrada, e é o pior caso de altura.
+  await campo.fill("abcdefghijklmnopqrst");
+  await expect(f.locator(".str-tab tbody tr")).toHaveCount(20);
+  await medicaoTerminou(f);
+
+  // Agora não cabe mais, e a medição recolhe sozinha. O rótulo diz o que sumiu:
+  // "tabela", e não "código", que é o padrão do hook e mentiria aqui.
+  await expect(alternar).toHaveText("Mostrar tabela");
+  const recolhida = await altura(f);
+  // Recolher é altura, não largura: a tabela segue no DOM com caixa zerada.
+  await expect.poll(() => altura(tabela)).toBeLessThanOrEqual(4);
+  await expect(tabela).toHaveAttribute("aria-hidden", "true");
+
+  await alternar.click();
+  await expect(alternar).toHaveText("Ocultar tabela");
+  await expect.poll(() => altura(tabela)).toBeGreaterThan(400);
+  const aberta = await altura(f);
+  // O recolhimento vale o que ele promete: 680px medidos entre os dois estados.
+  expect(aberta - recolhida).toBeGreaterThan(400);
+});
+
+test("bytes: sem linha do tempo, o cabeçalho conta bytes e o número acompanha o encoding", async ({
+  page,
+}) => {
+  await abrirTopico(page);
+  const f = figura(page, BYTES);
+  const resumo = f.locator(".viz-step");
+
+  // `total: 1`: nada de "passo N de M", nada de controles de reprodução.
+  await expect(resumo).toHaveText("3 bytes em UTF-8");
+  await expect(f.locator(".viz-foot")).toHaveCount(0);
+  await expect(f.getByRole("button", { name: "▶ Rodar" })).toHaveCount(0);
+
+  // Número E rótulo juntos: o mesmo texto tem que trocar os dois ao mesmo tempo,
+  // senão a peça ensina o total de um encoding com o nome de outro.
+  await f.getByRole("button", { name: /^UTF-32/ }).click();
+  await expect(resumo).toHaveText("12 bytes em UTF-32");
+  await f.getByRole("button", { name: /^ASCII/ }).click();
+  await expect(resumo).toHaveText("3 bytes em ASCII");
+  await f.locator("input.viz-input").fill("ção");
+  await expect(resumo).toHaveText("3 bytes em ASCII");
+  // E o aviso de perda aparece com a conta certa, não com um texto genérico.
+  await expect(f.locator(".str-enc.perde .str-enc-sub")).toHaveText(
+    'perde 2 caracteres, viram "?"'
+  );
+});
+
+test("bytes expandido: o cabeçalho fica parado enquanto a tabela aberta rola", async ({ page }) => {
+  await abrirTopico(page);
+  const f = figura(page, BYTES);
+  await f.locator("input.viz-input").fill("abcdefghijklmnopqrst");
+  await expect(f).toHaveAttribute("data-codigo", "off");
+  await expandir(page, BYTES);
+  const p = painel(page);
+
+  const alternar = p.getByRole("button", { name: /tabela$/ });
+  if ((await alternar.textContent())?.includes("Mostrar")) await alternar.click();
+  await expect(alternar).toHaveText("Ocultar tabela");
+  await expect.poll(() => altura(p.locator(".str-scroll"))).toBeGreaterThan(400);
+
+  const miolo = p.locator(".viz-body");
+  const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
+  expect(sobra).toBeGreaterThan(0);
+
+  const cabeca = p.locator(".viz-head");
+  const antes = (await cabeca.boundingBox())!.y;
+  const desvios: number[] = [];
+  for (const destino of [0.34, 0.67, 1]) {
+    await miolo.evaluate((el, ff) => {
+      el.scrollTop = (el.scrollHeight - el.clientHeight) * ff;
+    }, destino);
+    await page.waitForTimeout(120);
+    desvios.push(Math.abs((await cabeca.boundingBox())!.y - antes));
+  }
+  expect(Math.max(...desvios)).toBeLessThanOrEqual(1);
+  // O cabeçalho parado só serve se ele continuar dizendo alguma coisa.
+  await expect(p.locator(".viz-step")).toHaveText("20 bytes em UTF-8");
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`useVisualizer` + `VizHeader` + `VizFooter`) nos
**três** visualizadores do tópico `strings`, traduz os identificadores deles
para inglês no mesmo PR e prova o resultado com sete testes de comportamento.

## Inventário: 3 visualizadores, 3 adaptados, 0 fora

| arquivo | overlay | código | variáveis | controles | o que entrou |
|---|---|---|---|---|---|
| `StringsBytesVisualizer.tsx` | sim | – | – | – | camadas 1, 2 e 3, com `total: 1` e o recolhível sendo a **tabela** |
| `StringsVisualizer.tsx` | sim | sim | sim | sim | as três camadas |
| `StringsRotateVisualizer.tsx` | sim | sim | sim | sim | as três camadas |

Nenhum ficou de fora.

## Medição, em 1512x900, com a animação congelada e depois de `document.fonts.ready`

Orçamento no fluxo do artigo: `900 - 60 (--ccc-header-h) - 24 (respiro) = 816px`.

| peça (estado) | artigo antes | artigo depois | sobra no expandido |
|---|---|---|---|
| Bytes, padrão `CCC` (3 code points) | 730px | 730px | 0px → 0px |
| Bytes, 20 code points em UTF-8 | **1.410px** | 580px | **507px** → 0px |
| Bytes, 20 code points em UTF-32 | **1.512px** | 682px | **575px** → 0px |
| Strings, padrão `CRAFTCODE`, concat | 876px | 722px | 13px → 0px |
| Strings, `join` com n = 16 | **1.042px** | 888px | 100px → 0px |
| Rotate, padrão caso feliz, laço | **931px** | 722px | **117px** → 0px |
| Rotate, truque com n = 10 | 876px | 722px | 25px → 0px |

Duas leituras honestas destes números:

- **O de bytes já cabia no estado padrão** (730px contra 816 de orçamento), e
  continua cabendo exatamente igual — a medição deixa a tabela à mostra. O
  problema dele só existe quando o aluno digita: com os 20 code points que o
  campo aceita, a peça vai a 1.410px e, em UTF-32, a 1.512px.
- **`Strings · concat n = 16` fica em 821px depois**, cinco pixels acima dos 816
  nominais e dentro da folga de 8px que o hook usa contra ruído de subpixel. É o
  máximo que dá para encolher: o código já está recolhido.

O caso que doía era o **Rotate**: no expandido o `▶ Rodar` ficava com o topo em
**922px numa janela de 900**, ou seja, o botão que faz o algoritmo andar estava
fora da tela, e o cabeçalho subia 92px ao rolar. Agora cabeçalho, rodapé e
`▶ Rodar` não se movem nem 1px em quatro pontos da rolagem.

## O visualizador de bytes, que é o fora do padrão

Duas decisões, as duas medidas e não por gosto:

- **`total: 1`** — não existe linha do tempo para percorrer. Somem o contador de
  passo, o rodapé e os atalhos. O contador de bytes vai como `children` do
  `VizHeader` e ocupa o lugar do "passo N de M".
- **o recolhível é a TABELA**, com `blockName: "tabela"` para o rótulo dizer o
  que some. Não é bloco inventado para ter botão: ir de 3 para 20 code points
  sobe a peça de 730px para 1.410px, e **os 680px de diferença são todos linha
  de tabela**. Os quatro contadores e a fita de bytes, que é o que o artigo manda
  olhar (*"acompanhe os quatro contadores de cima"*), continuam sempre à mostra.

## Idioma

Os identificadores foram para inglês num commit separado, de propósito: assim o
`scripts/guarda-idioma.py` roda contra um diff que só deveria ter renomeações, e
ele sai **limpo nos três arquivos**. A única exceção são as duas chaves do tipo
`Mode` do Rotate (`laco`/`truque` → `loop`/`trick`), que são discriminantes de
união e nunca chegam à tela.

O Python que aparece na tela (`dobrado = s + s`, `partes.append(c)`), os rótulos
do painel (`cópias`, `strings novas`, `len(partes)`) e as notas do passo a passo
seguem intactos. Uma colisão no caminho: o campo `janela` virou `window`, seguro
como propriedade mas não como variável local — a local que guardava a fatia virou
`chunk` para não sombrear o `window` global.

## O que a prova de quebra contrariou

Eu tinha escrito **três regras de CSS** para a tabela encolher junto com a trilha
do grid, do jeito que o `.viz-code` faz, com um comentário longo explicando por
que elas eram necessárias. A prova de quebra mostrou que **eram inertes**: com as
três removidas o teste de altura continuava passando.

O motivo: um item de grid só ganha tamanho mínimo automático quando o `overflow`
dele é `visible`, e o `.str-scroll` já tinha `overflow-x: auto`. Este PR portanto
**não acrescenta uma regra de CSS sequer** — só troca o comentário do
`.str-scroll` por um que explica por que a regra que parece faltar não faz falta.
O bloco `viz-fit` compartilhado não foi tocado.

A regra virou item da §7 do contrato, junto com o caso do `VizHeader` sem passo.

## Testes: `tests/viz-strings.spec.ts` (arquivo novo, zero conflito)

Nenhum conta elemento; todos medem comportamento e leem o rótulo ao lado do
número.

1. Rotate expandido: cabeçalho, rodapé e `▶ Rodar` não se movem mais que 1px em
   quatro pontos da rolagem, e o botão fica inteiro na janela;
2. Strings em tela de 700px: código recolhido, botão dizendo `Mostrar código`, e
   caixa do bloco com altura ≤ 4px (recolher é **altura**, não largura);
3. Strings em tela de 1500px: já vem aberto, com `concat.py · O(n²)` no cabeçalho;
4. abrir o código na mão sobrevive a trocar de modo, que dispara medição nova —
   e a permanência é **amostrada**, não lida uma vez só;
5. setas andam o passo e o espaço roda até o fim; com o cursor no campo, a seta é
   do cursor e o espaço é um espaço digitado;
6. Bytes: o botão fala em `tabela` e recolher tira 400px+ de altura, com a tabela
   seguindo no DOM e com `aria-hidden`;
7. Bytes: o cabeçalho conta bytes com o nome do encoding certo ao lado do número,
   e fica parado enquanto a tabela aberta rola.

A espera não é sono fixo: o `data-anim` do `<figure>` é o sinal que a casca
publica quando a medição termina. Trocar os `waitForTimeout` por ele tirou 3,4s
do arquivo e deixou de ler layout no meio do caminho.

### As quebras provadas, todas compilando e restauradas com `cp`

| quebra | teste que reprovou |
|---|---|
| A) rodapé de volta para dentro do `.viz-body` (Rotate) | 1 |
| B) cabeçalho de volta para dentro do `.viz-body` (Rotate) | 1 |
| C) `.viz-code-slot` sem a classe (Strings) | 2 |
| D) condição da medição invertida no artigo (hook) | 2 e 3 |
| E) `manualChoice` não anotada no `toggleOpen` (hook) | 4 |
| F) `stepBy(0)`, argumento neutro na seta (hook) | 5 (e o do Big O) |
| G) espaço sequestrado de quem digita (hook) | 5 (e o do Big O) |
| H) `blockName: "código"` no lugar de `"tabela"` | 6 |
| I) as três regras de CSS que eu tinha escrito | **nenhum — por isso elas saíram** |
| J) `.viz-code-slot` sem a classe (Bytes) | 6 |
| K) número de um encoding com o nome de outro | 7 |
| M) cabeçalho de volta para dentro do miolo (Bytes) | 7 |

Rodei também um controle (uma mudança inócua no mesmo arquivo) para confirmar que
a suíte não reprova por qualquer coisa: passou.

## Estado

`npm run test:build`: **98 passando**, 31,6s.
