### PR TITLE
Casca adaptativa nos visualizadores de prefix-sum

### DIFF
--- a/content/visualizers/PrefixSumGrade2D.tsx
+++ b/content/visualizers/PrefixSumGrade2D.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // PrefixSumGrade2D, a soma de um retângulo em quatro leituras.
 //
-// Padrão passo a passo (gerador PURO de passos + a mesma casca), mas o dado
-// não é uma fita de células e sim duas grades: a matriz e a tabela de
+// Padrão passo a passo (gerador PURO de passos + a casca compartilhada), mas o
+// dado não é uma fita de células e sim duas grades: a matriz e a tabela de
 // prefixos, esta com uma linha e uma coluna sentinela.
 //
 // A ideia que o passo a passo precisa entregar é a inclusão e exclusão: cada
@@ -15,25 +16,32 @@ import { createPortal } from "react-dom";
 // retângulo qualquer é um retângulo grande menos duas faixas mais o canto que
 // foi descontado duas vezes. Por isso cada passo pinta NA MATRIZ o retângulo
 // que aquele termo representa, em vez de só acender um número na tabela.
+//
+// A casca vem do `useVisualizer`. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Regiao = { r1: number; c1: number; r2: number; c2: number };
+type Region = { r1: number; c1: number; r2: number; c2: number };
 
-type Passo = {
-  linha: number;
-  regiao: Regiao | null;
-  tipo: "alvo" | "mais" | "menos";
-  lerP: { r: number; c: number } | null;
-  sinais: Record<string, "mais" | "menos">;
-  acumulado: number | null;
+// `"alvo" | "mais" | "menos"` continuam em português porque `mais` e `menos`
+// são NOMES DE CLASSE do CSS (`.ps-cell.mais`), não identificadores do
+// componente: traduzir aqui obrigaria a mexer no `globals.css` compartilhado.
+type Kind = "alvo" | "mais" | "menos";
+
+type Step = {
+  line: number;
+  region: Region | null;
+  kind: Kind;
+  readP: { r: number; c: number } | null;
+  signs: Record<string, "mais" | "menos">;
+  accumulated: number | null;
   ops: number;
-  nota: string;
+  note: string;
   ok?: boolean;
 };
 
-// As linhas mapeiam 1:1 com os passos (campo `linha` em gerarPassos), então a
+// As linhas mapeiam 1:1 com os passos (campo `line` em generateSteps), então a
 // ordem e a quantidade de linhas não podem mudar.
-const CODIGO = [
+const CODE = [
   "def construir(m):",
   "    linhas, colunas = len(m), len(m[0])",
   "    p = [[0] * (colunas + 1)",
@@ -49,12 +57,11 @@ const CODIGO = [
   "            - p[r2+1][c1] + p[r1][c1])",
 ];
 
-const VELOCIDADES = [0, 1600, 1100, 750, 500, 300];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1600, 1100, 750, 500, 300];
 
 // A matriz do LeetCode 304, que é a referência mais fácil de conferir: a
 // consulta (2, 1) até (4, 3) tem que dar 8.
-const MATRIZ_PADRAO = [
+const DEFAULT_MATRIX = [
   [3, 0, 1, 4, 2],
   [5, 6, 3, 2, 1],
   [1, 2, 0, 1, 5],
@@ -62,131 +69,131 @@ const MATRIZ_PADRAO = [
   [1, 0, 3, 0, 5],
 ];
 
-type Preset = { rotulo: string; sel: Regiao };
+type Preset = { label: string; sel: Region };
 
 const PRESETS: Preset[] = [
-  { rotulo: "LeetCode 304", sel: { r1: 2, c1: 1, r2: 4, c2: 3 } },
-  { rotulo: "Uma linha", sel: { r1: 1, c1: 0, r2: 1, c2: 4 } },
-  { rotulo: "Uma coluna", sel: { r1: 0, c1: 2, r2: 4, c2: 2 } },
-  { rotulo: "Encostado na origem", sel: { r1: 0, c1: 0, r2: 1, c2: 2 } },
-  { rotulo: "Uma célula", sel: { r1: 3, c1: 3, r2: 3, c2: 3 } },
-  { rotulo: "A matriz toda", sel: { r1: 0, c1: 0, r2: 4, c2: 4 } },
+  { label: "LeetCode 304", sel: { r1: 2, c1: 1, r2: 4, c2: 3 } },
+  { label: "Uma linha", sel: { r1: 1, c1: 0, r2: 1, c2: 4 } },
+  { label: "Uma coluna", sel: { r1: 0, c1: 2, r2: 4, c2: 2 } },
+  { label: "Encostado na origem", sel: { r1: 0, c1: 0, r2: 1, c2: 2 } },
+  { label: "Uma célula", sel: { r1: 3, c1: 3, r2: 3, c2: 3 } },
+  { label: "A matriz toda", sel: { r1: 0, c1: 0, r2: 4, c2: 4 } },
 ];
 
 // Matriz aleatória do tamanho pedido. Só sai de handler de clique, nunca do
 // caminho de render, para não divergir entre servidor e cliente na hidratação.
-function matrizAleatoria(linhas: number, colunas: number): number[][] {
-  return Array.from({ length: linhas }, () =>
-    Array.from({ length: colunas }, () => Math.floor(Math.random() * 10))
+function randomMatrix(rows: number, cols: number): number[][] {
+  return Array.from({ length: rows }, () =>
+    Array.from({ length: cols }, () => Math.floor(Math.random() * 10))
   );
 }
 
-function construir(m: number[][]): number[][] {
-  const linhas = m.length;
-  const colunas = m[0].length;
-  const p: number[][] = Array.from({ length: linhas + 1 }, () => new Array(colunas + 1).fill(0));
-  for (let r = 0; r < linhas; r++) {
-    for (let c = 0; c < colunas; c++) {
+function build(m: number[][]): number[][] {
+  const rows = m.length;
+  const cols = m[0].length;
+  const p: number[][] = Array.from({ length: rows + 1 }, () => new Array(cols + 1).fill(0));
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
       p[r + 1][c + 1] = m[r][c] + p[r][c + 1] + p[r + 1][c] - p[r][c];
     }
   }
   return p;
 }
 
-function chave(r: number, c: number) {
+function key(r: number, c: number) {
   return `${r},${c}`;
 }
 
-function gerarPassos(m: number[][], p: number[][], sel: Regiao): Passo[] {
+function generateSteps(m: number[][], p: number[][], sel: Region): Step[] {
   const { r1, c1, r2, c2 } = sel;
-  const celulas = (r2 - r1 + 1) * (c2 - c1 + 1);
-  const grande = p[r2 + 1][c2 + 1];
-  const cima = p[r1][c2 + 1];
-  const esquerda = p[r2 + 1][c1];
-  const canto = p[r1][c1];
-  const total = grande - cima - esquerda + canto;
+  const cells = (r2 - r1 + 1) * (c2 - c1 + 1);
+  const big = p[r2 + 1][c2 + 1];
+  const above = p[r1][c2 + 1];
+  const left = p[r2 + 1][c1];
+  const corner = p[r1][c1];
+  const total = big - above - left + corner;
 
-  const sinais: Record<string, "mais" | "menos"> = {};
-  const out: Passo[] = [];
+  const signs: Record<string, "mais" | "menos"> = {};
+  const out: Step[] = [];
 
   out.push({
-    linha: 10,
-    regiao: sel,
-    tipo: "alvo",
-    lerP: null,
-    sinais: { ...sinais },
-    acumulado: null,
+    line: 10,
+    region: sel,
+    kind: "alvo",
+    readP: null,
+    signs: { ...signs },
+    accumulated: null,
     ops: 0,
-    nota: `Quero a soma do retângulo que vai de (${r1}, ${c1}) até (${r2}, ${c2}): são ${celulas} ${celulas === 1 ? "célula" : "células"}. Na força bruta eu somaria uma por uma.`,
+    note: `Quero a soma do retângulo que vai de (${r1}, ${c1}) até (${r2}, ${c2}): são ${cells} ${cells === 1 ? "célula" : "células"}. Na força bruta eu somaria uma por uma.`,
   });
 
-  sinais[chave(r2 + 1, c2 + 1)] = "mais";
+  signs[key(r2 + 1, c2 + 1)] = "mais";
   out.push({
-    linha: 11,
-    regiao: { r1: 0, c1: 0, r2, c2 },
-    tipo: "mais",
-    lerP: { r: r2 + 1, c: c2 + 1 },
-    sinais: { ...sinais },
-    acumulado: grande,
+    line: 11,
+    region: { r1: 0, c1: 0, r2, c2 },
+    kind: "mais",
+    readP: { r: r2 + 1, c: c2 + 1 },
+    signs: { ...signs },
+    accumulated: big,
     ops: 1,
-    nota: `Somo p[${r2 + 1}][${c2 + 1}] = ${grande}, que é o retângulo inteiro da origem até (${r2}, ${c2}). Peguei demais de propósito, agora é só devolver o que sobrou.`,
+    note: `Somo p[${r2 + 1}][${c2 + 1}] = ${big}, que é o retângulo inteiro da origem até (${r2}, ${c2}). Peguei demais de propósito, agora é só devolver o que sobrou.`,
   });
 
-  sinais[chave(r1, c2 + 1)] = "menos";
+  signs[key(r1, c2 + 1)] = "menos";
   out.push({
-    linha: 11,
-    regiao: r1 > 0 ? { r1: 0, c1: 0, r2: r1 - 1, c2 } : null,
-    tipo: "menos",
-    lerP: { r: r1, c: c2 + 1 },
-    sinais: { ...sinais },
-    acumulado: grande - cima,
+    line: 11,
+    region: r1 > 0 ? { r1: 0, c1: 0, r2: r1 - 1, c2 } : null,
+    kind: "menos",
+    readP: { r: r1, c: c2 + 1 },
+    signs: { ...signs },
+    accumulated: big - above,
     ops: 2,
-    nota:
+    note:
       r1 > 0
-        ? `Tiro p[${r1}][${c2 + 1}] = ${cima}, a faixa que fica acima da linha ${r1}. Restaram ${grande - cima}.`
+        ? `Tiro p[${r1}][${c2 + 1}] = ${above}, a faixa que fica acima da linha ${r1}. Restaram ${big - above}.`
         : `Tiro p[0][${c2 + 1}] = 0: o retângulo já começa na linha 0, então não existe faixa de cima. É a linha sentinela evitando um if.`,
   });
 
-  sinais[chave(r2 + 1, c1)] = "menos";
+  signs[key(r2 + 1, c1)] = "menos";
   out.push({
-    linha: 12,
-    regiao: c1 > 0 ? { r1: 0, c1: 0, r2, c2: c1 - 1 } : null,
-    tipo: "menos",
-    lerP: { r: r2 + 1, c: c1 },
-    sinais: { ...sinais },
-    acumulado: grande - cima - esquerda,
+    line: 12,
+    region: c1 > 0 ? { r1: 0, c1: 0, r2, c2: c1 - 1 } : null,
+    kind: "menos",
+    readP: { r: r2 + 1, c: c1 },
+    signs: { ...signs },
+    accumulated: big - above - left,
     ops: 3,
-    nota:
+    note:
       c1 > 0
-        ? `Tiro p[${r2 + 1}][${c1}] = ${esquerda}, a faixa que fica à esquerda da coluna ${c1}. Restaram ${grande - cima - esquerda}.`
+        ? `Tiro p[${r2 + 1}][${c1}] = ${left}, a faixa que fica à esquerda da coluna ${c1}. Restaram ${big - above - left}.`
         : `Tiro p[${r2 + 1}][0] = 0: o retângulo já começa na coluna 0, então não existe faixa à esquerda. É a coluna sentinela evitando outro if.`,
   });
 
-  sinais[chave(r1, c1)] = "mais";
+  signs[key(r1, c1)] = "mais";
   out.push({
-    linha: 12,
-    regiao: r1 > 0 && c1 > 0 ? { r1: 0, c1: 0, r2: r1 - 1, c2: c1 - 1 } : null,
-    tipo: "mais",
-    lerP: { r: r1, c: c1 },
-    sinais: { ...sinais },
-    acumulado: total,
+    line: 12,
+    region: r1 > 0 && c1 > 0 ? { r1: 0, c1: 0, r2: r1 - 1, c2: c1 - 1 } : null,
+    kind: "mais",
+    readP: { r: r1, c: c1 },
+    signs: { ...signs },
+    accumulated: total,
     ops: 4,
-    nota:
+    note:
       r1 > 0 && c1 > 0
-        ? `As duas faixas se sobrepõem neste canto, então ele saiu duas vezes. Devolvo p[${r1}][${c1}] = ${canto} uma vez.`
+        ? `As duas faixas se sobrepõem neste canto, então ele saiu duas vezes. Devolvo p[${r1}][${c1}] = ${corner} uma vez.`
         : `Aqui p[${r1}][${c1}] = 0: como o retângulo encosta na borda, as faixas não se sobrepõem e não há canto para devolver.`,
   });
 
   out.push({
-    linha: 11,
-    regiao: sel,
-    tipo: "alvo",
-    lerP: null,
-    sinais: { ...sinais },
-    acumulado: total,
+    line: 11,
+    region: sel,
+    kind: "alvo",
+    readP: null,
+    signs: { ...signs },
+    accumulated: total,
     ops: 4,
     ok: true,
-    nota: `${grande} - ${cima} - ${esquerda} + ${canto} = ${total}. Quatro leituras contra as ${celulas} somas da força bruta, e esse 4 não muda nem se o retângulo cobrir a matriz inteira.`,
+    note: `${big} - ${above} - ${left} + ${corner} = ${total}. Quatro leituras contra as ${cells} somas da força bruta, e esse 4 não muda nem se o retângulo cobrir a matriz inteira.`,
   });
 
   return out;
@@ -198,154 +205,117 @@ function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function dentro(reg: Regiao | null, r: number, c: number) {
+function inside(reg: Region | null, r: number, c: number) {
   return !!reg && r >= reg.r1 && r <= reg.r2 && c >= reg.c1 && c <= reg.c2;
 }
 
 export function PrefixSumGrade2D() {
-  const [matriz, setMatriz] = useState<number[][]>(MATRIZ_PADRAO);
-  const [selBruta, setSel] = useState<Regiao>({ r1: 2, c1: 1, r2: 4, c2: 3 });
-  const [ancora, setAncora] = useState<{ r: number; c: number } | null>(null);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [matrix, setMatrix] = useState<number[][]>(DEFAULT_MATRIX);
+  const [rawSel, setSel] = useState<Region>({ r1: 2, c1: 1, r2: 4, c2: 3 });
+  const [anchor, setAnchor] = useState<{ r: number; c: number } | null>(null);
 
-  useEffect(() => setMounted(true), []);
-
-  const linhas = matriz.length;
-  const colunas = matriz[0].length;
+  const rows = matrix.length;
+  const cols = matrix[0].length;
   // A seleção é presa ao tamanho da matriz aqui, e não em quem chama setSel:
   // trocar para uma matriz menor com um retângulo grande selecionado leria
   // fora da tabela de prefixos e derrubaria o componente.
-  const sel = useMemo<Regiao>(
+  const sel = useMemo<Region>(
     () => ({
-      r1: Math.min(Math.max(selBruta.r1, 0), linhas - 1),
-      c1: Math.min(Math.max(selBruta.c1, 0), colunas - 1),
-      r2: Math.min(Math.max(selBruta.r2, 0), linhas - 1),
-      c2: Math.min(Math.max(selBruta.c2, 0), colunas - 1),
+      r1: Math.min(Math.max(rawSel.r1, 0), rows - 1),
+      c1: Math.min(Math.max(rawSel.c1, 0), cols - 1),
+      r2: Math.min(Math.max(rawSel.r2, 0), rows - 1),
+      c2: Math.min(Math.max(rawSel.c2, 0), cols - 1),
     }),
-    [selBruta, linhas, colunas]
+    [rawSel, rows, cols]
   );
-  const p = useMemo(() => construir(matriz), [matriz]);
-  const passos = useMemo(() => gerarPassos(matriz, p, sel), [matriz, p, sel]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const s = passos[idx];
+  const p = useMemo(() => build(matrix), [matrix]);
+  const steps = useMemo(() => generateSteps(matrix, p, sel), [matrix, p, sel]);
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const viz = useVisualizer({
+    title: "Visualizador · soma de um retângulo em 4 leituras",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o tamanho da matriz. As duas grades crescem
+    // com o número de linhas (5 × 5 → 8 × 8 é o botão que mais mexe nisso).
+    measureOn: [rows, cols],
+  });
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((v) => (v >= total - 1 ? v : v + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
+  const s = steps[viz.step];
 
   // Primeiro clique fixa um canto, o segundo fecha o retângulo. O terceiro
   // começa de novo, então dá para explorar sem nenhum botão de modo.
-  const clicar = (r: number, c: number) => {
-    reiniciar();
-    if (!ancora) {
-      setAncora({ r, c });
+  const pick = (r: number, c: number) => {
+    viz.reset();
+    if (!anchor) {
+      setAnchor({ r, c });
       setSel({ r1: r, c1: c, r2: r, c2: c });
       return;
     }
     setSel({
-      r1: Math.min(ancora.r, r),
-      c1: Math.min(ancora.c, c),
-      r2: Math.max(ancora.r, r),
-      c2: Math.max(ancora.c, c),
+      r1: Math.min(anchor.r, r),
+      c1: Math.min(anchor.c, c),
+      r2: Math.max(anchor.r, r),
+      c2: Math.max(anchor.c, c),
     });
-    setAncora(null);
+    setAnchor(null);
   };
 
   // O preset devolve o cenário inteiro, matriz incluída: os números citados no
   // artigo (o 8 do LeetCode 304, as 25 células da matriz toda) só fecham sobre
   // a matriz padrão, e o aluno pode ter sorteado outra antes de clicar.
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
-    setAncora(null);
-    setMatriz(MATRIZ_PADRAO);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setAnchor(null);
+    setMatrix(DEFAULT_MATRIX);
     setSel(pr.sel);
   };
 
-  const sortear = () => {
-    reiniciar();
-    setAncora(null);
-    setMatriz(matrizAleatoria(linhas, colunas));
+  const shuffle = () => {
+    viz.reset();
+    setAnchor(null);
+    setMatrix(randomMatrix(rows, cols));
   };
 
   // Trocar o tamanho é o argumento central da seção: a força bruta sobe com a
   // área do retângulo, as leituras na tabela continuam sendo 4.
-  const trocarTamanho = () => {
-    reiniciar();
-    setAncora(null);
-    if (linhas === 5) {
-      setMatriz(matrizAleatoria(8, 8));
+  const toggleSize = () => {
+    viz.reset();
+    setAnchor(null);
+    if (rows === 5) {
+      setMatrix(randomMatrix(8, 8));
       setSel({ r1: 1, c1: 2, r2: 6, c2: 6 });
     } else {
-      setMatriz(MATRIZ_PADRAO);
+      setMatrix(DEFAULT_MATRIX);
       setSel({ r1: 2, c1: 1, r2: 4, c2: 3 });
     }
   };
 
-  const celulas = (sel.r2 - sel.r1 + 1) * (sel.c2 - sel.c1 + 1);
-  const alvo: Regiao = sel;
+  const cells = (sel.r2 - sel.r1 + 1) * (sel.c2 - sel.c1 + 1);
+  const target: Region = sel;
 
-  const variaveis = [
-    { nome: "r1, c1", valor: `${sel.r1}, ${sel.c1}` },
-    { nome: "r2, c2", valor: `${sel.r2}, ${sel.c2}` },
-    { nome: "leituras", valor: `${s.ops}` },
-    { nome: "soma", valor: s.acumulado == null ? "-" : `${s.acumulado}`, best: true },
+  const vars = [
+    { name: "r1, c1", value: `${sel.r1}, ${sel.c1}` },
+    { name: "r2, c2", value: `${sel.r2}, ${sel.c2}` },
+    { name: "leituras", value: `${s.ops}` },
+    { name: "soma", value: s.accumulated == null ? "-" : `${s.accumulated}`, best: true },
   ];
 
-  const notaCls = "viz-note" + (s.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (s.ok ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · soma de um retângulo em 4 leituras</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.rotulo} className="bigo-chip" onClick={() => aplicarPreset(pr)}>
-              {pr.rotulo}
+            <button key={pr.label} className="bigo-chip" onClick={() => applyPreset(pr)}>
+              {pr.label}
             </button>
           ))}
-          <button className="bigo-chip" onClick={sortear}>Sortear valores</button>
-          <button className="bigo-chip" onClick={trocarTamanho}>
-            {linhas === 5 ? "Aumentar para 8 × 8" : "Voltar para 5 × 5"}
+          <button className="bigo-chip" onClick={shuffle}>Sortear valores</button>
+          <button className="bigo-chip" onClick={toggleSize}>
+            {rows === 5 ? "Aumentar para 8 × 8" : "Voltar para 5 × 5"}
           </button>
         </div>
 
@@ -355,27 +325,27 @@ export function PrefixSumGrade2D() {
               matriz · clique em duas células para escolher o retângulo
             </div>
             <div className="ps-grade-scroll">
-              <div className="ps-grade" style={{ gridTemplateColumns: `repeat(${colunas + 1}, auto)` }}>
+              <div className="ps-grade" style={{ gridTemplateColumns: `repeat(${cols + 1}, auto)` }}>
                 <div className="ps-rot" />
-                {Array.from({ length: colunas }, (_, c) => (
+                {Array.from({ length: cols }, (_, c) => (
                   <div className="ps-rot" key={`hc-${c}`}>{c}</div>
                 ))}
-                {matriz.map((linha, r) => (
+                {matrix.map((row, r) => (
                   <div key={`lin-${r}`} style={{ display: "contents" }}>
                     <div className="ps-rot">{r}</div>
-                    {linha.map((v, c) => {
+                    {row.map((v, c) => {
                       let cls = "ps-cell";
-                      if (dentro(alvo, r, c)) cls += " alvo";
-                      if (dentro(s.regiao, r, c)) {
-                        cls += s.tipo === "alvo" ? " foco" : s.tipo === "mais" ? " mais" : " menos";
+                      if (inside(target, r, c)) cls += " alvo";
+                      if (inside(s.region, r, c)) {
+                        cls += s.kind === "alvo" ? " foco" : s.kind === "mais" ? " mais" : " menos";
                       }
-                      if (ancora && ancora.r === r && ancora.c === c) cls += " ancora";
+                      if (anchor && anchor.r === r && anchor.c === c) cls += " ancora";
                       return (
                         <button
                           key={`m-${r}-${c}`}
                           className={cls}
-                          onClick={() => clicar(r, c)}
-                          aria-pressed={dentro(alvo, r, c)}
+                          onClick={() => pick(r, c)}
+                          aria-pressed={inside(target, r, c)}
                           aria-label={`Linha ${r}, coluna ${c}, valor ${v}`}
                         >
                           {v}
@@ -393,22 +363,22 @@ export function PrefixSumGrade2D() {
               p · tabela de prefixos, com linha e coluna sentinela
             </div>
             <div className="ps-grade-scroll">
-              <div className="ps-grade" style={{ gridTemplateColumns: `repeat(${colunas + 2}, auto)` }}>
+              <div className="ps-grade" style={{ gridTemplateColumns: `repeat(${cols + 2}, auto)` }}>
                 <div className="ps-rot" />
-                {Array.from({ length: colunas + 1 }, (_, c) => (
+                {Array.from({ length: cols + 1 }, (_, c) => (
                   <div className="ps-rot" key={`ph-${c}`}>{c}</div>
                 ))}
-                {p.map((linha, r) => (
+                {p.map((row, r) => (
                   <div key={`plin-${r}`} style={{ display: "contents" }}>
                     <div className="ps-rot">{r}</div>
-                    {linha.map((v, c) => {
-                      const sinal = s.sinais[chave(r, c)];
-                      const emFoco = !!s.lerP && s.lerP.r === r && s.lerP.c === c;
+                    {row.map((v, c) => {
+                      const sign = s.signs[key(r, c)];
+                      const focused = !!s.readP && s.readP.r === r && s.readP.c === c;
                       let cls = "ps-cell est";
-                      if (sinal === "mais") cls += " mais";
-                      else if (sinal === "menos") cls += " menos";
+                      if (sign === "mais") cls += " mais";
+                      else if (sign === "menos") cls += " menos";
                       else if (r === 0 || c === 0) cls += " eixo";
-                      if (emFoco) cls += " atual";
+                      if (focused) cls += " atual";
                       return <div key={`p-${r}-${c}`} className={cls}>{v}</div>;
                     })}
                   </div>
@@ -421,72 +391,58 @@ export function PrefixSumGrade2D() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>células no retângulo</span>
-            <strong style={{ color: "#fbbf24" }}>{num(celulas)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{num(cells)}</strong>
           </div>
           <div className="bigo-stat">
             <span>leituras na tabela</span>
             <strong style={{ color: "var(--ccc-green)" }}>{num(s.ops)}</strong>
           </div>
           <div className="bigo-stat">
-            <span>pré-processamento ({linhas} × {colunas})</span>
-            <strong>{num(linhas * colunas)}</strong>
+            <span>pré-processamento ({rows} × {cols})</span>
+            <strong>{num(rows * cols)}</strong>
           </div>
           <div className="bigo-stat">
             <span>soma do retângulo</span>
-            <strong>{s.acumulado == null ? "-" : num(s.acumulado)}</strong>
+            <strong>{s.accumulated == null ? "-" : num(s.accumulated)}</strong>
           </div>
         </div>
 
-        <p className={notaCls}>{s.nota}</p>
+        <p className={noteClass}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">prefixo_2d.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === s.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">prefixo_2d.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === s.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/PrefixSumTradeoff.tsx
+++ b/content/visualizers/PrefixSumTradeoff.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+
+import { useVisualizer, VizHeader } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // PrefixSumTradeoff, o ponto de virada do pré-processamento.
@@ -16,15 +17,28 @@ import { createPortal } from "react-dom";
 // Elas se cruzam em q = n / (m - 1). Antes do cruzamento, montar a tabela é
 // desperdício; depois, é a diferença entre milhões de operações e milhares.
 //
-// A casca (viz-head, viz-body, controles, Expandir) é a mesma dos demais.
+// É o canto fora do padrão da casca, nas DUAS pontas da tabela §6 do contrato:
+//
+//   · `collapsible: false` — não há bloco dispensável. O gráfico é canvas e é o
+//     conteúdo; não se inventa um bloco só para ganhar o botão. (E `measureOn`
+//     seria inerte aqui, então nem é passado.)
+//   · `total: 1` — não há linha do tempo. O eixo q é um slider contínuo, não
+//     uma sequência de passos.
+//
+// E as duas juntas têm uma consequência que morde: `VizFooter` devolve `null`
+// quando `total <= 1`, **descartando os `children` em silêncio**. Os dois
+// sliders e o Reiniciar sumiriam da tela sem erro nenhum. Por isso o rodapé é
+// escrito à mão com `.viz-foot` + `.viz-controls`, que é API de CSS pública
+// (§4) e recebe a mesma linha divisória e o mesmo respiro do rodapé do hook.
+// Consertar o `VizFooter` é PR de plataforma, não carona desta adaptação.
 // ---------------------------------------------------------------------------
 
 const ARRAYS = [10, 50, 100, 500, 1000, 5000, 10000, 100000];
-const FATIAS = [0.01, 0.05, 0.1, 0.25, 0.5, 1];
-const ROTULOS_FATIA = ["1% de n", "5% de n", "10% de n", "25% de n", "50% de n", "n inteiro"];
+const SLICES = [0.01, 0.05, 0.1, 0.25, 0.5, 1];
+const SLICE_LABELS = ["1% de n", "5% de n", "10% de n", "25% de n", "50% de n", "n inteiro"];
 
-const COR_BRUTA = "#fbbf24";
-const COR_PREFIXO = "#34d399";
+const BRUTE_COLOR = "#fbbf24";
+const PREFIX_COLOR = "#34d399";
 
 // Formatação determinística (nada de Intl, para o HTML do servidor e do
 // cliente baterem exatamente na hidratação). Um separador de milhar só, o
@@ -35,7 +49,7 @@ function num(v: number): string {
 
 // A razão entre as duas curvas é o único número que costuma cair no meio do
 // caminho (4,5 não é 5), então ela ganha uma casa decimal enquanto for pequena.
-function razaoTexto(v: number): string {
+function ratioText(v: number): string {
   if (v >= 10) return num(v);
   const d = Math.round(v * 10);
   return `${Math.floor(d / 10)},${d % 10}`;
@@ -43,7 +57,7 @@ function razaoTexto(v: number): string {
 
 // Arredonda para cima até o próximo 1, 2, 5 ou 10 vezes uma potência de 10,
 // para os eixos caírem sempre em números redondos.
-function bonito(v: number): number {
+function nice(v: number): number {
   if (v <= 10) return 10;
   const k = Math.pow(10, Math.floor(Math.log10(v)));
   for (const f of [1, 2, 5, 10]) if (f * k >= v) return f * k;
@@ -51,39 +65,34 @@ function bonito(v: number): number {
 }
 
 export function PrefixSumTradeoff() {
-  const [iArray, setIArray] = useState(4); // n = 1.000
-  const [iFatia, setIFatia] = useState(1); // m = 5% de n
-  const [qSel, setQSel] = useState(21);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [largura, setLargura] = useState(720);
+  const [arrayIndex, setArrayIndex] = useState(4); // n = 1.000
+  const [sliceIndex, setSliceIndex] = useState(1); // m = 5% de n
+  const [rawQ, setRawQ] = useState(21);
+  const [width, setWidth] = useState(720);
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const viz = useVisualizer({
+    title: "Visualizador · quando o pré-processamento se paga",
+    total: 1,
+    collapsible: false,
+  });
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const n = ARRAYS[iArray];
-  const m = Math.max(2, Math.min(n, Math.round(n * FATIAS[iFatia])));
+  const n = ARRAYS[arrayIndex];
+  const m = Math.max(2, Math.min(n, Math.round(n * SLICES[sliceIndex])));
   // Menor q inteiro em que n + q fica estritamente menor que q * m.
-  const virada = Math.floor(n / (m - 1)) + 1;
-  const qMax = Math.max(10, bonito(virada * 3));
-  const q = Math.min(Math.max(qSel, 0), qMax);
+  const turningPoint = Math.floor(n / (m - 1)) + 1;
+  const qMax = Math.max(10, nice(turningPoint * 3));
+  const q = Math.min(Math.max(rawQ, 0), qMax);
 
-  const custoBruta = q * m;
-  const custoPrefixo = n + q;
-  const yMax = bonito(qMax * m);
+  const bruteCost = q * m;
+  const prefixCost = n + q;
+  const yMax = nice(qMax * m);
 
-  const medir = useCallback((el: HTMLDivElement | null) => {
+  const measure = useCallback((el: HTMLDivElement | null) => {
     wrapRef.current = el;
-    if (el) setLargura(el.clientWidth || 720);
+    if (el) setWidth(el.clientWidth || 720);
   }, []);
 
   // O gráfico é redesenhado quando o container muda de tamanho (viewport ou
@@ -91,14 +100,14 @@ export function PrefixSumTradeoff() {
   useEffect(() => {
     const el = wrapRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => setLargura(el.clientWidth || 720));
+    const ro = new ResizeObserver(() => setWidth(el.clientWidth || 720));
     ro.observe(el);
     return () => ro.disconnect();
-  }, [expanded, mounted]);
+  }, [viz.expanded]);
 
-  const altura = expanded ? 380 : 290;
-  const padE = 78;
-  const padD = 16;
+  const height = viz.expanded ? 380 : 290;
+  const padL = 78;
+  const padR = 16;
 
   useEffect(() => {
     const cv = canvasRef.current;
@@ -107,8 +116,8 @@ export function PrefixSumTradeoff() {
     if (!ctx) return;
 
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    const W = Math.max(280, largura);
-    const H = altura;
+    const W = Math.max(280, width);
+    const H = height;
     cv.width = Math.round(W * dpr);
     cv.height = Math.round(H * dpr);
     cv.style.height = `${H}px`;
@@ -117,11 +126,11 @@ export function PrefixSumTradeoff() {
 
     const padT = 26;
     const padB = 34;
-    const gw = W - padE - padD;
+    const gw = W - padL - padR;
     const gh = H - padT - padB;
     const mono = '11px ui-monospace, SFMono-Regular, Menlo, monospace';
 
-    const px = (v: number) => padE + (v / qMax) * gw;
+    const px = (v: number) => padL + (v / qMax) * gw;
     const py = (v: number) => padT + gh - Math.min(1.05, v / yMax) * gh;
 
     // Grade e eixo Y
@@ -133,11 +142,11 @@ export function PrefixSumTradeoff() {
       const y = padT + gh - (k / 5) * gh;
       ctx.strokeStyle = "rgba(255,255,255,0.06)";
       ctx.beginPath();
-      ctx.moveTo(padE, Math.round(y) + 0.5);
-      ctx.lineTo(padE + gw, Math.round(y) + 0.5);
+      ctx.moveTo(padL, Math.round(y) + 0.5);
+      ctx.lineTo(padL + gw, Math.round(y) + 0.5);
       ctx.stroke();
       ctx.fillStyle = "#61748c";
-      ctx.fillText(num((k / 5) * yMax), padE - 8, y);
+      ctx.fillText(num((k / 5) * yMax), padL - 8, y);
     }
 
     // Eixo X
@@ -157,25 +166,25 @@ export function PrefixSumTradeoff() {
 
     ctx.textAlign = "left";
     ctx.fillStyle = "#4c5f79";
-    ctx.fillText("q (número de consultas) →", padE, padT + gh + 21);
-    ctx.fillText("↑ operações no total", padE, 7);
+    ctx.fillText("q (número de consultas) →", padL, padT + gh + 21);
+    ctx.fillText("↑ operações no total", padL, 7);
 
     // Retas, recortadas na área do gráfico
     ctx.save();
     ctx.beginPath();
-    ctx.rect(padE, padT - 1, gw, gh + 2);
+    ctx.rect(padL, padT - 1, gw, gh + 2);
     ctx.clip();
     ctx.lineWidth = 2;
     ctx.lineJoin = "round";
     ctx.lineCap = "round";
 
-    ctx.strokeStyle = COR_BRUTA;
+    ctx.strokeStyle = BRUTE_COLOR;
     ctx.beginPath();
     ctx.moveTo(px(0), py(0));
     ctx.lineTo(px(qMax), py(qMax * m));
     ctx.stroke();
 
-    ctx.strokeStyle = COR_PREFIXO;
+    ctx.strokeStyle = PREFIX_COLOR;
     ctx.beginPath();
     ctx.moveTo(px(0), py(n));
     ctx.lineTo(px(qMax), py(n + qMax));
@@ -194,7 +203,7 @@ export function PrefixSumTradeoff() {
     ctx.fillStyle = "#93a9c2";
     ctx.textAlign = "left";
     ctx.textBaseline = "top";
-    ctx.fillText("virada", Math.min(xv + 5, padE + gw - 44), padT + 4);
+    ctx.fillText("virada", Math.min(xv + 5, padL + gw - 44), padT + 4);
 
     // Marcador do q escolhido
     const xm = px(q);
@@ -205,10 +214,10 @@ export function PrefixSumTradeoff() {
     ctx.lineTo(Math.round(xm) + 0.5, padT + gh);
     ctx.stroke();
     ctx.setLineDash([]);
-    for (const [valor, cor] of [[custoBruta, COR_BRUTA], [custoPrefixo, COR_PREFIXO]] as const) {
-      ctx.fillStyle = cor;
+    for (const [value, color] of [[bruteCost, BRUTE_COLOR], [prefixCost, PREFIX_COLOR]] as const) {
+      ctx.fillStyle = color;
       ctx.beginPath();
-      ctx.arc(xm, py(valor), 4, 0, Math.PI * 2);
+      ctx.arc(xm, py(value), 4, 0, Math.PI * 2);
       ctx.fill();
       ctx.strokeStyle = "#0d1420";
       ctx.lineWidth = 1.5;
@@ -219,126 +228,118 @@ export function PrefixSumTradeoff() {
     // Moldura
     ctx.strokeStyle = "rgba(255,255,255,0.08)";
     ctx.lineWidth = 1;
-    ctx.strokeRect(padE + 0.5, padT + 0.5, gw - 1, gh - 1);
-  }, [largura, altura, n, m, q, qMax, yMax, custoBruta, custoPrefixo, padE, padD]);
+    ctx.strokeRect(padL + 0.5, padT + 0.5, gw - 1, gh - 1);
+  }, [width, height, n, m, q, qMax, yMax, bruteCost, prefixCost, padL, padR]);
 
   // Só move com o ponteiro pressionado: seguir o hover redesenharia o canvas a
   // cada mousemove.
-  const mover = (e: React.PointerEvent<HTMLCanvasElement>) => {
+  const onMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
     const cv = canvasRef.current;
     if (!cv) return;
     const r = cv.getBoundingClientRect();
-    const gw = r.width - padE - padD;
-    const pct = (e.clientX - r.left - padE) / Math.max(1, gw);
-    setQSel(Math.round(Math.min(1, Math.max(0, pct)) * qMax));
+    const gw = r.width - padL - padR;
+    const pct = (e.clientX - r.left - padL) / Math.max(1, gw);
+    setRawQ(Math.round(Math.min(1, Math.max(0, pct)) * qMax));
   };
 
   // O canvas é um slider ao longo do eixo q: setas andam de pouco em pouco,
-  // PageUp/PageDown de muito em muito e Home/End vão para as pontas.
-  const aoTeclar = (e: React.KeyboardEvent<HTMLCanvasElement>) => {
-    const fino = Math.max(1, Math.round(qMax / 50));
-    const grosso = Math.max(1, Math.round(qMax / 10));
-    const passos: Record<string, number> = {
-      ArrowLeft: -fino, ArrowRight: fino, ArrowDown: -fino, ArrowUp: fino,
-      PageDown: -grosso, PageUp: grosso,
+  // PageUp/PageDown de muito em muito e Home/End vão para as pontas. O hook não
+  // disputa essas teclas porque este visualizador não tem linha do tempo.
+  const onKeyDown = (e: React.KeyboardEvent<HTMLCanvasElement>) => {
+    const fine = Math.max(1, Math.round(qMax / 50));
+    const coarse = Math.max(1, Math.round(qMax / 10));
+    const deltas: Record<string, number> = {
+      ArrowLeft: -fine, ArrowRight: fine, ArrowDown: -fine, ArrowUp: fine,
+      PageDown: -coarse, PageUp: coarse,
     };
     if (e.key === "Home" || e.key === "End") {
       e.preventDefault();
-      setQSel(e.key === "Home" ? 0 : qMax);
+      setRawQ(e.key === "Home" ? 0 : qMax);
       return;
     }
-    const d = passos[e.key];
+    const d = deltas[e.key];
     if (d === undefined) return;
     e.preventDefault();
-    setQSel((v) => Math.min(qMax, Math.max(0, v + d)));
+    setRawQ((v) => Math.min(qMax, Math.max(0, v + d)));
   };
 
   // Capturar o ponteiro mantém o arrasto vivo com o cursor fora do canvas. É
   // um extra: se o navegador recusar o id, o arrasto normal segue funcionando.
-  const capturar = (e: React.PointerEvent<HTMLCanvasElement>) => {
+  const capture = (e: React.PointerEvent<HTMLCanvasElement>) => {
     try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* segue sem captura */ }
   };
-  const soltar = (e: React.PointerEvent<HTMLCanvasElement>) => {
+  const release = (e: React.PointerEvent<HTMLCanvasElement>) => {
     try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* nada a soltar */ }
   };
 
-  const vencedor = custoPrefixo < custoBruta ? "prefixo" : custoPrefixo > custoBruta ? "bruta" : "empate";
-  const razao = custoPrefixo > 0 ? custoBruta / custoPrefixo : 0;
+  const winner = prefixCost < bruteCost ? "prefixo" : prefixCost > bruteCost ? "bruta" : "empate";
+  const ratio = prefixCost > 0 ? bruteCost / prefixCost : 0;
 
-  const leitura = useMemo(() => {
-    if (vencedor === "empate") return `Com ${num(q)} consultas as duas abordagens custam o mesmo: ${num(custoBruta)} operações. Este é o ponto de virada.`;
-    if (vencedor === "bruta") return `Com só ${num(q)} ${q === 1 ? "consulta" : "consultas"}, a força bruta ainda ganha: ${num(custoBruta)} operações contra ${num(custoPrefixo)} do prefixo. Montar a tabela custou mais do que ela economizou.`;
-    if (razao < 2) return `Com ${num(q)} consultas, o prefixo faz ${num(custoPrefixo)} operações contra ${num(custoBruta)} da força bruta. O pré-processamento acabou de se pagar, e a distância só cresce daqui para frente.`;
-    return `Com ${num(q)} consultas, o prefixo faz ${num(custoPrefixo)} operações contra ${num(custoBruta)} da força bruta, ${razaoTexto(razao)} vezes menos. O pré-processamento já se pagou com folga.`;
-  }, [vencedor, q, custoBruta, custoPrefixo, razao]);
+  const reading = useMemo(() => {
+    if (winner === "empate") return `Com ${num(q)} consultas as duas abordagens custam o mesmo: ${num(bruteCost)} operações. Este é o ponto de virada.`;
+    if (winner === "bruta") return `Com só ${num(q)} ${q === 1 ? "consulta" : "consultas"}, a força bruta ainda ganha: ${num(bruteCost)} operações contra ${num(prefixCost)} do prefixo. Montar a tabela custou mais do que ela economizou.`;
+    if (ratio < 2) return `Com ${num(q)} consultas, o prefixo faz ${num(prefixCost)} operações contra ${num(bruteCost)} da força bruta. O pré-processamento acabou de se pagar, e a distância só cresce daqui para frente.`;
+    return `Com ${num(q)} consultas, o prefixo faz ${num(prefixCost)} operações contra ${num(bruteCost)} da força bruta, ${ratioText(ratio)} vezes menos. O pré-processamento já se pagou com folga.`;
+  }, [winner, q, bruteCost, prefixCost, ratio]);
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" style={{ background: COR_PREFIXO }} />
-          <span>Visualizador · quando o pré-processamento se paga</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">q = {num(q)}</span>
-          <button className="viz-expand" onClick={() => setExpanded((v) => !v)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} color={PREFIX_COLOR}>
+        <span className="viz-step">q = {num(q)}</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className="bigo-chip" onClick={() => setQSel(1)}>
-            <span className="sw" style={{ background: COR_BRUTA }} />
+          <button className="bigo-chip" onClick={() => setRawQ(1)}>
+            <span className="sw" style={{ background: BRUTE_COLOR }} />
             Uma consulta só
           </button>
-          <button className="bigo-chip" onClick={() => setQSel(virada)}>
+          <button className="bigo-chip" onClick={() => setRawQ(turningPoint)}>
             <span className="sw" style={{ background: "#93a9c2" }} />
             No ponto de virada
           </button>
-          <button className="bigo-chip" onClick={() => setQSel(qMax)}>
-            <span className="sw" style={{ background: COR_PREFIXO }} />
+          <button className="bigo-chip" onClick={() => setRawQ(qMax)}>
+            <span className="sw" style={{ background: PREFIX_COLOR }} />
             Muitas consultas
           </button>
         </div>
 
-        <div className="bigo-canvas-wrap" ref={medir}>
+        <div className="bigo-canvas-wrap" ref={measure}>
           <canvas
             ref={canvasRef}
             className="bigo-canvas"
-            style={{ height: altura }}
+            style={{ height }}
             role="slider"
             tabIndex={0}
             aria-label="Número de consultas comparado entre força bruta e tabela de prefixos"
             aria-valuemin={0}
             aria-valuemax={qMax}
             aria-valuenow={q}
-            aria-valuetext={`${num(q)} consultas: força bruta ${num(custoBruta)} operações, com prefixo ${num(custoPrefixo)} operações. Ponto de virada em ${num(virada)} consultas.`}
-            onKeyDown={aoTeclar}
-            onPointerDown={(e) => { mover(e); capturar(e); }}
-            onPointerMove={(e) => { if (e.buttons === 1) mover(e); }}
-            onPointerUp={soltar}
-            onPointerCancel={soltar}
+            aria-valuetext={`${num(q)} consultas: força bruta ${num(bruteCost)} operações, com prefixo ${num(prefixCost)} operações. Ponto de virada em ${num(turningPoint)} consultas.`}
+            onKeyDown={onKeyDown}
+            onPointerDown={(e) => { onMove(e); capture(e); }}
+            onPointerMove={(e) => { if (e.buttons === 1) onMove(e); }}
+            onPointerUp={release}
+            onPointerCancel={release}
           />
         </div>
 
-        <p className={`viz-note${vencedor === "prefixo" ? " ok" : vencedor === "bruta" ? " invalid" : ""}`}>
-          {leitura} Arraste sobre o gráfico, ou use as setas do teclado, para mover o marcador.
+        <p className={`viz-note${winner === "prefixo" ? " ok" : winner === "bruta" ? " invalid" : ""}`}>
+          {reading} Arraste sobre o gráfico, ou use as setas do teclado, para mover o marcador.
         </p>
 
         <div className="bigo-grid">
-          <div className="bigo-card" style={{ borderLeftColor: COR_BRUTA }}>
+          <div className="bigo-card" style={{ borderLeftColor: BRUTE_COLOR }}>
             <div className="bigo-card-top">
-              <span className="bigo-card-nome" style={{ color: COR_BRUTA }}>força bruta</span>
-              <span className="bigo-card-val">{num(custoBruta)}</span>
+              <span className="bigo-card-nome" style={{ color: BRUTE_COLOR }}>força bruta</span>
+              <span className="bigo-card-val">{num(bruteCost)}</span>
             </div>
             <div className="bigo-card-ex">q × m = {num(q)} × {num(m)}</div>
           </div>
-          <div className="bigo-card" style={{ borderLeftColor: COR_PREFIXO }}>
+          <div className="bigo-card" style={{ borderLeftColor: PREFIX_COLOR }}>
             <div className="bigo-card-top">
-              <span className="bigo-card-nome" style={{ color: COR_PREFIXO }}>com prefixo</span>
-              <span className="bigo-card-val">{num(custoPrefixo)}</span>
+              <span className="bigo-card-nome" style={{ color: PREFIX_COLOR }}>com prefixo</span>
+              <span className="bigo-card-val">{num(prefixCost)}</span>
             </div>
             <div className="bigo-card-ex">n + q = {num(n)} + {num(q)}</div>
           </div>
@@ -355,14 +356,19 @@ export function PrefixSumTradeoff() {
           </div>
           <div className="bigo-stat">
             <span>ponto de virada</span>
-            <strong>{num(virada)}</strong>
+            <strong>{num(turningPoint)}</strong>
           </div>
           <div className="bigo-stat">
             <span>memória extra</span>
             <strong>{num(n + 1)}</strong>
           </div>
         </div>
+      </div>
 
+      {/* Rodapé à mão porque `VizFooter` devolve `null` com `total: 1` e leva os
+          `children` junto — ver o cabeçalho deste arquivo. Fora do `.viz-body`
+          é o que deixa os dois sliders parados no pé do painel expandido. */}
+      <div className="viz-foot">
         <div className="viz-controls">
           <div className="viz-field grow">
             <span>n: array de {num(n)} posições</span>
@@ -371,36 +377,28 @@ export function PrefixSumTradeoff() {
               min={0}
               max={ARRAYS.length - 1}
               step={1}
-              value={iArray}
-              onChange={(e) => setIArray(parseInt(e.target.value, 10))}
+              value={arrayIndex}
+              onChange={(e) => setArrayIndex(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </div>
           <div className="viz-field grow">
-            <span>m: intervalo médio de {ROTULOS_FATIA[iFatia]}</span>
+            <span>m: intervalo médio de {SLICE_LABELS[sliceIndex]}</span>
             <input
               type="range"
               min={0}
-              max={FATIAS.length - 1}
+              max={SLICES.length - 1}
               step={1}
-              value={iFatia}
-              onChange={(e) => setIFatia(parseInt(e.target.value, 10))}
+              value={sliceIndex}
+              onChange={(e) => setSliceIndex(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </div>
-          <button className="viz-btn" onClick={() => { setIArray(4); setIFatia(1); setQSel(21); }}>↺ Reiniciar</button>
+          <button className="viz-btn" onClick={() => { setArrayIndex(4); setSliceIndex(1); setRawQ(21); }}>↺ Reiniciar</button>
         </div>
       </div>
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/PrefixSumVisualizer.tsx
+++ b/content/visualizers/PrefixSumVisualizer.tsx
@@ -214,6 +214,15 @@ export function PrefixSumVisualizer() {
   const s = steps[viz.step];
   const queryStart = n + 1;
 
+  // Salto ABSOLUTO, não um delta a partir de `viz.step`: dois cliques rápidos
+  // leem o mesmo passo do closure e somariam o mesmo delta duas vezes, passando
+  // direto da consulta (medido: dois cliques no mesmo quadro iam do passo 9 ao
+  // 12 de 12). `reset` é o que para o relógio, como nos outros controles.
+  const jumpToQuery = () => {
+    viz.reset();
+    viz.setStep(queryStart);
+  };
+
   const onInputChange = (v: string) => {
     const arr = v
       .split(",")
@@ -405,7 +414,7 @@ export function PrefixSumVisualizer() {
           enxerga nó de texto JSX quebrado em várias linhas, e o que ele não vê
           ele não protege. */}
       <VizFooter viz={viz}>
-        <button className="viz-btn" onClick={() => viz.stepBy(queryStart - viz.step)}>Pular para a consulta</button>
+        <button className="viz-btn" onClick={jumpToQuery}>Pular para a consulta</button>
       </VizFooter>
     </figure>
   );

--- a/content/visualizers/PrefixSumVisualizer.tsx
+++ b/content/visualizers/PrefixSumVisualizer.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // PrefixSumVisualizer, a construção da tabela de prefixos e a consulta O(1).
 //
-// Mesmo padrão do TwoPointersVisualizer: gerador PURO de passos + a mesma casca
-// (células, código sincronizado, variáveis, controles, Expandir). A história
-// tem duas fases numa linha do tempo só:
+// Gerador PURO de passos + a casca compartilhada. A história tem duas fases
+// numa linha do tempo só:
 //
 //   1. construir  -> preenche p[k + 1] = p[k] + nums[k], uma posição por passo
 //   2. consultar  -> acende p[j + 1] (entra) e p[i] (sai) e faz a subtração
@@ -16,28 +16,35 @@ import { createPortal } from "react-dom";
 // O contador de operações é o que amarra o visualizador ao artigo: a consulta
 // custa 1 subtração contra as (j - i + 1) somas da força bruta, e o painel
 // mostra os dois números ao mesmo tempo.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Fase = "construir" | "consultar";
+// Os valores das uniões (`"construir"`, `"consultar"`) ficam como estão de
+// propósito: identificador é inglês, mas trocar o LITERAL só aumentaria o ruído
+// do guarda de idioma sem ninguém ganhar nada — ele não aparece na tela.
+type Phase = "construir" | "consultar";
 
-type Passo = {
-  fase: Fase;
-  linha: number;
-  escritos: number; // quantas posições de p já foram preenchidas
-  atualNums: number | null; // índice destacado em nums
-  atualP: number | null; // índice sendo escrito em p
-  somas: number; // somas feitas no pré-processamento
-  opsConsulta: number;
-  mais: number | null; // índice de p que entra na soma
-  menos: number | null; // índice de p que sai da soma
-  resultado: number | null;
-  nota: string;
+type Step = {
+  phase: Phase;
+  line: number;
+  written: number; // quantas posições de p já foram preenchidas
+  currentNums: number | null; // índice destacado em nums
+  currentP: number | null; // índice sendo escrito em p
+  sums: number; // somas feitas no pré-processamento
+  queryOps: number;
+  plus: number | null; // índice de p que entra na soma
+  minus: number | null; // índice de p que sai da soma
+  result: number | null;
+  note: string;
   ok?: boolean;
 };
 
-// As linhas mapeiam 1:1 com os passos (campo `linha` em gerarPassos), então a
+// As linhas mapeiam 1:1 com os passos (campo `line` em generateSteps), então a
 // ordem e a quantidade de linhas não podem mudar.
-const CODIGO = [
+const CODE = [
   "class SomaDeIntervalo:",
   "    def __init__(self, nums):",
   "        self.p = [0] * (len(nums) + 1)",
@@ -48,108 +55,108 @@ const CODIGO = [
   "        return self.p[j + 1] - self.p[i]",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-const MAX_ITENS = 12;
+const MAX_ITEMS = 12;
 
-// O array do encontro, com a consulta que apareceu na tela: soma(1, 4) = 155.
+// O array de referência do tópico, com a consulta que o artigo destrincha:
+// soma(1, 4) = 155.
 const DEFAULT_NUMS = [10, 30, 20, 45, 60, 40, 50];
 
-type Preset = { rotulo: string; nums: number[]; i: number; j: number };
+type Preset = { label: string; nums: number[]; i: number; j: number };
 
 const PRESETS: Preset[] = [
-  { rotulo: "Encontro: soma(1, 4)", nums: DEFAULT_NUMS, i: 1, j: 4 },
-  { rotulo: "Miolo: soma(2, 3)", nums: DEFAULT_NUMS, i: 2, j: 3 },
-  { rotulo: "Do início: soma(0, 2)", nums: DEFAULT_NUMS, i: 0, j: 2 },
-  { rotulo: "Um elemento: soma(3, 3)", nums: DEFAULT_NUMS, i: 3, j: 3 },
-  { rotulo: "Tudo: soma(0, 6)", nums: DEFAULT_NUMS, i: 0, j: 6 },
-  { rotulo: "Com negativos", nums: [3, -2, 5, -1, 4, -6, 2], i: 1, j: 4 },
+  { label: "Encontro: soma(1, 4)", nums: DEFAULT_NUMS, i: 1, j: 4 },
+  { label: "Miolo: soma(2, 3)", nums: DEFAULT_NUMS, i: 2, j: 3 },
+  { label: "Do início: soma(0, 2)", nums: DEFAULT_NUMS, i: 0, j: 2 },
+  { label: "Um elemento: soma(3, 3)", nums: DEFAULT_NUMS, i: 3, j: 3 },
+  { label: "Tudo: soma(0, 6)", nums: DEFAULT_NUMS, i: 0, j: 6 },
+  { label: "Com negativos", nums: [3, -2, 5, -1, 4, -6, 2], i: 1, j: 4 },
 ];
 
-function prefixos(nums: number[]): number[] {
+function prefixSums(nums: number[]): number[] {
   const p: number[] = [0];
   for (let k = 0; k < nums.length; k++) p.push(p[k] + nums[k]);
   return p;
 }
 
-function gerarPassos(nums: number[], i: number, j: number): Passo[] {
+function generateSteps(nums: number[], i: number, j: number): Step[] {
   const n = nums.length;
-  const p = prefixos(nums);
-  const out: Passo[] = [];
+  const p = prefixSums(nums);
+  const out: Step[] = [];
 
   out.push({
-    fase: "construir",
-    linha: 2,
-    escritos: 1,
-    atualNums: null,
-    atualP: 0,
-    somas: 0,
-    opsConsulta: 0,
-    mais: null,
-    menos: null,
-    resultado: null,
-    nota: `Crio p com ${n + 1} posições, uma a mais que o array, e deixo p[0] = 0. Essa posição extra é a sentinela: ela guarda a soma de nada.`,
+    phase: "construir",
+    line: 2,
+    written: 1,
+    currentNums: null,
+    currentP: 0,
+    sums: 0,
+    queryOps: 0,
+    plus: null,
+    minus: null,
+    result: null,
+    note: `Crio p com ${n + 1} posições, uma a mais que o array, e deixo p[0] = 0. Essa posição extra é a sentinela: ela guarda a soma de nada.`,
   });
 
-  let guarda = 0;
-  for (let k = 0; k < n && guarda++ < 100; k++) {
+  let guard = 0;
+  for (let k = 0; k < n && guard++ < 100; k++) {
     out.push({
-      fase: "construir",
-      linha: 4,
-      escritos: k + 2,
-      atualNums: k,
-      atualP: k + 1,
-      somas: k + 1,
-      opsConsulta: 0,
-      mais: null,
-      menos: null,
-      resultado: null,
-      nota: `p[${k + 1}] = p[${k}] + nums[${k}] = ${p[k]} + ${nums[k]} = ${p[k + 1]}. Agora sei a soma de tudo do início até a posição ${k}.`,
+      phase: "construir",
+      line: 4,
+      written: k + 2,
+      currentNums: k,
+      currentP: k + 1,
+      sums: k + 1,
+      queryOps: 0,
+      plus: null,
+      minus: null,
+      result: null,
+      note: `p[${k + 1}] = p[${k}] + nums[${k}] = ${p[k]} + ${nums[k]} = ${p[k + 1]}. Agora sei a soma de tudo do início até a posição ${k}.`,
     });
   }
 
-  const largura = j - i + 1;
+  const width = j - i + 1;
   out.push({
-    fase: "consultar",
-    linha: 6,
-    escritos: n + 1,
-    atualNums: null,
-    atualP: null,
-    somas: n,
-    opsConsulta: 0,
-    mais: null,
-    menos: null,
-    resultado: null,
-    nota: `Tabela pronta com ${n} ${n === 1 ? "soma" : "somas"}, e ela não muda mais. Agora quero soma(${i}, ${j}): na força bruta eu somaria ${largura} ${largura === 1 ? "número" : "números"} de novo.`,
+    phase: "consultar",
+    line: 6,
+    written: n + 1,
+    currentNums: null,
+    currentP: null,
+    sums: n,
+    queryOps: 0,
+    plus: null,
+    minus: null,
+    result: null,
+    note: `Tabela pronta com ${n} ${n === 1 ? "soma" : "somas"}, e ela não muda mais. Agora quero soma(${i}, ${j}): na força bruta eu somaria ${width} ${width === 1 ? "número" : "números"} de novo.`,
   });
 
   out.push({
-    fase: "consultar",
-    linha: 7,
-    escritos: n + 1,
-    atualNums: null,
-    atualP: null,
-    somas: n,
-    opsConsulta: 0,
-    mais: j + 1,
-    menos: null,
-    resultado: null,
-    nota: `p[${j + 1}] = ${p[j + 1]} é a soma de nums[0] até nums[${j}]. O fim do intervalo já está incluído aqui, é por isso que o índice é j + 1 e não j.`,
+    phase: "consultar",
+    line: 7,
+    written: n + 1,
+    currentNums: null,
+    currentP: null,
+    sums: n,
+    queryOps: 0,
+    plus: j + 1,
+    minus: null,
+    result: null,
+    note: `p[${j + 1}] = ${p[j + 1]} é a soma de nums[0] até nums[${j}]. O fim do intervalo já está incluído aqui, é por isso que o índice é j + 1 e não j.`,
   });
 
   out.push({
-    fase: "consultar",
-    linha: 7,
-    escritos: n + 1,
-    atualNums: null,
-    atualP: null,
-    somas: n,
-    opsConsulta: 0,
-    mais: j + 1,
-    menos: i,
-    resultado: null,
-    nota:
+    phase: "consultar",
+    line: 7,
+    written: n + 1,
+    currentNums: null,
+    currentP: null,
+    sums: n,
+    queryOps: 0,
+    plus: j + 1,
+    minus: i,
+    result: null,
+    note:
       i === 0
         ? "p[0] = 0: antes da posição 0 não existe nada para descontar. É exatamente para isso que a sentinela serve, sem ela eu precisaria de um if bem aqui."
         : `p[${i}] = ${p[i]} é a soma de nums[0] até nums[${i - 1}], ou seja, tudo que vem antes do intervalo. Esse é o pedaço que sobra e precisa sair.`,
@@ -157,18 +164,18 @@ function gerarPassos(nums: number[], i: number, j: number): Passo[] {
 
   const res = p[j + 1] - p[i];
   out.push({
-    fase: "consultar",
-    linha: 7,
-    escritos: n + 1,
-    atualNums: null,
-    atualP: null,
-    somas: n,
-    opsConsulta: 1,
-    mais: j + 1,
-    menos: i,
-    resultado: res,
+    phase: "consultar",
+    line: 7,
+    written: n + 1,
+    currentNums: null,
+    currentP: null,
+    sums: n,
+    queryOps: 1,
+    plus: j + 1,
+    minus: i,
+    result: res,
     ok: true,
-    nota: `${p[j + 1]} - ${p[i]} = ${res}. Duas leituras e uma subtração, e o custo seria exatamente o mesmo para um intervalo de um milhão de posições.`,
+    note: `${p[j + 1]} - ${p[i]} = ${res}. Duas leituras e uma subtração, e o custo seria exatamente o mesmo para um intervalo de um milhão de posições.`,
   });
 
   return out;
@@ -182,151 +189,114 @@ function num(v: number): string {
 
 export function PrefixSumVisualizer() {
   const [nums, setNums] = useState<number[]>(DEFAULT_NUMS);
-  const [entrada, setEntrada] = useState(DEFAULT_NUMS.join(", "));
-  const [iBruto, setIBruto] = useState(1);
-  const [jBruto, setJBruto] = useState(4);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [input, setInput] = useState(DEFAULT_NUMS.join(", "));
+  const [rawI, setRawI] = useState(1);
+  const [rawJ, setRawJ] = useState(4);
 
   const n = nums.length;
   // Os índices são presos aqui, e não no onChange, para o aluno poder digitar
   // qualquer coisa nos campos sem o visualizador entrar em estado inválido.
-  const j = Math.min(Math.max(jBruto, 0), n - 1);
-  const i = Math.min(Math.max(iBruto, 0), j);
+  const j = Math.min(Math.max(rawJ, 0), n - 1);
+  const i = Math.min(Math.max(rawI, 0), j);
 
-  const passos = useMemo(() => gerarPassos(nums, i, j), [nums, i, j]);
-  const p = useMemo(() => prefixos(nums), [nums]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const s = passos[idx];
-  const inicioConsulta = n + 1;
+  const steps = useMemo(() => generateSteps(nums, i, j), [nums, i, j]);
+  const p = useMemo(() => prefixSums(nums), [nums]);
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const viz = useVisualizer({
+    title: "Visualizador · construir a tabela e consultar em O(1)",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o tamanho do array. As duas fitas de células
+    // (nums e p, com n + 1 posições) quebram linha, e a nota fica mais longa.
+    measureOn: [n],
+  });
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((v) => (v >= total - 1 ? v : v + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+  const s = steps[viz.step];
+  const queryStart = n + 1;
 
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-
-  const aoMudarEntrada = (v: string) => {
+  const onInputChange = (v: string) => {
     const arr = v
       .split(",")
       .map((x) => parseInt(x.trim(), 10))
       .filter((x) => !isNaN(x))
-      .slice(0, MAX_ITENS);
-    reiniciar();
-    setEntrada(v);
+      .slice(0, MAX_ITEMS);
+    viz.reset();
+    setInput(v);
     setNums(arr.length ? arr : [1]);
   };
 
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setNums(pr.nums);
-    setEntrada(pr.nums.join(", "));
-    setIBruto(pr.i);
-    setJBruto(pr.j);
+    setInput(pr.nums.join(", "));
+    setRawI(pr.i);
+    setRawJ(pr.j);
   };
 
-  const sortear = () => {
-    const tam = 6 + Math.floor(Math.random() * 4);
-    const arr = Array.from({ length: tam }, () => 1 + Math.floor(Math.random() * 60));
-    const a = Math.floor(Math.random() * tam);
-    const b = Math.floor(Math.random() * tam);
-    reiniciar();
+  const shuffle = () => {
+    const size = 6 + Math.floor(Math.random() * 4);
+    const arr = Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 60));
+    const a = Math.floor(Math.random() * size);
+    const b = Math.floor(Math.random() * size);
+    viz.reset();
     setNums(arr);
-    setEntrada(arr.join(", "));
-    setIBruto(Math.min(a, b));
-    setJBruto(Math.max(a, b));
+    setInput(arr.join(", "));
+    setRawI(Math.min(a, b));
+    setRawJ(Math.max(a, b));
   };
 
   const cellsNums = nums.map((v, k) => {
     let cls = "viz-cell";
-    if (s.fase === "consultar") {
+    if (s.phase === "consultar") {
       if (k >= i && k <= j) cls += " in";
       else cls += " drop";
     }
-    if (s.atualNums === k) cls += " entra";
-    let marca = "";
-    if (s.fase === "consultar") {
-      if (k === i && k === j) marca = "i j";
-      else if (k === i) marca = "i";
-      else if (k === j) marca = "j";
-    } else if (s.atualNums === k) {
-      marca = "k";
+    if (s.currentNums === k) cls += " entra";
+    let mark = "";
+    if (s.phase === "consultar") {
+      if (k === i && k === j) mark = "i j";
+      else if (k === i) mark = "i";
+      else if (k === j) mark = "j";
+    } else if (s.currentNums === k) {
+      mark = "k";
     }
-    return { k, v, cls, marca };
+    return { k, v, cls, mark };
   });
 
   const cellsP = p.map((v, k) => {
     let cls = "viz-cell";
-    if (k >= s.escritos) cls += " drop";
-    if (s.atualP === k) cls += " in entra";
-    if (s.mais === k) cls += " in entra";
-    if (s.menos === k) cls += " sai";
-    let marca = "";
-    if (s.mais === k) marca = "+";
-    else if (s.menos === k) marca = "-";
-    else if (s.atualP === k) marca = "p";
-    return { k, v: k >= s.escritos ? 0 : v, cls, marca };
+    if (k >= s.written) cls += " drop";
+    if (s.currentP === k) cls += " in entra";
+    if (s.plus === k) cls += " in entra";
+    if (s.minus === k) cls += " sai";
+    let mark = "";
+    if (s.plus === k) mark = "+";
+    else if (s.minus === k) mark = "-";
+    else if (s.currentP === k) mark = "p";
+    return { k, v: k >= s.written ? 0 : v, cls, mark };
   });
 
-  const largura = j - i + 1;
+  const width = j - i + 1;
 
-  const variaveis = [
-    { nome: "i", valor: `${i}` },
-    { nome: "j", valor: `${j}` },
-    { nome: `p[${j + 1}]`, valor: s.mais == null ? "-" : `${p[j + 1]}` },
-    { nome: `p[${i}]`, valor: s.menos == null ? "-" : `${p[i]}` },
-    { nome: "soma", valor: s.resultado == null ? "-" : `${s.resultado}`, best: true },
+  const vars = [
+    { name: "i", value: `${i}` },
+    { name: "j", value: `${j}` },
+    { name: `p[${j + 1}]`, value: s.plus == null ? "-" : `${p[j + 1]}` },
+    { name: `p[${i}]`, value: s.minus == null ? "-" : `${p[i]}` },
+    { name: "soma", value: s.result == null ? "-" : `${s.result}`, best: true },
   ];
 
-  const notaCls = "viz-note" + (s.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (s.ok ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · construir a tabela e consultar em O(1)</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.rotulo} className="bigo-chip" onClick={() => aplicarPreset(pr)}>
-              {pr.rotulo}
+            <button key={pr.label} className="bigo-chip" onClick={() => applyPreset(pr)}>
+              {pr.label}
             </button>
           ))}
         </div>
@@ -334,15 +304,15 @@ export function PrefixSumVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Array (nums)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>i</span>
             <input
               className="viz-input k"
               type="number"
-              value={iBruto}
-              onChange={(e) => { reiniciar(); setIBruto(parseInt(e.target.value, 10) || 0); }}
+              value={rawI}
+              onChange={(e) => { viz.reset(); setRawI(parseInt(e.target.value, 10) || 0); }}
             />
           </label>
           <label className="viz-field">
@@ -350,11 +320,11 @@ export function PrefixSumVisualizer() {
             <input
               className="viz-input k"
               type="number"
-              value={jBruto}
-              onChange={(e) => { reiniciar(); setJBruto(parseInt(e.target.value, 10) || 0); }}
+              value={rawJ}
+              onChange={(e) => { viz.reset(); setRawJ(parseInt(e.target.value, 10) || 0); }}
             />
           </label>
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="viz-vars-head">nums, o array de entrada</div>
@@ -363,7 +333,7 @@ export function PrefixSumVisualizer() {
             <div className="viz-cell-wrap" key={c.k}>
               <span className="viz-cell-idx">{c.k}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
@@ -374,7 +344,7 @@ export function PrefixSumVisualizer() {
             <div className="viz-cell-wrap" key={c.k}>
               <span className="viz-cell-idx">{c.k}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
@@ -382,15 +352,15 @@ export function PrefixSumVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>somas no pré-processamento</span>
-            <strong>{num(s.somas)}</strong>
+            <strong>{num(s.sums)}</strong>
           </div>
           <div className="bigo-stat">
             <span>operações desta consulta</span>
-            <strong style={{ color: "var(--ccc-green)" }}>{num(s.opsConsulta)}</strong>
+            <strong style={{ color: "var(--ccc-green)" }}>{num(s.queryOps)}</strong>
           </div>
           <div className="bigo-stat">
             <span>a mesma consulta na força bruta</span>
-            <strong style={{ color: "#fbbf24" }}>{num(largura)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{num(width)}</strong>
           </div>
           <div className="bigo-stat">
             <span>n (tamanho do array)</span>
@@ -398,57 +368,47 @@ export function PrefixSumVisualizer() {
           </div>
         </div>
 
-        <p className={notaCls}>{s.nota}</p>
+        <p className={noteClass}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">soma_de_intervalo.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === s.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">soma_de_intervalo.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === s.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <button className="viz-btn" onClick={() => { parar(); setTocando(false); setPasso(inicioConsulta); }}>Pular para a consulta</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      {/* O rótulo fica numa linha só de propósito: o guarda de idioma não
+          enxerga nó de texto JSX quebrado em várias linhas, e o que ele não vê
+          ele não protege. */}
+      <VizFooter viz={viz}>
+        <button className="viz-btn" onClick={() => viz.stepBy(queryStart - viz.step)}>Pular para a consulta</button>
+      </VizFooter>
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/tests/viz-prefix-sum.spec.ts
+++ b/tests/viz-prefix-sum.spec.ts
@@ -232,6 +232,39 @@ test("no expandido, seta e espaço andam a animação e não roubam a tecla de q
   await expect(page.locator(".viz-overlay")).toHaveCount(0);
 });
 
+test("o Pular para a consulta cai no mesmo passo por mais que se clique", async ({ page }) => {
+  // A tecla e o clique rápido repetem mais depressa do que o React re-renderiza:
+  // um salto escrito como delta a partir do passo atual soma o mesmo delta duas
+  // vezes e passa direto. Medido antes do conserto: dois cliques no mesmo quadro
+  // levavam do passo 9 ao 12 de 12, e o aluno via o resultado em vez da conta.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const botao = peca.getByRole("button", { name: "Pular para a consulta" });
+
+  // A ORDEM aqui é o teste. Os dois cliques precisam sair do passo 1: com a
+  // peça já na consulta o delta vale zero e a versão quebrada passaria verde —
+  // aconteceu, e o defeito era o experimento, não a asserção.
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 12");
+  await peca.evaluate((f) => {
+    const b = [...f.querySelectorAll("button")].find((x) =>
+      /Pular para a consulta/.test(x.textContent ?? "")
+    ) as HTMLButtonElement;
+    b.click();
+    b.click();
+  });
+  await expect(peca.locator(".viz-step")).toHaveText("passo 9 de 12");
+  // O rótulo do passo e a nota contam a mesma coisa: é o começo da consulta,
+  // não o resultado dela.
+  await expect(peca.locator(".viz-note")).toContainText("Tabela pronta com 7 somas");
+
+  // E clicar de novo, já lá, continua no mesmo lugar.
+  await botao.click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 9 de 12");
+  await expect(peca.locator(".viz-note")).toContainText("Tabela pronta com 7 somas");
+});
+
 test("o trade-off não promete esconder bloco nenhum, e os controles ficam parados", async ({
   page,
 }) => {

--- a/tests/viz-prefix-sum.spec.ts
+++ b/tests/viz-prefix-sum.spec.ts
@@ -1,0 +1,316 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa dos três visualizadores de prefix-sum.
+//
+// A página tem três peças, nesta ordem:
+//   0 · PrefixSumVisualizer — construir a tabela e consultar em O(1)
+//   1 · PrefixSumTradeoff   — o canto fora do padrão: `total: 1` e
+//                             `collapsible: false` (sem passos, sem bloco)
+//   2 · PrefixSumGrade2D    — soma de um retângulo em 4 leituras
+//
+// Todo teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada, e comportamento certo debaixo do rótulo errado ensina errado do mesmo
+// jeito — por isso os cartões do trade-off são lidos com nome e valor juntos,
+// no mesmo cartão.
+
+const URL = "/topico/prefix-sum/";
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+/** Congela a animação e espera as fontes: medir antes disso mede o fallback. */
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Abre o painel expandido da peça `i` e devolve o `<figure>` do painel. */
+async function expandir(page: Page, i: number) {
+  await page.goto(URL);
+  await preparar(page);
+  await page.locator("article figure.viz").nth(i).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+/** Orçamento de altura do fluxo do artigo: janela menos cabeçalho e respiro. */
+function orcamento(page: Page) {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+        60) -
+      24
+  );
+}
+
+/**
+ * Altura que parou de mudar. O `data-anim` do hook congela a transição da
+ * MEDIÇÃO dele, e não a do clique do aluno: ler no meio dos 0,32s devolve o
+ * layout a caminho e conclui "cabe" para uma peça que não cabe.
+ */
+async function alturaEstavel(alvo: Locator) {
+  let anterior = -1;
+  for (let k = 0; k < 40; k++) {
+    const h = await alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    if (h === anterior) return h;
+    anterior = h;
+    await alvo.page().waitForTimeout(60);
+  }
+  return anterior;
+}
+
+/** Rola o miolo até o fim e diz quanto o cabeçalho e o rodapé se mexeram. */
+async function rolarAteOFim(painel: Locator) {
+  return painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const foot = f.querySelector<HTMLElement>(".viz-foot")!;
+    const headAntes = Math.round(head.getBoundingClientRect().top);
+    const footAntes = Math.round(foot.getBoundingClientRect().top);
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return {
+      sobra,
+      rolou: Math.round(body.scrollTop),
+      headMoveu: Math.round(head.getBoundingClientRect().top) - headAntes,
+      footMoveu: Math.round(foot.getBoundingClientRect().top) - footAntes,
+    };
+  });
+}
+
+test("no expandido do construtor, o ▶ Rodar fica parado enquanto o miolo rola", async ({ page }) => {
+  // 1440x600: medido, o miolo do construtor sobra 91px. Antes da casca o `.viz`
+  // inteiro rolava e a linha de controles era desenhada 387px ABAIXO do pé da
+  // peça — o aluno perdia de vista justamente o botão que faz o algoritmo andar.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 0);
+
+  const r = await rolarAteOFim(painel);
+  // Sem sobra o teste não testaria nada: ele precisa de miolo para rolar.
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // E o botão continua LEGÍVEL, com o rótulo dele, depois de rolar até o fim.
+  const rodar = painel.getByRole("button", { name: "▶ Rodar" });
+  await expect(rodar).toBeInViewport();
+  await expect(painel.getByText("Visualizador · construir a tabela e consultar em O(1)")).toBeInViewport();
+});
+
+test("no expandido do prefixo 2D, o Próximo › anda o passo depois da rolagem", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 2);
+
+  await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 6");
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // O contador vive no cabeçalho e o botão no rodapé: se qualquer um dos dois
+  // tivesse ido junto com a rolagem, este passo a passo seria impossível de
+  // acompanhar. Clico no botão que ficou à vista e leio o contador que ficou.
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeInViewport();
+  await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 6");
+  // O passo 2 é o do retângulo grande: o rótulo e o número contam a mesma coisa.
+  await expect(painel.locator(".viz-note")).toContainText("Peguei demais de propósito");
+});
+
+test("em 1512x900 o código do construtor vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const codigo = peca.locator(".viz-code");
+
+  // O rótulo diz o que o botão FAZ, e o bloco está mesmo sem altura (2px de
+  // borda). Rótulo sem medida, ou medida sem rótulo, deixaria passar o caso em
+  // que o botão promete uma coisa e a peça faz outra.
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // A premissa medida, dentro do teste: com o código à mostra a peça NÃO cabe
+  // no orçamento da janela. Sem isto o teste ficaria verde no dia em que o
+  // recolhimento fosse decidido por engano.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em janela alta o código do construtor já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra a peça pede 1005px. Em 1300px de janela o
+  // orçamento é 1216px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1300 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  // E o código é o deste visualizador, não um bloco qualquer.
+  await expect(peca.locator(".viz-code-head")).toHaveText("soma_de_intervalo.py");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+});
+
+test("a escolha de mostrar o código sobrevive à troca do array", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // Trocar o array muda o `measureOn` do hook e pede medição nova.
+  await peca.locator("input.viz-input").first().fill("1, 2, 3, 4, 5, 6, 7, 8, 9, 10");
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 15");
+
+  // Premissa medida: neste estado, com o código à mostra, a peça estoura o
+  // orçamento — ou seja, uma medição sem a escolha do aluno recolheria. Sem
+  // esta asserção o teste passaria mesmo se o estado escolhido coubesse.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+
+  // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+});
+
+test("no expandido, seta e espaço andam a animação e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 0);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 12");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 12");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 12");
+
+  // Espaço roda e pausa, e o rótulo do botão diz em qual dos dois estados está.
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Com o cursor num campo, espaço é espaço e seta é cursor. Sequestrar isso
+  // deixaria o array impossível de editar, que é pior que não ter atalho.
+  const campo = painel.locator("input.viz-input").first();
+  await campo.fill("10, 20, 30");
+  await expect(passo).toHaveText("passo 1 de 8");
+
+  await campo.press("Space");
+  await expect(campo).toHaveValue("10, 20, 30 ");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // `fill` deixa o cursor no fim sem depender de `End`, que no macOS não leva o
+  // cursor ao fim de um input. Comparo o cursor com ele mesmo.
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(passo).toHaveText("passo 1 de 8");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+test("o trade-off não promete esconder bloco nenhum, e os controles ficam parados", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 1);
+
+  // Sem bloco dispensável não existe botão de recolher: `collapsible: true`
+  // aqui renderizaria "Ocultar código" sobre nada.
+  await expect(painel.getByRole("button", { name: /código/ })).toHaveCount(0);
+  // Sem linha do tempo, o cabeçalho mostra o q e não um "passo N de M".
+  await expect(painel.locator(".viz-step")).toHaveText("q = 21");
+  await expect(painel.locator(".viz-progress")).toHaveCount(0);
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // O `click()` do Playwright ROLA o contêiner para alcançar o alvo, então
+  // clicar num botão nunca prova que ele estava à vista. Volto o miolo ao topo
+  // e exijo que ele CONTINUE em 0 depois do clique: alcançável não é à vista.
+  const miolo = painel.locator(".viz-body");
+  await miolo.evaluate((el) => { el.scrollTop = 0; });
+  await painel.getByRole("button", { name: "Muitas consultas" }).click();
+  await expect(painel.locator(".viz-step")).toHaveText("q = 100");
+  await expect(miolo).toHaveJSProperty("scrollTop", 0);
+
+  const reiniciar = painel.getByRole("button", { name: "↺ Reiniciar" });
+  await expect(reiniciar).toBeInViewport();
+  await reiniciar.click();
+  await expect(painel.locator(".viz-step")).toHaveText("q = 21");
+  await expect(miolo).toHaveJSProperty("scrollTop", 0);
+
+  // O painel não sequestra as setas: sem linha do tempo elas são do slider do
+  // gráfico, que é quem tem role="slider" aqui.
+  const grafico = painel.locator("canvas.bigo-canvas");
+  await grafico.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(painel.locator(".viz-step")).toHaveText("q = 23");
+  await expect(grafico).toHaveAttribute("aria-valuenow", "23");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+test("no trade-off, cada cartão mostra o valor do rótulo que ele carrega", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  /** O cartão que leva ESTE nome. Ler o número sem o nome não prova nada. */
+  const cartao = (nome: string) =>
+    peca.locator(".bigo-card", { has: page.getByText(nome, { exact: true }) });
+
+  // n = 1.000, m = 5% = 50, virada em 21. No q inicial (21) o prefixo já ganha.
+  await expect(peca.locator(".viz-step")).toHaveText("q = 21");
+  await expect(cartao("força bruta").locator(".bigo-card-val")).toHaveText("1.050");
+  await expect(cartao("força bruta").locator(".bigo-card-ex")).toHaveText("q × m = 21 × 50");
+  await expect(cartao("com prefixo").locator(".bigo-card-val")).toHaveText("1.021");
+  await expect(cartao("com prefixo").locator(".bigo-card-ex")).toHaveText("n + q = 1.000 + 21");
+
+  // Uma consulta só: a força bruta ganha, e o texto diz isso com esse número.
+  await peca.getByRole("button", { name: "Uma consulta só" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("q = 1");
+  await expect(cartao("força bruta").locator(".bigo-card-val")).toHaveText("50");
+  await expect(cartao("força bruta").locator(".bigo-card-ex")).toHaveText("q × m = 1 × 50");
+  await expect(cartao("com prefixo").locator(".bigo-card-val")).toHaveText("1.001");
+  await expect(peca.locator(".viz-note")).toContainText(
+    "a força bruta ainda ganha: 50 operações contra 1.001 do prefixo"
+  );
+
+  // Muitas consultas: o prefixo ganha, e a razão é a dos dois números acima.
+  await peca.getByRole("button", { name: "Muitas consultas" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("q = 100");
+  await expect(cartao("força bruta").locator(".bigo-card-val")).toHaveText("5.000");
+  await expect(cartao("com prefixo").locator(".bigo-card-val")).toHaveText("1.100");
+  await expect(peca.locator(".viz-note")).toContainText(
+    "1.100 operações contra 5.000 da força bruta, 4,5 vezes menos"
+  );
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos **três** visualizadores de
`prefix-sum`, com a mecânica vindo do `useVisualizer` — adaptar aqui foi
majoritariamente **remover** código, não acrescentar.

## Inventário: 3 visualizadores, 3 adaptados, 0 fora

| arquivo | overlay | código | variáveis | o que ganhou |
|---|---|---|---|---|
| `PrefixSumVisualizer.tsx` | sim | sim | sim | as três camadas |
| `PrefixSumGrade2D.tsx` | sim | sim | sim | as três camadas |
| `PrefixSumTradeoff.tsx` | sim | **não** | **não** | camadas 1 e 2 (`collapsible: false`, `total: 1`) |

Nenhum ficou de fora.

## Medições

Janela de 1512x900 (a régua do contrato), painel expandido aberto, animação
congelada e depois de `document.fonts.ready`. "Cabeçalho sobe" é quanto o
`.viz-head` se move quando o aluno rola até o fim; "controles" é onde a linha de
reprodução é desenhada em relação ao pé visível da peça.

| peça | | antes | depois |
|---|---|---|---|
| **construtor** | no artigo | 995px / 816 de orçamento | **786px** |
| | sobra do miolo no expandido | 122px (rolava a peça INTEIRA) | 0px |
| | cabeçalho sobe ao rolar | −122px | **0px** |
| | `▶ Rodar` | **87px ABAIXO do pé** | 35px acima |
| **prefixo 2D** | no artigo | 1113px / 816 | **776px** |
| | sobra do miolo no expandido | 273px (peça inteira) | 0px |
| | cabeçalho sobe ao rolar | −273px | **0px** |
| | `Próximo ›` | **238px ABAIXO do pé** | 35px acima |
| **trade-off** | no artigo | 731px / 816 — **já cabia** | 741px, ainda com 75px de folga |
| | sobra do miolo no expandido | 0px | 0px |

O trade-off **não tinha problema de altura na régua do contrato**, e este PR não
inventa um. O defeito dele era outro, e só aparece abaixo de 900px:

| janela | | antes | depois |
|---|---|---|---|
| 1440x700 | cabeçalho sobe ao rolar até o fim | −154px | **0px** |
| | onde o `↺ Reiniciar` era desenhado | **135px ABAIXO do pé** | 19px acima |
| 1440x600 | cabeçalho sobe / rodapé fora | −254px / 235px | **0px** / dentro |

E as outras duas peças abaixo de 900px, com a casca: em 1440x600 o miolo do
construtor sobra 91px e o do prefixo 2D 121px, rolando **sozinhos**, com o
cabeçalho e o rodapé parados.

### A camada 3 é decidida por medição, não por breakpoint

| peça | altura com o código à mostra | recolhe em 1512x900? |
|---|---|---|
| construtor | 1005px | sim (orçamento 816). Em 1512x1300 já vem **aberto** |
| prefixo 2D | 1123px | sim, e continua recolhendo em 1512x1100 (orçamento 1016) |
| trade-off | — | `collapsible: false`: não há bloco dispensável |

No expandido de 1512x900, com o código aberto o miolo estourava 33px no
construtor e 197px no prefixo 2D.

### Limite conhecido, medido e não resolvido

Abaixo de ~700px de altura de janela, nenhuma das três peças cabe no **fluxo do
artigo** nem com o código recolhido (786px e 776px contra 616px de orçamento em
1440x700). A casca já jogou a última carta que tem ali; o resto é o expandido,
que agora funciona. Registrado, não escondido.

## Idioma

Identificadores traduzidos para inglês no mesmo PR (contrato §0). Os **valores**
das uniões de string ficaram como estão — `"mais"` e `"menos"` do prefixo 2D são
nomes de classe do `globals.css` compartilhado, não identificadores do
componente. `scripts/guarda-idioma.py` acusa só nome de import, classe de CSS e
rótulo de botão que migrou para `VizHeader`/`VizFooter`: **nenhum texto de tela
mudou**, nos três arquivos.

## Provas de quebra

Oito testes novos em `tests/viz-prefix-sum.spec.ts` (arquivo novo, zero conflito
com as adaptações que rodam em paralelo). Cada um reprovou contra o código
quebrado, com o build **visível**, quebra que **compila**, `assert` no alvo
antes de substituir e restauração por `cp`:

| quebra | teste que reprovou |
|---|---|
| A: `VizFooter` do construtor volta para dentro do miolo | o `▶ Rodar` fica parado |
| B: `.viz-code-slot` deixa de ser o slot | vem recolhido |
| C: `manualChoice.current = null` no hook | sobrevive à troca do array |
| D: rodapé do trade-off volta para dentro do miolo | os controles ficam parados |
| E: os dois cartões trocam de valor | o valor do rótulo que ele carrega |
| F: `stepBy(0)` na seta do hook | não roubam a tecla |
| G: `VizFooter` do prefixo 2D volta para dentro do miolo | o `Próximo ›` anda o passo |

`npm run test:build`: **98 passed**.

## Achado para um PR de plataforma (não feito aqui)

`VizFooter` devolve `null` quando `total <= 1` e **descarta os `children` em
silêncio**. O trade-off cai exatamente aí: seguir a tabela §6 ao pé da letra faz
os dois sliders e o `↺ Reiniciar` sumirem da tela, sem erro, sem aviso do `tsc`.
O contorno aqui foi escrever o rodapé à mão com `.viz-foot` + `.viz-controls`,
que é API de CSS pública (§4). O conserto de verdade é em
`src/lib/visualizer.tsx`, e mexer nele com várias adaptações em paralelo saindo
do mesmo `origin/main` criaria conflito para todo mundo.

Nenhum arquivo compartilhado foi tocado: nem o bloco `viz-fit` do
`globals.css` (nenhum CSS novo foi preciso), nem `content/roadmap.ts`, nem
`mdx-components.tsx`, nem `tests/navegacao.spec.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEdnPeF2dmxUHMUyW84scB
