### PR TITLE
feat(intervals): casca adaptativa nos três visualizadores

### DIFF
--- a/content/topics/intervals.mdx
+++ b/content/topics/intervals.mdx
@@ -213,7 +213,7 @@ Dois detalhes do código que decidem casos de teste inteiros:
 - A fase 1 testa `intervalos[i][1] < inicio` com **`<` estrito**, e isso é proposital. Um intervalo que termina exatamente onde o novo começa, como `[1, 7]` contra o novo `[7, 13]`, **não** sai copiado: ele reprova na fase 1, cai na fase 2 e é fundido, que é o que o LeetCode 57 espera. Trocar aquele `<` por `<=` devolveria `[[1, 7], [7, 13]]` em vez de `[[1, 13]]`.
 - O `min` do início só muda alguma coisa na **primeira** absorção. Como a lista chega ordenada e sem sobreposição, do segundo engolido em diante todo mundo começa depois do que o novo já cobre, e o `min` devolve o valor que já estava lá. O `max` do fim, ao contrário, pode mudar em qualquer uma das absorções, e foi o que aconteceu com `[12, 16]`. Mantenha os dois no laço mesmo assim: o `min` não custa nada e é ele que salva o caso em que a fase 2 abre com um intervalo que nasceu antes do novo.
 
-<IntervalsVisualizer modo="insert" />
+<IntervalsVisualizer mode="insert" />
 
 Troque entre os cenários e observe o painel: a estatística **ordenações** fica em zero o tempo todo, e o total de comparações nunca passa de `n + 1` (só o intervalo que reprova na fase 1 é testado duas vezes). É a diferença entre O(n) e O(n log n) aparecendo na tela. Vale rodar mais dois cenários: **Não toca ninguém** (`[4, 5]`, o único que exercita as três fases de verdade) e **Engole tudo** (`[0, 20]`, que absorve a lista inteira e devolve um intervalo só).
 
@@ -318,7 +318,7 @@ def maximo_sem_conflito(intervalos):
 
 Na agenda do começo, esse guloso fica com `[1, 4] [8, 10] [13, 16] [17, 18]`, ou seja, **4 dos 6 compromissos**, e descarta 2. E esse número 2 é exatamente a resposta do LeetCode 435, que pergunta quantos intervalos remover para não sobrar sobreposição: é sempre `n` menos o máximo que cabe.
 
-<IntervalsVisualizer modo="greedy" />
+<IntervalsVisualizer mode="greedy" />
 
 Compare os cenários **Caso base** e **Pelo início falharia** lado a lado. No segundo, a lista já está desenhada de propósito para punir quem ordena pelo início. E rode também o **Cadeia perfeita** (`[1,3] [3,5] [5,7] [7,9]`): os quatro cabem, porque `inicio >= fim_anterior` aceita encostar. Se o seu problema disser que encostar já é conflito, o `>=` vira `>` e a resposta cai. O cenário **Todos em cima** (`[1,5] [2,6] [3,7] [4,8]`) é o extremo oposto: como todo mundo se atropela, sobra 1 escolhido e 3 descartados, e o painel mostra os dois números.
 

--- a/content/visualizers/IntervalsLinhaDoTempo.tsx
+++ b/content/visualizers/IntervalsLinhaDoTempo.tsx
@@ -10,30 +10,35 @@
 //
 // Tudo aqui é determinístico (nada de Intl, Date ou Math.random no caminho de
 // render) para o HTML do build bater com o do cliente na hidratação.
+//
+// Identificadores em inglês, tela em português (contrato §0): o `state` de uma
+// barra vira classe de CSS (`.iv-bar.espera`, `.iv-bar.atual`...), então os
+// VALORES continuam em português — eles são a API do `globals.css`, não texto.
 // ---------------------------------------------------------------------------
 
-export type Intervalo = [number, number];
+export type Interval = [number, number];
 
-export type BarraTL = {
-  chave: string;
-  inicio: number;
-  fim: number;
-  classe: string;
-  texto?: string;
+export type TimelineBar = {
+  id: string;
+  start: number;
+  end: number;
+  /** Estado visual da barra. Vira classe de CSS: espera, atual, usado, novo... */
+  state: string;
+  label?: string;
 };
 
-export type LinhaTL = {
-  chave: string;
-  rotulo: string;
-  barras: BarraTL[];
+export type TimelineRow = {
+  id: string;
+  label: string;
+  bars: TimelineBar[];
 };
 
 /** Arredonda um passo de eixo para 1, 2, 5 ou 10 vezes uma potência de 10. */
-function passoBonito(bruto: number): number {
-  const alvo = Math.max(1, bruto);
-  const expo = Math.floor(Math.log10(alvo));
+function niceStep(raw: number): number {
+  const target = Math.max(1, raw);
+  const expo = Math.floor(Math.log10(target));
   const base = Math.pow(10, expo);
-  const n = alvo / base;
+  const n = target / base;
   const m = n <= 1 ? 1 : n <= 2 ? 2 : n <= 5 ? 5 : 10;
   return Math.max(1, Math.round(m * base));
 }
@@ -43,24 +48,24 @@ function passoBonito(bruto: number): number {
  * próxima marca redonda dos dois lados. Assim todo rótulo do eixo é um número
  * inteiro e bonito, e as barras nunca encostam na borda do quadro.
  */
-export function eixoDe(valores: number[], alvo = 6): { min: number; max: number; marcas: number[] } {
-  const vs = valores.filter((v) => Number.isFinite(v));
-  const bruMin = vs.length ? Math.min(...vs) : 0;
-  const bruMax = vs.length ? Math.max(...vs) : 10;
-  const p = passoBonito(Math.max(1, bruMax - bruMin) / alvo);
-  const min = Math.floor(bruMin / p) * p;
-  let max = Math.ceil(bruMax / p) * p;
-  if (max <= min) max = min + p;
-  const marcas: number[] = [];
-  for (let t = min; t <= max + 1e-9 && marcas.length < 40; t += p) marcas.push(Math.round(t));
-  return { min, max, marcas };
+export function axisFor(values: number[], target = 6): { min: number; max: number; ticks: number[] } {
+  const vs = values.filter((v) => Number.isFinite(v));
+  const rawMin = vs.length ? Math.min(...vs) : 0;
+  const rawMax = vs.length ? Math.max(...vs) : 10;
+  const step = niceStep(Math.max(1, rawMax - rawMin) / target);
+  const min = Math.floor(rawMin / step) * step;
+  let max = Math.ceil(rawMax / step) * step;
+  if (max <= min) max = min + step;
+  const ticks: number[] = [];
+  for (let t = min; t <= max + 1e-9 && ticks.length < 40; t += step) ticks.push(Math.round(t));
+  return { min, max, ticks };
 }
 
-export function fmtIv(iv: Intervalo | null): string {
+export function fmtIv(iv: Interval | null): string {
   return iv ? `[${iv[0]}, ${iv[1]}]` : "-";
 }
 
-export function fmtLista(ivs: Intervalo[]): string {
+export function fmtList(ivs: Interval[]): string {
   return ivs.length ? ivs.map(fmtIv).join(" ") : "vazia";
 }
 
@@ -70,10 +75,10 @@ export function fmtLista(ivs: Intervalo[]): string {
  * enunciado do LeetCode) funcionam. Só números não negativos: em `1-4` o hífen
  * é separador, não sinal.
  */
-export function lerIntervalos(texto: string, limite = 10): Intervalo[] {
-  const nums = (texto.match(/\d+/g) ?? []).map((x) => parseInt(x, 10));
-  const out: Intervalo[] = [];
-  for (let i = 0; i + 1 < nums.length && out.length < limite; i += 2) {
+export function parseIntervals(text: string, limit = 10): Interval[] {
+  const nums = (text.match(/\d+/g) ?? []).map((x) => parseInt(x, 10));
+  const out: Interval[] = [];
+  for (let i = 0; i + 1 < nums.length && out.length < limit; i += 2) {
     const a = nums[i];
     const b = nums[i + 1];
     out.push(a <= b ? [a, b] : [b, a]);
@@ -81,54 +86,54 @@ export function lerIntervalos(texto: string, limite = 10): Intervalo[] {
   return out;
 }
 
-export function escreverIntervalos(ivs: Intervalo[]): string {
+export function writeIntervals(ivs: Interval[]): string {
   return ivs.map((iv) => `[${iv[0]},${iv[1]}]`).join(", ");
 }
 
 type Props = {
-  linhas: LinhaTL[];
+  rows: TimelineRow[];
   min: number;
   max: number;
-  marcas: number[];
-  guia?: number | null;
-  guiaVerde?: boolean;
-  rotuloEixo?: string;
+  ticks: number[];
+  guide?: number | null;
+  guideGreen?: boolean;
+  axisLabel?: string;
 };
 
 export function LinhaDoTempo({
-  linhas,
+  rows,
   min,
   max,
-  marcas,
-  guia = null,
-  guiaVerde = false,
-  rotuloEixo = "tempo →",
+  ticks,
+  guide = null,
+  guideGreen = false,
+  axisLabel = "tempo →",
 }: Props) {
   const span = Math.max(1, max - min);
   const pct = (v: number) => Math.min(100, Math.max(0, ((v - min) / span) * 100));
-  const guiaPct = guia == null ? null : pct(guia);
+  const guidePct = guide == null ? null : pct(guide);
 
   return (
     <div className="iv-tl">
       <div className="iv-tl-in">
-        {linhas.map((l) => (
-          <div className="iv-linha" key={l.chave}>
-            <span className="iv-rot" title={l.rotulo}>{l.rotulo}</span>
+        {rows.map((row) => (
+          <div className="iv-linha" key={row.id}>
+            <span className="iv-rot" title={row.label}>{row.label}</span>
             <div className="iv-trilha">
-              {guiaPct == null ? null : (
-                <span className={`iv-guia${guiaVerde ? " verde" : ""}`} style={{ left: `${guiaPct}%` }} />
+              {guidePct == null ? null : (
+                <span className={`iv-guia${guideGreen ? " verde" : ""}`} style={{ left: `${guidePct}%` }} />
               )}
-              {l.barras.map((b) => {
-                const e = pct(b.inicio);
-                const larg = Math.max(0, pct(b.fim) - e);
+              {row.bars.map((b) => {
+                const left = pct(b.start);
+                const width = Math.max(0, pct(b.end) - left);
                 return (
                   <span
-                    key={b.chave}
-                    className={`iv-bar ${b.classe}`}
-                    style={{ left: `${e}%`, width: `${larg}%` }}
-                    title={`de ${b.inicio} a ${b.fim}`}
+                    key={b.id}
+                    className={`iv-bar ${b.state}`}
+                    style={{ left: `${left}%`, width: `${width}%` }}
+                    title={`de ${b.start} a ${b.end}`}
                   >
-                    {b.texto && larg >= 13 ? b.texto : ""}
+                    {b.label && width >= 13 ? b.label : ""}
                   </span>
                 );
               })}
@@ -136,9 +141,9 @@ export function LinhaDoTempo({
           </div>
         ))}
         <div className="iv-eixo">
-          <span className="iv-rot">{rotuloEixo}</span>
+          <span className="iv-rot">{axisLabel}</span>
           <div className="iv-eixo-trilha">
-            {marcas.map((t) => (
+            {ticks.map((t) => (
               <span className="iv-tick" key={t} style={{ left: `${pct(t)}%` }}>{t}</span>
             ))}
           </div>

--- a/content/visualizers/IntervalsSobreposicaoVisualizer.tsx
+++ b/content/visualizers/IntervalsSobreposicaoVisualizer.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import { LinhaDoTempo, eixoDe, fmtIv } from "./IntervalsLinhaDoTempo";
-import type { Intervalo, LinhaTL } from "./IntervalsLinhaDoTempo";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
+import { LinhaDoTempo, axisFor, fmtIv } from "./IntervalsLinhaDoTempo";
+import type { Interval, TimelineRow } from "./IntervalsLinhaDoTempo";
 
 // ---------------------------------------------------------------------------
 // IntervalsSobreposicaoVisualizer, o laboratório da condição de sobreposição.
@@ -17,26 +19,30 @@ import type { Intervalo, LinhaTL } from "./IntervalsLinhaDoTempo";
 // O botão de bordas troca o modelo de intervalo entre fechado [inicio, fim] e
 // meio aberto [inicio, fim), que é onde mora quase todo erro de borda: em
 // [1, 3] e [3, 5], fechado diz que se tocam e meio aberto diz que não.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Vars = { nome: string; valor: string; best?: boolean }[];
+type Vars = { name: string; value: string; best?: boolean }[];
 
-type Teste = { titulo: string; corpo: string; ok: boolean };
+type Check = { title: string; body: string; ok: boolean };
 
-type Passo = {
-  linha: number;
-  b: Intervalo;
-  sobrepoe: boolean;
-  relacao: string;
-  interseccao: Intervalo | null;
-  uniao: Intervalo | null;
-  nota: string;
-  testes: Teste[];
+type Step = {
+  line: number;
+  b: Interval;
+  overlaps: boolean;
+  relation: string;
+  intersection: Interval | null;
+  union: Interval | null;
+  note: string;
+  checks: Check[];
   vars: Vars;
 };
 
-function codigoDe(fechado: boolean): string[] {
-  return fechado
+function codeFor(closed: boolean): string[] {
+  return closed
     ? [
         "def sobrepoe(a, b):",
         "    if b[0] > a[1]:",
@@ -55,249 +61,240 @@ function codigoDe(fechado: boolean): string[] {
       ];
 }
 
-function relacaoEntre(a: Intervalo, b: Intervalo, fechado: boolean): string {
-  const [aI, aF] = a;
-  const [bI, bF] = b;
-  const encosta = (t: number, onde: string) =>
-    fechado
-      ? `B encosta no ${onde} de A: o instante ${t} é o único ponto em comum`
-      : `B encosta no ${onde} de A, e com bordas [início, fim) encostar não é sobrepor`;
-  if (bI === aI && bF === aF) return "A e B são exatamente o mesmo intervalo";
-  if (bF < aI) return "B termina antes de A começar";
-  if (bF === aI) return encosta(aI, "início");
-  if (bI > aF) return "B começa depois de A terminar";
-  if (bI === aF) return encosta(aF, "fim");
-  if (bI <= aI && bF >= aF) return "B contém A inteiro";
-  if (bI >= aI && bF <= aF) return "A contém B inteiro";
-  if (bI < aI) return "B invade A pela esquerda";
+function relationBetween(a: Interval, b: Interval, closed: boolean): string {
+  const [aStart, aEnd] = a;
+  const [bStart, bEnd] = b;
+  const touches = (t: number, where: string) =>
+    closed
+      ? `B encosta no ${where} de A: o instante ${t} é o único ponto em comum`
+      : `B encosta no ${where} de A, e com bordas [início, fim) encostar não é sobrepor`;
+  if (bStart === aStart && bEnd === aEnd) return "A e B são exatamente o mesmo intervalo";
+  if (bEnd < aStart) return "B termina antes de A começar";
+  if (bEnd === aStart) return touches(aStart, "início");
+  if (bStart > aEnd) return "B começa depois de A terminar";
+  if (bStart === aEnd) return touches(aEnd, "fim");
+  if (bStart <= aStart && bEnd >= aEnd) return "B contém A inteiro";
+  if (bStart >= aStart && bEnd <= aEnd) return "A contém B inteiro";
+  if (bStart < aStart) return "B invade A pela esquerda";
   return "B invade A pela direita";
 }
 
-function gerarPassos(a: Intervalo, compB: number, fechado: boolean, bMax: number): Passo[] {
-  const [aI, aF] = a;
-  const op = fechado ? ">" : ">=";
-  const out: Passo[] = [];
+function generateSteps(a: Interval, lenB: number, closed: boolean, bMax: number): Step[] {
+  const [aStart, aEnd] = a;
+  const op = closed ? ">" : ">=";
+  const out: Step[] = [];
 
   for (let t = 0; t <= bMax; t++) {
-    const b: Intervalo = [t, t + compB];
-    const [bI, bF] = b;
-    const depois = fechado ? bI > aF : bI >= aF;
-    const antes = fechado ? aI > bF : aI >= bF;
-    const sobrepoe = !depois && !antes;
+    const b: Interval = [t, t + lenB];
+    const [bStart, bEnd] = b;
+    const after = closed ? bStart > aEnd : bStart >= aEnd;
+    const before = closed ? aStart > bEnd : aStart >= bEnd;
+    const overlaps = !after && !before;
 
-    const maiorInicio = Math.max(aI, bI);
-    const menorFim = Math.min(aF, bF);
-    const interseccao: Intervalo | null = sobrepoe ? [maiorInicio, menorFim] : null;
-    const uniao: Intervalo | null = sobrepoe ? [Math.min(aI, bI), Math.max(aF, bF)] : null;
-    const relacao = relacaoEntre(a, b, fechado);
+    const maxStart = Math.max(aStart, bStart);
+    const minEnd = Math.min(aEnd, bEnd);
+    const intersection: Interval | null = overlaps ? [maxStart, minEnd] : null;
+    const union: Interval | null = overlaps ? [Math.min(aStart, bStart), Math.max(aEnd, bEnd)] : null;
+    const relation = relationBetween(a, b, closed);
 
-    const testes: Teste[] = [
+    const checks: Check[] = [
       {
-        titulo: `b[0] ${op} a[1]`,
-        corpo: `${bI} ${op} ${aF} é ${depois ? "verdadeiro" : "falso"}: B ${depois ? "começa depois de A acabar" : "não começa depois de A acabar"}.`,
-        ok: !depois,
+        title: `b[0] ${op} a[1]`,
+        body: `${bStart} ${op} ${aEnd} é ${after ? "verdadeiro" : "falso"}: B ${after ? "começa depois de A acabar" : "não começa depois de A acabar"}.`,
+        ok: !after,
       },
       {
-        titulo: `a[0] ${op} b[1]`,
-        corpo: `${aI} ${op} ${bF} é ${antes ? "verdadeiro" : "falso"}: A ${antes ? "começa depois de B acabar" : "não começa depois de B acabar"}.`,
-        ok: !antes,
+        title: `a[0] ${op} b[1]`,
+        body: `${aStart} ${op} ${bEnd} é ${before ? "verdadeiro" : "falso"}: A ${before ? "começa depois de B acabar" : "não começa depois de B acabar"}.`,
+        ok: !before,
       },
       {
-        titulo: "[max(inícios), min(fins)]",
-        corpo: sobrepoe
-          ? `[${maiorInicio}, ${menorFim}] é a interseção, com ${menorFim - maiorInicio} de duração.`
-          : `[${maiorInicio}, ${menorFim}] tem início maior que fim, então a interseção é vazia.`,
-        ok: sobrepoe,
+        title: "[max(inícios), min(fins)]",
+        body: overlaps
+          ? `[${maxStart}, ${minEnd}] é a interseção, com ${minEnd - maxStart} de duração.`
+          : `[${maxStart}, ${minEnd}] tem início maior que fim, então a interseção é vazia.`,
+        ok: overlaps,
       },
     ];
 
-    let nota: string;
-    if (depois) {
-      nota = `B começa em ${bI} e A termina em ${aF}. Como ${bI} ${op} ${aF}, saio no primeiro teste com False: nem preciso olhar o resto.`;
-    } else if (antes) {
-      nota = `A começa em ${aI} e B termina em ${bF}. Como ${aI} ${op} ${bF}, B já tinha acabado quando A nasceu. False.`;
-    } else if (interseccao && interseccao[0] === interseccao[1]) {
-      nota = `Passei nos dois testes por um fio: A e B dividem só o instante ${interseccao[0]}, uma interseção de duração zero. Fundidos, eles viram ${fmtIv(uniao)}.`;
+    let note: string;
+    if (after) {
+      note = `B começa em ${bStart} e A termina em ${aEnd}. Como ${bStart} ${op} ${aEnd}, saio no primeiro teste com False: nem preciso olhar o resto.`;
+    } else if (before) {
+      note = `A começa em ${aStart} e B termina em ${bEnd}. Como ${aStart} ${op} ${bEnd}, B já tinha acabado quando A nasceu. False.`;
+    } else if (intersection && intersection[0] === intersection[1]) {
+      note = `Passei nos dois testes por um fio: A e B dividem só o instante ${intersection[0]}, uma interseção de duração zero. Fundidos, eles viram ${fmtIv(union)}.`;
     } else {
-      nota = `Passei nos dois testes: A e B dividem ${fmtIv(interseccao)}. Se eu fosse fundir os dois, o resultado seria ${fmtIv(uniao)}, que é [min dos inícios, max dos fins].`;
+      note = `Passei nos dois testes: A e B dividem ${fmtIv(intersection)}. Se eu fosse fundir os dois, o resultado seria ${fmtIv(union)}, que é [min dos inícios, max dos fins].`;
     }
 
     out.push({
-      linha: depois ? 2 : antes ? 4 : 5,
+      line: after ? 2 : before ? 4 : 5,
       b,
-      sobrepoe,
-      relacao,
-      interseccao,
-      uniao,
-      nota,
-      testes,
+      overlaps,
+      relation,
+      intersection,
+      union,
+      note,
+      checks,
       vars: [
-        { nome: "a", valor: fmtIv(a) },
-        { nome: "b", valor: fmtIv(b) },
-        { nome: "max(inicios)", valor: `${maiorInicio}` },
-        { nome: "min(fins)", valor: `${menorFim}` },
-        { nome: "sobrepoe", valor: sobrepoe ? "True" : "False", best: sobrepoe },
+        { name: "a", value: fmtIv(a) },
+        { name: "b", value: fmtIv(b) },
+        { name: "max(inicios)", value: `${maxStart}` },
+        { name: "min(fins)", value: `${minEnd}` },
+        { name: "sobrepoe", value: overlaps ? "True" : "False", best: overlaps },
       ],
     });
   }
   return out;
 }
 
-const VELOCIDADES = [0, 900, 620, 420, 280, 160];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// Ritmo próprio: B desliza um instante por passo, e um instante pede menos
+// tempo de leitura que uma varredura inteira de intervalos.
+const SPEEDS = [0, 900, 620, 420, 280, 160];
 
-const A_PADRAO: Intervalo = [6, 12];
-const COMP_PADRAO = 4;
-const PASSO_INICIAL = 4;
+const DEFAULT_A: Interval = [6, 12];
+const DEFAULT_LEN_B = 4;
+// A peça abre com B já invadindo A: em t = 0 os dois nem se tocam, e abrir num
+// caso sem sobreposição num visualizador sobre sobreposição ensina ao contrário.
+const INITIAL_STEP = 4;
 
 export function IntervalsSobreposicaoVisualizer() {
-  const [a0, setA0] = useState(A_PADRAO[0]);
-  const [a1, setA1] = useState(A_PADRAO[1]);
-  const [compB, setCompB] = useState(COMP_PADRAO);
-  const [fechado, setFechado] = useState(true);
-  const [passo, setPasso] = useState(PASSO_INICIAL);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [aStart, setAStart] = useState(DEFAULT_A[0]);
+  const [aEnd, setAEnd] = useState(DEFAULT_A[1]);
+  const [lenB, setLenB] = useState(DEFAULT_LEN_B);
+  const [closed, setClosed] = useState(true);
 
-  useEffect(() => setMounted(true), []);
-
-  const a = useMemo<Intervalo>(() => [Math.min(a0, a1), Math.max(a0, a1)], [a0, a1]);
+  const a = useMemo<Interval>(() => [Math.min(aStart, aEnd), Math.max(aStart, aEnd)], [aStart, aEnd]);
   // Teto de passos: sem ele, um "A termina" digitado com muitos zeros geraria
   // dezenas de milhares de passos e travaria a aba.
-  const bMax = useMemo(() => Math.min(60, Math.max(a[1] + 3, a[0] + compB + 3)), [a, compB]);
-  const passos = useMemo(() => gerarPassos(a, compB, fechado, bMax), [a, compB, fechado, bMax]);
-  const codigo = useMemo(() => codigoDe(fechado), [fechado]);
+  const bMax = useMemo(() => Math.min(60, Math.max(a[1] + 3, a[0] + lenB + 3)), [a, lenB]);
+  const steps = useMemo(() => generateSteps(a, lenB, closed, bMax), [a, lenB, closed, bMax]);
+  const code = useMemo(() => codeFor(closed), [closed]);
 
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · quando dois intervalos se sobrepõem",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que mexe na altura: o modelo de borda (troca o cabeçalho do código e o
+    // texto do veredito) e os três números da entrada, que mudam quantos passos
+    // existem e quanto texto o veredito e a nota ocupam.
+    measureOn: [closed, aStart, aEnd, lenB],
+  });
 
-  const eixo = useMemo(() => eixoDe([0, a[1] + 1, bMax + compB]), [a, bMax, compB]);
+  // Ajuste na fase de render, e não num efeito: assim ele acontece antes da
+  // pintura E dentro do build estático, e o HTML pré-renderizado já sai no
+  // passo certo em vez de piscar o passo 1 na hidratação.
+  const [placed, setPlaced] = useState(false);
+  if (!placed) {
+    setPlaced(true);
+    viz.setStep(INITIAL_STEP);
+  }
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const irPara = (t: number) => {
-    parar();
-    setTocando(false);
-    setPasso(Math.min(total - 1, Math.max(0, t)));
+  // Mexer na entrada ou escolher um cenário PAUSA a animação, como antes: se
+  // ela seguisse rodando, o instante escolhido sumiria no quadro seguinte.
+  // `stepBy(0)` é o "pausa e fica onde está", já com o passo limitado ao novo
+  // total quando a entrada encurtou a linha do tempo.
+  const pause = () => viz.stepBy(0);
+  const goTo = (t: number) => {
+    pause();
+    viz.setStep(Math.min(steps.length - 1, Math.max(0, t)));
   };
 
-  const cenarios: { nome: string; t: number }[] = [
-    { nome: "B bem antes", t: 0 },
-    { nome: "Encostando no início", t: a[0] - compB },
-    { nome: "Invadindo pela esquerda", t: a[0] - Math.ceil(compB / 2) },
-    { nome: "Dentro de A", t: Math.round((a[0] + a[1]) / 2 - compB / 2) },
-    { nome: "Encostando no fim", t: a[1] },
-    { nome: "B bem depois", t: bMax },
+  const backToDefaults = () => {
+    setAStart(DEFAULT_A[0]);
+    setAEnd(DEFAULT_A[1]);
+    setLenB(DEFAULT_LEN_B);
+    setClosed(true);
+    viz.reset();
+    viz.setStep(INITIAL_STEP);
+  };
+
+  const axis = useMemo(() => axisFor([0, a[1] + 1, bMax + lenB]), [a, bMax, lenB]);
+
+  const scenarios: { name: string; t: number }[] = [
+    { name: "B bem antes", t: 0 },
+    { name: "Encostando no início", t: a[0] - lenB },
+    { name: "Invadindo pela esquerda", t: a[0] - Math.ceil(lenB / 2) },
+    { name: "Dentro de A", t: Math.round((a[0] + a[1]) / 2 - lenB / 2) },
+    { name: "Encostando no fim", t: a[1] },
+    { name: "B bem depois", t: bMax },
   ];
 
-  const linhasTL: LinhaTL[] = [
+  const rows: TimelineRow[] = [
     {
-      chave: "a",
-      rotulo: `A = ${fmtIv(a)}`,
-      barras: [{ chave: "ba", inicio: a[0], fim: a[1], classe: "atual", texto: `${a[0]},${a[1]}` }],
+      id: "a",
+      label: `A = ${fmtIv(a)}`,
+      bars: [{ id: "ba", start: a[0], end: a[1], state: "atual", label: `${a[0]},${a[1]}` }],
     },
     {
-      chave: "b",
-      rotulo: `B = ${fmtIv(p.b)}`,
-      barras: [{ chave: "bb", inicio: p.b[0], fim: p.b[1], classe: "novo", texto: `${p.b[0]},${p.b[1]}` }],
+      id: "b",
+      label: `B = ${fmtIv(p.b)}`,
+      bars: [{ id: "bb", start: p.b[0], end: p.b[1], state: "novo", label: `${p.b[0]},${p.b[1]}` }],
     },
     {
-      chave: "inter",
-      rotulo: "interseção",
-      barras: p.interseccao
-        ? [{ chave: "bi", inicio: p.interseccao[0], fim: p.interseccao[1], classe: "bloco", texto: `${p.interseccao[0]},${p.interseccao[1]}` }]
+      id: "inter",
+      label: "interseção",
+      bars: p.intersection
+        ? [{ id: "bi", start: p.intersection[0], end: p.intersection[1], state: "bloco", label: `${p.intersection[0]},${p.intersection[1]}` }]
         : [],
     },
     {
-      chave: "uniao",
-      rotulo: "fundidos",
-      barras: p.uniao
-        ? [{ chave: "bu", inicio: p.uniao[0], fim: p.uniao[1], classe: "pronto", texto: `${p.uniao[0]},${p.uniao[1]}` }]
+      id: "uniao",
+      label: "fundidos",
+      bars: p.union
+        ? [{ id: "bu", start: p.union[0], end: p.union[1], state: "pronto", label: `${p.union[0]},${p.union[1]}` }]
         : [],
     },
   ];
 
-  const notaCls = "viz-note" + (p.sobrepoe ? " ok" : " invalid");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.overlaps ? " ok" : " invalid");
+  const color = p.overlaps ? "#34d399" : "#f87171";
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" style={{ background: p.sobrepoe ? "#34d399" : "#f87171" }} />
-          <span>Visualizador · quando dois intervalos se sobrepõem</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} color={color} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <label className="viz-field">
             <span>A começa</span>
-            <input className="viz-input k" type="number" min={0} max={40} value={a0}
-              onChange={(e) => { irPara(idx); setA0(Math.min(40, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
+            <input className="viz-input k" type="number" min={0} max={40} value={aStart}
+              onChange={(e) => { pause(); setAStart(Math.min(40, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
           </label>
           <label className="viz-field">
             <span>A termina</span>
-            <input className="viz-input k" type="number" min={0} max={40} value={a1}
-              onChange={(e) => { irPara(idx); setA1(Math.min(40, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
+            <input className="viz-input k" type="number" min={0} max={40} value={aEnd}
+              onChange={(e) => { pause(); setAEnd(Math.min(40, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
           </label>
           <label className="viz-field">
             <span>duração de B</span>
-            <input className="viz-input k" type="number" min={0} max={20} value={compB}
-              onChange={(e) => { irPara(idx); setCompB(Math.min(20, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
+            <input className="viz-input k" type="number" min={0} max={20} value={lenB}
+              onChange={(e) => { pause(); setLenB(Math.min(20, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
           </label>
-          <button className="viz-btn" onClick={() => { irPara(idx); setFechado((v) => !v); }} aria-pressed={fechado}>
-            Bordas: {fechado ? "[início, fim]" : "[início, fim)"}
+          <button className="viz-btn" onClick={() => { pause(); setClosed((v) => !v); }} aria-pressed={closed}>
+            Bordas: {closed ? "[início, fim]" : "[início, fim)"}
           </button>
         </div>
 
         <div className="iv-presets">
           <span className="iv-presets-lbl">Cenários</span>
-          {cenarios.map((c) => (
-            <button key={c.nome} className={`iv-preset${idx === Math.min(total - 1, Math.max(0, c.t)) ? " on" : ""}`} onClick={() => irPara(c.t)}>
-              {c.nome}
+          {scenarios.map((c) => (
+            <button key={c.name} className={`iv-preset${viz.step === Math.min(steps.length - 1, Math.max(0, c.t)) ? " on" : ""}`} onClick={() => goTo(c.t)}>
+              {c.name}
             </button>
           ))}
         </div>
 
         <LinhaDoTempo
-          linhas={linhasTL}
-          min={eixo.min}
-          max={eixo.max}
-          marcas={eixo.marcas}
-          guia={a[1]}
-          guiaVerde
+          rows={rows}
+          min={axis.min}
+          max={axis.max}
+          ticks={axis.ticks}
+          guide={a[1]}
+          guideGreen
         />
 
         <div className="viz-field grow" style={{ marginTop: 14 }}>
@@ -305,83 +302,75 @@ export function IntervalsSobreposicaoVisualizer() {
           <input
             type="range"
             min={0}
-            max={total - 1}
+            max={steps.length - 1}
             step={1}
-            value={idx}
-            onChange={(e) => irPara(parseInt(e.target.value, 10))}
+            value={viz.step}
+            onChange={(e) => goTo(parseInt(e.target.value, 10))}
             aria-label="Instante em que B começa"
             style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
           />
         </div>
 
         <div className="iv-veredito">
-          <span className={`iv-selo ${p.sobrepoe ? "ok" : "no"}`}>
-            {p.sobrepoe ? "sobrepõem" : "não se sobrepõem"}
+          <span className={`iv-selo ${p.overlaps ? "ok" : "no"}`}>
+            {p.overlaps ? "sobrepõem" : "não se sobrepõem"}
           </span>
-          <span className="iv-veredito-txt">{p.relacao}</span>
+          <span className="iv-veredito-txt">{p.relation}</span>
         </div>
 
         <div className="iv-testes">
-          {p.testes.map((t) => (
-            <div className={`iv-teste ${t.ok ? "ok" : "no"}`} key={t.titulo}>
-              <b>{t.titulo}</b>
-              {t.corpo}
+          {p.checks.map((t) => (
+            <div className={`iv-teste ${t.ok ? "ok" : "no"}`} key={t.title}>
+              <b>{t.title}</b>
+              {t.body}
             </div>
           ))}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">
-              sobreposicao.py · {fechado ? "encostar conta como sobrepor" : "encostar não conta"}
-            </div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra é pela ALTURA: zerar a trilha da coluna só tira a
+              largura, e a linha do grid continua com a altura inteira do bloco.
+              O código fica no DOM mesmo recolhido — é isso que permite medir o
+              pior caso —, e `inert` o tira do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">
+                sobreposicao.py · {closed ? "encostar conta como sobrepor" : "encostar não conta"}
+              </div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {p.vars.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={() => { setA0(A_PADRAO[0]); setA1(A_PADRAO[1]); setCompB(COMP_PADRAO); setFechado(true); parar(); setTocando(false); setPasso(PASSO_INICIAL); }}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => irPara(idx - 1)}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => irPara(idx + 1)}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%`, background: p.sobrepoe ? "#34d399" : "#f87171" }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola.
+          O `↺` do rodapé compartilhado é `viz.reset()`, isto é, volta ao passo
+          1 e nada mais. Quem devolve A, a duração de B e o modelo de borda ao
+          padrão é o botão ao lado — o rodapé não promete o que não faz. */}
+      <VizFooter viz={viz} color={color}>
+        <button className="viz-btn" onClick={backToDefaults}>Voltar ao padrão</button>
+      </VizFooter>
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/IntervalsSweepVisualizer.tsx
+++ b/content/visualizers/IntervalsSweepVisualizer.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 import {
   LinhaDoTempo,
-  eixoDe,
-  escreverIntervalos,
+  axisFor,
   fmtIv,
-  lerIntervalos,
+  parseIntervals,
+  writeIntervals,
 } from "./IntervalsLinhaDoTempo";
-import type { Intervalo, LinhaTL } from "./IntervalsLinhaDoTempo";
+import type { Interval, TimelineRow } from "./IntervalsLinhaDoTempo";
 
 // ---------------------------------------------------------------------------
 // IntervalsSweepVisualizer, a contagem por eventos (sweep line).
@@ -23,34 +25,38 @@ import type { Intervalo, LinhaTL } from "./IntervalsLinhaDoTempo";
 // entrada, uma sala que vagou às 12 recebe quem chega às 12; com a entrada
 // antes, não. A mesma entrada dá respostas diferentes, e é o enunciado que
 // decide qual das duas está certa.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Contrato
+// em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Evento = { t: number; delta: number; iv: number; tipo: "entra" | "sai" };
+type SweepEvent = { t: number; delta: number; iv: number; kind: "entra" | "sai" };
 
-type Vars = { nome: string; valor: string; best?: boolean }[];
+type Vars = { name: string; value: string; best?: boolean }[];
 
-type Passo = {
-  linha: number;
-  iEvento: number;
-  atual: number;
-  maximo: number;
-  ativos: number[];
-  fechados: number[];
-  perfil: number[];
-  tempo: number | null;
-  nota: string;
+type Step = {
+  line: number;
+  eventIndex: number;
+  current: number;
+  peak: number;
+  active: number[];
+  closed: number[];
+  profile: number[];
+  time: number | null;
+  note: string;
   vars: Vars;
   ok?: boolean;
 };
 
-function codigoDe(saidaPrimeiro: boolean): string[] {
+function codeFor(exitFirst: boolean): string[] {
   return [
     "def salas_necessarias(reunioes):",
     "    eventos = []",
     "    for inicio, fim in reunioes:",
     "        eventos.append((inicio, +1))",
     "        eventos.append((fim, -1))",
-    saidaPrimeiro ? "    eventos.sort()" : "    eventos.sort(key=lambda e: (e[0], -e[1]))",
+    exitFirst ? "    eventos.sort()" : "    eventos.sort(key=lambda e: (e[0], -e[1]))",
     "    atual = maximo = 0",
     "    for tempo, delta in eventos:",
     "        atual += delta",
@@ -59,268 +65,228 @@ function codigoDe(saidaPrimeiro: boolean): string[] {
   ];
 }
 
-function eventosDe(ivs: Intervalo[], saidaPrimeiro: boolean): Evento[] {
-  const evs: Evento[] = [];
+function eventsFor(ivs: Interval[], exitFirst: boolean): SweepEvent[] {
+  const evs: SweepEvent[] = [];
   ivs.forEach((iv, i) => {
-    evs.push({ t: iv[0], delta: 1, iv: i, tipo: "entra" });
-    evs.push({ t: iv[1], delta: -1, iv: i, tipo: "sai" });
+    evs.push({ t: iv[0], delta: 1, iv: i, kind: "entra" });
+    evs.push({ t: iv[1], delta: -1, iv: i, kind: "sai" });
   });
   // No empate de tempo, `delta` crescente coloca o -1 (saída) na frente, e
   // `-delta` coloca o +1 (entrada). O índice desempata o resto para o gerador
   // continuar puro.
   return evs.sort((a, b) => {
     if (a.t !== b.t) return a.t - b.t;
-    const da = saidaPrimeiro ? a.delta : -a.delta;
-    const db = saidaPrimeiro ? b.delta : -b.delta;
+    const da = exitFirst ? a.delta : -a.delta;
+    const db = exitFirst ? b.delta : -b.delta;
     if (da !== db) return da - db;
     return a.iv - b.iv;
   });
 }
 
 /** Máximo de intervalos simultâneos, sem passo a passo. Serve para comparar as duas regras de empate. */
-function maxSimultaneo(ivs: Intervalo[], saidaPrimeiro: boolean): number {
-  let atual = 0;
-  let maximo = 0;
-  for (const e of eventosDe(ivs, saidaPrimeiro)) {
-    atual += e.delta;
-    if (atual > maximo) maximo = atual;
+function maxConcurrent(ivs: Interval[], exitFirst: boolean): number {
+  let current = 0;
+  let peak = 0;
+  for (const e of eventsFor(ivs, exitFirst)) {
+    current += e.delta;
+    if (current > peak) peak = current;
   }
-  return maximo;
+  return peak;
 }
 
 /** Merge Intervals puro, só para desenhar a linha de contraste "o merge diria isto". */
-function fundir(ivs: Intervalo[]): Intervalo[] {
+function merge(ivs: Interval[]): Interval[] {
   if (!ivs.length) return [];
-  const ord = [...ivs].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
-  const out: Intervalo[] = [[ord[0][0], ord[0][1]]];
-  for (let i = 1; i < ord.length; i++) {
-    const ultimo = out[out.length - 1];
-    if (ord[i][0] <= ultimo[1]) ultimo[1] = Math.max(ultimo[1], ord[i][1]);
-    else out.push([ord[i][0], ord[i][1]]);
+  const order = [...ivs].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const out: Interval[] = [[order[0][0], order[0][1]]];
+  for (let i = 1; i < order.length; i++) {
+    const last = out[out.length - 1];
+    if (order[i][0] <= last[1]) last[1] = Math.max(last[1], order[i][1]);
+    else out.push([order[i][0], order[i][1]]);
   }
   return out;
 }
 
-function pl(n: number, um: string, muitos: string): string {
-  return n === 1 ? um : muitos;
+function pl(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
 }
 
-function gerarPassos(ivs: Intervalo[], saidaPrimeiro: boolean): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(ivs: Interval[], exitFirst: boolean): Step[] {
+  const steps: Step[] = [];
   const n = ivs.length;
 
   if (n === 0) {
-    out.push({
-      linha: 10, iEvento: -1, atual: 0, maximo: 0, ativos: [], fechados: [], perfil: [], tempo: null,
-      nota: "Nenhuma reunião marcada: zero eventos, zero salas. O contador nem chega a subir.",
-      vars: [{ nome: "eventos", valor: "0" }, { nome: "maximo", valor: "0", best: true }],
+    steps.push({
+      line: 10, eventIndex: -1, current: 0, peak: 0, active: [], closed: [], profile: [], time: null,
+      note: "Nenhuma reunião marcada: zero eventos, zero salas. O contador nem chega a subir.",
+      vars: [{ name: "eventos", value: "0" }, { name: "maximo", value: "0", best: true }],
     });
-    return out;
+    return steps;
   }
 
-  const evs = eventosDe(ivs, saidaPrimeiro);
-  const regra = saidaPrimeiro
+  const evs = eventsFor(ivs, exitFirst);
+  const rule = exitFirst
     ? "no empate, a saída vem antes da entrada: quem desocupa às 12 entrega a sala para quem chega às 12"
     : "no empate, a entrada vem antes da saída: quem chega às 12 precisa de outra sala, porque a de quem sai às 12 ainda conta como ocupada";
 
-  out.push({
-    linha: 2, iEvento: -1, atual: 0, maximo: 0, ativos: [], fechados: [], perfil: [], tempo: null,
-    nota: `${n} ${pl(n, "reunião vira", "reuniões viram")} ${evs.length} eventos: um +1 no início de cada uma e um -1 no fim. A partir daqui eu esqueço quem é quem, só me importa o vaivém do contador.`,
-    vars: [{ nome: "eventos", valor: `${evs.length}` }, { nome: "atual", valor: "0" }, { nome: "maximo", valor: "0", best: true }],
+  steps.push({
+    line: 2, eventIndex: -1, current: 0, peak: 0, active: [], closed: [], profile: [], time: null,
+    note: `${n} ${pl(n, "reunião vira", "reuniões viram")} ${evs.length} eventos: um +1 no início de cada uma e um -1 no fim. A partir daqui eu esqueço quem é quem, só me importa o vaivém do contador.`,
+    vars: [{ name: "eventos", value: `${evs.length}` }, { name: "atual", value: "0" }, { name: "maximo", value: "0", best: true }],
   });
 
-  out.push({
-    linha: 5, iEvento: -1, atual: 0, maximo: 0, ativos: [], fechados: [], perfil: [], tempo: null,
-    nota: `Ordenei os ${evs.length} eventos por tempo, e ${regra}.`,
-    vars: [{ nome: "eventos", valor: `${evs.length}` }, { nome: "atual", valor: "0" }, { nome: "maximo", valor: "0", best: true }],
+  steps.push({
+    line: 5, eventIndex: -1, current: 0, peak: 0, active: [], closed: [], profile: [], time: null,
+    note: `Ordenei os ${evs.length} eventos por tempo, e ${rule}.`,
+    vars: [{ name: "eventos", value: `${evs.length}` }, { name: "atual", value: "0" }, { name: "maximo", value: "0", best: true }],
   });
 
-  let atual = 0;
-  let maximo = 0;
-  const ativos = new Set<number>();
-  const fechados = new Set<number>();
-  const perfil: number[] = [];
+  let current = 0;
+  let peak = 0;
+  const active = new Set<number>();
+  const closed = new Set<number>();
+  const profile: number[] = [];
 
   for (let k = 0; k < evs.length; k++) {
     const e = evs[k];
-    atual += e.delta;
-    if (e.tipo === "entra") ativos.add(e.iv);
-    else { ativos.delete(e.iv); fechados.add(e.iv); }
-    perfil.push(atual);
-    const subiu = atual > maximo;
-    if (subiu) maximo = atual;
+    current += e.delta;
+    if (e.kind === "entra") active.add(e.iv);
+    else { active.delete(e.iv); closed.add(e.iv); }
+    profile.push(current);
+    const rose = current > peak;
+    if (rose) peak = current;
 
-    out.push({
-      linha: subiu ? 9 : 8,
-      iEvento: k,
-      atual,
-      maximo,
-      ativos: [...ativos],
-      fechados: [...fechados],
-      perfil: [...perfil],
-      tempo: e.t,
-      nota: e.tipo === "entra"
-        ? `t = ${e.t}: começa ${fmtIv(ivs[e.iv])}. atual = ${atual - 1} + 1 = ${atual}.${subiu ? ` Recorde novo: preciso de ${atual} ${pl(atual, "sala", "salas")} neste instante.` : ""}`
-        : `t = ${e.t}: termina ${fmtIv(ivs[e.iv])} e a sala vaga. atual = ${atual + 1} - 1 = ${atual}. O máximo já visto continua ${maximo}.`,
+    steps.push({
+      line: rose ? 9 : 8,
+      eventIndex: k,
+      current,
+      peak,
+      active: [...active],
+      closed: [...closed],
+      profile: [...profile],
+      time: e.t,
+      note: e.kind === "entra"
+        ? `t = ${e.t}: começa ${fmtIv(ivs[e.iv])}. atual = ${current - 1} + 1 = ${current}.${rose ? ` Recorde novo: preciso de ${current} ${pl(current, "sala", "salas")} neste instante.` : ""}`
+        : `t = ${e.t}: termina ${fmtIv(ivs[e.iv])} e a sala vaga. atual = ${current + 1} - 1 = ${current}. O máximo já visto continua ${peak}.`,
       vars: [
-        { nome: "tempo", valor: `${e.t}` },
-        { nome: "delta", valor: e.delta > 0 ? "+1" : "-1" },
-        { nome: "atual", valor: `${atual}` },
-        { nome: "maximo", valor: `${maximo}`, best: true },
+        { name: "tempo", value: `${e.t}` },
+        { name: "delta", value: e.delta > 0 ? "+1" : "-1" },
+        { name: "atual", value: `${current}` },
+        { name: "maximo", value: `${peak}`, best: true },
       ],
     });
   }
 
-  out.push({
-    linha: 10, iEvento: evs.length - 1, atual, maximo, ativos: [], fechados: ivs.map((_, i) => i),
-    perfil: [...perfil], tempo: null, ok: true,
-    nota: `Fim: o contador voltou a ${atual} e o pico foi ${maximo}. Preciso de ${maximo} ${pl(maximo, "sala", "salas")} para que nenhuma reunião fique esperando.`,
+  steps.push({
+    line: 10, eventIndex: evs.length - 1, current, peak, active: [], closed: ivs.map((_, i) => i),
+    profile: [...profile], time: null, ok: true,
+    note: `Fim: o contador voltou a ${current} e o pico foi ${peak}. Preciso de ${peak} ${pl(peak, "sala", "salas")} para que nenhuma reunião fique esperando.`,
     vars: [
-      { nome: "tempo", valor: "-" },
-      { nome: "delta", valor: "-" },
-      { nome: "atual", valor: `${atual}` },
-      { nome: "maximo", valor: `${maximo}`, best: true },
+      { name: "tempo", value: "-" },
+      { name: "delta", value: "-" },
+      { name: "atual", value: `${current}` },
+      { name: "maximo", value: `${peak}`, best: true },
     ],
   });
-  return out;
+  return steps;
 }
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-type Preset = { nome: string; ivs: string };
+type Preset = { name: string; ivs: string };
 
 const PRESETS: Preset[] = [
-  { nome: "Reuniões do dia", ivs: "[9,12], [10,13], [11,14], [12,15], [16,18], [17,19]" },
-  { nome: "Uma sala basta", ivs: "[9,10], [10,11], [11,12], [12,13]" },
-  { nome: "Tudo aninhado", ivs: "[9,17], [10,16], [11,15]" },
-  { nome: "Dois picos", ivs: "[1,4], [2,9], [3,5], [6,8], [7,10]" },
-  { nome: "Nenhuma reunião", ivs: "" },
+  { name: "Reuniões do dia", ivs: "[9,12], [10,13], [11,14], [12,15], [16,18], [17,19]" },
+  { name: "Uma sala basta", ivs: "[9,10], [10,11], [11,12], [12,13]" },
+  { name: "Tudo aninhado", ivs: "[9,17], [10,16], [11,15]" },
+  { name: "Dois picos", ivs: "[1,4], [2,9], [3,5], [6,8], [7,10]" },
+  { name: "Nenhuma reunião", ivs: "" },
 ];
 
 export function IntervalsSweepVisualizer() {
-  const [entrada, setEntrada] = useState(PRESETS[0].ivs);
-  const [saidaPrimeiro, setSaidaPrimeiro] = useState(true);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [input, setInput] = useState(PRESETS[0].ivs);
+  const [exitFirst, setExitFirst] = useState(true);
 
-  useEffect(() => setMounted(true), []);
-
-  const ivs = useMemo(() => lerIntervalos(entrada, 8), [entrada]);
-  const evs = useMemo(() => eventosDe(ivs, saidaPrimeiro), [ivs, saidaPrimeiro]);
-  const passos = useMemo(() => gerarPassos(ivs, saidaPrimeiro), [ivs, saidaPrimeiro]);
-  const merged = useMemo(() => fundir(ivs), [ivs]);
-  const outraRegra = useMemo(() => maxSimultaneo(ivs, !saidaPrimeiro), [ivs, saidaPrimeiro]);
+  const ivs = useMemo(() => parseIntervals(input, 8), [input]);
+  const evs = useMemo(() => eventsFor(ivs, exitFirst), [ivs, exitFirst]);
+  const steps = useMemo(() => generateSteps(ivs, exitFirst), [ivs, exitFirst]);
+  const merged = useMemo(() => merge(ivs), [ivs]);
+  const otherRule = useMemo(() => maxConcurrent(ivs, !exitFirst), [ivs, exitFirst]);
   // Altura fixa do perfil: usa o pico da execução inteira para as barras não
   // reescalarem a cada passo.
-  const picoFinal = useMemo(() => maxSimultaneo(ivs, saidaPrimeiro), [ivs, saidaPrimeiro]);
+  const finalPeak = useMemo(() => maxConcurrent(ivs, exitFirst), [ivs, exitFirst]);
 
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const codigo = useMemo(() => codigoDe(saidaPrimeiro), [saidaPrimeiro]);
+  const viz = useVisualizer({
+    title: "Visualizador · quantos intervalos ao mesmo tempo",
+    // O que MAIS muda a altura: quantas reuniões a entrada tem (cada uma é uma
+    // faixa na linha do tempo e dois selos de evento) e a regra de empate, que
+    // troca a linha de ordenação do código. `steps.length` atravessa 1 quando a
+    // lista fica vazia, e aí o rodapé inteiro some — o que também é altura.
+    total: steps.length,
+    measureOn: [ivs.length, steps.length, exitFirst],
+  });
 
-  const eixo = useMemo(() => {
-    const vals: number[] = [];
-    for (const iv of ivs) { vals.push(iv[0], iv[1]); }
-    if (!vals.length) vals.push(0, 10);
-    return eixoDe(vals);
+  const p = steps[viz.step];
+  const code = useMemo(() => codeFor(exitFirst), [exitFirst]);
+
+  const axis = useMemo(() => {
+    const values: number[] = [];
+    for (const iv of ivs) { values.push(iv[0], iv[1]); }
+    if (!values.length) values.push(0, 10);
+    return axisFor(values);
   }, [ivs]);
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => { parar(); setTocando(false); setPasso(0); }, [parar]);
-
   // Math.random só no handler, nunca no render, para a hidratação bater.
-  const sortear = () => {
-    const qtd = 4 + Math.floor(Math.random() * 3);
-    const gerados: Intervalo[] = [];
-    for (let i = 0; i < qtd; i++) {
-      const ini = 8 + Math.floor(Math.random() * 8);
-      gerados.push([ini, ini + 1 + Math.floor(Math.random() * 4)]);
+  const randomize = () => {
+    const count = 4 + Math.floor(Math.random() * 3);
+    const drawn: Interval[] = [];
+    for (let i = 0; i < count; i++) {
+      const start = 8 + Math.floor(Math.random() * 8);
+      drawn.push([start, start + 1 + Math.floor(Math.random() * 4)]);
     }
-    reiniciar();
-    setEntrada(escreverIntervalos(gerados));
+    viz.reset();
+    setInput(writeIntervals(drawn));
   };
 
-  const linhasTL: LinhaTL[] = [
+  const rows: TimelineRow[] = [
     ...ivs.map((iv, i) => {
-      const classe = p.ativos.includes(i) ? "atual" : p.fechados.includes(i) ? "usado" : "espera";
+      const state = p.active.includes(i) ? "atual" : p.closed.includes(i) ? "usado" : "espera";
       return {
-        chave: `iv${i}`,
-        rotulo: `[${iv[0]}, ${iv[1]}]`,
-        barras: [{ chave: `b${i}`, inicio: iv[0], fim: iv[1], classe, texto: `${iv[0]},${iv[1]}` }],
+        id: `iv${i}`,
+        label: `[${iv[0]}, ${iv[1]}]`,
+        bars: [{ id: `b${i}`, start: iv[0], end: iv[1], state, label: `${iv[0]},${iv[1]}` }],
       };
     }),
     {
-      chave: "merge",
-      rotulo: "o merge diria",
-      barras: merged.map((s, k) => ({ chave: `m${k}`, inicio: s[0], fim: s[1], classe: "pronto", texto: `${s[0]},${s[1]}` })),
+      id: "merge",
+      label: "o merge diria",
+      bars: merged.map((s, k) => ({ id: `m${k}`, start: s[0], end: s[1], state: "pronto", label: `${s[0]},${s[1]}` })),
     },
   ];
 
-  const alturaMax = Math.max(1, picoFinal);
-  const notaCls = "viz-note" + (p.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const maxBar = Math.max(1, finalPeak);
+  const noteClass = "viz-note" + (p.ok ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" style={{ background: "#a78bfa" }} />
-          <span>Visualizador · quantos intervalos ao mesmo tempo</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} color="#a78bfa" />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Reuniões</span>
             <input
               className="viz-input"
-              value={entrada}
-              onChange={(e) => { reiniciar(); setEntrada(e.target.value); }}
+              value={input}
+              onChange={(e) => { viz.reset(); setInput(e.target.value); }}
               placeholder="[9,12], [10,13], [11,14]"
             />
           </label>
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={randomize}>Sortear</button>
           <button
             className="viz-btn"
-            aria-pressed={saidaPrimeiro}
-            onClick={() => { reiniciar(); setSaidaPrimeiro((v) => !v); }}
+            aria-pressed={exitFirst}
+            onClick={() => { viz.reset(); setExitFirst((v) => !v); }}
           >
-            Empate: {saidaPrimeiro ? "saída primeiro" : "entrada primeiro"}
+            Empate: {exitFirst ? "saída primeiro" : "entrada primeiro"}
           </button>
         </div>
 
@@ -328,28 +294,28 @@ export function IntervalsSweepVisualizer() {
           <span className="iv-presets-lbl">Cenários</span>
           {PRESETS.map((pr) => (
             <button
-              key={pr.nome}
-              className={`iv-preset${entrada === pr.ivs ? " on" : ""}`}
-              onClick={() => { reiniciar(); setEntrada(pr.ivs); }}
+              key={pr.name}
+              className={`iv-preset${input === pr.ivs ? " on" : ""}`}
+              onClick={() => { viz.reset(); setInput(pr.ivs); }}
             >
-              {pr.nome}
+              {pr.name}
             </button>
           ))}
         </div>
 
         <LinhaDoTempo
-          linhas={linhasTL}
-          min={eixo.min}
-          max={eixo.max}
-          marcas={eixo.marcas}
-          guia={p.tempo}
+          rows={rows}
+          min={axis.min}
+          max={axis.max}
+          ticks={axis.ticks}
+          guide={p.time}
         />
 
         <div className="iv-eventos">
           {evs.map((e, k) => (
             <span
-              key={`${e.t}-${e.tipo}-${e.iv}`}
-              className={`iv-ev ${e.tipo}${k === p.iEvento ? " on" : ""}${k < p.iEvento ? " feito" : ""}`}
+              key={`${e.t}-${e.kind}-${e.iv}`}
+              className={`iv-ev ${e.kind}${k === p.eventIndex ? " on" : ""}${k < p.eventIndex ? " feito" : ""}`}
             >
               {e.t} {e.delta > 0 ? "+1" : "-1"}
             </span>
@@ -358,13 +324,13 @@ export function IntervalsSweepVisualizer() {
 
         <div className="iv-perfil" aria-hidden="true">
           {evs.map((e, k) => {
-            const v = k < p.perfil.length ? p.perfil[k] : null;
-            const alt = v == null ? 0 : (v / alturaMax) * 100;
-            const cls = v != null && v === picoFinal && picoFinal > 0 ? " max" : k === p.iEvento ? " on" : "";
+            const v = k < p.profile.length ? p.profile[k] : null;
+            const h = v == null ? 0 : (v / maxBar) * 100;
+            const cls = v != null && v === finalPeak && finalPeak > 0 ? " max" : k === p.eventIndex ? " on" : "";
             return (
-              <div className={`iv-perfil-col${cls}`} key={`c${e.t}-${e.tipo}-${e.iv}`}>
+              <div className={`iv-perfil-col${cls}`} key={`c${e.t}-${e.kind}-${e.iv}`}>
                 <span className="iv-perfil-n">{v == null ? "" : v}</span>
-                <span className="iv-perfil-bar" style={{ height: `${alt}%` }} />
+                <span className="iv-perfil-bar" style={{ height: `${h}%` }} />
               </div>
             );
           })}
@@ -377,70 +343,57 @@ export function IntervalsSweepVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>em uso agora</span>
-            <strong style={{ color: "#a78bfa" }}>{p.atual}</strong>
+            <strong style={{ color: "#a78bfa" }}>{p.current}</strong>
           </div>
           <div className="bigo-stat">
             <span>máximo até aqui</span>
-            <strong style={{ color: "#fbbf24" }}>{p.maximo}</strong>
+            <strong style={{ color: "#fbbf24" }}>{p.peak}</strong>
           </div>
           <div className="bigo-stat">
             <span>com a outra regra de empate</span>
-            <strong>{outraRegra}</strong>
+            <strong>{otherRule}</strong>
           </div>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">
-              salas.py · {saidaPrimeiro ? "a saída libera a sala" : "a saída não libera a sala"}
-            </div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra é pela ALTURA: zerar a trilha da coluna só tira a
+              largura, e a linha do grid continua com a altura inteira do bloco.
+              O código fica no DOM mesmo recolhido — é isso que permite medir o
+              pior caso —, e `inert` o tira do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">
+                salas.py · {exitFirst ? "a saída libera a sala" : "a saída não libera a sala"}
+              </div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {p.vars.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%`, background: "#a78bfa" }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} color="#a78bfa" />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/IntervalsVisualizer.tsx
+++ b/content/visualizers/IntervalsVisualizer.tsx
@@ -1,23 +1,25 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 import {
   LinhaDoTempo,
-  eixoDe,
-  escreverIntervalos,
+  axisFor,
   fmtIv,
-  fmtLista,
-  lerIntervalos,
+  fmtList,
+  parseIntervals,
+  writeIntervals,
 } from "./IntervalsLinhaDoTempo";
-import type { Intervalo, LinhaTL } from "./IntervalsLinhaDoTempo";
+import type { Interval, TimelineRow } from "./IntervalsLinhaDoTempo";
 
 // ---------------------------------------------------------------------------
 // IntervalsVisualizer, os três varreduras de intervalos numa linha do tempo.
 //
 // Mesmo padrão dos outros visualizadores do repo (gerador PURO de passos +
 // a casca compartilhada), no formato do BigOCounterVisualizer: vários modos,
-// cada um com o seu `codigo` e o seu `gerar`. Os três compartilham a mesma
+// cada um com o seu `code` e o seu `generate`. Os três compartilham a mesma
 // tela porque a lição é justamente que são a MESMA varredura com uma regra
 // diferente na hora de decidir:
 //
@@ -27,25 +29,29 @@ import type { Intervalo, LinhaTL } from "./IntervalsLinhaDoTempo";
 //
 // A linha tracejada na trilha é sempre a fronteira do teste (`fim` do bloco,
 // `fim` do novo intervalo, `fim_anterior`), que é a única coisa que muda.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Contrato
+// em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Vars = { nome: string; valor: string; best?: boolean }[];
+type Vars = { name: string; value: string; best?: boolean }[];
 
-type Passo = {
-  linha: number;
-  ordem: number[];
-  estados: Record<number, string>;
-  saida: Intervalo[];
-  bloco: Intervalo | null;
-  guia: number | null;
-  testes: number;
-  cortados: number;
-  nota: string;
+type Step = {
+  line: number;
+  order: number[];
+  states: Record<number, string>;
+  output: Interval[];
+  block: Interval | null;
+  guide: number | null;
+  tests: number;
+  dropped: number;
+  note: string;
   vars: Vars;
   ok?: boolean;
 };
 
-const CODIGO_MERGE = [
+const CODE_MERGE = [
   "def merge(intervalos):",
   "    if not intervalos:",
   "        return []",
@@ -59,7 +65,7 @@ const CODIGO_MERGE = [
   "    return saida",
 ];
 
-const CODIGO_INSERT = [
+const CODE_INSERT = [
   "def inserir(intervalos, novo):",
   "    inicio, fim = novo",
   "    saida, i, n = [], 0, len(intervalos)",
@@ -77,7 +83,7 @@ const CODIGO_INSERT = [
   "    return saida",
 ];
 
-const CODIGO_GREEDY = [
+const CODE_GREEDY = [
   "def maximo_sem_conflito(intervalos):",
   "    intervalos.sort(key=lambda x: x[1])",
   "    escolhidos = []",
@@ -89,364 +95,361 @@ const CODIGO_GREEDY = [
   "    return escolhidos",
 ];
 
-function pl(n: number, um: string, muitos: string): string {
-  return n === 1 ? um : muitos;
+function pl(n: number, one: string, many: string): string {
+  return n === 1 ? one : many;
 }
 
-function copiar(ivs: Intervalo[]): Intervalo[] {
-  return ivs.map((iv) => [iv[0], iv[1]] as Intervalo);
+function copyIvs(ivs: Interval[]): Interval[] {
+  return ivs.map((iv) => [iv[0], iv[1]] as Interval);
 }
 
 // --------------------------------- merge -----------------------------------
 
-function gerarMerge(ivs: Intervalo[]): Passo[] {
-  const out: Passo[] = [];
+function generateMerge(ivs: Interval[]): Step[] {
+  const steps: Step[] = [];
   const n = ivs.length;
   const idx = ivs.map((_, i) => i);
-  const todos = (c: string): Record<number, string> => {
+  const allStates = (c: string): Record<number, string> => {
     const e: Record<number, string> = {};
     for (const i of idx) e[i] = c;
     return e;
   };
 
   if (n === 0) {
-    out.push({
-      linha: 2, ordem: [], estados: {}, saida: [], bloco: null, guia: null, testes: 0, cortados: 0,
-      nota: "Lista vazia: devolvo [] antes de qualquer coisa. É o caso de borda que mais derruba submissão, porque intervalos[0] em lista vazia estoura.",
-      vars: [{ nome: "intervalos", valor: "[]" }, { nome: "saida", valor: "[]" }],
+    steps.push({
+      line: 2, order: [], states: {}, output: [], block: null, guide: null, tests: 0, dropped: 0,
+      note: "Lista vazia: devolvo [] antes de qualquer coisa. É o caso de borda que mais derruba submissão, porque intervalos[0] em lista vazia estoura.",
+      vars: [{ name: "intervalos", value: "[]" }, { name: "saida", value: "[]" }],
     });
-    return out;
+    return steps;
   }
 
-  const ord = [...idx].sort((a, b) => ivs[a][0] - ivs[b][0] || ivs[a][1] - ivs[b][1]);
+  const order = [...idx].sort((a, b) => ivs[a][0] - ivs[b][0] || ivs[a][1] - ivs[b][1]);
 
-  out.push({
-    linha: 0, ordem: idx, estados: todos("espera"), saida: [], bloco: null, guia: null, testes: 0, cortados: 0,
-    nota: n === 1
+  steps.push({
+    line: 0, order: idx, states: allStates("espera"), output: [], block: null, guide: null, tests: 0, dropped: 0,
+    note: n === 1
       ? "Entrada com um intervalo só: não existe par para comparar, então a resposta já é ele mesmo. Vale rodar mesmo assim para ver que nenhum teste chega a acontecer."
       : `Entrada como veio: ${n} intervalos, fora de ordem. Assim, qualquer um pode encostar em qualquer outro, e eu teria que comparar todos os pares.`,
-    vars: [{ nome: "n", valor: `${n}` }, { nome: "saida[-1]", valor: "-" }, { nome: "len(saida)", valor: "0" }, { nome: "testes", valor: "0", best: true }],
+    vars: [{ name: "n", value: `${n}` }, { name: "saida[-1]", value: "-" }, { name: "len(saida)", value: "0" }, { name: "testes", value: "0", best: true }],
   });
 
-  out.push({
-    linha: 3, ordem: ord, estados: todos("espera"), saida: [], bloco: null, guia: null, testes: 0, cortados: 0,
-    nota: `Ordenei por início: ${fmtLista(ord.map((i) => ivs[i]))}. Com a lista assim, cada intervalo só pode encostar no bloco imediatamente anterior.`,
-    vars: [{ nome: "n", valor: `${n}` }, { nome: "saida[-1]", valor: "-" }, { nome: "len(saida)", valor: "0" }, { nome: "testes", valor: "0", best: true }],
+  steps.push({
+    line: 3, order, states: allStates("espera"), output: [], block: null, guide: null, tests: 0, dropped: 0,
+    note: `Ordenei por início: ${fmtList(order.map((i) => ivs[i]))}. Com a lista assim, cada intervalo só pode encostar no bloco imediatamente anterior.`,
+    vars: [{ name: "n", value: `${n}` }, { name: "saida[-1]", value: "-" }, { name: "len(saida)", value: "0" }, { name: "testes", value: "0", best: true }],
   });
 
-  const estados = todos("espera");
-  const saida: Intervalo[] = [];
-  let bloco: Intervalo = [ivs[ord[0]][0], ivs[ord[0]][1]];
-  let testes = 0;
+  const states = allStates("espera");
+  const output: Interval[] = [];
+  let block: Interval = [ivs[order[0]][0], ivs[order[0]][1]];
+  let tests = 0;
 
-  const vars = (atual: Intervalo | null): Vars => [
-    { nome: "atual", valor: fmtIv(atual) },
-    { nome: "saida[-1]", valor: fmtIv(bloco) },
-    { nome: "len(saida)", valor: `${saida.length + 1}` },
-    { nome: "testes", valor: `${testes}`, best: true },
+  const vars = (current: Interval | null): Vars => [
+    { name: "atual", value: fmtIv(current) },
+    { name: "saida[-1]", value: fmtIv(block) },
+    { name: "len(saida)", value: `${output.length + 1}` },
+    { name: "testes", value: `${tests}`, best: true },
   ];
 
-  estados[ord[0]] = "usado";
-  out.push({
-    linha: 4, ordem: ord, estados: { ...estados }, saida: [], bloco: [bloco[0], bloco[1]], guia: bloco[1], testes, cortados: 0,
-    nota: `Abro o primeiro bloco em ${fmtIv(bloco)}. A linha tracejada marca o fim dele: é contra ela que todo mundo vai ser testado.`,
-    vars: vars(ivs[ord[0]]),
+  states[order[0]] = "usado";
+  steps.push({
+    line: 4, order, states: { ...states }, output: [], block: [block[0], block[1]], guide: block[1], tests, dropped: 0,
+    note: `Abro o primeiro bloco em ${fmtIv(block)}. A linha tracejada marca o fim dele: é contra ela que todo mundo vai ser testado.`,
+    vars: vars(ivs[order[0]]),
   });
 
   for (let k = 1; k < n; k++) {
-    const i = ord[k];
-    const ini = ivs[i][0];
-    const fim = ivs[i][1];
-    testes++;
-    const encosta = ini <= bloco[1];
+    const i = order[k];
+    const start = ivs[i][0];
+    const end = ivs[i][1];
+    tests++;
+    const touches = start <= block[1];
 
-    out.push({
-      linha: 6, ordem: ord, estados: { ...estados, [i]: "atual" }, saida: copiar(saida), bloco: [bloco[0], bloco[1]], guia: bloco[1], testes, cortados: 0,
-      nota: `Teste ${testes}: o bloco termina em ${bloco[1]} e ${fmtIv(ivs[i])} começa em ${ini}. ${ini} <= ${bloco[1]}? ${encosta ? "Sim, os dois se sobrepõem." : "Não, este começa depois do bloco acabar."}`,
+    steps.push({
+      line: 6, order, states: { ...states, [i]: "atual" }, output: copyIvs(output), block: [block[0], block[1]], guide: block[1], tests, dropped: 0,
+      note: `Teste ${tests}: o bloco termina em ${block[1]} e ${fmtIv(ivs[i])} começa em ${start}. ${start} <= ${block[1]}? ${touches ? "Sim, os dois se sobrepõem." : "Não, este começa depois do bloco acabar."}`,
       vars: vars(ivs[i]),
     });
 
-    estados[i] = "usado";
-    if (encosta) {
-      const antes = bloco[1];
-      bloco = [bloco[0], Math.max(antes, fim)];
-      out.push({
-        linha: 7, ordem: ord, estados: { ...estados }, saida: copiar(saida), bloco: [bloco[0], bloco[1]], guia: bloco[1], testes, cortados: 0,
-        nota: `Estico o bloco: fim = max(${antes}, ${fim}) = ${bloco[1]}, então o bloco virou ${fmtIv(bloco)}.${fim < antes ? " Repare no que o max acabou de salvar: este intervalo estava inteiro dentro do bloco, e sem o max eu teria encolhido o fim." : ""}`,
+    states[i] = "usado";
+    if (touches) {
+      const before = block[1];
+      block = [block[0], Math.max(before, end)];
+      steps.push({
+        line: 7, order, states: { ...states }, output: copyIvs(output), block: [block[0], block[1]], guide: block[1], tests, dropped: 0,
+        note: `Estico o bloco: fim = max(${before}, ${end}) = ${block[1]}, então o bloco virou ${fmtIv(block)}.${end < before ? " Repare no que o max acabou de salvar: este intervalo estava inteiro dentro do bloco, e sem o max eu teria encolhido o fim." : ""}`,
         vars: vars(ivs[i]),
       });
     } else {
-      saida.push([bloco[0], bloco[1]]);
-      const fechado = saida[saida.length - 1];
-      bloco = [ini, fim];
-      out.push({
-        linha: 9, ordem: ord, estados: { ...estados }, saida: copiar(saida), bloco: [bloco[0], bloco[1]], guia: bloco[1], testes, cortados: 0,
-        nota: `Fecho ${fmtIv(fechado)} para sempre: todo mundo que ainda falta começa em ${ini} ou mais tarde, então ninguém alcança mais esse bloco. Abro ${fmtIv(bloco)}.`,
+      output.push([block[0], block[1]]);
+      const sealed = output[output.length - 1];
+      block = [start, end];
+      steps.push({
+        line: 9, order, states: { ...states }, output: copyIvs(output), block: [block[0], block[1]], guide: block[1], tests, dropped: 0,
+        note: `Fecho ${fmtIv(sealed)} para sempre: todo mundo que ainda falta começa em ${start} ou mais tarde, então ninguém alcança mais esse bloco. Abro ${fmtIv(block)}.`,
         vars: vars(ivs[i]),
       });
     }
   }
 
-  saida.push([bloco[0], bloco[1]]);
-  const pares = (n * (n - 1)) / 2;
-  out.push({
-    linha: 10, ordem: ord, estados: todos("usado"), saida: copiar(saida), bloco: null, guia: null, testes, cortados: 0, ok: true,
-    nota: `Fim: ${n} ${pl(n, "intervalo virou", "intervalos viraram")} ${saida.length}. ${testes === 0 ? "Nenhum teste de sobreposição aconteceu: com um intervalo só, o laço nem chega a rodar." : `Foram ${testes} ${pl(testes, "teste", "testes")} de sobreposição, contra ${pares} ${pl(pares, "comparação", "comparações")} se eu tivesse olhado todos os pares.`}`,
+  output.push([block[0], block[1]]);
+  const pairs = (n * (n - 1)) / 2;
+  steps.push({
+    line: 10, order, states: allStates("usado"), output: copyIvs(output), block: null, guide: null, tests, dropped: 0, ok: true,
+    note: `Fim: ${n} ${pl(n, "intervalo virou", "intervalos viraram")} ${output.length}. ${tests === 0 ? "Nenhum teste de sobreposição aconteceu: com um intervalo só, o laço nem chega a rodar." : `Foram ${tests} ${pl(tests, "teste", "testes")} de sobreposição, contra ${pairs} ${pl(pairs, "comparação", "comparações")} se eu tivesse olhado todos os pares.`}`,
     vars: [
-      { nome: "atual", valor: "-" },
-      { nome: "saida[-1]", valor: fmtIv(saida[saida.length - 1]) },
-      { nome: "len(saida)", valor: `${saida.length}` },
-      { nome: "testes", valor: `${testes}`, best: true },
+      { name: "atual", value: "-" },
+      { name: "saida[-1]", value: fmtIv(output[output.length - 1]) },
+      { name: "len(saida)", value: `${output.length}` },
+      { name: "testes", value: `${tests}`, best: true },
     ],
   });
-  return out;
+  return steps;
 }
 
 // --------------------------------- insert ----------------------------------
 
-function gerarInsert(ivs: Intervalo[], novo: Intervalo): Passo[] {
-  const out: Passo[] = [];
+function generateInsert(ivs: Interval[], incoming: Interval): Step[] {
+  const steps: Step[] = [];
   const n = ivs.length;
   const idx = ivs.map((_, i) => i);
-  const estados: Record<number, string> = {};
-  for (const i of idx) estados[i] = "espera";
+  const states: Record<number, string> = {};
+  for (const i of idx) states[i] = "espera";
 
-  const saida: Intervalo[] = [];
-  let ini = novo[0];
-  let fim = novo[1];
-  let testes = 0;
+  const output: Interval[] = [];
+  let start = incoming[0];
+  let end = incoming[1];
+  let tests = 0;
   let i = 0;
 
   const vars = (): Vars => [
-    { nome: "i", valor: `${i}` },
-    { nome: "novo", valor: fmtIv([ini, fim]) },
-    { nome: "len(saida)", valor: `${saida.length}` },
-    { nome: "comparações", valor: `${testes}`, best: true },
+    { name: "i", value: `${i}` },
+    { name: "novo", value: fmtIv([start, end]) },
+    { name: "len(saida)", value: `${output.length}` },
+    { name: "comparações", value: `${tests}`, best: true },
   ];
 
-  const passo = (linha: number, nota: string, est: Record<number, string>, comBloco = true): Passo => ({
-    linha, ordem: idx, estados: est, saida: copiar(saida), bloco: comBloco ? [ini, fim] : null,
-    guia: comBloco ? fim : null, testes, cortados: 0, nota, vars: vars(),
+  const mkStep = (line: number, note: string, st: Record<number, string>, withBlock = true): Step => ({
+    line, order: idx, states: st, output: copyIvs(output), block: withBlock ? [start, end] : null,
+    guide: withBlock ? end : null, tests, dropped: 0, note, vars: vars(),
   });
 
-  out.push(passo(1, `Quero encaixar ${fmtIv([ini, fim])} numa lista que já chega ordenada e sem sobreposição. Como a ordem veio pronta, não pago O(n log n) nenhum: uma passada resolve.`, { ...estados }));
+  steps.push(mkStep(1, `Quero encaixar ${fmtIv([start, end])} numa lista que já chega ordenada e sem sobreposição. Como a ordem veio pronta, não pago O(n log n) nenhum: uma passada resolve.`, { ...states }));
 
   // Fase 1: tudo que termina antes do novo começar sai copiado.
   while (i < n) {
-    testes++;
-    const antes = ivs[i][1] < ini;
-    out.push(passo(3, `Fase 1, comparação ${testes}: ${fmtIv(ivs[i])} termina em ${ivs[i][1]} e o novo começa em ${ini}. ${ivs[i][1]} < ${ini}? ${antes ? "Sim, acaba antes de o novo nascer." : "Não, este já alcança o novo. A fase 1 termina aqui."}`, { ...estados, [i]: "atual" }));
-    if (!antes) break;
-    saida.push([ivs[i][0], ivs[i][1]]);
-    estados[i] = "usado";
-    const copiado = ivs[i];
+    tests++;
+    const before = ivs[i][1] < start;
+    steps.push(mkStep(3, `Fase 1, comparação ${tests}: ${fmtIv(ivs[i])} termina em ${ivs[i][1]} e o novo começa em ${start}. ${ivs[i][1]} < ${start}? ${before ? "Sim, acaba antes de o novo nascer." : "Não, este já alcança o novo. A fase 1 termina aqui."}`, { ...states, [i]: "atual" }));
+    if (!before) break;
+    output.push([ivs[i][0], ivs[i][1]]);
+    states[i] = "usado";
+    const copied = ivs[i];
     i++;
-    out.push(passo(4, `Copio ${fmtIv(copiado)} para a saída sem tocar nele. Ele não briga com ninguém.`, { ...estados }));
+    steps.push(mkStep(4, `Copio ${fmtIv(copied)} para a saída sem tocar nele. Ele não briga com ninguém.`, { ...states }));
   }
 
   // Fase 2: tudo que encosta é absorvido pelo novo intervalo.
   while (i < n) {
-    testes++;
-    const toca = ivs[i][0] <= fim;
-    out.push(passo(6, `Fase 2, comparação ${testes}: ${fmtIv(ivs[i])} começa em ${ivs[i][0]} e o novo termina em ${fim}. ${ivs[i][0]} <= ${fim}? ${toca ? "Sim, sobrepõe: vou engolir este." : "Não, este começa depois. A fase 2 termina aqui."}`, { ...estados, [i]: "atual" }));
-    if (!toca) break;
-    const iniAntes = ini;
-    const fimAntes = fim;
-    const comido = ivs[i];
-    ini = Math.min(ini, comido[0]);
-    fim = Math.max(fim, comido[1]);
-    estados[i] = "comido";
+    tests++;
+    const touches = ivs[i][0] <= end;
+    steps.push(mkStep(6, `Fase 2, comparação ${tests}: ${fmtIv(ivs[i])} começa em ${ivs[i][0]} e o novo termina em ${end}. ${ivs[i][0]} <= ${end}? ${touches ? "Sim, sobrepõe: vou engolir este." : "Não, este começa depois. A fase 2 termina aqui."}`, { ...states, [i]: "atual" }));
+    if (!touches) break;
+    const startBefore = start;
+    const endBefore = end;
+    const eaten = ivs[i];
+    start = Math.min(start, eaten[0]);
+    end = Math.max(end, eaten[1]);
+    states[i] = "comido";
     i++;
-    out.push(passo(8, `Engulo ${fmtIv(comido)}: inicio = min(${iniAntes}, ${comido[0]}) = ${ini} e fim = max(${fimAntes}, ${comido[1]}) = ${fim}. O novo cresceu para ${fmtIv([ini, fim])}.`, { ...estados }));
+    steps.push(mkStep(8, `Engulo ${fmtIv(eaten)}: inicio = min(${startBefore}, ${eaten[0]}) = ${start} e fim = max(${endBefore}, ${eaten[1]}) = ${end}. O novo cresceu para ${fmtIv([start, end])}.`, { ...states }));
   }
 
-  saida.push([ini, fim]);
-  out.push(passo(10, `Empurro ${fmtIv([ini, fim])} para a saída. Ele já absorveu tudo que encostava nele, então nunca mais vai mudar.`, { ...estados }, false));
+  output.push([start, end]);
+  steps.push(mkStep(10, `Empurro ${fmtIv([start, end])} para a saída. Ele já absorveu tudo que encostava nele, então nunca mais vai mudar.`, { ...states }, false));
 
   // Fase 3: o rabo da lista entra inteiro, sem comparação nenhuma.
-  const sobrou = n - i;
+  const leftOver = n - i;
   while (i < n) {
-    const resto = ivs[i];
-    saida.push([resto[0], resto[1]]);
-    estados[i] = "usado";
+    const rest = ivs[i];
+    output.push([rest[0], rest[1]]);
+    states[i] = "usado";
     i++;
-    out.push(passo(12, `Fase 3: ${fmtIv(resto)} começa depois do novo terminar. Copio direto, sem comparar: a lista está ordenada, então daqui para frente é tudo mais tarde ainda.`, { ...estados }, false));
+    steps.push(mkStep(12, `Fase 3: ${fmtIv(rest)} começa depois do novo terminar. Copio direto, sem comparar: a lista está ordenada, então daqui para frente é tudo mais tarde ainda.`, { ...states }, false));
   }
 
-  const fin = passo(14, `Fim: a lista de ${n} ${pl(n, "intervalo", "intervalos")} virou ${saida.length}. Foram ${testes} ${pl(testes, "comparação", "comparações")} e zero ordenações${sobrou > 0 ? `, e as últimas ${sobrou} ${pl(sobrou, "cópia foi feita", "cópias foram feitas")} sem teste nenhum` : ""}.`, { ...estados }, false);
-  fin.ok = true;
-  out.push(fin);
-  return out;
+  const last = mkStep(14, `Fim: a lista de ${n} ${pl(n, "intervalo", "intervalos")} virou ${output.length}. Foram ${tests} ${pl(tests, "comparação", "comparações")} e zero ordenações${leftOver > 0 ? `, e as últimas ${leftOver} ${pl(leftOver, "cópia foi feita", "cópias foram feitas")} sem teste nenhum` : ""}.`, { ...states }, false);
+  last.ok = true;
+  steps.push(last);
+  return steps;
 }
 
 // --------------------------------- greedy ----------------------------------
 
-function gerarGreedy(ivs: Intervalo[]): Passo[] {
-  const out: Passo[] = [];
+function generateGreedy(ivs: Interval[]): Step[] {
+  const steps: Step[] = [];
   const n = ivs.length;
   const idx = ivs.map((_, i) => i);
-  const todos = (c: string): Record<number, string> => {
+  const allStates = (c: string): Record<number, string> => {
     const e: Record<number, string> = {};
     for (const i of idx) e[i] = c;
     return e;
   };
 
   if (n === 0) {
-    out.push({
-      linha: 8, ordem: [], estados: {}, saida: [], bloco: null, guia: null, testes: 0, cortados: 0,
-      nota: "Lista vazia: dá para encaixar zero intervalos. Devolvo [].",
-      vars: [{ nome: "escolhidos", valor: "0" }],
+    steps.push({
+      line: 8, order: [], states: {}, output: [], block: null, guide: null, tests: 0, dropped: 0,
+      note: "Lista vazia: dá para encaixar zero intervalos. Devolvo [].",
+      vars: [{ name: "escolhidos", value: "0" }],
     });
-    return out;
+    return steps;
   }
 
-  const ord = [...idx].sort((a, b) => ivs[a][1] - ivs[b][1] || ivs[a][0] - ivs[b][0]);
+  const order = [...idx].sort((a, b) => ivs[a][1] - ivs[b][1] || ivs[a][0] - ivs[b][0]);
 
-  out.push({
-    linha: 0, ordem: idx, estados: todos("espera"), saida: [], bloco: null, guia: null, testes: 0, cortados: 0,
-    nota: `${n} intervalos concorrendo pelo mesmo recurso. Quero ficar com o máximo possível deles sem que dois se sobreponham.`,
-    vars: [{ nome: "fim_anterior", valor: "-inf" }, { nome: "escolhidos", valor: "0" }, { nome: "descartados", valor: "0" }, { nome: "testes", valor: "0", best: true }],
+  steps.push({
+    line: 0, order: idx, states: allStates("espera"), output: [], block: null, guide: null, tests: 0, dropped: 0,
+    note: `${n} intervalos concorrendo pelo mesmo recurso. Quero ficar com o máximo possível deles sem que dois se sobreponham.`,
+    vars: [{ name: "fim_anterior", value: "-inf" }, { name: "escolhidos", value: "0" }, { name: "descartados", value: "0" }, { name: "testes", value: "0", best: true }],
   });
 
-  out.push({
-    linha: 1, ordem: ord, estados: todos("espera"), saida: [], bloco: null, guia: null, testes: 0, cortados: 0,
-    nota: `Ordenei pelo FIM, não pelo início: ${fmtLista(ord.map((i) => ivs[i]))}. Quem termina mais cedo é quem deixa mais espaço livre para os próximos.`,
-    vars: [{ nome: "fim_anterior", valor: "-inf" }, { nome: "escolhidos", valor: "0" }, { nome: "descartados", valor: "0" }, { nome: "testes", valor: "0", best: true }],
+  steps.push({
+    line: 1, order, states: allStates("espera"), output: [], block: null, guide: null, tests: 0, dropped: 0,
+    note: `Ordenei pelo FIM, não pelo início: ${fmtList(order.map((i) => ivs[i]))}. Quem termina mais cedo é quem deixa mais espaço livre para os próximos.`,
+    vars: [{ name: "fim_anterior", value: "-inf" }, { name: "escolhidos", value: "0" }, { name: "descartados", value: "0" }, { name: "testes", value: "0", best: true }],
   });
 
-  const estados = todos("espera");
-  const saida: Intervalo[] = [];
-  let fimAnterior: number | null = null;
-  let testes = 0;
-  let cortados = 0;
+  const states = allStates("espera");
+  const output: Interval[] = [];
+  let prevEnd: number | null = null;
+  let tests = 0;
+  let dropped = 0;
 
   const vars = (): Vars => [
-    { nome: "fim_anterior", valor: fimAnterior == null ? "-inf" : `${fimAnterior}` },
-    { nome: "escolhidos", valor: `${saida.length}` },
-    { nome: "descartados", valor: `${cortados}` },
-    { nome: "testes", valor: `${testes}`, best: true },
+    { name: "fim_anterior", value: prevEnd == null ? "-inf" : `${prevEnd}` },
+    { name: "escolhidos", value: `${output.length}` },
+    { name: "descartados", value: `${dropped}` },
+    { name: "testes", value: `${tests}`, best: true },
   ];
 
   for (let k = 0; k < n; k++) {
-    const i = ord[k];
-    const ini = ivs[i][0];
-    const fim = ivs[i][1];
-    testes++;
-    const cabe = fimAnterior == null || ini >= fimAnterior;
+    const i = order[k];
+    const start = ivs[i][0];
+    const end = ivs[i][1];
+    tests++;
+    const fits = prevEnd == null || start >= prevEnd;
 
-    out.push({
-      linha: 5, ordem: ord, estados: { ...estados, [i]: "atual" }, saida: copiar(saida), bloco: null, guia: fimAnterior, testes, cortados,
-      nota: `Teste ${testes}: ${fmtIv(ivs[i])} começa em ${ini} e o último escolhido terminou em ${fimAnterior == null ? "menos infinito (ainda não escolhi nada)" : fimAnterior}. ${ini} >= ${fimAnterior == null ? "-inf" : fimAnterior}? ${cabe ? "Sim, cabe sem conflito." : "Não, ele invade o anterior."}`,
+    steps.push({
+      line: 5, order, states: { ...states, [i]: "atual" }, output: copyIvs(output), block: null, guide: prevEnd, tests, dropped,
+      note: `Teste ${tests}: ${fmtIv(ivs[i])} começa em ${start} e o último escolhido terminou em ${prevEnd == null ? "menos infinito (ainda não escolhi nada)" : prevEnd}. ${start} >= ${prevEnd == null ? "-inf" : prevEnd}? ${fits ? "Sim, cabe sem conflito." : "Não, ele invade o anterior."}`,
       vars: vars(),
     });
 
-    if (cabe) {
-      saida.push([ini, fim]);
-      fimAnterior = fim;
-      estados[i] = "usado";
-      out.push({
-        linha: 6, ordem: ord, estados: { ...estados }, saida: copiar(saida), bloco: null, guia: fimAnterior, testes, cortados,
-        nota: `Pego ${fmtIv(ivs[i])}. Agora fim_anterior = ${fim}, e a tracejada anda junto: é a nova fronteira.`,
+    if (fits) {
+      output.push([start, end]);
+      prevEnd = end;
+      states[i] = "usado";
+      steps.push({
+        line: 6, order, states: { ...states }, output: copyIvs(output), block: null, guide: prevEnd, tests, dropped,
+        note: `Pego ${fmtIv(ivs[i])}. Agora fim_anterior = ${end}, e a tracejada anda junto: é a nova fronteira.`,
         vars: vars(),
       });
     } else {
-      cortados++;
-      estados[i] = "corta";
-      out.push({
-        linha: 4, ordem: ord, estados: { ...estados }, saida: copiar(saida), bloco: null, guia: fimAnterior, testes, cortados,
-        nota: `Descarto ${fmtIv(ivs[i])}. Trocá-lo pelo que já escolhi nunca melhora a conta: o que escolhi termina antes ou junto, então deixa pelo menos tanto espaço quanto ele.`,
+      dropped++;
+      states[i] = "corta";
+      steps.push({
+        line: 4, order, states: { ...states }, output: copyIvs(output), block: null, guide: prevEnd, tests, dropped,
+        note: `Descarto ${fmtIv(ivs[i])}. Trocá-lo pelo que já escolhi nunca melhora a conta: o que escolhi termina antes ou junto, então deixa pelo menos tanto espaço quanto ele.`,
         vars: vars(),
       });
     }
   }
 
-  out.push({
-    linha: 8, ordem: ord, estados: { ...estados }, saida: copiar(saida), bloco: null, guia: fimAnterior, testes, cortados, ok: true,
-    nota: `Fim: ${saida.length} de ${n} ${pl(n, "intervalo cabe", "intervalos cabem")} sem conflito, ${cortados} ${pl(cortados, "sobra de fora", "sobram de fora")}. Para o LeetCode 435, a resposta é justamente esse ${cortados}.`,
+  steps.push({
+    line: 8, order, states: { ...states }, output: copyIvs(output), block: null, guide: prevEnd, tests, dropped, ok: true,
+    note: `Fim: ${output.length} de ${n} ${pl(n, "intervalo cabe", "intervalos cabem")} sem conflito, ${dropped} ${pl(dropped, "sobra de fora", "sobram de fora")}. Para o LeetCode 435, a resposta é justamente esse ${dropped}.`,
     vars: vars(),
   });
-  return out;
+  return steps;
 }
 
 // --------------------------------- modos -----------------------------------
 
-type Preset = { nome: string; ivs: string; novo?: string };
+type Preset = { name: string; ivs: string; incoming?: string };
 
-type Modo = {
+type Mode = {
   key: "merge" | "insert" | "greedy";
-  nome: string;
-  familia: string;
-  cor: string;
-  arquivo: string;
-  rodape: string;
-  codigo: string[];
-  usaNovo: boolean;
-  rotuloSaida: string;
+  name: string;
+  family: string;
+  color: string;
+  file: string;
+  caption: string;
+  code: string[];
+  usesIncoming: boolean;
+  outputLabel: string;
   presets: Preset[];
 };
 
-const MODOS: Modo[] = [
+const MODES: Mode[] = [
   {
     key: "merge",
-    nome: "funde quem encosta",
-    familia: "Merge",
-    cor: "#3b82f6",
-    arquivo: "merge_intervals.py",
-    rodape: "ordena por início · O(n log n)",
-    codigo: CODIGO_MERGE,
-    usaNovo: false,
-    rotuloSaida: "saída",
+    name: "funde quem encosta",
+    family: "Merge",
+    color: "#3b82f6",
+    file: "merge_intervals.py",
+    caption: "ordena por início · O(n log n)",
+    code: CODE_MERGE,
+    usesIncoming: false,
+    outputLabel: "saída",
     presets: [
-      { nome: "Caso base", ivs: "[13,16], [1,4], [8,10], [2,6], [9,12], [17,18]" },
-      { nome: "Tudo vira um", ivs: "[1,4], [3,7], [6,10], [9,12]" },
-      { nome: "Nada funde", ivs: "[1,2], [3,4], [5,6], [7,8]" },
-      { nome: "Só encostam", ivs: "[1,3], [3,5], [5,7]" },
-      { nome: "Um dentro do outro", ivs: "[1,10], [2,3], [4,5], [11,12]" },
-      { nome: "Um intervalo só", ivs: "[5,9]" },
-      { nome: "Lista vazia", ivs: "" },
+      { name: "Caso base", ivs: "[13,16], [1,4], [8,10], [2,6], [9,12], [17,18]" },
+      { name: "Tudo vira um", ivs: "[1,4], [3,7], [6,10], [9,12]" },
+      { name: "Nada funde", ivs: "[1,2], [3,4], [5,6], [7,8]" },
+      { name: "Só encostam", ivs: "[1,3], [3,5], [5,7]" },
+      { name: "Um dentro do outro", ivs: "[1,10], [2,3], [4,5], [11,12]" },
+      { name: "Um intervalo só", ivs: "[5,9]" },
+      { name: "Lista vazia", ivs: "" },
     ],
   },
   {
     key: "insert",
-    nome: "encaixa um novo",
-    familia: "Insert",
-    cor: "#f59e0b",
-    arquivo: "insert_interval.py",
-    rodape: "não ordena nada · O(n)",
-    codigo: CODIGO_INSERT,
-    usaNovo: true,
-    rotuloSaida: "saída",
+    name: "encaixa um novo",
+    family: "Insert",
+    color: "#f59e0b",
+    file: "insert_interval.py",
+    caption: "não ordena nada · O(n)",
+    code: CODE_INSERT,
+    usesIncoming: true,
+    outputLabel: "saída",
     presets: [
-      { nome: "Engole dois", ivs: "[1,3], [6,9], [12,16]", novo: "[7,13]" },
-      { nome: "Não toca ninguém", ivs: "[1,3], [6,9], [12,16]", novo: "[4,5]" },
-      { nome: "Vai para o fim", ivs: "[1,3], [6,9], [12,16]", novo: "[20,25]" },
-      { nome: "Engole tudo", ivs: "[1,3], [6,9], [12,16]", novo: "[0,20]" },
-      { nome: "Lista vazia", ivs: "", novo: "[4,8]" },
+      { name: "Engole dois", ivs: "[1,3], [6,9], [12,16]", incoming: "[7,13]" },
+      { name: "Não toca ninguém", ivs: "[1,3], [6,9], [12,16]", incoming: "[4,5]" },
+      { name: "Vai para o fim", ivs: "[1,3], [6,9], [12,16]", incoming: "[20,25]" },
+      { name: "Engole tudo", ivs: "[1,3], [6,9], [12,16]", incoming: "[0,20]" },
+      { name: "Lista vazia", ivs: "", incoming: "[4,8]" },
     ],
   },
   {
     key: "greedy",
-    nome: "máximo sem conflito",
-    familia: "Greedy",
-    cor: "#34d399",
-    arquivo: "interval_scheduling.py",
-    rodape: "ordena pelo fim · O(n log n)",
-    codigo: CODIGO_GREEDY,
-    usaNovo: false,
-    rotuloSaida: "escolhidos",
+    name: "máximo sem conflito",
+    family: "Greedy",
+    color: "#34d399",
+    file: "interval_scheduling.py",
+    caption: "ordena pelo fim · O(n log n)",
+    code: CODE_GREEDY,
+    usesIncoming: false,
+    outputLabel: "escolhidos",
     presets: [
-      { nome: "Caso base", ivs: "[13,16], [1,4], [8,10], [2,6], [9,12], [17,18]" },
-      { nome: "Pelo início falharia", ivs: "[1,10], [2,3], [4,5], [6,7]" },
-      { nome: "Todos em cima", ivs: "[1,5], [2,6], [3,7], [4,8]" },
-      { nome: "Cadeia perfeita", ivs: "[1,3], [3,5], [5,7], [7,9]" },
+      { name: "Caso base", ivs: "[13,16], [1,4], [8,10], [2,6], [9,12], [17,18]" },
+      { name: "Pelo início falharia", ivs: "[1,10], [2,3], [4,5], [6,7]" },
+      { name: "Todos em cima", ivs: "[1,5], [2,6], [3,7], [4,8]" },
+      { name: "Cadeia perfeita", ivs: "[1,3], [3,5], [5,7], [7,9]" },
     ],
   },
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-function temSobreposicao(ivs: Intervalo[]): boolean {
+function hasOverlap(ivs: Interval[]): boolean {
   for (let i = 1; i < ivs.length; i++) {
     if (ivs[i][0] <= ivs[i - 1][1]) return true;
   }
@@ -454,207 +457,171 @@ function temSobreposicao(ivs: Intervalo[]): boolean {
 }
 
 /**
- * `modo` só escolhe com qual varredura o visualizador ABRE. O artigo usa o
+ * `mode` só escolhe com qual varredura o visualizador ABRE. O artigo usa o
  * mesmo componente três vezes, cada vez na seção que ensina aquele modo, e o
  * aluno continua podendo trocar pelos chips.
  */
-export function IntervalsVisualizer({ modo: modoInicial = "merge" }: { modo?: Modo["key"] } = {}) {
-  const iInicial = Math.max(0, MODOS.findIndex((m) => m.key === modoInicial));
-  const [iModo, setIModo] = useState(iInicial);
-  const [entrada, setEntrada] = useState(MODOS[iInicial].presets[0].ivs);
-  const [entradaNovo, setEntradaNovo] = useState(
-    MODOS.find((m) => m.key === "insert")?.presets[0].novo ?? "[7,13]"
+export function IntervalsVisualizer({ mode: initialMode = "merge" }: { mode?: Mode["key"] } = {}) {
+  const initialIndex = Math.max(0, MODES.findIndex((m) => m.key === initialMode));
+  const [modeIndex, setModeIndex] = useState(initialIndex);
+  const [input, setInput] = useState(MODES[initialIndex].presets[0].ivs);
+  const [incomingInput, setIncomingInput] = useState(
+    MODES.find((m) => m.key === "insert")?.presets[0].incoming ?? "[7,13]"
   );
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
-
-  const modo = MODOS[iModo];
+  const mode = MODES[modeIndex];
 
   // O Insert pressupõe a lista já ordenada, então aqui ela chega ordenada por
   // início: é o contrato do problema, não uma etapa do algoritmo.
   const ivs = useMemo(() => {
-    const lidos = lerIntervalos(entrada);
-    return modo.key === "insert" ? [...lidos].sort((a, b) => a[0] - b[0] || a[1] - b[1]) : lidos;
-  }, [entrada, modo.key]);
+    const read = parseIntervals(input);
+    return mode.key === "insert" ? [...read].sort((a, b) => a[0] - b[0] || a[1] - b[1]) : read;
+  }, [input, mode.key]);
 
-  const novo = useMemo<Intervalo>(() => {
-    const lido = lerIntervalos(entradaNovo, 1);
-    return lido.length ? lido[0] : [0, 0];
-  }, [entradaNovo]);
+  const incoming = useMemo<Interval>(() => {
+    const read = parseIntervals(incomingInput, 1);
+    return read.length ? read[0] : [0, 0];
+  }, [incomingInput]);
 
-  const passos = useMemo(() => {
-    if (modo.key === "merge") return gerarMerge(ivs);
-    if (modo.key === "greedy") return gerarGreedy(ivs);
-    return gerarInsert(ivs, novo);
-  }, [modo.key, ivs, novo]);
+  const steps = useMemo(() => {
+    if (mode.key === "merge") return generateMerge(ivs);
+    if (mode.key === "greedy") return generateGreedy(ivs);
+    return generateInsert(ivs, incoming);
+  }, [mode.key, ivs, incoming]);
 
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
   const n = ivs.length;
 
-  const eixo = useMemo(() => {
-    const vals: number[] = [];
-    for (const iv of ivs) { vals.push(iv[0], iv[1]); }
-    if (modo.usaNovo) vals.push(novo[0], novo[1]);
-    if (!vals.length) vals.push(0, 10);
-    return eixoDe(vals);
-  }, [ivs, novo, modo.usaNovo]);
+  const viz = useVisualizer({
+    title: "Visualizador · varrendo intervalos na linha do tempo",
+    total: steps.length,
+    // O que MAIS muda a altura: o modo (o código vai de 9 a 15 linhas e a fila
+    // de cenários muda de tamanho) e quantos intervalos a entrada tem, porque
+    // cada um é uma faixa a mais na linha do tempo. `steps.length` entra porque
+    // ele atravessa 1 — e em `total: 1` o rodapé inteiro some, o que é altura.
+    measureOn: [modeIndex, n, steps.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+  const axis = useMemo(() => {
+    const values: number[] = [];
+    for (const iv of ivs) { values.push(iv[0], iv[1]); }
+    if (mode.usesIncoming) values.push(incoming[0], incoming[1]);
+    if (!values.length) values.push(0, 10);
+    return axisFor(values);
+  }, [ivs, incoming, mode.usesIncoming]);
 
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => { parar(); setTocando(false); setPasso(0); }, [parar]);
-
-  const trocarModo = (i: number) => {
-    reiniciar();
-    setIModo(i);
-    const pr = MODOS[i].presets[0];
-    setEntrada(pr.ivs);
-    if (pr.novo) setEntradaNovo(pr.novo);
+  const pickMode = (i: number) => {
+    viz.reset();
+    setModeIndex(i);
+    const pr = MODES[i].presets[0];
+    setInput(pr.ivs);
+    if (pr.incoming) setIncomingInput(pr.incoming);
   };
 
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
-    setEntrada(pr.ivs);
-    if (pr.novo) setEntradaNovo(pr.novo);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setInput(pr.ivs);
+    if (pr.incoming) setIncomingInput(pr.incoming);
   };
 
   // Math.random só no handler, nunca no render: o HTML do build e o do cliente
   // precisam bater na hidratação.
-  const sortear = () => {
-    const qtd = 4 + Math.floor(Math.random() * 3);
-    const gerados: Intervalo[] = [];
-    for (let i = 0; i < qtd; i++) {
-      const ini = Math.floor(Math.random() * 16);
-      gerados.push([ini, ini + 1 + Math.floor(Math.random() * 5)]);
+  const randomize = () => {
+    const count = 4 + Math.floor(Math.random() * 3);
+    const drawn: Interval[] = [];
+    for (let i = 0; i < count; i++) {
+      const start = Math.floor(Math.random() * 16);
+      drawn.push([start, start + 1 + Math.floor(Math.random() * 5)]);
     }
-    reiniciar();
-    if (modo.key === "insert") {
-      const ordenados = [...gerados].sort((a, b) => a[0] - b[0]);
-      const limpos: Intervalo[] = [];
-      for (const iv of ordenados) {
-        if (!limpos.length || iv[0] > limpos[limpos.length - 1][1]) limpos.push(iv);
+    viz.reset();
+    if (mode.key === "insert") {
+      const sorted = [...drawn].sort((a, b) => a[0] - b[0]);
+      const clean: Interval[] = [];
+      for (const iv of sorted) {
+        if (!clean.length || iv[0] > clean[clean.length - 1][1]) clean.push(iv);
       }
-      setEntrada(escreverIntervalos(limpos));
-      const ini = Math.floor(Math.random() * 14);
-      setEntradaNovo(`[${ini},${ini + 2 + Math.floor(Math.random() * 6)}]`);
+      setInput(writeIntervals(clean));
+      const start = Math.floor(Math.random() * 14);
+      setIncomingInput(`[${start},${start + 2 + Math.floor(Math.random() * 6)}]`);
       return;
     }
-    setEntrada(escreverIntervalos(gerados));
+    setInput(writeIntervals(drawn));
   };
 
-  const linhasTL: LinhaTL[] = [
-    ...p.ordem.map((i) => ({
-      chave: `iv${i}`,
-      rotulo: fmtIv(ivs[i]),
-      barras: [{ chave: `b${i}`, inicio: ivs[i][0], fim: ivs[i][1], classe: p.estados[i] ?? "espera", texto: `${ivs[i][0]},${ivs[i][1]}` }],
+  const rows: TimelineRow[] = [
+    ...p.order.map((i) => ({
+      id: `iv${i}`,
+      label: fmtIv(ivs[i]),
+      bars: [{ id: `b${i}`, start: ivs[i][0], end: ivs[i][1], state: p.states[i] ?? "espera", label: `${ivs[i][0]},${ivs[i][1]}` }],
     })),
-    ...(modo.usaNovo
+    ...(mode.usesIncoming
       ? [{
-          chave: "novo",
-          rotulo: "novo",
-          barras: p.bloco ? [{ chave: "nv", inicio: p.bloco[0], fim: p.bloco[1], classe: "novo", texto: `${p.bloco[0]},${p.bloco[1]}` }] : [],
+          id: "novo",
+          label: "novo",
+          bars: p.block ? [{ id: "nv", start: p.block[0], end: p.block[1], state: "novo", label: `${p.block[0]},${p.block[1]}` }] : [],
         }]
       : []),
     {
-      chave: "saida",
-      rotulo: modo.rotuloSaida,
-      barras: [
-        ...p.saida.map((s, k) => ({ chave: `s${k}`, inicio: s[0], fim: s[1], classe: "pronto", texto: `${s[0]},${s[1]}` })),
-        ...(modo.key === "merge" && p.bloco
-          ? [{ chave: "bloco", inicio: p.bloco[0], fim: p.bloco[1], classe: "bloco", texto: `${p.bloco[0]},${p.bloco[1]}` }]
+      id: "saida",
+      label: mode.outputLabel,
+      bars: [
+        ...p.output.map((s, k) => ({ id: `s${k}`, start: s[0], end: s[1], state: "pronto", label: `${s[0]},${s[1]}` })),
+        ...(mode.key === "merge" && p.block
+          ? [{ id: "bloco", start: p.block[0], end: p.block[1], state: "bloco", label: `${p.block[0]},${p.block[1]}` }]
           : []),
       ],
     },
   ];
 
   const stats =
-    modo.key === "merge"
+    mode.key === "merge"
       ? [
-          { rot: "intervalos na entrada", val: `${n}` },
-          { rot: "blocos na saída", val: `${p.saida.length + (p.bloco ? 1 : 0)}` },
-          { rot: "testes de sobreposição", val: `${p.testes}` },
-          { rot: "todos os pares seriam", val: `${(n * (n - 1)) / 2}` },
+          { label: "intervalos na entrada", value: `${n}` },
+          { label: "blocos na saída", value: `${p.output.length + (p.block ? 1 : 0)}` },
+          { label: "testes de sobreposição", value: `${p.tests}` },
+          { label: "todos os pares seriam", value: `${(n * (n - 1)) / 2}` },
         ]
-      : modo.key === "insert"
+      : mode.key === "insert"
         ? [
-            { rot: "intervalos na lista", val: `${n}` },
-            { rot: "intervalos na saída", val: `${p.saida.length}` },
-            { rot: "comparações", val: `${p.testes}` },
-            { rot: "ordenações", val: "0" },
+            { label: "intervalos na lista", value: `${n}` },
+            { label: "intervalos na saída", value: `${p.output.length}` },
+            { label: "comparações", value: `${p.tests}` },
+            { label: "ordenações", value: "0" },
           ]
         : [
-            { rot: "intervalos na entrada", val: `${n}` },
-            { rot: "escolhidos", val: `${p.saida.length}` },
-            { rot: "descartados", val: `${p.cortados}` },
-            { rot: "testes", val: `${p.testes}` },
+            { label: "intervalos na entrada", value: `${n}` },
+            { label: "escolhidos", value: `${p.output.length}` },
+            { label: "descartados", value: `${p.dropped}` },
+            { label: "testes", value: `${p.tests}` },
           ];
 
-  const avisoInsert = modo.key === "insert" && temSobreposicao(ivs);
-  const notaCls = "viz-note" + (p.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const resultado = p.saida.length
-    ? fmtLista(p.saida) + (modo.key === "merge" && p.bloco ? ` ${fmtIv(p.bloco)}` : "")
-    : modo.key === "merge" && p.bloco
-      ? fmtIv(p.bloco)
+  const insertWarning = mode.key === "insert" && hasOverlap(ivs);
+  const noteClass = "viz-note" + (p.ok ? " ok" : "");
+  const result = p.output.length
+    ? fmtList(p.output) + (mode.key === "merge" && p.block ? ` ${fmtIv(p.block)}` : "")
+    : mode.key === "merge" && p.block
+      ? fmtIv(p.block)
       : "ainda vazia";
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" style={{ background: modo.cor }} />
-          <span>Visualizador · varrendo intervalos na linha do tempo</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} color={mode.color} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {MODOS.map((m, i) => {
-            const on = i === iModo;
+          {MODES.map((m, i) => {
+            const on = i === modeIndex;
             return (
               <button
                 key={m.key}
                 className={`bigo-chip${on ? " on" : ""}`}
-                style={on ? { borderColor: m.cor, color: m.cor } : undefined}
-                onClick={() => trocarModo(i)}
+                style={on ? { borderColor: m.color, color: m.color } : undefined}
+                onClick={() => pickMode(i)}
                 aria-pressed={on}
               >
-                <span className="sw" style={{ background: on ? m.cor : "#3a4a60" }} />
-                {m.familia} · {m.nome}
+                <span className="sw" style={{ background: on ? m.color : "#3a4a60" }} />
+                {m.family} · {m.name}
               </button>
             );
           })}
@@ -665,39 +632,39 @@ export function IntervalsVisualizer({ modo: modoInicial = "merge" }: { modo?: Mo
             <span>Intervalos</span>
             <input
               className="viz-input"
-              value={entrada}
-              onChange={(e) => { reiniciar(); setEntrada(e.target.value); }}
+              value={input}
+              onChange={(e) => { viz.reset(); setInput(e.target.value); }}
               placeholder="[1,4], [2,6], [8,10]"
             />
           </label>
-          {modo.usaNovo && (
+          {mode.usesIncoming && (
             <label className="viz-field">
               <span>novo</span>
               <input
                 className="viz-input"
                 style={{ width: 96 }}
-                value={entradaNovo}
-                onChange={(e) => { reiniciar(); setEntradaNovo(e.target.value); }}
+                value={incomingInput}
+                onChange={(e) => { viz.reset(); setIncomingInput(e.target.value); }}
               />
             </label>
           )}
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={randomize}>Sortear</button>
         </div>
 
         <div className="iv-presets">
           <span className="iv-presets-lbl">Cenários</span>
-          {modo.presets.map((pr) => (
+          {mode.presets.map((pr) => (
             <button
-              key={pr.nome}
-              className={`iv-preset${entrada === pr.ivs && (!pr.novo || entradaNovo === pr.novo) ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              key={pr.name}
+              className={`iv-preset${input === pr.ivs && (!pr.incoming || incomingInput === pr.incoming) ? " on" : ""}`}
+              onClick={() => applyPreset(pr)}
             >
-              {pr.nome}
+              {pr.name}
             </button>
           ))}
         </div>
 
-        {avisoInsert && (
+        {insertWarning && (
           <p className="viz-note invalid">
             Esta lista tem sobreposição entre os próprios intervalos. O Insert Interval pressupõe que ela chegue limpa,
             então rode o modo Merge antes para ver o que aconteceria de verdade.
@@ -705,78 +672,65 @@ export function IntervalsVisualizer({ modo: modoInicial = "merge" }: { modo?: Mo
         )}
 
         <LinhaDoTempo
-          linhas={linhasTL}
-          min={eixo.min}
-          max={eixo.max}
-          marcas={eixo.marcas}
-          guia={p.guia}
-          guiaVerde={modo.key !== "insert"}
+          rows={rows}
+          min={axis.min}
+          max={axis.max}
+          ticks={axis.ticks}
+          guide={p.guide}
+          guideGreen={mode.key !== "insert"}
         />
 
         <div className="iv-saida">
-          <span className="iv-saida-lbl">{modo.rotuloSaida}</span>
-          <span className="iv-saida-val">{resultado}</span>
+          <span className="iv-saida-lbl">{mode.outputLabel}</span>
+          <span className="iv-saida-val">{result}</span>
         </div>
 
         <div className="bigo-stats">
           {stats.map((s) => (
-            <div className="bigo-stat" key={s.rot}>
-              <span>{s.rot}</span>
-              <strong style={{ color: modo.cor }}>{s.val}</strong>
+            <div className="bigo-stat" key={s.label}>
+              <span>{s.label}</span>
+              <strong style={{ color: mode.color }}>{s.value}</strong>
             </div>
           ))}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo.arquivo} · {modo.rodape}</div>
-            <div className="viz-code-body">
-              {modo.codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra é pela ALTURA: zerar a trilha da coluna só tira a
+              largura, e a linha do grid continua com a altura inteira do bloco.
+              O código fica no DOM mesmo recolhido — é isso que permite medir o
+              pior caso —, e `inert` o tira do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode.file} · {mode.caption}</div>
+              <div className="viz-code-body">
+                {mode.code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {p.vars.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%`, background: modo.cor }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} color={mode.color} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -302,3 +302,53 @@ regras que custaram caro:
   foi o experimento. Escolha uma quebra que **compile** (inverter uma condição,
   não acrescentar um `return` que deixa código inalcançável).
 - Use `npm run test:build`. `npm test` sozinho exercita o build anterior.
+
+## 9. Dois limites medidos da casca
+
+Ambos apareceram adaptando o tópico `intervals`, e ambos são do comportamento
+da casca — não do componente. Estão aqui porque um explica um número que o
+relatório de qualquer adaptação vai encontrar, e o outro é um recurso que o hook
+não tem.
+
+### A compressão da camada 2 não alcança o fluxo do artigo
+
+O bloco `@media (max-height: 950px)` do `globals.css` é escopado em
+`.viz-overlay-fit`: ele só aperta o respiro **dentro do painel expandido**.
+Medido, com o código à mostra nas cinco peças do `intervals`: as alturas numa
+janela de 940px (dentro da consulta) e numa de 1000px (fora dela) são
+**idênticas ao pixel** — 1004, 1176, 1180, 1208 e 1071.
+
+A consequência prática é a ordem em que as camadas agem no artigo: lá só valem
+a 3 (recolher) e o layout base, porque a 2 nunca entra. Por isso uma peça pode
+caber com folga no expandido e ainda passar do orçamento no fluxo do artigo,
+com o bloco já recolhido — e o relatório deve dizer isso com número, em vez de
+tratar como defeito do componente.
+
+Estender a compressão ao artigo é **PR de plataforma**: mexe em base
+compartilhada e alcança página que ninguém abriu. Não vá de carona numa
+adaptação de tópico.
+
+### O hook não tem passo inicial, e a saída não é um efeito
+
+`useVisualizer` sempre começa no passo 0. Quando a peça precisa abrir noutro
+instante — no `intervals`, a sobreposição abre com B já invadindo A, porque em
+t = 0 os dois nem se tocam e abrir sem sobreposição num visualizador sobre
+sobreposição ensina ao contrário —, o ajuste vai na **fase de render**, não num
+`useEffect`:
+
+```tsx
+const [placed, setPlaced] = useState(false);
+if (!placed) {
+  setPlaced(true);
+  viz.setStep(INITIAL_STEP);
+}
+```
+
+É o padrão documentado do React para estado derivado, e a diferença importa duas
+vezes: ele roda antes da pintura (nada pisca na hidratação) **e dentro do build
+estático**, então o HTML pré-renderizado já sai no passo certo. Com `useEffect`,
+o `out/` congela o passo 1 e só o cliente corrige — conferido no HTML do build.
+
+Uma consequência a assumir: o `↺` do `VizFooter` é `viz.reset()`, que volta ao
+passo **0**, e não ao passo inicial escolhido. Se o estado de partida for para
+valer, ele precisa de um botão próprio — ver a nota do `↺` na §6.

--- a/tests/viz-intervals.spec.ts
+++ b/tests/viz-intervals.spec.ts
@@ -1,0 +1,426 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa nos três visualizadores do tópico `intervals`.
+//
+// O artigo monta CINCO peças a partir de três arquivos: o
+// `IntervalsVisualizer` aparece três vezes, uma por seção, com a prop `mode`
+// escolhendo com qual varredura ele abre. Por isso os índices abaixo.
+//
+// Cada teste mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova nada —
+// já passaram por uma suíte verde um visualizador sem botão nenhum e um painel
+// de 0px de largura —, e comportamento certo com rótulo errado ensina errado do
+// mesmo jeito: por isso todo número verificado vem junto do texto ao lado dele.
+//
+// A janela é 1512x900 (notebook de 16"), a régua do contrato. Nela, antes da
+// casca, o expandido do sweep rolava INTEIRO: o cabeçalho subia 367px e o
+// "▶ Rodar" era desenhado com a base em 1208px numa janela de 900.
+// ---------------------------------------------------------------------------
+
+const SOBREPOSICAO = 0;
+const MERGE = 1;
+const INSERT = 2;
+const SWEEP = 3;
+const GREEDY = 4;
+
+function figura(page: Page, n: number): Locator {
+  return page.locator("article figure.viz").nth(n);
+}
+
+function painel(page: Page): Locator {
+  return page.locator(".viz-overlay-fit figure.viz-fit");
+}
+
+async function abrirTopico(page: Page, largura = 1512, altura = 900) {
+  await page.setViewportSize({ width: largura, height: altura });
+  await page.goto("/topico/intervals/");
+  // As fontes chegam com `display: swap`: medir antes mede a de fallback.
+  await page.evaluate(() => document.fonts.ready);
+}
+
+/** Altura da caixa de um elemento, arredondada. Zero quando ele não tem caixa. */
+async function altura(alvo: Locator): Promise<number> {
+  const caixa = await alvo.boundingBox();
+  return caixa ? Math.round(caixa.height) : 0;
+}
+
+/**
+ * Espera a medição TERMINAR, em vez de dormir um tanto e torcer. O `data-anim`
+ * é o sinal que a própria casca publica: fica em "off" enquanto a medição roda
+ * com a transição congelada, e só volta para "on" depois da decisão.
+ */
+async function medicaoTerminou(alvo: Locator) {
+  await expect(alvo).toHaveAttribute("data-anim", "on");
+}
+
+/** Deixa o bloco de código à mostra, que é o pior caso de altura. */
+async function abrirCodigo(alvo: Locator) {
+  const alternar = alvo.getByRole("button", { name: /código$/ });
+  if (((await alternar.textContent()) ?? "").includes("Mostrar")) await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect.poll(() => altura(alvo.locator(".viz-code"))).toBeGreaterThan(100);
+}
+
+/**
+ * Rola o miolo até uma fração da sobra e só volta quando o navegador aplicou a
+ * rolagem e pintou o quadro seguinte. O retorno é o `scrollTop` REAL: se a
+ * rolagem não acontecer, "o cabeçalho não se mexeu" vira verdade à toa.
+ */
+async function rolarMiolo(miolo: Locator, fracao: number): Promise<number> {
+  return miolo.evaluate(
+    (el, f) =>
+      new Promise<number>((resolve) => {
+        el.scrollTop = (el.scrollHeight - el.clientHeight) * f;
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve(el.scrollTop)));
+      }),
+    fracao
+  );
+}
+
+async function expandir(page: Page, n: number) {
+  await figura(page, n).getByRole("button", { name: "⤢ Expandir" }).click();
+  await expect(painel(page)).toBeVisible();
+  await medicaoTerminou(painel(page));
+}
+
+// ---------------------------------------------------------------------------
+// 1. Cabeçalho e rodapé parados, e o botão que faz o algoritmo andar na tela.
+// ---------------------------------------------------------------------------
+
+test("sweep expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({
+  page,
+}) => {
+  await abrirTopico(page);
+  await expandir(page, SWEEP);
+  const p = painel(page);
+  await abrirCodigo(p);
+
+  const miolo = p.locator(".viz-body");
+  // Duas pré-condições, e nenhuma das duas é decoração. A primeira: existe
+  // sobra para rolar — sem ela o teste vira verde à toa no dia em que a peça
+  // encolher. A segunda: quem rola é o `.viz-body`, e não a figura inteira,
+  // que era exatamente o defeito antigo (com a figura rolando, o `scrollTop`
+  // do miolo fica em zero, o cabeçalho não se mexe e o teste aprova a quebra).
+  const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
+  expect(sobra).toBeGreaterThan(20);
+  const sobraFigura = await p.evaluate((el) => el.scrollHeight - el.clientHeight);
+  expect(sobraFigura).toBeLessThanOrEqual(1);
+
+  const cabeca = p.locator(".viz-head");
+  const rodape = p.locator(".viz-foot");
+  const rodar = p.getByRole("button", { name: "▶ Rodar" });
+
+  const antes = {
+    cabeca: (await cabeca.boundingBox())!.y,
+    rodape: (await rodape.boundingBox())!.y,
+    rodar: (await rodar.boundingBox())!.y,
+  };
+
+  // "Está parado agora" não é "continua parado": amostra ao longo da rolagem.
+  const desvios: number[] = [];
+  for (const destino of [0.25, 0.5, 0.75, 1]) {
+    const real = await rolarMiolo(miolo, destino);
+    expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
+    desvios.push(
+      Math.abs((await cabeca.boundingBox())!.y - antes.cabeca),
+      Math.abs((await rodape.boundingBox())!.y - antes.rodape),
+      Math.abs((await rodar.boundingBox())!.y - antes.rodar)
+    );
+  }
+  expect(Math.max(...desvios)).toBeLessThanOrEqual(1);
+
+  // E o botão que move o algoritmo continua inteiro dentro da janela — que é o
+  // que ele NÃO fazia antes da casca (medido: base em 1208px numa janela de 900).
+  const caixa = (await rodar.boundingBox())!;
+  const janela = page.viewportSize()!.height;
+  expect(caixa.y).toBeGreaterThanOrEqual(0);
+  expect(caixa.y + caixa.height).toBeLessThanOrEqual(janela);
+  // O rótulo, e não só a posição: botão no lugar certo dizendo outra coisa
+  // manda o aluno clicar no que ele não quer.
+  await expect(rodar).toHaveText("▶ Rodar");
+  // O cabeçalho parado só serve se continuar dizendo alguma coisa.
+  await expect(p.locator(".viz-step")).toHaveText(/^passo \d+ de \d+$/);
+});
+
+// ---------------------------------------------------------------------------
+// 2 e 3. Quem decide é a medição: recolhido na tela baixa, aberto na tela alta.
+// ---------------------------------------------------------------------------
+
+test("merge no artigo: tela baixa recolhe o código e diz Mostrar código", async ({ page }) => {
+  await abrirTopico(page, 1512, 700);
+  const f = figura(page, MERGE);
+  const alternar = f.getByRole("button", { name: /código$/ });
+
+  await expect(alternar).toHaveText("Mostrar código");
+  await expect(f).toHaveAttribute("data-codigo", "off");
+  // Recolhido é ALTURA zerada, não só coluna estreita: zerar a trilha da coluna
+  // deixava a linha do grid com a altura inteira do bloco (armadilha medida).
+  await expect.poll(() => altura(f.locator(".viz-code"))).toBeLessThanOrEqual(4);
+  // E ele continua no DOM, fora do teclado e dos leitores de tela.
+  await expect(f.locator(".viz-code")).toHaveAttribute("aria-hidden", "true");
+  // O que o aluno veio ver continua inteiro: as faixas da linha do tempo.
+  expect(await altura(f.locator(".iv-tl"))).toBeGreaterThan(100);
+});
+
+test("merge no artigo: tela alta já vem com o código aberto e legível", async ({ page }) => {
+  await abrirTopico(page, 1512, 1500);
+  const f = figura(page, MERGE);
+  const alternar = f.getByRole("button", { name: /código$/ });
+
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect(f).toHaveAttribute("data-codigo", "on");
+  await expect.poll(() => altura(f.locator(".viz-code"))).toBeGreaterThan(100);
+  // O código certo do modo certo: rótulo junto do conteúdo, sempre.
+  await expect(f.locator(".viz-code-head")).toHaveText(
+    "merge_intervals.py · ordena por início · O(n log n)"
+  );
+  await expect(f.locator(".viz-code-body")).toContainText("intervalos.sort(key=lambda x: x[0])");
+});
+
+// ---------------------------------------------------------------------------
+// 4. A escolha do aluno vence a medição, e não é desfeita por troca de estado.
+// ---------------------------------------------------------------------------
+
+test("merge: abrir o código na mão sobrevive a trocar de modo, que pediria medição nova", async ({
+  page,
+}) => {
+  await abrirTopico(page, 1512, 700);
+  const f = figura(page, MERGE);
+  const alternar = f.getByRole("button", { name: /código$/ });
+
+  await expect(alternar).toHaveText("Mostrar código");
+  await alternar.click();
+  await expect(alternar).toHaveText("Ocultar código");
+  await expect.poll(() => altura(f.locator(".viz-code"))).toBeGreaterThan(100);
+
+  // Trocar de modo mexe em DUAS entradas do `measureOn` (o índice do modo e o
+  // número de passos) e dispara medição nova. A premissa é medida, não suposta:
+  // numa janela de 700px a peça com o código à mostra não cabe no orçamento do
+  // fluxo do artigo (janela - cabeçalho do site - respiro), então a medição
+  // recolheria — e mesmo assim a escolha do aluno manda.
+  await f.getByRole("button", { name: /Greedy · máximo sem conflito/ }).click();
+  await expect(f.locator(".viz-code-head")).toHaveText(
+    "interval_scheduling.py · ordena pelo fim · O(n log n)"
+  );
+  await medicaoTerminou(f);
+  const orcamento = await page.evaluate(() => {
+    const h = parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")
+    ) || 60;
+    return window.innerHeight - h - 24;
+  });
+  expect(await altura(f)).toBeGreaterThan(orcamento);
+
+  // E um gatilho de medição que a casca NÃO pode ignorar, para o teste não
+  // depender de eu ter listado o modo no `measureOn`: redimensionar mede sempre.
+  // Sem esta parte, esquecer o modo na lista deixaria o teste verde sem que
+  // medição nenhuma tivesse acontecido — que é como um preset inócuo já virou
+  // prova vazia neste repositório.
+  await page.setViewportSize({ width: 1512, height: 640 });
+  await medicaoTerminou(f);
+  await page.setViewportSize({ width: 1512, height: 700 });
+  await medicaoTerminou(f);
+
+  // A promessa aqui é de PERMANÊNCIA, então uma leitura só depois de uma espera
+  // olha um instante. Amostra ao longo do intervalo em que a medição nova teria
+  // tempo de desfazer a escolha (ela roda em `requestAnimationFrame`).
+  for (let i = 0; i < 5; i++) {
+    await expect(alternar).toHaveText("Ocultar código");
+    await expect(f).toHaveAttribute("data-codigo", "on");
+    expect(await altura(f.locator(".viz-code"))).toBeGreaterThan(100);
+    await page.waitForTimeout(150);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. Teclado: as setas e o espaço dirigem a animação, e o campo em edição manda.
+// ---------------------------------------------------------------------------
+
+test("merge expandido: setas andam o passo e o espaço roda, sem roubar a tecla de quem digita", async ({
+  page,
+}) => {
+  await abrirTopico(page);
+  await expandir(page, MERGE);
+  const p = painel(page);
+  const passo = p.locator(".viz-step");
+
+  await expect(passo).toHaveText(/^passo 1 de \d+$/);
+  const total = Number((await passo.textContent())!.match(/de (\d+)/)![1]);
+  expect(total).toBeGreaterThan(2);
+
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo 3 de ${total}`);
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+  // Espaço roda: o passo tem que ANDAR sozinho até o fim, não só o rótulo mudar.
+  await page.keyboard.press("Space");
+  await expect(passo).toHaveText(`passo ${total} de ${total}`);
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo ${total - 1} de ${total}`);
+
+  // Com o cursor num campo, seta é cursor e espaço é espaço. Sequestrar isso
+  // deixa a entrada impossível de editar, que é pior que não ter atalho.
+  const campo = p.locator("input.viz-input").first();
+  await campo.click();
+  const valorAntes = await campo.inputValue();
+
+  // Uma asserção DEPOIS DE CADA tecla, e não só no fim: `→` seguido de `←`
+  // volta para o mesmo passo, então uma leitura só no fim aprova o sequestro
+  // das duas setas. Medido — foi assim que uma quebra passou verde aqui.
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo ${total - 1} de ${total}`);
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo ${total - 1} de ${total}`);
+  await expect(campo).toHaveValue(valorAntes);
+
+  // E o espaço é um espaço digitado. Se ele tivesse sido sequestrado para
+  // rodar/pausar, o `preventDefault` engoliria o caractere e o valor ficaria
+  // igual — é essa diferença que a asserção pega.
+  //
+  // As duas asserções juntas dizem "entrou UM espaço e nada mais mudou": o
+  // comprimento cresceu exatamente 1, e o valor sem espaço nenhum continua
+  // idêntico. Comparar com o fim da string não serviria (a entrada deste
+  // visualizador já tem espaços, e onde o clique deixou o cursor depende do
+  // sistema — `End` não vai ao fim de um input no macOS).
+  const semEspacos = (s: string) => s.replace(/ /g, "");
+  await page.keyboard.press("Space");
+  await expect.poll(() => campo.inputValue()).toHaveLength(valorAntes.length + 1);
+  expect(semEspacos(await campo.inputValue())).toBe(semEspacos(valorAntes));
+  // Trocar a entrada reinicia a animação, e ela fica PARADA no primeiro passo.
+  // O segundo `waitForTimeout` também é objeto do teste: a marcha padrão anda a
+  // cada 650ms, então se o espaço tivesse ligado a reprodução o passo teria
+  // andado pelo menos uma vez dentro da janela.
+  await expect(passo).toHaveText(/^passo 1 de \d+$/);
+  await page.waitForTimeout(1000);
+  await expect(passo).toHaveText(/^passo 1 de \d+$/);
+});
+
+// ---------------------------------------------------------------------------
+// 6. A prop `mode` escolhe com qual varredura cada peça do artigo abre.
+// ---------------------------------------------------------------------------
+
+test("as três peças do IntervalsVisualizer abrem cada uma no seu modo", async ({ page }) => {
+  await abrirTopico(page, 1512, 1500);
+
+  const esperado = [
+    [MERGE, "Merge · funde quem encosta", "merge_intervals.py · ordena por início · O(n log n)"],
+    [INSERT, "Insert · encaixa um novo", "insert_interval.py · não ordena nada · O(n)"],
+    [GREEDY, "Greedy · máximo sem conflito", "interval_scheduling.py · ordena pelo fim · O(n log n)"],
+  ] as const;
+
+  for (const [i, chip, cabecalho] of esperado) {
+    const f = figura(page, i);
+    // O chip aceso e o cabeçalho do código na MESMA asserção: chip certo com
+    // código de outro modo ensina a lição trocada.
+    await expect(f.getByRole("button", { name: chip })).toHaveAttribute("aria-pressed", "true");
+    await expect(f.locator(".viz-code-head")).toHaveText(cabecalho);
+  }
+
+  // E o Insert é o único com o campo do intervalo que chega depois.
+  await expect(figura(page, INSERT).locator(".viz-field", { hasText: "novo" })).toHaveCount(1);
+  await expect(figura(page, MERGE).locator(".viz-field", { hasText: "novo" })).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 7. O rodapé compartilhado não promete o que não faz.
+// ---------------------------------------------------------------------------
+
+test("sobreposição: o ↺ volta ao passo 1 e o botão ao lado é quem devolve a entrada", async ({
+  page,
+}) => {
+  await abrirTopico(page, 1512, 1500);
+  const f = figura(page, SOBREPOSICAO);
+  const passo = f.locator(".viz-step");
+  const aTermina = f.locator(".viz-field", { hasText: "A termina" }).locator("input");
+
+  // A peça abre num instante em que os dois se sobrepõem, e não em t = 0.
+  await expect(passo).toHaveText("passo 5 de 16");
+  await expect(f.locator(".iv-selo")).toHaveText("sobrepõem");
+
+  await aTermina.fill("20");
+  await expect(passo).toHaveText("passo 5 de 24");
+
+  // O ↺ do rodapé compartilhado é `viz.reset()`: volta ao passo 1 e NADA mais.
+  await f.getByRole("button", { name: "↺" }).click();
+  await expect(passo).toHaveText("passo 1 de 24");
+  await expect(aTermina).toHaveValue("20");
+
+  // Quem devolve A, a duração de B e o modelo de borda é o botão ao lado.
+  await f.getByRole("button", { name: /^Bordas:/ }).click();
+  await expect(f.getByRole("button", { name: /^Bordas:/ })).toHaveText("Bordas: [início, fim)");
+  await f.getByRole("button", { name: "Voltar ao padrão" }).click();
+  await expect(aTermina).toHaveValue("12");
+  await expect(f.getByRole("button", { name: /^Bordas:/ })).toHaveText("Bordas: [início, fim]");
+  await expect(passo).toHaveText("passo 5 de 16");
+  await expect(f.locator(".iv-selo")).toHaveText("sobrepõem");
+});
+
+// ---------------------------------------------------------------------------
+// 8. `total: 1`: sem linha do tempo o rodapé some, e a volta fica no miolo.
+// ---------------------------------------------------------------------------
+
+test("merge: a lista vazia apaga o rodapé, e o cenário que traz de volta está no miolo", async ({
+  page,
+}) => {
+  await abrirTopico(page, 1512, 1500);
+  const f = figura(page, MERGE);
+
+  await expect(f.locator(".viz-step")).toHaveText(/^passo 1 de \d+$/);
+  await expect(f.locator(".viz-foot")).toHaveCount(1);
+
+  await f.getByRole("button", { name: "Lista vazia" }).click();
+  // Um passo só: some o contador, some o rodapé inteiro e somem os controles.
+  await expect(f.locator(".viz-step")).toHaveCount(0);
+  await expect(f.locator(".viz-foot")).toHaveCount(0);
+  await expect(f.getByRole("button", { name: "▶ Rodar" })).toHaveCount(0);
+  // E a peça continua ensinando: a nota diz por que a lista vazia importa.
+  await expect(f.locator(".viz-note")).toContainText("intervalos[0] em lista vazia estoura");
+
+  // A volta não pode depender de um botão que sumiu junto: os cenários vivem
+  // no miolo, então continuam clicáveis.
+  await f.getByRole("button", { name: "Caso base" }).click();
+  await expect(f.locator(".viz-foot")).toHaveCount(1);
+  await expect(f.locator(".viz-step")).toHaveText(/^passo 1 de \d+$/);
+});
+
+// ---------------------------------------------------------------------------
+// 9. Rótulo e número mudam juntos quando a regra de empate troca.
+// ---------------------------------------------------------------------------
+
+test("sweep: trocar a regra de empate troca o código, o rótulo e o número ao mesmo tempo", async ({
+  page,
+}) => {
+  await abrirTopico(page, 1512, 1500);
+  const f = figura(page, SWEEP);
+  const botao = f.getByRole("button", { name: /^Empate:/ });
+  const pico = f.locator(".bigo-stat", { hasText: "máximo até aqui" }).locator("strong");
+  const outra = f.locator(".bigo-stat", { hasText: "com a outra regra de empate" }).locator("strong");
+
+  await expect(botao).toHaveText("Empate: saída primeiro");
+  await expect(f.locator(".viz-code-head")).toHaveText("salas.py · a saída libera a sala");
+  await expect(f.locator(".viz-code-body")).toContainText("eventos.sort()");
+
+  // Anda até o fim para o pico ser o da execução inteira, e não o do passo 1.
+  const total = Number((await f.locator(".viz-step").textContent())!.match(/de (\d+)/)![1]);
+  for (let k = 1; k < total; k++) await f.getByRole("button", { name: /Próximo/ }).click();
+  await expect(f.locator(".viz-step")).toHaveText(`passo ${total} de ${total}`);
+  const comSaidaPrimeiro = await pico.textContent();
+  const previsaoDaOutra = await outra.textContent();
+
+  await botao.click();
+  await expect(botao).toHaveText("Empate: entrada primeiro");
+  await expect(f.locator(".viz-code-head")).toHaveText("salas.py · a saída não libera a sala");
+  await expect(f.locator(".viz-code-body")).toContainText(
+    "eventos.sort(key=lambda e: (e[0], -e[1]))"
+  );
+
+  // O número que a peça anunciava como "com a outra regra" tem que ser o que
+  // ela mostra agora como "máximo até aqui" no fim — senão um dos dois mente.
+  for (let k = 1; k < total; k++) await f.getByRole("button", { name: /Próximo/ }).click();
+  await expect(pico).toHaveText(previsaoDaOutra!);
+  await expect(outra).toHaveText(comSaidaPrimeiro!);
+  expect(previsaoDaOutra).not.toBe(comSaidaPrimeiro);
+});


### PR DESCRIPTION
## O que muda

Os três visualizadores do tópico **Intervalos** passam a usar a casca
adaptativa: `useVisualizer` com `VizHeader` e `VizFooter`. Adaptar foi
sobretudo **remover** — o estado de reprodução, o `setInterval`, o portal do
expandido e o `keydown` do Esc saíram dos três arquivos e viraram três linhas.

Junto vai a padronização de idioma do contrato §0 (identificador em inglês,
tela em português), inclusive no módulo compartilhado `IntervalsLinhaDoTempo`
e na prop `mode` que o MDX usa.

## Inventário: 3 arquivos, 3 adaptados, 0 fora

Os três tinham overlay, bloco de código, painel de variáveis e controles — as
três camadas nos três. O `IntervalsLinhaDoTempo.tsx` aparece no diretório mas
**não é visualizador**: é a linha do tempo compartilhada, sem overlay e sem
registro no `mdx-components.tsx`. Entrou só na padronização de idioma.

O artigo monta **cinco peças** a partir dos três arquivos: o
`IntervalsVisualizer` aparece três vezes, uma por seção, com a prop `mode`
escolhendo com qual varredura ele abre. O inventário conta arquivo; a medição
conta peça na tela.

## Medições

1512x900, painel expandido aberto, animação congelada, depois de
`document.fonts.ready`. Orçamento no fluxo do artigo = 900 − 60 − 24 = **816px**.

### No artigo

| peça | antes | depois | pior caso da entrada, antes → depois |
|---|---|---|---|
| sobreposição | 994 (+178) | **794 (cabe)** | 994 → 794 (a altura não depende da entrada) |
| merge | 1166 (+350) | 880 (+64) | 1294 → **1008** (10 intervalos) |
| insert | 1170 (+354) | **782 (cabe)** | — |
| sweep | 1198 (+382) | 912 (+96) | 1290 → **1004** (8 reuniões) |
| greedy | 1061 (+245) | 826 (+10) | — |

### No expandido, que é onde a mudança é inteira

Antes, a figura rolava **inteira**, e rolar até o fim levava o cabeçalho para
fora da tela. O `▶ Rodar` era desenhado abaixo da janela nas cinco peças:

| peça | cabeçalho ao rolar até o fim | base do `▶ Rodar` (janela = 900) |
|---|---|---|
| sobreposição | −68px | 909 |
| merge | −315px | 1156 |
| insert | −373px | 1214 |
| sweep | −367px | 1208 |
| greedy | −253px | 1094 |

Depois: quem rola é o `.viz-body`, o cabeçalho e o rodapé **não se movem 1px**,
e a base do `▶ Rodar` fica entre **759 e 838px**. Com o pior caso da entrada
carregado (10 intervalos / 8 reuniões) o miolo passa a ter 58 e 52px de sobra,
o cabeçalho segue em 0 e o `▶ Rodar` em 843.

Em janelas baixas, expandido: **1440x700** → sobra 22 (sobreposição) e 179
(sweep), cabeçalho 0, `▶ Rodar` em 648; **1440x600** → 117 e 274, cabeçalho 0,
`▶ Rodar` em 551; **1440x520** → 193 e 350, cabeçalho 0, `▶ Rodar` em 473.

### O que ficou de fora, com número

Três peças **continuam passando do orçamento no fluxo do artigo** com o código
já recolhido: merge +64, sweep +96 e greedy +10. A casca fez o que sabe — no
expandido as cinco cabem sem sobra nenhuma.

Quebrei a altura por bloco antes de concluir que "a peça é grande", e não há
desenho inflado aqui (a linha do tempo tem trilhas de altura fixa, nada de
`width: 100%` esticando junto): no merge recolhido, `iv-tl` = 244px para 7
faixas, `bigo-stats` = 64, `iv-presets` = 61. É conteúdo.

O que sobra é **respiro**, e ele é justamente o que a camada 2 aperta — só que
a camada 2 é escopada em `.viz-overlay-fit` e **não alcança o fluxo do artigo**.
Medido: as cinco peças, com o código à mostra, têm a mesma altura ao pixel numa
janela de 940px (dentro do `@media (max-height: 950px)`) e numa de 1000px:
1004, 1176, 1180, 1208, 1071. Estender a compressão ao artigo mexe em base
compartilhada, então é **PR de plataforma** — reportado, não feito de carona.
**Este PR não tem uma linha de CSS nova.**

## Nenhum texto de tela mudou

Varri **115 estados renderizados** da página antes e depois — todos os passos
das cinco peças, os três modos, todos os cenários de cada modo, as duas regras
de empate e os dois modelos de borda —, comparando o texto renderizado mais
`title`, `aria-label`, `aria-pressed` e `placeholder`. Diferenças, todas
esperadas:

- o botão novo **"Mostrar/Ocultar código"** no cabeçalho;
- o botão novo **"Voltar ao padrão"** na sobreposição (abaixo);
- a dica `← → passo · espaço roda`, que só aparece no expandido;
- em três estados — "Lista vazia" no merge e "Nenhuma reunião" no sweep, nas
  duas regras de empate — `total` cai para 1 e o contador de passo e o rodapé
  somem. É o contrato §6, e os cenários que trazem de volta ficam no miolo.

O `guarda-idioma.py` acusa, nos três visualizadores, só o que migrou para o
hook (`▶ Rodar`, `Próximo ›`, `Velocidade`, `Reiniciar`, as marchas e as classes
do cabeçalho e do rodapé) mais `@/lib/visualizer` e `viz-code-slot`.

## Duas decisões que valem revisão

**O `↺` encolheria sem avisar.** No `VizFooter` ele é `viz.reset()`: volta ao
passo 1 e nada mais. Na sobreposição ele antes devolvia também A, a duração de
B e o modelo de borda. Adotar o rodapé compartilhado sem mais nada encolheria a
promessa mantendo o rótulo, então esse trabalho ficou num botão próprio,
**"Voltar ao padrão"** — é o único texto novo do PR fora do botão do hook.

**O passo inicial.** A sobreposição abre com B já invadindo A, e não em t = 0,
onde os dois nem se tocam. O hook não tem passo inicial, e a saída não é um
`useEffect`: o ajuste vai na fase de render, e assim o HTML do build estático já
sai no passo certo (conferido: `passo 5` no `out/topico/intervals/index.html`).
As duas viraram seção nova no `content/visualizers/README.md`.

## Testes

Nove testes em `tests/viz-intervals.spec.ts` (arquivo novo, zero conflito com
`navegacao.spec.ts`). `npm run test:build`: **99 passed**.

Cada um mede comportamento e lê rótulo. Além do mínimo do contrato §8: a prop
`mode` das três peças com o chip aceso e o cabeçalho do código na mesma
asserção; o `↺` e o "Voltar ao padrão" provados pelo que fazem **e pelo que não
fazem**; e a lista vazia apagando o rodapé com a volta garantida pelo miolo.

### As doze quebras, todas com build visível e todas compilando

| quebra | teste que reprova |
|---|---|
| A — `VizFooter` movido para DENTRO do `.viz-body` | cabeçalho e rodapé não se mexem |
| B — `.viz-code-slot` renomeado (recolhe coluna, não altura) | tela baixa recolhe o código |
| C — nome do arquivo no cabeçalho do código trocado | tela alta já vem com o código aberto |
| D — `manualChoice.current = null` no hook | a escolha sobrevive à troca de modo |
| E1 — `stepBy(0)` no lugar de `stepBy(±1)` | setas andam o passo |
| E2 — seta sequestrada com o cursor num campo | sem roubar a tecla de quem digita |
| E3 — espaço sequestrado com o cursor num campo | sem roubar a tecla de quem digita |
| F — MDX volta a passar a prop `modo` | as três peças abrem cada uma no seu modo |
| G1 — passo inicial vai para 0 | o botão ao lado é quem devolve a entrada |
| G2 — "Voltar ao padrão" esquece o fim de A | o botão ao lado é quem devolve a entrada |
| H — `total: Math.max(2, steps.length)` | a lista vazia apaga o rodapé |
| I — regra de empate invertida no código | o rótulo, o código e o número mudam juntos |

Restauração por `cp`, nunca `git checkout --`. As quebras D, E1, E2 e E3 são no
`src/lib/visualizer.tsx` e foram só para a prova — **o PR não toca no hook**.

Três experimentos deram errado antes de dar certo, e nos três o errado foi o
experimento:

- **E1 na primeira versão trocava `ArrowRight` por `ArrowUp` e não compilava**
  (o `tsc` reclamou de comparação sem sobreposição). Build falhando deixa o
  `out/` anterior no lugar, o teste roda contra o código bom e passa. Virou
  `stepBy(0)`, que compila.
- **E2 passou verde na primeira tentativa, e o teste é que estava cego**: ele
  pressionava `→` e depois `←` e só afirmava no fim — e as duas setas se
  cancelam. Agora ele afirma **depois de cada tecla**.
- **G1 "passou" porque a quebra nunca foi aplicada**: o alvo aparecia duas vezes
  no arquivo e o `assert` acusou antes de eu tirar conclusão errada.

## Fora de escopo, reportado

- **A compressão da camada 2 no fluxo do artigo** é PR de plataforma (acima).
- **`VizFooter` devolve `null` quando `total <= 1` e descarta os `children` em
  silêncio.** Não é problema aqui (na sobreposição `total` nunca é menor que 4),
  mas o `IntervalsVisualizer` e o sweep chegam a `total: 1` com a lista vazia, e
  aí um botão extra no rodapé sumiria sem aviso. Já documentado no contrato §6
  por PR anterior; segue sem conserto no hook, de propósito.
- O `content/visualizers/README.md` ganhou **seção nova no fim** (§9), sem
  reescrever trecho existente, porque há outros PRs abertos mexendo nele.
