### PR TITLE
feat(viz): casca adaptativa em Hashing e Listas Encadeadas

### DIFF
--- a/content/visualizers/HashTableBuscaVisualizer.tsx
+++ b/content/visualizers/HashTableBuscaVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { Fragment, useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // HashTableBuscaVisualizer, a corrida entre busca linear e busca por hash.
@@ -11,174 +12,178 @@ import { createPortal } from "react-dom";
 // (o contador da esquerda subindo sozinho) que ensina a diferença entre O(n) e
 // O(1) melhor do que qualquer parágrafo.
 //
-// O botão "hash ruim" troca a função por uma que devolve 0 para qualquer chave,
-// que é exatamente o acidente do encontro (sobrescrever o hash code sem
-// pensar). Aí os dois contadores empatam e o O(n) do pior caso aparece.
+// A casca vem do `useVisualizer`, com `collapsible: false`: esta peça não tem
+// bloco dispensável — os dois painéis, a fita de buckets e os cartões de pior
+// caso são todos conteúdo, e o contrato é explícito em não inventar um bloco só
+// para ganhar o botão. Ela leva as camadas 1 e 2 (cabeçalho e controles parados
+// no painel, respiro comprimido em tela baixa) e nada mais.
 //
-// Capacidade fixa em 11 de propósito: número primo, como a técnica que apareceu
-// no encontro para espalhar melhor os restos.
+// O botão "hash ruim" troca a função por uma que devolve 0 para qualquer chave,
+// que é o acidente clássico de sobrescrever o hash code sem pensar. Aí os dois
+// contadores empatam e o O(n) do pior caso aparece.
+//
+// Capacidade fixa em 11 de propósito: número primo espalha melhor os restos.
 // ---------------------------------------------------------------------------
 
-type No = { chave: string; soma: number };
+type Entry = { key: string; sum: number };
 
-type PassoLista = {
+type ListStep = {
   pos: number;
-  comparacoes: number;
-  achou: boolean;
-  fim: boolean;
-  nota: string;
+  comparisons: number;
+  found: boolean;
+  done: boolean;
+  note: string;
 };
 
-type PassoHash = {
-  indice: number | null;
+type HashStep = {
+  index: number | null;
   pos: number | null;
-  comparacoes: number;
-  achou: boolean;
-  fim: boolean;
-  nota: string;
+  comparisons: number;
+  found: boolean;
+  done: boolean;
+  note: string;
 };
 
 const CAP = 11;
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-function somaAscii(s: string): number {
+function asciiSum(s: string): number {
   let t = 0;
   for (const c of s) t += c.codePointAt(0) ?? 0;
   return t;
 }
 
-function detalheAscii(s: string): string {
-  const partes: string[] = [];
-  for (const c of s) partes.push(String(c.codePointAt(0) ?? 0));
-  return partes.join(" + ");
+function asciiDetail(s: string): string {
+  const parts: string[] = [];
+  for (const c of s) parts.push(String(c.codePointAt(0) ?? 0));
+  return parts.join(" + ");
 }
 
 // Formatação determinística de milhar (nada de Intl no render).
-function milhar(v: number): string {
+function thousands(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function plural(v: number, um: string, muitos: string): string {
-  return `${v} ${v === 1 ? um : muitos}`;
+function plural(v: number, one: string, many: string): string {
+  return `${v} ${v === 1 ? one : many}`;
 }
 
-function construir(nomes: string[], ruim: boolean): No[][] {
-  const buckets: No[][] = Array.from({ length: CAP }, () => [] as No[]);
-  for (const nome of nomes) {
-    const soma = somaAscii(nome);
-    buckets[ruim ? 0 : soma % CAP].push({ chave: nome, soma });
+function build(names: string[], bad: boolean): Entry[][] {
+  const buckets: Entry[][] = Array.from({ length: CAP }, () => [] as Entry[]);
+  for (const name of names) {
+    const sum = asciiSum(name);
+    buckets[bad ? 0 : sum % CAP].push({ key: name, sum });
   }
   return buckets;
 }
 
-function gerarLista(nomes: string[], alvo: string): PassoLista[] {
-  const out: PassoLista[] = [];
+function generateListSteps(names: string[], target: string): ListStep[] {
+  const out: ListStep[] = [];
   out.push({
     pos: -1,
-    comparacoes: 0,
-    achou: false,
-    fim: false,
-    nota: `${plural(nomes.length, "nome guardado", "nomes guardados")} e nenhuma ordem que me ajude: não dá para cortar nada. Vou comparar "${alvo}" com a posição 0, depois a 1, e assim por diante.`,
+    comparisons: 0,
+    found: false,
+    done: false,
+    note: `${plural(names.length, "nome guardado", "nomes guardados")} e nenhuma ordem que me ajude: não dá para cortar nada. Vou comparar "${target}" com a posição 0, depois a 1, e assim por diante.`,
   });
-  for (let j = 0; j < nomes.length; j++) {
-    const igual = nomes[j] === alvo;
+  for (let j = 0; j < names.length; j++) {
+    const same = names[j] === target;
     out.push({
       pos: j,
-      comparacoes: j + 1,
-      achou: igual,
-      fim: igual,
-      nota: igual
-        ? `Posição ${j}: "${nomes[j]}" é o alvo. Achei, depois de ${plural(j + 1, "comparação", "comparações")}.`
-        : `Posição ${j}: "${nomes[j]}" não é "${alvo}". Passo para a próxima.`,
+      comparisons: j + 1,
+      found: same,
+      done: same,
+      note: same
+        ? `Posição ${j}: "${names[j]}" é o alvo. Achei, depois de ${plural(j + 1, "comparação", "comparações")}.`
+        : `Posição ${j}: "${names[j]}" não é "${target}". Passo para a próxima.`,
     });
-    if (igual) return out;
+    if (same) return out;
   }
   out.push({
-    pos: nomes.length,
-    comparacoes: nomes.length,
-    achou: false,
-    fim: true,
-    nota: `Cheguei ao fim da lista: "${alvo}" não está aqui. Só que precisei de ${plural(nomes.length, "comparação", "comparações")} para ter certeza disso.`,
+    pos: names.length,
+    comparisons: names.length,
+    found: false,
+    done: true,
+    note: `Cheguei ao fim da lista: "${target}" não está aqui. Só que precisei de ${plural(names.length, "comparação", "comparações")} para ter certeza disso.`,
   });
   return out;
 }
 
-function gerarHash(buckets: No[][], alvo: string, ruim: boolean): PassoHash[] {
-  const out: PassoHash[] = [];
-  const soma = somaAscii(alvo);
+function generateHashSteps(buckets: Entry[][], target: string, bad: boolean): HashStep[] {
+  const out: HashStep[] = [];
+  const sum = asciiSum(target);
   out.push({
-    indice: null,
+    index: null,
     pos: null,
-    comparacoes: 0,
-    achou: false,
-    fim: false,
-    nota: ruim
-      ? `A função ruim ignora a chave e devolve 0 para tudo, inclusive para "${alvo}".`
-      : `Somo os códigos ASCII de "${alvo}": ${detalheAscii(alvo)} = ${soma}.`,
+    comparisons: 0,
+    found: false,
+    done: false,
+    note: bad
+      ? `A função ruim ignora a chave e devolve 0 para tudo, inclusive para "${target}".`
+      : `Somo os códigos ASCII de "${target}": ${asciiDetail(target)} = ${sum}.`,
   });
-  const i = ruim ? 0 : soma % CAP;
+  const i = bad ? 0 : sum % CAP;
   out.push({
-    indice: i,
+    index: i,
     pos: null,
-    comparacoes: 0,
-    achou: false,
-    fim: false,
-    nota: ruim
+    comparisons: 0,
+    found: false,
+    done: false,
+    note: bad
       ? `Endereço 0, igual a todas as outras chaves: ${plural(buckets[0].length, "chave está amontoada", "chaves estão amontoadas")} no bucket 0 e os outros ${CAP - 1} estão vazios.`
-      : `${soma} % ${CAP} = ${i}. Salto direto para o bucket ${i} e nem olho os outros ${CAP - 1}.`,
+      : `${sum} % ${CAP} = ${i}. Salto direto para o bucket ${i} e nem olho os outros ${CAP - 1}.`,
   });
-  const corrente = buckets[i];
-  if (corrente.length === 0) {
+  const chain = buckets[i];
+  if (chain.length === 0) {
     out.push({
-      indice: i,
+      index: i,
       pos: null,
-      comparacoes: 0,
-      achou: false,
-      fim: true,
-      nota: `O bucket ${i} está vazio. Sem comparar nenhuma chave, eu já sei que "${alvo}" não está na tabela.`,
+      comparisons: 0,
+      found: false,
+      done: true,
+      note: `O bucket ${i} está vazio. Sem comparar nenhuma chave, eu já sei que "${target}" não está na tabela.`,
     });
     return out;
   }
-  for (let k = 0; k < corrente.length; k++) {
-    const igual = corrente[k].chave === alvo;
+  for (let k = 0; k < chain.length; k++) {
+    const same = chain[k].key === target;
     out.push({
-      indice: i,
+      index: i,
       pos: k,
-      comparacoes: k + 1,
-      achou: igual,
-      fim: igual,
-      nota: igual
-        ? `"${corrente[k].chave}" bate com o alvo. ${plural(k + 1, "comparação", "comparações")} e acabou.`
-        : `"${corrente[k].chave}" caiu no mesmo bucket, mas não é "${alvo}". Ando um nó na corrente.`,
+      comparisons: k + 1,
+      found: same,
+      done: same,
+      note: same
+        ? `"${chain[k].key}" bate com o alvo. ${plural(k + 1, "comparação", "comparações")} e acabou.`
+        : `"${chain[k].key}" caiu no mesmo bucket, mas não é "${target}". Ando um nó na corrente.`,
     });
-    if (igual) return out;
+    if (same) return out;
   }
   out.push({
-    indice: i,
+    index: i,
     pos: null,
-    comparacoes: corrente.length,
-    achou: false,
-    fim: true,
-    nota: `A corrente do bucket ${i} acabou e "${alvo}" não estava nela. Não está na tabela.`,
+    comparisons: chain.length,
+    found: false,
+    done: true,
+    note: `A corrente do bucket ${i} acabou e "${target}" não estava nela. Não está na tabela.`,
   });
   return out;
 }
 
-const NOMES_PADRAO = "Ana, Bob, Lia, Leo, Eva, Kim, Ben, Mia";
+const DEFAULT_NAMES = "Ana, Bob, Lia, Leo, Eva, Kim, Ben, Mia";
 const POOL = ["Ana", "Bob", "Lia", "Leo", "Eva", "Kim", "Ben", "Mia", "Rui", "Zoe", "Ivo", "Gil", "Tom", "Nina"];
 
-type Preset = { rotulo: string; nomes: string; alvo: string; ruim: boolean };
+type Preset = { label: string; names: string; target: string; bad: boolean };
 
 const PRESETS: Preset[] = [
-  { rotulo: "Alvo no fim da lista", nomes: NOMES_PADRAO, alvo: "Mia", ruim: false },
-  { rotulo: "Alvo na primeira posição", nomes: NOMES_PADRAO, alvo: "Ana", ruim: false },
-  { rotulo: "Chave que não existe", nomes: NOMES_PADRAO, alvo: "Zoe", ruim: false },
-  { rotulo: "Com hash ruim", nomes: NOMES_PADRAO, alvo: "Mia", ruim: true },
+  { label: "Alvo no fim da lista", names: DEFAULT_NAMES, target: "Mia", bad: false },
+  { label: "Alvo na primeira posição", names: DEFAULT_NAMES, target: "Ana", bad: false },
+  { label: "Chave que não existe", names: DEFAULT_NAMES, target: "Zoe", bad: false },
+  { label: "Com hash ruim", names: DEFAULT_NAMES, target: "Mia", bad: true },
 ];
 
-function lerNomes(texto: string): string[] {
-  return texto
+function readNames(text: string): string[] {
+  return text
     .split(",")
     .map((x) => x.trim().slice(0, 12))
     .filter((x) => x.length > 0)
@@ -186,121 +191,73 @@ function lerNomes(texto: string): string[] {
 }
 
 export function HashTableBuscaVisualizer() {
-  const [entrada, setEntrada] = useState(NOMES_PADRAO);
-  const [alvo, setAlvo] = useState("Mia");
-  const [ruim, setRuim] = useState(false);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [input, setInput] = useState(DEFAULT_NAMES);
+  const [target, setTarget] = useState("Mia");
+  const [bad, setBad] = useState(false);
 
-  useEffect(() => setMounted(true), []);
+  const names = useMemo(() => {
+    const read = readNames(input);
+    return read.length ? read : ["Ana"];
+  }, [input]);
+  const cleanTarget = target.trim().slice(0, 12) || names[names.length - 1];
+  const buckets = useMemo(() => build(names, bad), [names, bad]);
+  const listSteps = useMemo(() => generateListSteps(names, cleanTarget), [names, cleanTarget]);
+  const hashSteps = useMemo(() => generateHashSteps(buckets, cleanTarget, bad), [buckets, cleanTarget, bad]);
 
-  const nomes = useMemo(() => {
-    const lidos = lerNomes(entrada);
-    return lidos.length ? lidos : ["Ana"];
-  }, [entrada]);
-  const alvoLimpo = alvo.trim().slice(0, 12) || nomes[nomes.length - 1];
-  const buckets = useMemo(() => construir(nomes, ruim), [nomes, ruim]);
-  const passosLista = useMemo(() => gerarLista(nomes, alvoLimpo), [nomes, alvoLimpo]);
-  const passosHash = useMemo(() => gerarHash(buckets, alvoLimpo, ruim), [buckets, alvoLimpo, ruim]);
+  const viz = useVisualizer({
+    title: "Visualizador · busca linear x busca por hash",
+    total: Math.max(listSteps.length, hashSteps.length),
+    speeds: SPEEDS,
+    // Sem `measureOn`: com `collapsible: false` não há bloco para recolher, o
+    // hook não toma decisão nenhuma e a lista seria ruído sugerindo uma medição
+    // que não acontece (contrato §6).
+    collapsible: false,
+  });
 
-  const total = Math.max(passosLista.length, passosHash.length);
-  const idx = Math.min(passo, total - 1);
-  const pl = passosLista[Math.min(idx, passosLista.length - 1)];
-  const ph = passosHash[Math.min(idx, passosHash.length - 1)];
+  const pl = listSteps[Math.min(viz.step, listSteps.length - 1)];
+  const ph = hashSteps[Math.min(viz.step, hashSteps.length - 1)];
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aplicar = (pr: Preset) => {
-    reiniciar();
-    setEntrada(pr.nomes);
-    setAlvo(pr.alvo);
-    setRuim(pr.ruim);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setInput(pr.names);
+    setTarget(pr.target);
+    setBad(pr.bad);
   };
 
   // Math.random só aqui, num handler de clique. No caminho de render ele
   // quebraria a hidratação (o HTML do build divergiria do cliente).
-  const sortear = () => {
-    const restantes = [...POOL];
-    const escolhidas: string[] = [];
-    const quantas = 6 + Math.floor(Math.random() * 3);
-    for (let k = 0; k < quantas && restantes.length; k++) {
-      escolhidas.push(restantes.splice(Math.floor(Math.random() * restantes.length), 1)[0]);
+  const shuffle = () => {
+    const remaining = [...POOL];
+    const picked: string[] = [];
+    const howMany = 6 + Math.floor(Math.random() * 3);
+    for (let k = 0; k < howMany && remaining.length; k++) {
+      picked.push(remaining.splice(Math.floor(Math.random() * remaining.length), 1)[0]);
     }
-    reiniciar();
-    setEntrada(escolhidas.join(", "));
-    setAlvo(escolhidas[escolhidas.length - 1]);
+    viz.reset();
+    setInput(picked.join(", "));
+    setTarget(picked[picked.length - 1]);
   };
 
-  const corrente = ph.indice == null ? [] : buckets[ph.indice];
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const chain = ph.index == null ? [] : buckets[ph.index];
 
-  const resumo = ruim
-    ? `Com todas as chaves no mesmo bucket, a tabela hash faz ${plural(ph.comparacoes, "comparação", "comparações")}, o mesmo trabalho da lista. Esse é o O(n) do pior caso, e ele não vem de azar: vem de uma função de hash que não distribui.`
-    : `A lista gastou ${plural(pl.comparacoes, "comparação", "comparações")} e a tabela hash gastou ${plural(ph.comparacoes, "comparação", "comparações")}. O que importa não é a diferença aqui, é o que acontece quando a entrada cresce: a lista acompanha n, a tabela hash não se mexe.`;
+  const summary = bad
+    ? `Com todas as chaves no mesmo bucket, a tabela hash faz ${plural(ph.comparisons, "comparação", "comparações")}, o mesmo trabalho da lista. Esse é o O(n) do pior caso, e ele não vem de azar: vem de uma função de hash que não distribui.`
+    : `A lista gastou ${plural(pl.comparisons, "comparação", "comparações")} e a tabela hash gastou ${plural(ph.comparisons, "comparação", "comparações")}. O que importa não é a diferença aqui, é o que acontece quando a entrada cresce: a lista acompanha n, a tabela hash não se mexe.`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · busca linear x busca por hash</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Nomes guardados</span>
             <input
               className="viz-input"
-              value={entrada}
+              value={input}
               onChange={(e) => {
-                reiniciar();
-                setEntrada(e.target.value);
+                viz.reset();
+                setInput(e.target.value);
               }}
             />
           </label>
@@ -308,39 +265,39 @@ export function HashTableBuscaVisualizer() {
             <span>Procurar por</span>
             <input
               className="viz-input ht-sel"
-              value={alvo}
+              value={target}
               onChange={(e) => {
-                reiniciar();
-                setAlvo(e.target.value);
+                viz.reset();
+                setTarget(e.target.value);
               }}
             />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={shuffle}>
             Sortear
           </button>
         </div>
 
         <div className="bigo-chips">
           <button
-            className={`bigo-chip${!ruim ? " on" : ""}`}
-            aria-pressed={!ruim}
+            className={`bigo-chip${!bad ? " on" : ""}`}
+            aria-pressed={!bad}
             onClick={() => {
-              reiniciar();
-              setRuim(false);
+              viz.reset();
+              setBad(false);
             }}
           >
-            <span className="sw" style={{ background: !ruim ? "#34d399" : "#3a4a60" }} />
+            <span className="sw" style={{ background: !bad ? "#34d399" : "#3a4a60" }} />
             Hash que distribui
           </button>
           <button
-            className={`bigo-chip${ruim ? " on" : ""}`}
-            aria-pressed={ruim}
+            className={`bigo-chip${bad ? " on" : ""}`}
+            aria-pressed={bad}
             onClick={() => {
-              reiniciar();
-              setRuim(true);
+              viz.reset();
+              setBad(true);
             }}
           >
-            <span className="sw" style={{ background: ruim ? "#f87171" : "#3a4a60" }} />
+            <span className="sw" style={{ background: bad ? "#f87171" : "#3a4a60" }} />
             Hash ruim (devolve 0 sempre)
           </button>
         </div>
@@ -348,8 +305,8 @@ export function HashTableBuscaVisualizer() {
         <div className="ht-presets">
           <span>Cenários</span>
           {PRESETS.map((pr) => (
-            <button className="viz-btn" key={pr.rotulo} onClick={() => aplicar(pr)}>
-              {pr.rotulo}
+            <button className="viz-btn" key={pr.label} onClick={() => applyPreset(pr)}>
+              {pr.label}
             </button>
           ))}
         </div>
@@ -357,34 +314,34 @@ export function HashTableBuscaVisualizer() {
         <div className="ht-painel">
           <div className="ht-painel-tit">
             <span>1. Busca linear na lista</span>
-            <em>{plural(pl.comparacoes, "comparação", "comparações")}</em>
+            <em>{plural(pl.comparisons, "comparação", "comparações")}</em>
           </div>
           <div className="ht-lista">
-            {nomes.map((nome, j) => {
+            {names.map((name, j) => {
               let cls = "ht-nome";
-              if (pl.pos === j) cls += pl.achou ? " achou" : " on";
+              if (pl.pos === j) cls += pl.found ? " achou" : " on";
               else if (j < pl.pos) cls += " passou";
               return (
-                <span className={cls} key={`${nome}-${j}`}>
+                <span className={cls} key={`${name}-${j}`}>
                   <span className="ord">{j}</span>
-                  {nome}
+                  {name}
                 </span>
               );
             })}
           </div>
-          <p className={`viz-note${pl.achou ? " ok" : pl.fim ? " invalid" : ""}`}>{pl.nota}</p>
+          <p className={`viz-note${pl.found ? " ok" : pl.done ? " invalid" : ""}`}>{pl.note}</p>
         </div>
 
         <div className="ht-painel">
           <div className="ht-painel-tit">
             <span>2. Busca na tabela hash ({CAP} buckets)</span>
-            <em>{plural(ph.comparacoes, "comparação", "comparações")}</em>
+            <em>{plural(ph.comparisons, "comparação", "comparações")}</em>
           </div>
           <div className="ht-strip">
             {buckets.map((b, i) => (
               <div
                 key={i}
-                className={`ht-bucket${b.length ? " cheio" : ""}${ph.indice === i ? " alvo" : ""}`}
+                className={`ht-bucket${b.length ? " cheio" : ""}${ph.index === i ? " alvo" : ""}`}
               >
                 {i}
                 <b>{b.length}</b>
@@ -392,121 +349,56 @@ export function HashTableBuscaVisualizer() {
             ))}
           </div>
           <div className="ht-row">
-            <span className="ht-idx">{ph.indice == null ? "?" : ph.indice}</span>
-            <div className={`ht-slot${ph.indice == null ? "" : " alvo"}`}>
-              {ph.indice == null ? (
+            <span className="ht-idx">{ph.index == null ? "?" : ph.index}</span>
+            <div className={`ht-slot${ph.index == null ? "" : " alvo"}`}>
+              {ph.index == null ? (
                 <span className="ht-vazio">ainda calculando o hash</span>
-              ) : corrente.length === 0 ? (
+              ) : chain.length === 0 ? (
                 <span className="ht-vazio">vazio</span>
               ) : (
-                corrente.map((no, k) => {
-                  let ncls = "ht-no";
-                  if (ph.pos === k) ncls += ph.achou ? " achou" : " compara";
+                chain.map((entry, k) => {
+                  let nodeClass = "ht-no";
+                  if (ph.pos === k) nodeClass += ph.found ? " achou" : " compara";
                   return (
-                    <Fragment key={`${no.chave}-${k}`}>
+                    <Fragment key={`${entry.key}-${k}`}>
                       {k > 0 ? <span className="ht-seta">→</span> : null}
-                      <span className={ncls}>{no.chave}</span>
+                      <span className={nodeClass}>{entry.key}</span>
                     </Fragment>
                   );
                 })
               )}
             </div>
           </div>
-          <p className={`viz-note${ph.achou ? " ok" : ph.fim ? " invalid" : ""}`}>{ph.nota}</p>
+          <p className={`viz-note${ph.found ? " ok" : ph.done ? " invalid" : ""}`}>{ph.note}</p>
         </div>
 
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>comparações · lista</span>
-            <strong>{pl.comparacoes}</strong>
+            <strong>{pl.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações · hash</span>
-            <strong>{ph.comparacoes}</strong>
+            <strong>{ph.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso · lista com 1 milhão</span>
-            <strong>{milhar(1000000)}</strong>
+            <strong>{thousands(1000000)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso · hash com 1 milhão</span>
-            <strong>{ruim ? milhar(1000000) : "1"}</strong>
+            <strong>{bad ? thousands(1000000) : "1"}</strong>
           </div>
         </div>
 
-        <p className="viz-note">{resumo}</p>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
+        <p className="viz-note">{summary}</p>
       </div>
+
+      {/* Fora do `.viz-body` de propósito: no expandido é ele que fica parado no
+          pé da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/HashTableVisualizer.tsx
+++ b/content/visualizers/HashTableVisualizer.tsx
@@ -1,49 +1,53 @@
 "use client";
 
-import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { Fragment, useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // HashTableVisualizer, a inserção de chaves numa tabela hash.
 //
-// Mesmo padrão do TwoPointersVisualizer: gerador PURO de passos + a casca
-// compartilhada (nota, código sincronizado, variáveis, controles, Expandir).
-// O que muda é o palco: em vez de uma fita de células, uma coluna de buckets,
-// porque o que o aluno precisa ver é o endereço saindo da chave e a colisão
-// acontecendo dentro de um bucket específico.
+// Gerador PURO de passos + a casca compartilhada. A casca vem do
+// `useVisualizer`: medição de altura, painel com cabeçalho e controles parados,
+// código recolhível e os controles de reprodução. Aqui fica só o que é DESTE
+// visualizador. Contrato em `content/visualizers/README.md`.
 //
-// A função de hash é a ingênua do encontro (soma dos códigos ASCII, depois o
-// resto pelo tamanho da tabela). Ela é ruim de propósito: é justamente por ser
-// ruim que ela produz colisões com nomes de três letras e deixa o conceito
-// visível. As estratégias de resolução são as duas do encontro: encadeamento
-// (uma corrente por bucket) e sondagem linear (procura o vizinho livre).
+// O palco é uma coluna de buckets em vez de uma fita de células, porque o que o
+// aluno precisa ver é o endereço saindo da chave e a colisão acontecendo dentro
+// de um bucket específico.
+//
+// A função de hash é a ingênua (soma dos códigos ASCII, depois o resto pelo
+// tamanho da tabela). Ela é ruim de propósito: é justamente por ser ruim que ela
+// produz colisões com nomes de três letras e deixa o conceito visível. As
+// estratégias de resolução são duas: encadeamento (uma corrente por bucket) e
+// sondagem linear (procura o vizinho livre).
 // ---------------------------------------------------------------------------
 
-type No = { chave: string; soma: number };
+type Entry = { key: string; sum: number };
 
-type Passo = {
-  linha: number;
+type Step = {
+  line: number;
   cap: number;
   n: number;
-  slots: No[][];
-  chave: string | null;
-  soma: number | null;
-  indice: number | null;
-  alvo: number | null;
-  sonda: number | null;
-  comparando: number | null;
-  inserido: string | null;
-  colisoes: number;
-  comparacoes: number;
+  slots: Entry[][];
+  key: string | null;
+  sum: number | null;
+  index: number | null;
+  target: number | null;
+  probe: number | null;
+  comparing: number | null;
+  inserted: string | null;
+  collisions: number;
+  comparisons: number;
   rehash: boolean;
-  fim: boolean;
+  done: boolean;
   ok: boolean;
-  nota: string;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO_ENCADEAMENTO = [
+const CHAINING_CODE = [
   "def _hash(self, chave):",
   "    soma = sum(ord(c) for c in chave)",
   "    return soma % len(self.buckets)",
@@ -60,7 +64,7 @@ const CODIGO_ENCADEAMENTO = [
   "    self.n += 1",
 ];
 
-const CODIGO_SONDAGEM = [
+const PROBING_CODE = [
   "def _hash(self, chave):",
   "    soma = sum(ord(c) for c in chave)",
   "    return soma % len(self.slots)",
@@ -78,11 +82,10 @@ const CODIGO_SONDAGEM = [
   "    self.n += 1",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-const LIMITE_CARGA = 0.75;
-const CAP_MAXIMA = 32;
+const LOAD_LIMIT = 0.75;
+const MAX_CAP = 32;
 
 // Formatação determinística: nada de Intl no caminho de render, senão o HTML
 // do build diverge do cliente na hidratação.
@@ -90,271 +93,271 @@ function dec(v: number): string {
   return (Math.round(v * 100) / 100).toFixed(2).replace(".", ",");
 }
 
-function somaAscii(s: string): number {
+function asciiSum(s: string): number {
   let t = 0;
   for (const c of s) t += c.codePointAt(0) ?? 0;
   return t;
 }
 
-function detalheAscii(s: string): string {
-  const partes: string[] = [];
-  for (const c of s) partes.push(String(c.codePointAt(0) ?? 0));
-  return partes.join(" + ");
+function asciiDetail(s: string): string {
+  const parts: string[] = [];
+  for (const c of s) parts.push(String(c.codePointAt(0) ?? 0));
+  return parts.join(" + ");
 }
 
-function clonar(slots: No[][]): No[][] {
+function clone(slots: Entry[][]): Entry[][] {
   return slots.map((b) => b.slice());
 }
 
-function plural(v: number, um: string, muitos: string): string {
-  return `${v} ${v === 1 ? um : muitos}`;
+function plural(v: number, one: string, many: string): string {
+  return `${v} ${v === 1 ? one : many}`;
 }
 
-function gerarPassos(chaves: string[], capInicial: number, encadeado: boolean, redimensiona: boolean): Passo[] {
-  const out: Passo[] = [];
-  let cap = Math.max(1, capInicial);
-  let slots: No[][] = Array.from({ length: cap }, () => [] as No[]);
+function generateSteps(keys: string[], initialCap: number, chained: boolean, resizes: boolean): Step[] {
+  const out: Step[] = [];
+  let cap = Math.max(1, initialCap);
+  let slots: Entry[][] = Array.from({ length: cap }, () => [] as Entry[]);
   let n = 0;
-  let colisoes = 0;
-  let comparacoes = 0;
+  let collisions = 0;
+  let comparisons = 0;
 
   const base = () => ({
     cap,
     n,
-    slots: clonar(slots),
-    chave: null as string | null,
-    soma: null as number | null,
-    indice: null as number | null,
-    alvo: null as number | null,
-    sonda: null as number | null,
-    comparando: null as number | null,
-    inserido: null as string | null,
-    colisoes,
-    comparacoes,
+    slots: clone(slots),
+    key: null as string | null,
+    sum: null as number | null,
+    index: null as number | null,
+    target: null as number | null,
+    probe: null as number | null,
+    comparing: null as number | null,
+    inserted: null as string | null,
+    collisions,
+    comparisons,
     rehash: false,
-    fim: false,
+    done: false,
     ok: false,
   });
 
   out.push({
     ...base(),
-    linha: 4,
-    nota: `Tabela vazia com ${plural(cap, "bucket", "buckets")}. Vou inserir ${plural(chaves.length, "chave", "chaves")}, uma de cada vez, e o endereço de cada uma sai da própria chave.`,
+    line: 4,
+    note: `Tabela vazia com ${plural(cap, "bucket", "buckets")}. Vou inserir ${plural(keys.length, "chave", "chaves")}, uma de cada vez, e o endereço de cada uma sai da própria chave.`,
   });
 
-  let guarda = 0;
-  for (const chave of chaves) {
-    if (guarda++ > 40) break;
-    const soma = somaAscii(chave);
+  let guard = 0;
+  for (const key of keys) {
+    if (guard++ > 40) break;
+    const sum = asciiSum(key);
 
     // Fator de carga: o redimensionamento acontece ANTES de inserir, para a
     // tabela nunca chegar de fato aos 75% de ocupação.
-    if (redimensiona && cap < CAP_MAXIMA && (n + 1) / cap > LIMITE_CARGA) {
+    if (resizes && cap < MAX_CAP && (n + 1) / cap > LOAD_LIMIT) {
       out.push({
         ...base(),
-        linha: 5,
-        chave,
-        soma,
-        nota: `Com "${chave}" seriam ${n + 1} chaves em ${cap} buckets: fator de carga ${dec((n + 1) / cap)}, acima de 0,75. Redimensiono antes de inserir.`,
+        line: 5,
+        key,
+        sum,
+        note: `Com "${key}" seriam ${n + 1} chaves em ${cap} buckets: fator de carga ${dec((n + 1) / cap)}, acima de 0,75. Redimensiono antes de inserir.`,
       });
-      const antigos: No[] = [];
-      for (const b of slots) for (const no of b) antigos.push(no);
-      const capAntiga = cap;
+      const previous: Entry[] = [];
+      for (const b of slots) for (const entry of b) previous.push(entry);
+      const oldCap = cap;
       cap = cap * 2;
-      slots = Array.from({ length: cap }, () => [] as No[]);
+      slots = Array.from({ length: cap }, () => [] as Entry[]);
       out.push({
         ...base(),
-        linha: 6,
-        chave,
-        soma,
+        line: 6,
+        key,
+        sum,
         rehash: true,
-        nota: `Dobro a capacidade de ${capAntiga} para ${cap}. O divisor do módulo mudou, então nenhum endereço antigo vale: preciso refazer o hash das ${plural(antigos.length, "chave que já estava dentro", "chaves que já estavam dentro")}.`,
+        note: `Dobro a capacidade de ${oldCap} para ${cap}. O divisor do módulo mudou, então nenhum endereço antigo vale: preciso refazer o hash das ${plural(previous.length, "chave que já estava dentro", "chaves que já estavam dentro")}.`,
       });
-      for (const no of antigos) {
-        const j = no.soma % cap;
-        const antes = no.soma % capAntiga;
-        slots[j].push(no);
+      for (const entry of previous) {
+        const j = entry.sum % cap;
+        const before = entry.sum % oldCap;
+        slots[j].push(entry);
         out.push({
           ...base(),
-          linha: 6,
-          chave: no.chave,
-          soma: no.soma,
-          indice: j,
-          alvo: j,
-          inserido: no.chave,
+          line: 6,
+          key: entry.key,
+          sum: entry.sum,
+          index: j,
+          target: j,
+          inserted: entry.key,
           rehash: true,
-          nota: `Rehash de "${no.chave}": ${no.soma} % ${cap} = ${j}. Com ${capAntiga} buckets ela morava no ${antes}${j === antes ? ", e por sorte não saiu do lugar." : "."}`,
+          note: `Rehash de "${entry.key}": ${entry.sum} % ${cap} = ${j}. Com ${oldCap} buckets ela morava no ${before}${j === before ? ", e por sorte não saiu do lugar." : "."}`,
         });
       }
     }
 
     out.push({
       ...base(),
-      linha: 1,
-      chave,
-      soma,
-      nota: `Somo os códigos ASCII de "${chave}": ${detalheAscii(chave)} = ${soma}.`,
+      line: 1,
+      key,
+      sum,
+      note: `Somo os códigos ASCII de "${key}": ${asciiDetail(key)} = ${sum}.`,
     });
 
-    const i = soma % cap;
+    const i = sum % cap;
     out.push({
       ...base(),
-      linha: 2,
-      chave,
-      soma,
-      indice: i,
-      alvo: i,
-      nota: `${soma} % ${cap} = ${i}. O endereço de "${chave}" é o bucket ${i}, e eu cheguei nele sem olhar nenhum outro.`,
+      line: 2,
+      key,
+      sum,
+      index: i,
+      target: i,
+      note: `${sum} % ${cap} = ${i}. O endereço de "${key}" é o bucket ${i}, e eu cheguei nele sem olhar nenhum outro.`,
     });
 
-    if (encadeado) {
-      const antes = slots[i].length;
-      let jaExiste = false;
-      for (let k = 0; k < antes; k++) {
-        comparacoes++;
-        const outro = slots[i][k];
-        const igual = outro.chave === chave;
+    if (chained) {
+      const before = slots[i].length;
+      let exists = false;
+      for (let k = 0; k < before; k++) {
+        comparisons++;
+        const other = slots[i][k];
+        const same = other.key === key;
         // Colisão é bater numa chave DIFERENTE no endereço calculado. Reinserir
         // a mesma chave é atualização, e contar isso como colisão mentiria para
         // quem está lendo o contador (tente "Ana, Ana": colisões continua 0).
-        if (k === 0 && !igual) colisoes++;
+        if (k === 0 && !same) collisions++;
         out.push({
           ...base(),
-          linha: 9,
-          chave,
-          soma,
-          indice: i,
-          alvo: i,
-          comparando: k,
-          nota: igual
-            ? `O bucket ${i} já guarda "${chave}". Mesma chave, mesmo hash: só troco o valor, a tabela não cresce.`
-            : `Colisão: o bucket ${i} já tem "${outro.chave}". O hash bateu, a chave não. Comparo, descarto e sigo na corrente.`,
+          line: 9,
+          key,
+          sum,
+          index: i,
+          target: i,
+          comparing: k,
+          note: same
+            ? `O bucket ${i} já guarda "${key}". Mesma chave, mesmo hash: só troco o valor, a tabela não cresce.`
+            : `Colisão: o bucket ${i} já tem "${other.key}". O hash bateu, a chave não. Comparo, descarto e sigo na corrente.`,
         });
-        if (igual) {
-          jaExiste = true;
+        if (same) {
+          exists = true;
           break;
         }
       }
-      if (jaExiste) continue;
-      slots[i].push({ chave, soma });
+      if (exists) continue;
+      slots[i].push({ key, sum });
       n++;
       out.push({
         ...base(),
-        linha: 12,
-        chave,
-        soma,
-        indice: i,
-        alvo: i,
-        inserido: chave,
-        nota:
-          antes > 0
-            ? `"${chave}" entra no fim da corrente do bucket ${i}, que agora tem ${plural(antes + 1, "nó", "nós")}.`
-            : `Bucket ${i} livre: "${chave}" entra como primeiro nó da corrente.`,
+        line: 12,
+        key,
+        sum,
+        index: i,
+        target: i,
+        inserted: key,
+        note:
+          before > 0
+            ? `"${key}" entra no fim da corrente do bucket ${i}, que agora tem ${plural(before + 1, "nó", "nós")}.`
+            : `Bucket ${i} livre: "${key}" entra como primeiro nó da corrente.`,
       });
     } else {
       let j = i;
-      let sondas = 0;
-      let jaExiste = false;
-      let cheia = false;
+      let probes = 0;
+      let exists = false;
+      let full = false;
       while (slots[j].length > 0) {
-        comparacoes++;
-        if (slots[j][0].chave === chave) {
+        comparisons++;
+        if (slots[j][0].key === key) {
           out.push({
             ...base(),
-            linha: 9,
-            chave,
-            soma,
-            indice: i,
-            alvo: i,
-            sonda: j,
-            comparando: 0,
-            nota: `O índice ${j} já guarda "${chave}". Mesma chave: só troco o valor, a tabela não cresce.`,
+            line: 9,
+            key,
+            sum,
+            index: i,
+            target: i,
+            probe: j,
+            comparing: 0,
+            note: `O índice ${j} já guarda "${key}". Mesma chave: só troco o valor, a tabela não cresce.`,
           });
-          jaExiste = true;
+          exists = true;
           break;
         }
-        if (sondas === 0) colisoes++;
-        const prox = (j + 1) % cap;
+        if (probes === 0) collisions++;
+        const next = (j + 1) % cap;
         out.push({
           ...base(),
-          linha: 12,
-          chave,
-          soma,
-          indice: i,
-          alvo: i,
-          sonda: j,
-          comparando: 0,
-          nota: `Índice ${j} ocupado por "${slots[j][0].chave}", que não é "${chave}". Sondagem linear: tento o vizinho, (${j} + 1) % ${cap} = ${prox}.`,
+          line: 12,
+          key,
+          sum,
+          index: i,
+          target: i,
+          probe: j,
+          comparing: 0,
+          note: `Índice ${j} ocupado por "${slots[j][0].key}", que não é "${key}". Sondagem linear: tento o vizinho, (${j} + 1) % ${cap} = ${next}.`,
         });
-        j = prox;
-        sondas++;
-        if (sondas >= cap) {
-          cheia = true;
+        j = next;
+        probes++;
+        if (probes >= cap) {
+          full = true;
           break;
         }
       }
-      if (jaExiste) continue;
-      if (cheia) {
+      if (exists) continue;
+      if (full) {
         out.push({
           ...base(),
-          linha: 8,
-          chave,
-          soma,
-          indice: i,
-          alvo: i,
-          fim: true,
-          nota: `Dei a volta inteira e não achei índice livre: a tabela lotou. Sem redimensionamento, a sondagem linear simplesmente não tem para onde ir.`,
+          line: 8,
+          key,
+          sum,
+          index: i,
+          target: i,
+          done: true,
+          note: `Dei a volta inteira e não achei índice livre: a tabela lotou. Sem redimensionamento, a sondagem linear simplesmente não tem para onde ir.`,
         });
         return out;
       }
-      slots[j].push({ chave, soma });
+      slots[j].push({ key, sum });
       n++;
       out.push({
         ...base(),
-        linha: 13,
-        chave,
-        soma,
-        indice: i,
-        alvo: i,
-        sonda: j === i ? null : j,
-        inserido: chave,
-        nota:
+        line: 13,
+        key,
+        sum,
+        index: i,
+        target: i,
+        probe: j === i ? null : j,
+        inserted: key,
+        note:
           j === i
-            ? `Índice ${i} livre: "${chave}" entra direto, sem sondagem nenhuma.`
-            : `Índice ${j} livre: "${chave}" mora aqui, ${plural(sondas, "casa", "casas")} depois do endereço que o hash mandou (${i}).`,
+            ? `Índice ${i} livre: "${key}" entra direto, sem sondagem nenhuma.`
+            : `Índice ${j} livre: "${key}" mora aqui, ${plural(probes, "casa", "casas")} depois do endereço que o hash mandou (${i}).`,
       });
     }
   }
 
   out.push({
     ...base(),
-    linha: encadeado ? 13 : 14,
-    fim: true,
+    line: chained ? 13 : 14,
+    done: true,
     ok: true,
-    nota: `Fim: ${plural(n, "chave", "chaves")} em ${plural(cap, "bucket", "buckets")}, fator de carga ${dec(cap ? n / cap : 0)}. Deu ${plural(colisoes, "colisão", "colisões")} e ${plural(comparacoes, "comparação de chave", "comparações de chave")} no caminho todo.`,
+    note: `Fim: ${plural(n, "chave", "chaves")} em ${plural(cap, "bucket", "buckets")}, fator de carga ${dec(cap ? n / cap : 0)}. Deu ${plural(collisions, "colisão", "colisões")} e ${plural(comparisons, "comparação de chave", "comparações de chave")} no caminho todo.`,
   });
   return out;
 }
 
 type Preset = {
-  rotulo: string;
-  chaves: string;
+  label: string;
+  keys: string;
   cap: number;
-  encadeado: boolean;
-  redimensiona: boolean;
+  chained: boolean;
+  resizes: boolean;
 };
 
 const PRESETS: Preset[] = [
-  { rotulo: "Quadro do encontro", chaves: "Ana, Bob, Lia, Leo, Eva", cap: 5, encadeado: true, redimensiona: false },
-  { rotulo: "Sondagem linear", chaves: "Ana, Bob, Lia, Leo, Eva", cap: 5, encadeado: false, redimensiona: false },
-  { rotulo: "Rehash acontecendo", chaves: "Ana, Bob, Lia, Leo, Eva", cap: 4, encadeado: true, redimensiona: true },
-  { rotulo: "Anagramas: o pior caso", chaves: "Lia, Ali, Ila, Lai", cap: 5, encadeado: true, redimensiona: false },
+  { label: "Quadro do encontro", keys: "Ana, Bob, Lia, Leo, Eva", cap: 5, chained: true, resizes: false },
+  { label: "Sondagem linear", keys: "Ana, Bob, Lia, Leo, Eva", cap: 5, chained: false, resizes: false },
+  { label: "Rehash acontecendo", keys: "Ana, Bob, Lia, Leo, Eva", cap: 4, chained: true, resizes: true },
+  { label: "Anagramas: o pior caso", keys: "Lia, Ali, Ila, Lai", cap: 5, chained: true, resizes: false },
 ];
 
 const POOL = ["Ana", "Bob", "Lia", "Leo", "Eva", "Kim", "Ben", "Mia", "Rui", "Zoe", "Ivo", "Gil", "Tom", "Vera"];
 
-function lerChaves(texto: string): string[] {
-  return texto
+function readKeys(text: string): string[] {
+  return text
     .split(",")
     .map((x) => x.trim().slice(0, 12))
     .filter((x) => x.length > 0)
@@ -362,125 +365,81 @@ function lerChaves(texto: string): string[] {
 }
 
 export function HashTableVisualizer() {
-  const [entrada, setEntrada] = useState(PRESETS[0].chaves);
+  const [input, setInput] = useState(PRESETS[0].keys);
   const [cap, setCap] = useState(PRESETS[0].cap);
-  const [encadeado, setEncadeado] = useState(PRESETS[0].encadeado);
-  const [redimensiona, setRedimensiona] = useState(PRESETS[0].redimensiona);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [chained, setChained] = useState(PRESETS[0].chained);
+  const [resizes, setResizes] = useState(PRESETS[0].resizes);
 
-  useEffect(() => setMounted(true), []);
-
-  const chaves = useMemo(() => lerChaves(entrada), [entrada]);
-  const passos = useMemo(
-    () => gerarPassos(chaves.length ? chaves : ["Ana"], cap, encadeado, redimensiona),
-    [chaves, cap, encadeado, redimensiona]
+  const keys = useMemo(() => readKeys(input), [input]);
+  const steps = useMemo(
+    () => generateSteps(keys.length ? keys : ["Ana"], cap, chained, resizes),
+    [keys, cap, chained, resizes]
   );
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const CODIGO = encadeado ? CODIGO_ENCADEAMENTO : CODIGO_SONDAGEM;
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const viz = useVisualizer({
+    title: "Visualizador · inserindo chaves numa tabela hash",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: a capacidade (cada bucket é uma linha da
+    // coluna), a estratégia (o código tem 14 ou 15 linhas, e a sondagem não
+    // desenha corrente) e quantas chaves entram (as correntes crescem).
+    // `resizes` entra porque o rehash dobra a capacidade durante a animação.
+    measureOn: [cap, chained, keys.length, resizes],
+  });
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+  const p = steps[viz.step];
+  const code = chained ? CHAINING_CODE : PROBING_CODE;
 
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aplicar = (pr: Preset) => {
-    reiniciar();
-    setEntrada(pr.chaves);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setInput(pr.keys);
     setCap(pr.cap);
-    setEncadeado(pr.encadeado);
-    setRedimensiona(pr.redimensiona);
+    setChained(pr.chained);
+    setResizes(pr.resizes);
   };
 
-  const sortear = () => {
-    const restantes = [...POOL];
-    const escolhidas: string[] = [];
-    const quantas = 5 + Math.floor(Math.random() * 3);
-    for (let k = 0; k < quantas && restantes.length; k++) {
-      escolhidas.push(restantes.splice(Math.floor(Math.random() * restantes.length), 1)[0]);
+  // Math.random só aqui, num handler de clique. No caminho de render ele
+  // quebraria a hidratação (o HTML do build divergiria do cliente).
+  const shuffle = () => {
+    const remaining = [...POOL];
+    const picked: string[] = [];
+    const howMany = 5 + Math.floor(Math.random() * 3);
+    for (let k = 0; k < howMany && remaining.length; k++) {
+      picked.push(remaining.splice(Math.floor(Math.random() * remaining.length), 1)[0]);
     }
-    reiniciar();
-    setEntrada(escolhidas.join(", "));
+    viz.reset();
+    setInput(picked.join(", "));
   };
 
-  const carga = p.cap ? p.n / p.cap : 0;
-  const variaveis = [
-    { nome: "chave", valor: p.chave ? `"${p.chave}"` : "-" },
-    { nome: "soma", valor: p.soma == null ? "-" : `${p.soma}` },
-    { nome: "indice", valor: p.indice == null ? "-" : `${p.indice}` },
-    { nome: "capacidade", valor: `${p.cap}` },
-    { nome: "n", valor: `${p.n}` },
-    { nome: "fator_carga", valor: dec(carga), best: carga <= LIMITE_CARGA },
-    { nome: "colisoes", valor: `${p.colisoes}` },
-    { nome: "comparacoes", valor: `${p.comparacoes}` },
+  const load = p.cap ? p.n / p.cap : 0;
+  const vars = [
+    { name: "chave", value: p.key ? `"${p.key}"` : "-" },
+    { name: "soma", value: p.sum == null ? "-" : `${p.sum}` },
+    { name: "indice", value: p.index == null ? "-" : `${p.index}` },
+    { name: "capacidade", value: `${p.cap}` },
+    { name: "n", value: `${p.n}` },
+    { name: "fator_carga", value: dec(load), best: load <= LOAD_LIMIT },
+    { name: "colisoes", value: `${p.collisions}` },
+    { name: "comparacoes", value: `${p.comparisons}` },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const destaque = p.sonda != null ? p.sonda : p.alvo;
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
+  const highlight = p.probe != null ? p.probe : p.target;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · inserindo chaves numa tabela hash</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Chaves (na ordem de inserção)</span>
             <input
               className="viz-input"
-              value={entrada}
+              value={input}
               onChange={(e) => {
-                reiniciar();
-                setEntrada(e.target.value);
+                viz.reset();
+                setInput(e.target.value);
               }}
             />
           </label>
@@ -490,7 +449,7 @@ export function HashTableVisualizer() {
               className="viz-input ht-sel"
               value={cap}
               onChange={(e) => {
-                reiniciar();
+                viz.reset();
                 setCap(parseInt(e.target.value, 10));
               }}
             >
@@ -500,43 +459,43 @@ export function HashTableVisualizer() {
               <option value={16}>16</option>
             </select>
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={shuffle}>
             Sortear
           </button>
         </div>
 
         <div className="bigo-chips">
           <button
-            className={`bigo-chip${encadeado ? " on" : ""}`}
-            aria-pressed={encadeado}
+            className={`bigo-chip${chained ? " on" : ""}`}
+            aria-pressed={chained}
             onClick={() => {
-              reiniciar();
-              setEncadeado(true);
+              viz.reset();
+              setChained(true);
             }}
           >
-            <span className="sw" style={{ background: encadeado ? "#34d399" : "#3a4a60" }} />
+            <span className="sw" style={{ background: chained ? "#34d399" : "#3a4a60" }} />
             Encadeamento
           </button>
           <button
-            className={`bigo-chip${!encadeado ? " on" : ""}`}
-            aria-pressed={!encadeado}
+            className={`bigo-chip${!chained ? " on" : ""}`}
+            aria-pressed={!chained}
             onClick={() => {
-              reiniciar();
-              setEncadeado(false);
+              viz.reset();
+              setChained(false);
             }}
           >
-            <span className="sw" style={{ background: !encadeado ? "#fbbf24" : "#3a4a60" }} />
+            <span className="sw" style={{ background: !chained ? "#fbbf24" : "#3a4a60" }} />
             Sondagem linear
           </button>
           <button
-            className={`bigo-chip${redimensiona ? " on" : ""}`}
-            aria-pressed={redimensiona}
+            className={`bigo-chip${resizes ? " on" : ""}`}
+            aria-pressed={resizes}
             onClick={() => {
-              reiniciar();
-              setRedimensiona((v) => !v);
+              viz.reset();
+              setResizes((v) => !v);
             }}
           >
-            <span className="sw" style={{ background: redimensiona ? "#60a5fa" : "#3a4a60" }} />
+            <span className="sw" style={{ background: resizes ? "#60a5fa" : "#3a4a60" }} />
             Rehash em 0,75
           </button>
         </div>
@@ -544,8 +503,8 @@ export function HashTableVisualizer() {
         <div className="ht-presets">
           <span>Cenários</span>
           {PRESETS.map((pr) => (
-            <button className="viz-btn" key={pr.rotulo} onClick={() => aplicar(pr)}>
-              {pr.rotulo}
+            <button className="viz-btn" key={pr.label} onClick={() => applyPreset(pr)}>
+              {pr.label}
             </button>
           ))}
         </div>
@@ -553,8 +512,8 @@ export function HashTableVisualizer() {
         <div className="ht-table">
           {p.slots.map((bucket, i) => {
             let cls = "ht-slot";
-            if (p.sonda === i) cls += " sonda";
-            else if (p.alvo === i) cls += " alvo";
+            if (p.probe === i) cls += " sonda";
+            else if (p.target === i) cls += " alvo";
             return (
               <div className="ht-row" key={i}>
                 <span className="ht-idx">{i}</span>
@@ -562,14 +521,14 @@ export function HashTableVisualizer() {
                   {bucket.length === 0 ? (
                     <span className="ht-vazio">vazio</span>
                   ) : (
-                    bucket.map((no, k) => {
-                      let ncls = "ht-no";
-                      if (no.chave === p.inserido) ncls += " novo";
-                      else if (destaque === i && p.comparando === k) ncls += " compara";
+                    bucket.map((entry, k) => {
+                      let nodeClass = "ht-no";
+                      if (entry.key === p.inserted) nodeClass += " novo";
+                      else if (highlight === i && p.comparing === k) nodeClass += " compara";
                       return (
-                        <Fragment key={`${no.chave}-${k}`}>
+                        <Fragment key={`${entry.key}-${k}`}>
                           {k > 0 ? <span className="ht-seta">→</span> : null}
-                          <span className={ncls}>{no.chave}</span>
+                          <span className={nodeClass}>{entry.key}</span>
                         </Fragment>
                       );
                     })
@@ -595,102 +554,44 @@ export function HashTableVisualizer() {
           </span>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">tabela_hash.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, n) => (
-                <div key={n} className={`viz-line${n === p.linha ? " on" : ""}`}>
-                  <span className="ln">{n + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">tabela_hash.py</div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
       </div>
+
+      {/* Fora do `.viz-body` de propósito: no expandido é ele que fica parado no
+          pé da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/LinkedListFloyd.tsx
+++ b/content/visualizers/LinkedListFloyd.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // LinkedListFloyd, o ponteiro rápido e o lento nas DUAS fases do algoritmo.
@@ -50,9 +51,6 @@ const CODIGO = [
   "            return lento          # início do ciclo",
   "    return None                   # não tem ciclo",
 ];
-
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 // prox(i): índice do próximo nó, ou null quando a lista acaba.
 function fazProx(cauda: number, ciclo: number) {
@@ -153,14 +151,6 @@ export function LinkedListFloyd() {
   const [cauda, setCauda] = useState(3);
   const [ciclo, setCiclo] = useState(5);
   const [preset, setPreset] = useState("classico");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   // Uma lista sem nenhum nó não teria o que percorrer nem o que desenhar.
   const nCauda = cauda + ciclo === 0 ? 1 : cauda;
@@ -168,33 +158,21 @@ export function LinkedListFloyd() {
 
   const passos = useMemo(() => gerarPassos(nCauda, ciclo), [nCauda, ciclo]);
   const qtd = passos.length;
-  const idx = Math.min(passo, qtd - 1);
+
+  const viz = useVisualizer({
+    title: "Visualizador · rápido e lento: o meio, o ciclo e onde ele começa",
+    total: qtd,
+    // O tamanho do ciclo é o que mais mexe na altura: o raio da roda cresce com
+    // ele e o viewBox cresce junto. A cauda alarga o desenho, o que com
+    // `height: auto` ENCOLHE a altura renderizada. O número de passos entra
+    // porque a nota do passo a passo muda de tamanho entre as duas fases.
+    measureOn: [nCauda, ciclo, qtd],
+  });
+
+  const idx = viz.step;
   const p = passos[idx];
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= qtd - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, qtd, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= qtd - 1) setTocando(false);
-  }, [tocando, idx, qtd]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
+  const reiniciar = viz.reset;
   const aoMudarCauda = (v: number) => { reiniciar(); setPreset(""); setCauda(v); };
   const aoMudarCiclo = (v: number) => { reiniciar(); setPreset(""); setCiclo(v); };
   const aplicarPreset = (pr: Preset) => { reiniciar(); setPreset(pr.key); setCauda(pr.cauda); setCiclo(pr.ciclo); };
@@ -298,25 +276,13 @@ export function LinkedListFloyd() {
   ];
 
   const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / qtd) * 100);
   const descricao = `Lista com ${total} nós, ${ciclo > 0 ? `com um ciclo de ${ciclo} nós que começa no nó ${nCauda}` : "sem ciclo"}. Lento em ${p.lento === null ? "None" : `nó ${p.lento}`}, rápido em ${p.rapido === null ? "None" : `nó ${p.rapido}`}. ${p.nota}`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · rápido e lento: o meio, o ciclo e onde ele começa</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {qtd}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const quadro = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="ll-grupo">
           <span className="ll-grupo-rot">Casos</span>
           <div className="bigo-chips">
@@ -424,18 +390,23 @@ export function LinkedListFloyd() {
         <p className={notaCls}>{p.nota}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">floyd.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">floyd.py</div>
+              <div className="viz-code-body">
+                {CODIGO.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {variaveis.map((v) => (
               <div className="viz-var" key={v.nome}>
@@ -455,31 +426,13 @@ export function LinkedListFloyd() {
           ))}
         </div>
 
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= qtd - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === qtd - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, qtd - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(quadro);
 }

--- a/content/visualizers/LinkedListFloyd.tsx
+++ b/content/visualizers/LinkedListFloyd.tsx
@@ -20,24 +20,24 @@ import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 // e quantos nós formam o ciclo. É a forma de "rho" que os livros desenham.
 // ---------------------------------------------------------------------------
 
-type Fase = 1 | 2 | 0;
+type Phase = 1 | 2 | 0;
 
-type Passo = {
-  linha: number;
-  lento: number | null;
-  rapido: number | null;
-  fase: Fase;
-  iteracao: number;
-  passos2: number;
-  encontro: number | null;
-  resultado: number | null;
-  nota: string;
+type Step = {
+  line: number;
+  slow: number | null;
+  fast: number | null;
+  phase: Phase;
+  round: number;
+  steps2: number;
+  meeting: number | null;
+  result: number | null;
+  note: string;
   ok?: boolean;
-  fim?: boolean;
+  done?: boolean;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo.
-const CODIGO = [
+// As linhas mapeiam 1:1 com o campo `line` de cada passo.
+const CODE = [
   "def inicio_do_ciclo(cabeca):",
   "    lento = rapido = cabeca",
   "    while rapido and rapido.prox:",
@@ -52,112 +52,112 @@ const CODIGO = [
   "    return None                   # não tem ciclo",
 ];
 
-// prox(i): índice do próximo nó, ou null quando a lista acaba.
-function fazProx(cauda: number, ciclo: number) {
-  const total = cauda + ciclo;
+// next(i): índice do próximo nó, ou null quando a lista acaba.
+function makeNext(tail: number, cycle: number) {
+  const total = tail + cycle;
   return (i: number | null): number | null => {
     if (i === null) return null;
     if (i < total - 1) return i + 1;
-    return ciclo > 0 ? cauda : null;
+    return cycle > 0 ? tail : null;
   };
 }
 
-function gerarPassos(cauda: number, ciclo: number): Passo[] {
-  const total = cauda + ciclo;
-  const prox = fazProx(cauda, ciclo);
-  const out: Passo[] = [];
+function generateSteps(tail: number, cycle: number): Step[] {
+  const total = tail + cycle;
+  const next = makeNext(tail, cycle);
+  const out: Step[] = [];
 
-  let lento: number | null = 0;
-  let rapido: number | null = 0;
-  let fase: Fase = 1;
-  let iteracao = 0;
-  let passos2 = 0;
-  let encontro: number | null = null;
-  let resultado: number | null = null;
+  let slow: number | null = 0;
+  let fast: number | null = 0;
+  let phase: Phase = 1;
+  let round = 0;
+  let steps2 = 0;
+  let meeting: number | null = null;
+  let result: number | null = null;
 
-  const push = (linha: number, nota: string, extra: Partial<Passo> = {}) => {
-    out.push({ linha, nota, lento, rapido, fase, iteracao, passos2, encontro, resultado, ...extra });
+  const push = (line: number, note: string, extra: Partial<Step> = {}) => {
+    out.push({ line, note, slow, fast, phase, round, steps2, meeting, result, ...extra });
   };
-  const nome = (i: number | null) => (i === null ? "None" : `nó ${i}`);
+  const nodeName = (i: number | null) => (i === null ? "None" : `nó ${i}`);
 
-  push(1, `Fase 1. O lento e o rápido começam os dois na cabeça, o nó 0. A lista tem ${total} ${total === 1 ? "nó" : "nós"}${ciclo > 0 ? `, e ${ciclo} ${ciclo === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`);
+  push(1, `Fase 1. O lento e o rápido começam os dois na cabeça, o nó 0. A lista tem ${total} ${total === 1 ? "nó" : "nós"}${cycle > 0 ? `, e ${cycle} ${cycle === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`);
 
-  let guarda = 0;
-  while (guarda++ < 300) {
-    if (rapido === null || prox(rapido) === null) {
-      resultado = lento;
-      const meio = lento;
-      const tamanho = `${total} ${total === 1 ? "nó" : "nós"}`;
-      const indice = `o índice ${total} // 2 = ${Math.floor(total / 2)}`;
-      push(11, rapido === null
-        ? `O rápido caiu fora da lista (None). Quem entra num ciclo nunca sai dele, então esta lista não tem ciclo: devolvo None. Agora repare no lento: ele parou no ${nome(meio)}, o meio da lista de ${tamanho} (${indice}). O mesmo laço que procura ciclo acha o meio de graça.`
-        : `O rápido está no ${nome(rapido)}, que aponta para None: acabou a lista, não tem ciclo. E o lento parou no ${nome(meio)}, exatamente o meio da lista de ${tamanho} (${indice}).`,
-        { fim: true });
+  let guard = 0;
+  while (guard++ < 300) {
+    if (fast === null || next(fast) === null) {
+      result = slow;
+      const mid = slow;
+      const size = `${total} ${total === 1 ? "nó" : "nós"}`;
+      const index = `o índice ${total} // 2 = ${Math.floor(total / 2)}`;
+      push(11, fast === null
+        ? `O rápido caiu fora da lista (None). Quem entra num ciclo nunca sai dele, então esta lista não tem ciclo: devolvo None. Agora repare no lento: ele parou no ${nodeName(mid)}, o meio da lista de ${size} (${index}). O mesmo laço que procura ciclo acha o meio de graça.`
+        : `O rápido está no ${nodeName(fast)}, que aponta para None: acabou a lista, não tem ciclo. E o lento parou no ${nodeName(mid)}, exatamente o meio da lista de ${size} (${index}).`,
+        { done: true });
       return out;
     }
-    iteracao++;
-    const deL = lento as number;
-    const deR = rapido as number;
-    lento = prox(lento);
-    push(3, `Iteração ${iteracao}: o lento sai do ${nome(deL)} e anda 1, chega no ${nome(lento)}.`);
-    const meio = prox(deR) as number;
-    rapido = prox(meio);
-    push(4, `O rápido sai do ${nome(deR)} e anda 2, passando pelo ${nome(meio)}: ${rapido === null ? "e cai fora da lista, no None" : `chega no ${nome(rapido)}`}.`);
-    if (rapido !== null && lento === rapido) {
-      encontro = lento;
-      push(5, `Os dois pararam no ${nome(lento)}: eles se encontraram, então a lista TEM ciclo. Foram ${iteracao} ${iteracao === 1 ? "iteração" : "iterações"}. Só que este nó quase nunca é o começo do ciclo, e é aí que entra a fase 2.`, { ok: true });
+    round++;
+    const fromSlow = slow as number;
+    const fromFast = fast as number;
+    slow = next(slow);
+    push(3, `Iteração ${round}: o lento sai do ${nodeName(fromSlow)} e anda 1, chega no ${nodeName(slow)}.`);
+    const mid = next(fromFast) as number;
+    fast = next(mid);
+    push(4, `O rápido sai do ${nodeName(fromFast)} e anda 2, passando pelo ${nodeName(mid)}: ${fast === null ? "e cai fora da lista, no None" : `chega no ${nodeName(fast)}`}.`);
+    if (fast !== null && slow === fast) {
+      meeting = slow;
+      push(5, `Os dois pararam no ${nodeName(slow)}: eles se encontraram, então a lista TEM ciclo. Foram ${round} ${round === 1 ? "iteração" : "iterações"}. Só que este nó quase nunca é o começo do ciclo, e é aí que entra a fase 2.`, { ok: true });
       break;
     }
-    push(5, `Lento no ${nome(lento)}, rápido ${rapido === null ? "fora da lista" : `no ${nome(rapido)}`}: ainda não estão no mesmo nó, volto para o topo do while.`);
+    push(5, `Lento no ${nodeName(slow)}, rápido ${fast === null ? "fora da lista" : `no ${nodeName(fast)}`}: ainda não estão no mesmo nó, volto para o topo do while.`);
   }
 
   // --- fase 2 ---------------------------------------------------------------
-  if (encontro === null) return out; // só chega aqui se a guarda estourar
-  fase = 2;
-  lento = 0;
-  push(6, `Fase 2: devolvo o lento para a cabeça (nó 0) e deixo o rápido parado no ${nome(encontro)}. Daqui para frente os dois andam de 1 em 1, no mesmo ritmo.`);
+  if (meeting === null) return out; // só chega aqui se a guarda estourar
+  phase = 2;
+  slow = 0;
+  push(6, `Fase 2: devolvo o lento para a cabeça (nó 0) e deixo o rápido parado no ${nodeName(meeting)}. Daqui para frente os dois andam de 1 em 1, no mesmo ritmo.`);
 
-  let guarda2 = 0;
-  while (guarda2++ < 300) {
-    if (lento === rapido) break;
-    push(7, `Lento no ${nome(lento)}, rápido no ${nome(rapido)}: ainda não é o mesmo nó, continuo.`);
-    lento = prox(lento);
-    passos2++;
-    push(8, `O lento anda 1 e vai para o ${nome(lento)}.`);
-    rapido = prox(rapido);
-    push(9, `O rápido também anda 1 e vai para o ${nome(rapido)}.`);
+  let guard2 = 0;
+  while (guard2++ < 300) {
+    if (slow === fast) break;
+    push(7, `Lento no ${nodeName(slow)}, rápido no ${nodeName(fast)}: ainda não é o mesmo nó, continuo.`);
+    slow = next(slow);
+    steps2++;
+    push(8, `O lento anda 1 e vai para o ${nodeName(slow)}.`);
+    fast = next(fast);
+    push(9, `O rápido também anda 1 e vai para o ${nodeName(fast)}.`);
   }
-  resultado = lento;
-  fase = 0;
-  push(7, `Lento e rápido estão os dois no ${nome(lento)}: a condição do while é falsa, saio do laço.`);
-  push(10, `Devolvo o ${nome(lento)}: é aqui que o ciclo começa. Os dois andaram ${passos2} ${passos2 === 1 ? "passo" : "passos"} na fase 2, que é exatamente o tamanho da cauda (${cauda} ${cauda === 1 ? "nó" : "nós"} antes do ciclo). Não é sorte, é a conta que fecha.`, { ok: true, fim: true });
+  result = slow;
+  phase = 0;
+  push(7, `Lento e rápido estão os dois no ${nodeName(slow)}: a condição do while é falsa, saio do laço.`);
+  push(10, `Devolvo o ${nodeName(slow)}: é aqui que o ciclo começa. Os dois andaram ${steps2} ${steps2 === 1 ? "passo" : "passos"} na fase 2, que é exatamente o tamanho da cauda (${tail} ${tail === 1 ? "nó" : "nós"} antes do ciclo). Não é sorte, é a conta que fecha.`, { ok: true, done: true });
   return out;
 }
 
 // --- geometria da forma de rho ----------------------------------------------
-const R_NO = 17;
+const R_NODE = 17;
 const GAP = 64;
 
-type Preset = { key: string; rotulo: string; cauda: number; ciclo: number };
+type Preset = { key: string; label: string; tail: number; cycle: number };
 const PRESETS: Preset[] = [
-  { key: "classico", rotulo: "Clássico: 3 antes + ciclo de 5", cauda: 3, ciclo: 5 },
-  { key: "meio6", rotulo: "Sem ciclo: 6 nós (acha o meio)", cauda: 6, ciclo: 0 },
-  { key: "meio5", rotulo: "Sem ciclo: 5 nós", cauda: 5, ciclo: 0 },
-  { key: "puro", rotulo: "Tudo é ciclo: 6 nós em roda", cauda: 0, ciclo: 6 },
-  { key: "laco", rotulo: "Laço em 1 nó: 4 + ciclo de 1", cauda: 4, ciclo: 1 },
+  { key: "classico", label: "Clássico: 3 antes + ciclo de 5", tail: 3, cycle: 5 },
+  { key: "meio6", label: "Sem ciclo: 6 nós (acha o meio)", tail: 6, cycle: 0 },
+  { key: "meio5", label: "Sem ciclo: 5 nós", tail: 5, cycle: 0 },
+  { key: "puro", label: "Tudo é ciclo: 6 nós em roda", tail: 0, cycle: 6 },
+  { key: "laco", label: "Laço em 1 nó: 4 + ciclo de 1", tail: 4, cycle: 1 },
 ];
 
 export function LinkedListFloyd() {
-  const [cauda, setCauda] = useState(3);
-  const [ciclo, setCiclo] = useState(5);
+  const [tail, setTail] = useState(3);
+  const [cycle, setCycle] = useState(5);
   const [preset, setPreset] = useState("classico");
 
   // Uma lista sem nenhum nó não teria o que percorrer nem o que desenhar.
-  const nCauda = cauda + ciclo === 0 ? 1 : cauda;
-  const total = nCauda + ciclo;
+  const nTail = tail + cycle === 0 ? 1 : tail;
+  const total = nTail + cycle;
 
-  const passos = useMemo(() => gerarPassos(nCauda, ciclo), [nCauda, ciclo]);
-  const qtd = passos.length;
+  const steps = useMemo(() => generateSteps(nTail, cycle), [nTail, cycle]);
+  const qtd = steps.length;
 
   const viz = useVisualizer({
     title: "Visualizador · rápido e lento: o meio, o ciclo e onde ele começa",
@@ -166,119 +166,119 @@ export function LinkedListFloyd() {
     // ele e o viewBox cresce junto. A cauda alarga o desenho, o que com
     // `height: auto` ENCOLHE a altura renderizada. O número de passos entra
     // porque a nota do passo a passo muda de tamanho entre as duas fases.
-    measureOn: [nCauda, ciclo, qtd],
+    measureOn: [nTail, cycle, qtd],
   });
 
   const idx = viz.step;
-  const p = passos[idx];
+  const p = steps[idx];
 
-  const reiniciar = viz.reset;
-  const aoMudarCauda = (v: number) => { reiniciar(); setPreset(""); setCauda(v); };
-  const aoMudarCiclo = (v: number) => { reiniciar(); setPreset(""); setCiclo(v); };
-  const aplicarPreset = (pr: Preset) => { reiniciar(); setPreset(pr.key); setCauda(pr.cauda); setCiclo(pr.ciclo); };
+  const reset = viz.reset;
+  const onTailChange = (v: number) => { reset(); setPreset(""); setTail(v); };
+  const onCycleChange = (v: number) => { reset(); setPreset(""); setCycle(v); };
+  const applyPreset = (pr: Preset) => { reset(); setPreset(pr.key); setTail(pr.tail); setCycle(pr.cycle); };
 
   // Com ciclo de 1 nó não existe circunferência: o laço vira um arco por cima
   // do próprio nó, e a altura precisa sobrar para ele.
-  const Rc = ciclo >= 2 ? Math.max(48, ciclo * 9) : 0;
-  const entradaX = 28 + nCauda * GAP;
-  const cx = entradaX + Rc;
-  const alturaSvg = ciclo >= 2 ? 2 * Rc + 96 : ciclo === 1 ? 158 : 130;
-  const cy = alturaSvg / 2;
-  const ultimoCaudaX = 28 + (nCauda - 1) * GAP;
+  const Rc = cycle >= 2 ? Math.max(48, cycle * 9) : 0;
+  const entryX = 28 + nTail * GAP;
+  const cx = entryX + Rc;
+  const svgHeight = cycle >= 2 ? 2 * Rc + 96 : cycle === 1 ? 158 : 130;
+  const cy = svgHeight / 2;
+  const lastTailX = 28 + (nTail - 1) * GAP;
   // Piso na largura: com poucos nós o viewBox ficaria estreito e o desenho
   // seria esticado até virar caricatura dentro do container.
-  const larguraSvg = Math.max(460, ciclo >= 2 ? cx + Rc + 36 : ciclo === 1 ? entradaX + 44 : ultimoCaudaX + GAP + 58);
+  const svgWidth = Math.max(460, cycle >= 2 ? cx + Rc + 36 : cycle === 1 ? entryX + 44 : lastTailX + GAP + 58);
 
   const pos = (i: number) => {
-    if (i < nCauda) return { x: 28 + i * GAP, y: cy, ang: null as number | null };
-    const k = i - nCauda;
-    const a = Math.PI + (k * 2 * Math.PI) / Math.max(1, ciclo);
+    if (i < nTail) return { x: 28 + i * GAP, y: cy, ang: null as number | null };
+    const k = i - nTail;
+    const a = Math.PI + (k * 2 * Math.PI) / Math.max(1, cycle);
     return { x: cx + Rc * Math.cos(a), y: cy + Rc * Math.sin(a), ang: a };
   };
 
   // Reta encurtada nas duas pontas, para não entrar por baixo dos nós.
-  const reta = (ax: number, ay: number, bx: number, by: number) => {
+  const line2 = (ax: number, ay: number, bx: number, by: number) => {
     const dx = bx - ax;
     const dy = by - ay;
     const d = Math.max(1, Math.hypot(dx, dy));
     return {
-      x1: ax + (dx / d) * (R_NO + 3),
-      y1: ay + (dy / d) * (R_NO + 3),
-      x2: bx - (dx / d) * (R_NO + 10),
-      y2: by - (dy / d) * (R_NO + 10),
+      x1: ax + (dx / d) * (R_NODE + 3),
+      y1: ay + (dy / d) * (R_NODE + 3),
+      x2: bx - (dx / d) * (R_NODE + 10),
+      y2: by - (dy / d) * (R_NODE + 10),
     };
   };
 
-  const retas: { k: string; x1: number; y1: number; x2: number; y2: number }[] = [];
-  for (let i = 0; i < nCauda; i++) {
+  const lines: { k: string; x1: number; y1: number; x2: number; y2: number }[] = [];
+  for (let i = 0; i < nTail; i++) {
     if (i + 1 < total) {
       const a = pos(i);
       const b = pos(i + 1);
-      retas.push({ k: `t${i}`, ...reta(a.x, a.y, b.x, b.y) });
+      lines.push({ k: `t${i}`, ...line2(a.x, a.y, b.x, b.y) });
     }
   }
-  if (ciclo === 0) {
-    retas.push({ k: "none", x1: ultimoCaudaX + R_NO + 3, y1: cy, x2: ultimoCaudaX + GAP - 24, y2: cy });
+  if (cycle === 0) {
+    lines.push({ k: "none", x1: lastTailX + R_NODE + 3, y1: cy, x2: lastTailX + GAP - 24, y2: cy });
   }
 
   // Arcos do ciclo: seguem a própria circunferência, então nunca se cruzam.
-  const arcos: string[] = [];
-  if (ciclo >= 2) {
-    const da = (2 * Math.PI) / ciclo;
-    const off = Math.min(da * 0.34, (R_NO + 9) / Rc);
-    for (let k = 0; k < ciclo; k++) {
+  const arcs: string[] = [];
+  if (cycle >= 2) {
+    const da = (2 * Math.PI) / cycle;
+    const off = Math.min(da * 0.34, (R_NODE + 9) / Rc);
+    for (let k = 0; k < cycle; k++) {
       const a1 = Math.PI + k * da + off;
       const a2 = Math.PI + (k + 1) * da - off;
-      arcos.push(
+      arcs.push(
         `M ${(cx + Rc * Math.cos(a1)).toFixed(1)},${(cy + Rc * Math.sin(a1)).toFixed(1)} A ${Rc},${Rc} 0 0,1 ${(cx + Rc * Math.cos(a2)).toFixed(1)},${(cy + Rc * Math.sin(a2)).toFixed(1)}`
       );
     }
-  } else if (ciclo === 1) {
-    const a = pos(nCauda);
-    arcos.push(
-      `M ${(a.x - 9).toFixed(1)},${(a.y - R_NO - 2).toFixed(1)} C ${(a.x - 52).toFixed(1)},${(a.y - R_NO - 62).toFixed(1)} ${(a.x + 52).toFixed(1)},${(a.y - R_NO - 62).toFixed(1)} ${(a.x + 11).toFixed(1)},${(a.y - R_NO - 4).toFixed(1)}`
+  } else if (cycle === 1) {
+    const a = pos(nTail);
+    arcs.push(
+      `M ${(a.x - 9).toFixed(1)},${(a.y - R_NODE - 2).toFixed(1)} C ${(a.x - 52).toFixed(1)},${(a.y - R_NODE - 62).toFixed(1)} ${(a.x + 52).toFixed(1)},${(a.y - R_NODE - 62).toFixed(1)} ${(a.x + 11).toFixed(1)},${(a.y - R_NODE - 4).toFixed(1)}`
     );
   }
 
-  const corNo = (i: number) => {
-    const eL = p.lento === i;
-    const eR = p.rapido === i;
-    if (eL && eR) return { fill: "rgba(52,211,153,0.26)", stroke: "#34d399", txt: "#eafff5" };
-    if (eL) return { fill: "rgba(59,130,246,0.22)", stroke: "#3b82f6", txt: "#ffffff" };
-    if (eR) return { fill: "rgba(245,158,11,0.2)", stroke: "#f59e0b", txt: "#ffffff" };
-    if (p.resultado === i && p.fim) return { fill: "rgba(167,139,250,0.18)", stroke: "#a78bfa", txt: "#ede9fe" };
-    return { fill: "#0f1826", stroke: "rgba(255,255,255,0.14)", txt: "#8ba0bb" };
+  const nodeColor = (i: number) => {
+    const isSlow = p.slow === i;
+    const isFast = p.fast === i;
+    if (isSlow && isFast) return { fill: "rgba(52,211,153,0.26)", stroke: "#34d399", text: "#eafff5" };
+    if (isSlow) return { fill: "rgba(59,130,246,0.22)", stroke: "#3b82f6", text: "#ffffff" };
+    if (isFast) return { fill: "rgba(245,158,11,0.2)", stroke: "#f59e0b", text: "#ffffff" };
+    if (p.result === i && p.done) return { fill: "rgba(167,139,250,0.18)", stroke: "#a78bfa", text: "#ede9fe" };
+    return { fill: "#0f1826", stroke: "rgba(255,255,255,0.14)", text: "#8ba0bb" };
   };
 
-  const marcaNo = (i: number) => {
-    const eL = p.lento === i;
-    const eR = p.rapido === i;
-    if (eL && eR) return { txt: "L R", cor: "#6ee7b7" };
-    if (eL) return { txt: "L", cor: "#93bbfd" };
-    if (eR) return { txt: "R", cor: "#fcd34d" };
-    if (p.encontro === i) return { txt: "encontro", cor: "#a78bfa" };
+  const nodeMark = (i: number) => {
+    const isSlow = p.slow === i;
+    const isFast = p.fast === i;
+    if (isSlow && isFast) return { text: "L R", color: "#6ee7b7" };
+    if (isSlow) return { text: "L", color: "#93bbfd" };
+    if (isFast) return { text: "R", color: "#fcd34d" };
+    if (p.meeting === i) return { text: "encontro", color: "#a78bfa" };
     return null;
   };
 
-  const variaveis = [
-    { nome: "lento", valor: p.lento === null ? "None" : `nó ${p.lento}` },
-    { nome: "rapido", valor: p.rapido === null ? "None" : `nó ${p.rapido}` },
-    { nome: "fase", valor: p.fase === 0 ? "terminou" : `${p.fase}` },
-    { nome: "retorno", valor: p.fim ? (ciclo > 0 ? `nó ${p.resultado}` : "None") : "?", best: !!p.fim && ciclo > 0 },
+  const vars = [
+    { name: "lento", value: p.slow === null ? "None" : `nó ${p.slow}` },
+    { name: "rapido", value: p.fast === null ? "None" : `nó ${p.fast}` },
+    { name: "fase", value: p.phase === 0 ? "terminou" : `${p.phase}` },
+    { name: "retorno", value: p.done ? (cycle > 0 ? `nó ${p.result}` : "None") : "?", best: !!p.done && cycle > 0 },
   ];
 
-  const rotuloResultado = ciclo > 0 ? "início do ciclo" : "nó do meio";
-  const estatisticas = [
-    { k: "n", rot: "nós na lista", val: `${total}` },
-    { k: "i1", rot: "iterações da fase 1", val: `${p.iteracao}` },
-    { k: "i2", rot: "passos da fase 2", val: `${p.passos2}` },
-    { k: "res", rot: rotuloResultado, val: p.fim && p.resultado !== null ? `nó ${p.resultado}` : "…" },
+  const resultLabel = cycle > 0 ? "início do ciclo" : "nó do meio";
+  const stats = [
+    { k: "n", label: "nós na lista", value: `${total}` },
+    { k: "i1", label: "iterações da fase 1", value: `${p.round}` },
+    { k: "i2", label: "passos da fase 2", value: `${p.steps2}` },
+    { k: "res", label: resultLabel, value: p.done && p.result !== null ? `nó ${p.result}` : "…" },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const descricao = `Lista com ${total} nós, ${ciclo > 0 ? `com um ciclo de ${ciclo} nós que começa no nó ${nCauda}` : "sem ciclo"}. Lento em ${p.lento === null ? "None" : `nó ${p.lento}`}, rápido em ${p.rapido === null ? "None" : `nó ${p.rapido}`}. ${p.nota}`;
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
+  const description = `Lista com ${total} nós, ${cycle > 0 ? `com um ciclo de ${cycle} nós que começa no nó ${nTail}` : "sem ciclo"}. Lento em ${p.slow === null ? "None" : `nó ${p.slow}`}, rápido em ${p.fast === null ? "None" : `nó ${p.fast}`}. ${p.note}`;
 
-  const quadro = (
+  const frame = (
     <figure {...viz.figureProps} style={{ margin: 0 }}>
       <VizHeader viz={viz} />
 
@@ -290,10 +290,10 @@ export function LinkedListFloyd() {
               <button
                 key={pr.key}
                 className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-                onClick={() => aplicarPreset(pr)}
+                onClick={() => applyPreset(pr)}
                 aria-pressed={preset === pr.key}
               >
-                {pr.rotulo}
+                {pr.label}
               </button>
             ))}
           </div>
@@ -301,18 +301,18 @@ export function LinkedListFloyd() {
 
         <div className="viz-inputs">
           <label className="viz-field grow">
-            <span>Nós antes do ciclo: {nCauda}{cauda + ciclo === 0 ? " (o mínimo)" : ""}</span>
+            <span>Nós antes do ciclo: {nTail}{tail + cycle === 0 ? " (o mínimo)" : ""}</span>
             <input
-              type="range" min={0} max={6} step={1} value={cauda}
-              onChange={(e) => aoMudarCauda(parseInt(e.target.value, 10))}
+              type="range" min={0} max={6} step={1} value={tail}
+              onChange={(e) => onTailChange(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </label>
           <label className="viz-field grow">
-            <span>Nós no ciclo: {ciclo === 0 ? "nenhum, a lista termina em None" : ciclo}</span>
+            <span>Nós no ciclo: {cycle === 0 ? "nenhum, a lista termina em None" : cycle}</span>
             <input
-              type="range" min={0} max={8} step={1} value={ciclo}
-              onChange={(e) => aoMudarCiclo(parseInt(e.target.value, 10))}
+              type="range" min={0} max={8} step={1} value={cycle}
+              onChange={(e) => onCycleChange(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </label>
@@ -321,9 +321,9 @@ export function LinkedListFloyd() {
         <div className="ll-svg-wrap">
           <svg
             className="ll-svg"
-            viewBox={`-22 -10 ${Math.round(larguraSvg + 44)} ${Math.round(alturaSvg + 20)}`}
+            viewBox={`-22 -10 ${Math.round(svgWidth + 44)} ${Math.round(svgHeight + 20)}`}
             role="img"
-            aria-label={descricao}
+            aria-label={description}
           >
             <defs>
               <marker id="llfl-seta" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
@@ -331,47 +331,47 @@ export function LinkedListFloyd() {
               </marker>
             </defs>
 
-            {retas.map((s) => (
+            {lines.map((s) => (
               <line key={s.k} x1={s.x1} y1={s.y1} x2={s.x2} y2={s.y2} stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#llfl-seta)" />
             ))}
-            {arcos.map((d, i) => (
+            {arcs.map((d, i) => (
               <path key={`a${i}`} d={d} fill="none" stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#llfl-seta)" />
             ))}
 
-            {ciclo === 0 ? (
-              <text x={ultimoCaudaX + GAP} y={cy} fill="#61748c" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={13} textAnchor="middle" dominantBaseline="middle">
+            {cycle === 0 ? (
+              <text x={lastTailX + GAP} y={cy} fill="#61748c" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={13} textAnchor="middle" dominantBaseline="middle">
                 None
               </text>
             ) : null}
 
             {Array.from({ length: total }, (_, i) => {
               const q = pos(i);
-              const c = corNo(i);
-              const m = marcaNo(i);
+              const c = nodeColor(i);
+              const m = nodeMark(i);
               // Rótulo para fora da roda nos nós do ciclo e acima nos da cauda.
               // Duas exceções, senão ele bate numa seta: o nó de entrada do
               // ciclo (a seta da cauda chega por ali) fica com o rótulo acima, e
               // o ciclo de um nó só o joga para baixo, porque o laço ocupa o
               // espaço de cima.
-              const entradaComCauda = i === nCauda && nCauda > 0;
-              const radial = q.ang !== null && Rc > 0 && !entradaComCauda;
+              const entryWithTail = i === nTail && nTail > 0;
+              const radial = q.ang !== null && Rc > 0 && !entryWithTail;
               let lx = q.x;
-              let ly = q.y - R_NO - 12;
+              let ly = q.y - R_NODE - 12;
               if (radial) {
-                lx = cx + (Rc + R_NO + 15) * Math.cos(q.ang as number);
-                ly = cy + (Rc + R_NO + 15) * Math.sin(q.ang as number);
+                lx = cx + (Rc + R_NODE + 15) * Math.cos(q.ang as number);
+                ly = cy + (Rc + R_NODE + 15) * Math.sin(q.ang as number);
               } else if (q.ang !== null && Rc === 0) {
-                ly = q.y + R_NO + 15;
+                ly = q.y + R_NODE + 15;
               }
               return (
                 <g key={i}>
-                  <circle cx={q.x} cy={q.y} r={R_NO} fill={c.fill} stroke={c.stroke} strokeWidth={1.8} />
-                  <text x={q.x} y={q.y} fill={c.txt} fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={13} fontWeight={600} textAnchor="middle" dominantBaseline="central">
+                  <circle cx={q.x} cy={q.y} r={R_NODE} fill={c.fill} stroke={c.stroke} strokeWidth={1.8} />
+                  <text x={q.x} y={q.y} fill={c.text} fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={13} fontWeight={600} textAnchor="middle" dominantBaseline="central">
                     {i}
                   </text>
                   {m ? (
-                    <text x={lx} y={ly} fill={m.cor} fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11.5} fontWeight={700} textAnchor="middle" dominantBaseline="central">
-                      {m.txt}
+                    <text x={lx} y={ly} fill={m.color} fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11.5} fontWeight={700} textAnchor="middle" dominantBaseline="central">
+                      {m.text}
                     </text>
                   ) : null}
                 </g>
@@ -387,7 +387,7 @@ export function LinkedListFloyd() {
           <span><i style={{ background: "#a78bfa" }} /> nó do encontro</span>
         </p>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
           {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
@@ -397,10 +397,10 @@ export function LinkedListFloyd() {
             <div className="viz-code" {...viz.blockProps}>
               <div className="viz-code-head">floyd.py</div>
               <div className="viz-code-body">
-                {CODIGO.map((txt, i) => (
-                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                {CODE.map((text, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
                     <span className="ln">{i + 1}</span>
-                    {txt}
+                    {text}
                   </div>
                 ))}
               </div>
@@ -408,20 +408,20 @@ export function LinkedListFloyd() {
           </div>
           <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
@@ -434,5 +434,5 @@ export function LinkedListFloyd() {
     </figure>
   );
 
-  return viz.inPanel(quadro);
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/LinkedListReversao.tsx
+++ b/content/visualizers/LinkedListReversao.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // LinkedListReversao, a inversão de uma lista encadeada com três ponteiros.
@@ -42,9 +43,6 @@ const CODIGO = [
   "        atual = proximo        # atual anda",
   "    return anterior",
 ];
-
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 function gerarPassos(nos: string[]): Passo[] {
   const n = nos.length;
@@ -120,44 +118,23 @@ export function LinkedListReversao() {
   const [nos, setNos] = useState<string[]>(PRESETS[0].nos);
   const [entrada, setEntrada] = useState(PRESETS[0].nos.join(", "));
   const [preset, setPreset] = useState("encontro");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   const passos = useMemo(() => gerarPassos(nos), [nos]);
   const total = passos.length;
-  const idx = Math.min(passo, total - 1);
+
+  const viz = useVisualizer({
+    title: "Visualizador · inverter a lista com três ponteiros",
+    total,
+    // O tamanho da lista alarga o viewBox, e com `height: auto` isso muda a
+    // ALTURA do desenho junto; o número de passos entra porque a nota do passo
+    // a passo é mais longa em alguns casos de borda.
+    measureOn: [nos.length, total],
+  });
+
+  const idx = viz.step;
   const p = passos[idx];
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
+  const reiniciar = viz.reset;
   const aoMudarEntrada = (v: string) => {
     const arr = v.split(",").map((x) => x.trim()).filter((x) => x.length > 0).map((x) => x.slice(0, 3)).slice(0, 7);
     reiniciar(); setPreset("");
@@ -189,7 +166,6 @@ export function LinkedListReversao() {
   ];
 
   const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
   const descricao = `Lista com ${n} nós: ${nos.join(", ") || "vazia"}. ${p.invertidas} setas já apontam para trás. ${p.nota}`;
 
   const corNo = (i: number) => {
@@ -206,22 +182,11 @@ export function LinkedListReversao() {
     return marcas.length ? marcas.join(" / ") : null;
   };
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · inverter a lista com três ponteiros</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const quadro = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="ll-grupo">
           <span className="ll-grupo-rot">Casos</span>
           <div className="bigo-chips">
@@ -325,18 +290,23 @@ export function LinkedListReversao() {
         <p className={notaCls}>{p.nota}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">reverter.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">reverter.py</div>
+              <div className="viz-code-body">
+                {CODIGO.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {variaveis.map((v) => (
               <div className="viz-var" key={v.nome}>
@@ -356,31 +326,13 @@ export function LinkedListReversao() {
           ))}
         </div>
 
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(quadro);
 }

--- a/content/visualizers/LinkedListReversao.tsx
+++ b/content/visualizers/LinkedListReversao.tsx
@@ -18,21 +18,21 @@ import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 // galera desenhou no encontro.
 // ---------------------------------------------------------------------------
 
-type Passo = {
-  linha: number;
-  anterior: number | null; // índice do nó, null = None
-  atual: number | null;
-  proximo: number | null;
-  temProximo: boolean; // a variável `proximo` já foi atribuída nesta volta
-  invertidas: number; // quantas setas já viraram (nós 0..invertidas-1)
-  iteracao: number;
-  nota: string;
+type Step = {
+  line: number;
+  prev: number | null; // índice do nó, null = None
+  curr: number | null;
+  next: number | null;
+  hasNext: boolean; // a variável `proximo` já foi atribuída nesta volta
+  flipped: number; // quantas setas já viraram (nós 0..invertidas-1)
+  round: number;
+  note: string;
   ok?: boolean;
-  fim?: boolean;
+  done?: boolean;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo.
-const CODIGO = [
+// As linhas mapeiam 1:1 com o campo `line` de cada passo.
+const CODE = [
   "def reverter(cabeca):",
   "    anterior = None",
   "    atual = cabeca",
@@ -44,54 +44,54 @@ const CODIGO = [
   "    return anterior",
 ];
 
-function gerarPassos(nos: string[]): Passo[] {
-  const n = nos.length;
-  const out: Passo[] = [];
-  let anterior: number | null = null;
-  let atual: number | null = n > 0 ? 0 : null;
-  let proximo: number | null = null;
-  let temProximo = false;
-  let invertidas = 0;
-  let iteracao = 0;
+function generateSteps(nodes: string[]): Step[] {
+  const n = nodes.length;
+  const out: Step[] = [];
+  let prev: number | null = null;
+  let curr: number | null = n > 0 ? 0 : null;
+  let next: number | null = null;
+  let hasNext = false;
+  let flipped = 0;
+  let round = 0;
 
-  const push = (linha: number, nota: string, extra: Partial<Passo> = {}) => {
-    out.push({ linha, nota, anterior, atual, proximo, temProximo, invertidas, iteracao, ...extra });
+  const push = (line: number, note: string, extra: Partial<Step> = {}) => {
+    out.push({ line, note, prev, curr, next, hasNext, flipped, round, ...extra });
   };
-  const nome = (i: number | null) => (i === null ? "None" : `nó ${nos[i]}`);
+  const nodeName = (i: number | null) => (i === null ? "None" : `nó ${nodes[i]}`);
 
-  anterior = null;
-  atual = null;
+  prev = null;
+  curr = null;
   push(1, `anterior começa em None. Ele é o segredo do algoritmo: numa lista simplesmente encadeada eu não consigo olhar para trás, então preciso carregar o "trás" comigo.`);
-  atual = n > 0 ? 0 : null;
+  curr = n > 0 ? 0 : null;
   push(2, n > 0
-    ? `atual começa na cabeça, ${nome(0)}. É ele que vai caminhar até o fim.`
+    ? `atual começa na cabeça, ${nodeName(0)}. É ele que vai caminhar até o fim.`
     : `atual começa na cabeça, que é None: a lista está vazia.`);
 
-  let guarda = 0;
-  while (atual !== null && guarda++ < 60) {
-    iteracao++;
-    const a = atual;
-    proximo = a + 1 < n ? a + 1 : null;
-    temProximo = true;
-    push(4, proximo === null
-      ? `Volta ${iteracao}. Guardo o resto da lista em proximo, que aqui já é None: ${nome(a)} é o último nó.`
-      : `Volta ${iteracao}. Primeiro guardo o resto da lista em proximo (${nome(proximo)}). A próxima linha vai apagar o único endereço que leva até ele, e sem essa cópia eu perderia ${nome(proximo)} e todo mundo depois dele.`);
-    invertidas = a + 1;
-    push(5, `Viro a seta: ${nome(a)} agora aponta para ${nome(anterior)}. A lista está partida em duas neste instante, e é por isso que a ordem das quatro linhas não é opinião.`);
-    anterior = a;
-    push(6, `anterior passa a ser ${nome(a)}: quando eu andar, ele vira o "trás" do próximo nó.`);
-    atual = proximo;
-    temProximo = false;
-    push(7, `atual passa a ser ${nome(atual)}.${atual === null ? " Chegamos ao fim da lista original." : ""}`);
+  let guard = 0;
+  while (curr !== null && guard++ < 60) {
+    round++;
+    const a = curr;
+    next = a + 1 < n ? a + 1 : null;
+    hasNext = true;
+    push(4, next === null
+      ? `Volta ${round}. Guardo o resto da lista em proximo, que aqui já é None: ${nodeName(a)} é o último nó.`
+      : `Volta ${round}. Primeiro guardo o resto da lista em proximo (${nodeName(next)}). A próxima linha vai apagar o único endereço que leva até ele, e sem essa cópia eu perderia ${nodeName(next)} e todo mundo depois dele.`);
+    flipped = a + 1;
+    push(5, `Viro a seta: ${nodeName(a)} agora aponta para ${nodeName(prev)}. A lista está partida em duas neste instante, e é por isso que a ordem das quatro linhas não é opinião.`);
+    prev = a;
+    push(6, `anterior passa a ser ${nodeName(a)}: quando eu andar, ele vira o "trás" do próximo nó.`);
+    curr = next;
+    hasNext = false;
+    push(7, `atual passa a ser ${nodeName(curr)}.${curr === null ? " Chegamos ao fim da lista original." : ""}`);
   }
 
   push(3, n === 0
     ? `atual já nasceu None, então o while não roda nenhuma vez: numa lista vazia não existe seta para virar.`
-    : `atual é None: não sobrou nó para virar. Foram ${iteracao} ${iteracao === 1 ? "volta" : "voltas"}, uma por nó, e cada volta escreveu exatamente 3 variáveis.`);
+    : `atual é None: não sobrou nó para virar. Foram ${round} ${round === 1 ? "volta" : "voltas"}, uma por nó, e cada volta escreveu exatamente 3 variáveis.`);
   push(8, n > 0
-    ? `Devolvo anterior, que parou em ${nome(n - 1)}: o antigo último virou a nova cabeça. ${n} ${n === 1 ? "seta" : "setas"} viradas, nenhuma cópia de nó e nenhuma lista nova.`
+    ? `Devolvo anterior, que parou em ${nodeName(n - 1)}: o antigo último virou a nova cabeça. ${n} ${n === 1 ? "seta" : "setas"} viradas, nenhuma cópia de nó e nenhuma lista nova.`
     : `Devolvo anterior, que é None: reverter uma lista vazia devolve uma lista vazia.`,
-    { ok: true, fim: true });
+    { ok: true, done: true });
   return out;
 }
 
@@ -102,25 +102,25 @@ const STEP = 92;
 const PAD_X = 14;
 const CY = 104; // linha dos nós
 const X0 = -62; // sobra à esquerda: cabe o None do começo
-const VB_TOPO = 18;
-const VB_ALTURA = 140;
+const VB_TOP = 18;
+const VB_HEIGHT = 140;
 
-type Preset = { key: string; rotulo: string; nos: string[] };
+type Preset = { key: string; label: string; nodes: string[] };
 const PRESETS: Preset[] = [
-  { key: "encontro", rotulo: "Do encontro: a b c d", nos: ["a", "b", "c", "d"] },
-  { key: "cinco", rotulo: "Cinco nós: 1 a 5", nos: ["1", "2", "3", "4", "5"] },
-  { key: "dois", rotulo: "Só dois nós", nos: ["a", "b"] },
-  { key: "um", rotulo: "Um nó só", nos: ["a"] },
-  { key: "vazia", rotulo: "Lista vazia", nos: [] },
+  { key: "encontro", label: "Do encontro: a b c d", nodes: ["a", "b", "c", "d"] },
+  { key: "cinco", label: "Cinco nós: 1 a 5", nodes: ["1", "2", "3", "4", "5"] },
+  { key: "dois", label: "Só dois nós", nodes: ["a", "b"] },
+  { key: "um", label: "Um nó só", nodes: ["a"] },
+  { key: "vazia", label: "Lista vazia", nodes: [] },
 ];
 
 export function LinkedListReversao() {
-  const [nos, setNos] = useState<string[]>(PRESETS[0].nos);
-  const [entrada, setEntrada] = useState(PRESETS[0].nos.join(", "));
+  const [nodes, setNodes] = useState<string[]>(PRESETS[0].nodes);
+  const [input, setInput] = useState(PRESETS[0].nodes.join(", "));
   const [preset, setPreset] = useState("encontro");
 
-  const passos = useMemo(() => gerarPassos(nos), [nos]);
-  const total = passos.length;
+  const steps = useMemo(() => generateSteps(nodes), [nodes]);
+  const total = steps.length;
 
   const viz = useVisualizer({
     title: "Visualizador · inverter a lista com três ponteiros",
@@ -128,61 +128,61 @@ export function LinkedListReversao() {
     // O tamanho da lista alarga o viewBox, e com `height: auto` isso muda a
     // ALTURA do desenho junto; o número de passos entra porque a nota do passo
     // a passo é mais longa em alguns casos de borda.
-    measureOn: [nos.length, total],
+    measureOn: [nodes.length, total],
   });
 
   const idx = viz.step;
-  const p = passos[idx];
+  const p = steps[idx];
 
-  const reiniciar = viz.reset;
-  const aoMudarEntrada = (v: string) => {
+  const reset = viz.reset;
+  const onInputChange = (v: string) => {
     const arr = v.split(",").map((x) => x.trim()).filter((x) => x.length > 0).map((x) => x.slice(0, 3)).slice(0, 7);
-    reiniciar(); setPreset("");
-    setEntrada(v); setNos(arr);
+    reset(); setPreset("");
+    setInput(v); setNodes(arr);
   };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar(); setPreset(pr.key);
-    setNos(pr.nos); setEntrada(pr.nos.join(", "));
+  const applyPreset = (pr: Preset) => {
+    reset(); setPreset(pr.key);
+    setNodes(pr.nodes); setInput(pr.nodes.join(", "));
   };
 
-  const n = nos.length;
-  const xNo = (i: number) => PAD_X + i * STEP;
+  const n = nodes.length;
+  const xNode = (i: number) => PAD_X + i * STEP;
   // Piso na largura: com um nó só o viewBox ficaria estreito e o desenho seria
   // esticado até virar caricatura dentro do container.
-  const larguraVB = Math.max(520, PAD_X + Math.max(1, n) * STEP + 52 - X0);
+  const vbWidth = Math.max(520, PAD_X + Math.max(1, n) * STEP + 52 - X0);
 
-  const variaveis = [
-    { nome: "anterior", valor: p.anterior === null ? "None" : `nó ${nos[p.anterior]}` },
-    { nome: "atual", valor: p.atual === null ? "None" : `nó ${nos[p.atual]}` },
-    { nome: "proximo", valor: !p.temProximo ? "-" : p.proximo === null ? "None" : `nó ${nos[p.proximo]}` },
-    { nome: "setas viradas", valor: `${p.invertidas} de ${n}`, best: p.invertidas === n && n > 0 },
+  const vars = [
+    { name: "anterior", value: p.prev === null ? "None" : `nó ${nodes[p.prev]}` },
+    { name: "atual", value: p.curr === null ? "None" : `nó ${nodes[p.curr]}` },
+    { name: "proximo", value: !p.hasNext ? "-" : p.next === null ? "None" : `nó ${nodes[p.next]}` },
+    { name: "setas viradas", value: `${p.flipped} de ${n}`, best: p.flipped === n && n > 0 },
   ];
 
-  const estatisticas = [
-    { k: "n", rot: "nós na lista", val: `${n}` },
-    { k: "it", rot: "voltas do while", val: `${p.iteracao}` },
-    { k: "op", rot: "ponteiros escritos", val: `${p.invertidas}` },
-    { k: "mem", rot: "memória extra", val: "O(1)" },
+  const stats = [
+    { k: "n", label: "nós na lista", value: `${n}` },
+    { k: "it", label: "voltas do while", value: `${p.round}` },
+    { k: "op", label: "ponteiros escritos", value: `${p.flipped}` },
+    { k: "mem", label: "memória extra", value: "O(1)" },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const descricao = `Lista com ${n} nós: ${nos.join(", ") || "vazia"}. ${p.invertidas} setas já apontam para trás. ${p.nota}`;
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
+  const description = `Lista com ${n} nós: ${nodes.join(", ") || "vazia"}. ${p.flipped} setas já apontam para trás. ${p.note}`;
 
-  const corNo = (i: number) => {
-    if (p.atual === i) return { fill: "rgba(59,130,246,0.2)", stroke: "#3b82f6", txt: "#ffffff" };
-    if (p.anterior === i) return { fill: "rgba(245,158,11,0.16)", stroke: "#f59e0b", txt: "#ffffff" };
-    if (p.temProximo && p.proximo === i) return { fill: "rgba(167,139,250,0.16)", stroke: "#a78bfa", txt: "#ffffff" };
+  const nodeColor = (i: number) => {
+    if (p.curr === i) return { fill: "rgba(59,130,246,0.2)", stroke: "#3b82f6", txt: "#ffffff" };
+    if (p.prev === i) return { fill: "rgba(245,158,11,0.16)", stroke: "#f59e0b", txt: "#ffffff" };
+    if (p.hasNext && p.next === i) return { fill: "rgba(167,139,250,0.16)", stroke: "#a78bfa", txt: "#ffffff" };
     return { fill: "#0f1826", stroke: "rgba(255,255,255,0.14)", txt: "#b9c9dd" };
   };
-  const marcaNo = (i: number): string | null => {
-    const marcas: string[] = [];
-    if (p.anterior === i) marcas.push("anterior");
-    if (p.atual === i) marcas.push("atual");
-    if (p.temProximo && p.proximo === i) marcas.push("proximo");
-    return marcas.length ? marcas.join(" / ") : null;
+  const nodeMark = (i: number): string | null => {
+    const marks: string[] = [];
+    if (p.prev === i) marks.push("anterior");
+    if (p.curr === i) marks.push("atual");
+    if (p.hasNext && p.next === i) marks.push("proximo");
+    return marks.length ? marks.join(" / ") : null;
   };
 
-  const quadro = (
+  const frame = (
     <figure {...viz.figureProps} style={{ margin: 0 }}>
       <VizHeader viz={viz} />
 
@@ -194,10 +194,10 @@ export function LinkedListReversao() {
               <button
                 key={pr.key}
                 className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-                onClick={() => aplicarPreset(pr)}
+                onClick={() => applyPreset(pr)}
                 aria-pressed={preset === pr.key}
               >
-                {pr.rotulo}
+                {pr.label}
               </button>
             ))}
           </div>
@@ -206,12 +206,12 @@ export function LinkedListReversao() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Valores dos nós (até 7)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
         </div>
 
         <div className="ll-svg-wrap">
-          <svg className="ll-svg" viewBox={`${X0} ${VB_TOPO} ${larguraVB} ${VB_ALTURA}`} role="img" aria-label={descricao}>
+          <svg className="ll-svg" viewBox={`${X0} ${VB_TOP} ${vbWidth} ${VB_HEIGHT}`} role="img" aria-label={description}>
             <defs>
               <marker id="llrev-seta" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
                 <path d="M0,0 L6,3 L0,6 z" fill="#4c5f79" />
@@ -228,28 +228,28 @@ export function LinkedListReversao() {
                 None
               </text>
             ) : null}
-            <text x={xNo(n) - 2} y={CY} fill="#61748c" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={12} textAnchor="start" dominantBaseline="central">
+            <text x={xNode(n) - 2} y={CY} fill="#61748c" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={12} textAnchor="start" dominantBaseline="central">
               None
             </text>
 
             {/* setas: as já viradas viram arco por cima, apontando para trás */}
             {Array.from({ length: n }, (_, i) => {
-              const virada = i < p.invertidas;
-              if (!virada) {
+              const isFlipped = i < p.flipped;
+              if (!isFlipped) {
                 return (
                   <line
                     key={`f${i}`}
-                    x1={xNo(i) + 52} y1={CY} x2={xNo(i + 1) - 7} y2={CY}
+                    x1={xNode(i) + 52} y1={CY} x2={xNode(i + 1) - 7} y2={CY}
                     stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#llrev-seta)"
                   />
                 );
               }
-              const destino = i === 0 ? -18 : xNo(i - 1) + BOX_W / 2 + 4;
-              const origem = xNo(i) + 52;
+              const endX = i === 0 ? -18 : xNode(i - 1) + BOX_W / 2 + 4;
+              const startX = xNode(i) + 52;
               return (
                 <path
                   key={`v${i}`}
-                  d={`M ${origem},${CY - 16} Q ${(origem + destino) / 2},${CY - 70} ${destino},${CY - 15}`}
+                  d={`M ${startX},${CY - 16} Q ${(startX + endX) / 2},${CY - 70} ${endX},${CY - 15}`}
                   fill="none" stroke="#34d399" strokeWidth={1.8} markerEnd="url(#llrev-seta-ok)"
                 />
               );
@@ -257,20 +257,20 @@ export function LinkedListReversao() {
 
             {/* os nós */}
             {Array.from({ length: n }, (_, i) => {
-              const x = xNo(i);
-              const c = corNo(i);
-              const marca = marcaNo(i);
+              const x = xNode(i);
+              const c = nodeColor(i);
+              const mark = nodeMark(i);
               return (
                 <g key={`n${i}`}>
                   <rect x={x} y={CY - BOX_H / 2} width={BOX_W} height={BOX_H} rx={9} fill={c.fill} stroke={c.stroke} strokeWidth={1.8} />
                   <line x1={x + 42} y1={CY - BOX_H / 2} x2={x + 42} y2={CY + BOX_H / 2} stroke="rgba(255,255,255,0.12)" strokeWidth={1.2} />
                   <text x={x + 21} y={CY} fill={c.txt} fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={15} fontWeight={600} textAnchor="middle" dominantBaseline="central">
-                    {nos[i]}
+                    {nodes[i]}
                   </text>
-                  <circle cx={x + 52} cy={CY} r={3.2} fill={i < p.invertidas ? "#34d399" : "#4c5f79"} />
-                  {marca ? (
+                  <circle cx={x + 52} cy={CY} r={3.2} fill={i < p.flipped ? "#34d399" : "#4c5f79"} />
+                  {mark ? (
                     <text x={x + 31} y={CY + BOX_H / 2 + 14} fill="#93bbfd" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={10.5} fontWeight={700} textAnchor="middle" dominantBaseline="central">
-                      {marca}
+                      {mark}
                     </text>
                   ) : null}
                 </g>
@@ -287,7 +287,7 @@ export function LinkedListReversao() {
           <span><i style={{ background: "#a78bfa" }} /> proximo</span>
         </p>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
           {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
@@ -297,8 +297,8 @@ export function LinkedListReversao() {
             <div className="viz-code" {...viz.blockProps}>
               <div className="viz-code-head">reverter.py</div>
               <div className="viz-code-body">
-                {CODIGO.map((txt, i) => (
-                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
                     <span className="ln">{i + 1}</span>
                     {txt}
                   </div>
@@ -308,20 +308,20 @@ export function LinkedListReversao() {
           </div>
           <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
@@ -334,5 +334,5 @@ export function LinkedListReversao() {
     </figure>
   );
 
-  return viz.inPanel(quadro);
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/LinkedListVisualizer.tsx
+++ b/content/visualizers/LinkedListVisualizer.tsx
@@ -23,29 +23,29 @@ import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 type Op = "inserir" | "append" | "remover" | "buscar";
 
-type Passo = {
-  linha: number;
-  ant: number | null; // índice VISUAL do nó sob o ponteiro que caminha
-  alvo: number | null; // nó encontrado na busca
-  mostraNovo: boolean;
-  novoDepoisDe: number; // índice visual do antecessor do nó novo (-1 = antes da cabeça)
-  ligaSaida: boolean; // novo.prox já aponta para o sucessor
-  ligaEntrada: boolean; // o antecessor já aponta para o novo
-  cabecaPara: number; // índice visual para onde a seta da cabeça aponta
-  cabecaNoNovo: boolean;
-  solto: number | null; // nó que ficou sem ninguém apontando para ele
+type Step = {
+  line: number;
+  prev: number | null; // índice VISUAL do nó sob o ponteiro que caminha
+  found: number | null; // nó encontrado na busca
+  showsNew: boolean;
+  newAfter: number; // índice visual do antecessor do nó novo (-1 = antes da cabeça)
+  linkedOut: boolean; // novo.prox já aponta para o sucessor
+  linkedIn: boolean; // o antecessor já aponta para o novo
+  headTo: number; // índice visual para onde a seta da cabeça aponta
+  headOnNew: boolean;
+  loose: number | null; // nó que ficou sem ninguém apontando para ele
   bypass: boolean; // o arco que pula o nó removido já existe
-  visitados: number;
-  religados: number;
-  nota: string;
+  visited: number;
+  relinked: number;
+  note: string;
   ok?: boolean;
-  fim?: boolean;
+  done?: boolean;
 };
 
 // Um bloco de código por variante. A chave sai de (operação, sentinela, cauda),
-// e o campo `linha` de cada passo indexa o bloco escolhido: o mapeamento é 1:1,
+// e o campo `line` de cada passo indexa o bloco escolhido: o mapeamento é 1:1,
 // então mexer numa linha obriga a mexer no gerador junto.
-const CODIGO: Record<string, string[]> = {
+const CODE: Record<string, string[]> = {
   "inserir-sent": [
     "def inserir(self, pos, valor):",
     "    novo = No(valor)",
@@ -116,236 +116,236 @@ const CODIGO: Record<string, string[]> = {
   ],
 };
 
-function chaveCodigo(op: Op, sentinela: boolean, temCauda: boolean): string {
-  if (op === "inserir") return sentinela ? "inserir-sent" : "inserir";
-  if (op === "remover") return sentinela ? "remover-sent" : "remover";
-  if (op === "append") return temCauda ? "append-cauda" : "append";
+function codeKey(op: Op, sentinel: boolean, hasTail: boolean): string {
+  if (op === "inserir") return sentinel ? "inserir-sent" : "inserir";
+  if (op === "remover") return sentinel ? "remover-sent" : "remover";
+  if (op === "append") return hasTail ? "append-cauda" : "append";
   return "buscar";
 }
 
-function gerarPassos(
-  valores: number[],
-  sentinela: boolean,
-  temCauda: boolean,
+function generateSteps(
+  values: number[],
+  sentinel: boolean,
+  hasTail: boolean,
   op: Op,
   pos: number,
-  valor: number
-): Passo[] {
-  const off = sentinela ? 1 : 0;
-  const n = valores.length;
+  value: number
+): Step[] {
+  const off = sentinel ? 1 : 0;
+  const n = values.length;
   const nVis = n + off;
 
-  const out: Passo[] = [];
-  let ant: number | null = null;
-  let alvo: number | null = null;
-  let mostraNovo = false;
-  let novoDepoisDe = -1;
-  let ligaSaida = false;
-  let ligaEntrada = false;
-  let cabecaPara = 0;
-  let cabecaNoNovo = false;
-  let solto: number | null = null;
+  const out: Step[] = [];
+  let prev: number | null = null;
+  let found: number | null = null;
+  let showsNew = false;
+  let newAfter = -1;
+  let linkedOut = false;
+  let linkedIn = false;
+  let headTo = 0;
+  let headOnNew = false;
+  let loose: number | null = null;
   let bypass = false;
-  let visitados = 0;
-  let religados = 0;
+  let visited = 0;
+  let relinked = 0;
 
-  const push = (linha: number, nota: string, extra: Partial<Passo> = {}) => {
+  const push = (line: number, note: string, extra: Partial<Step> = {}) => {
     out.push({
-      linha, nota, ant, alvo, mostraNovo, novoDepoisDe, ligaSaida, ligaEntrada,
-      cabecaPara, cabecaNoNovo, solto, bypass, visitados, religados, ...extra,
+      line, note, prev, found, showsNew, newAfter, linkedOut, linkedIn,
+      headTo, headOnNew, loose, bypass, visited, relinked, ...extra,
     });
   };
 
   // Nome de um nó pelo índice VISUAL, do jeito que a nota vai falar dele.
-  const nome = (v: number | null): string => {
+  const nodeName = (v: number | null): string => {
     if (v === null || v >= nVis || v < 0) return "None";
-    if (sentinela && v === 0) return "sentinela";
-    return `nó ${valores[v - off]}`;
+    if (sentinel && v === 0) return "sentinela";
+    return `nó ${values[v - off]}`;
   };
 
   if (op === "inserir") {
     const p = Math.max(0, Math.min(pos, n));
-    mostraNovo = true;
-    novoDepoisDe = p + off - 1;
-    push(1, `Crio o nó ${valor}. Ele já está na memória, solto: por enquanto ninguém aponta para ele e ele não aponta para ninguém.`);
+    showsNew = true;
+    newAfter = p + off - 1;
+    push(1, `Crio o nó ${value}. Ele já está na memória, solto: por enquanto ninguém aponta para ele e ele não aponta para ninguém.`);
 
-    if (!sentinela && p === 0) {
+    if (!sentinel && p === 0) {
       push(2, `pos = 0 é o caso especial: quem aponta para o primeiro nó não é outro nó, é a variável cabeça. Por isso o if.`);
-      ligaSaida = true;
-      religados++;
-      push(3, `novo.prox = cabeca: o nó ${valor} passa a apontar para ${nome(0)}. Faço esta ligação PRIMEIRO, porque se eu mexesse na cabeça antes perderia o endereço do resto da lista.`);
-      ligaEntrada = true;
-      cabecaNoNovo = true;
-      religados++;
-      push(4, `cabeca = novo: agora a lista começa no nó ${valor}. Dois ponteiros mexidos e nenhum nó saiu do lugar.`);
-      push(5, `Pronto. Inserir na frente custa o mesmo com 5 ou com 5 milhões de nós: O(1).`, { ok: true, fim: true });
+      linkedOut = true;
+      relinked++;
+      push(3, `novo.prox = cabeca: o nó ${value} passa a apontar para ${nodeName(0)}. Faço esta ligação PRIMEIRO, porque se eu mexesse na cabeça antes perderia o endereço do resto da lista.`);
+      linkedIn = true;
+      headOnNew = true;
+      relinked++;
+      push(4, `cabeca = novo: agora a lista começa no nó ${value}. Dois ponteiros mexidos e nenhum nó saiu do lugar.`);
+      push(5, `Pronto. Inserir na frente custa o mesmo com 5 ou com 5 milhões de nós: O(1).`, { ok: true, done: true });
       return out;
     }
 
-    const lAnt = sentinela ? 2 : 6;
-    const lHop = sentinela ? 4 : 8;
-    const lSaida = sentinela ? 5 : 9;
-    const lEntrada = sentinela ? 6 : 10;
+    const lPrev = sentinel ? 2 : 6;
+    const lHop = sentinel ? 4 : 8;
+    const lOut = sentinel ? 5 : 9;
+    const lIn = sentinel ? 6 : 10;
 
-    if (!sentinela) push(2, `pos = ${p}, não é 0: sigo pelo caminho de baixo, o que precisa achar o nó anterior à posição.`);
+    if (!sentinel) push(2, `pos = ${p}, não é 0: sigo pelo caminho de baixo, o que precisa achar o nó anterior à posição.`);
 
-    ant = 0;
-    visitados = 1;
-    push(lAnt, sentinela
+    prev = 0;
+    visited = 1;
+    push(lPrev, sentinel
       ? `anterior começa no sentinela. Repare que ele nunca é None, nem com a lista vazia: é isso que faz o if sumir.`
-      : `anterior começa na cabeça, ${nome(0)}.`);
+      : `anterior começa na cabeça, ${nodeName(0)}.`);
 
-    const saltos = sentinela ? p : p - 1;
-    for (let h = 0; h < saltos; h++) {
-      ant = (ant as number) + 1;
-      visitados++;
-      push(lHop, `Ainda não é aqui: avanço para ${nome(ant)}. Já são ${visitados} nós percorridos, e este é o único pedaço caro da inserção.`);
+    const hops = sentinel ? p : p - 1;
+    for (let h = 0; h < hops; h++) {
+      prev = (prev as number) + 1;
+      visited++;
+      push(lHop, `Ainda não é aqui: avanço para ${nodeName(prev)}. Já são ${visited} nós percorridos, e este é o único pedaço caro da inserção.`);
     }
 
-    const a = ant as number;
-    ligaSaida = true;
-    religados++;
-    push(lSaida, `novo.prox = anterior.prox: o nó ${valor} passa a apontar para ${nome(a + 1)}. A ordem importa, se eu religasse o anterior primeiro perderia o endereço de quem vem depois.`);
-    ligaEntrada = true;
-    religados++;
-    push(lEntrada, n === 0
-      ? `anterior.prox = novo: ${nome(a)} aponta para o nó ${valor}, que virou o único nó da lista. Repare que não precisei de nenhum if para isso.`
-      : `anterior.prox = novo: ${nome(a)} aponta para o nó ${valor} e a lista está inteira de novo. Foram 2 ponteiros, e os outros ${n} nós continuam exatamente onde estavam na memória.`,
-      { ok: true, fim: true });
+    const a = prev as number;
+    linkedOut = true;
+    relinked++;
+    push(lOut, `novo.prox = anterior.prox: o nó ${value} passa a apontar para ${nodeName(a + 1)}. A ordem importa, se eu religasse o anterior primeiro perderia o endereço de quem vem depois.`);
+    linkedIn = true;
+    relinked++;
+    push(lIn, n === 0
+      ? `anterior.prox = novo: ${nodeName(a)} aponta para o nó ${value}, que virou o único nó da lista. Repare que não precisei de nenhum if para isso.`
+      : `anterior.prox = novo: ${nodeName(a)} aponta para o nó ${value} e a lista está inteira de novo. Foram 2 ponteiros, e os outros ${n} nós continuam exatamente onde estavam na memória.`,
+      { ok: true, done: true });
     return out;
   }
 
   if (op === "append") {
-    mostraNovo = true;
-    novoDepoisDe = nVis - 1;
-    ligaSaida = true; // um nó recém-criado já aponta para None
-    push(1, `Crio o nó ${valor}, que já nasce apontando para None. O problema agora é achar quem vai apontar para ele.`);
+    showsNew = true;
+    newAfter = nVis - 1;
+    linkedOut = true; // um nó recém-criado já aponta para None
+    push(1, `Crio o nó ${value}, que já nasce apontando para None. O problema agora é achar quem vai apontar para ele.`);
 
     if (nVis === 0) {
       push(2, `A lista está vazia: não existe último nó. Este é o único caso em que o append precisa de um if.`);
-      cabecaNoNovo = true;
-      ligaEntrada = true;
-      religados++;
-      push(3, temCauda
-        ? `A cabeça e a cauda passam a apontar para o nó ${valor}, que é o primeiro e o último ao mesmo tempo.`
-        : `A cabeça passa a apontar para o nó ${valor}.`);
-      push(4, `Fim, com 0 nós percorridos.`, { ok: true, fim: true });
+      headOnNew = true;
+      linkedIn = true;
+      relinked++;
+      push(3, hasTail
+        ? `A cabeça e a cauda passam a apontar para o nó ${value}, que é o primeiro e o último ao mesmo tempo.`
+        : `A cabeça passa a apontar para o nó ${value}.`);
+      push(4, `Fim, com 0 nós percorridos.`, { ok: true, done: true });
       return out;
     }
 
-    if (temCauda) {
-      push(2, sentinela
+    if (hasTail) {
+      push(2, sentinel
         ? `A cauda não é None (com sentinela ela nunca é), então pulo o if.`
         : `A cauda não é None, então pulo o if.`);
-      ant = nVis - 1;
-      visitados = 1;
-      ligaEntrada = true;
-      religados++;
-      push(5, `cauda.prox = novo: ${nome(nVis - 1)} passa a apontar para o nó ${valor}. Não precisei procurar o fim, o ponteiro de cauda já sabia onde ele estava.`);
-      push(6, `cauda = novo. Um ponteiro religado, 1 nó percorrido: com cauda, inserir no fim é O(1).`, { ok: true, fim: true });
+      prev = nVis - 1;
+      visited = 1;
+      linkedIn = true;
+      relinked++;
+      push(5, `cauda.prox = novo: ${nodeName(nVis - 1)} passa a apontar para o nó ${value}. Não precisei procurar o fim, o ponteiro de cauda já sabia onde ele estava.`);
+      push(6, `cauda = novo. Um ponteiro religado, 1 nó percorrido: com cauda, inserir no fim é O(1).`, { ok: true, done: true });
       return out;
     }
 
     push(2, `A cabeça não é None, então pulo o if.`);
-    ant = 0;
-    visitados = 1;
-    push(5, `ultimo começa na cabeça, ${nome(0)}. Este é o ponteiro auxiliar da técnica do dummy pointer: ele existe só para caminhar, a cabeça fica parada.`);
-    while ((ant as number) < nVis - 1) {
-      push(6, `${nome(ant)}.prox não é None, então ainda não cheguei no fim.`);
-      ant = (ant as number) + 1;
-      visitados++;
-      push(7, `Avanço para ${nome(ant)}. ${visitados} nós percorridos até aqui.`);
+    prev = 0;
+    visited = 1;
+    push(5, `ultimo começa na cabeça, ${nodeName(0)}. Este é o ponteiro auxiliar da técnica do dummy pointer: ele existe só para caminhar, a cabeça fica parada.`);
+    while ((prev as number) < nVis - 1) {
+      push(6, `${nodeName(prev)}.prox não é None, então ainda não cheguei no fim.`);
+      prev = (prev as number) + 1;
+      visited++;
+      push(7, `Avanço para ${nodeName(prev)}. ${visited} nós percorridos até aqui.`);
     }
-    push(6, `${nome(ant)}.prox é None: cheguei no último. Para descobrir isso precisei visitar os ${visitados} nós da lista.`);
-    ligaEntrada = true;
-    religados++;
-    push(8, `ultimo.prox = novo. Religar foi 1 ponteiro, o caro foi achar o fim: sem ponteiro de cauda, o append é O(n).`, { ok: true, fim: true });
+    push(6, `${nodeName(prev)}.prox é None: cheguei no último. Para descobrir isso precisei visitar os ${visited} nós da lista.`);
+    linkedIn = true;
+    relinked++;
+    push(8, `ultimo.prox = novo. Religar foi 1 ponteiro, o caro foi achar o fim: sem ponteiro de cauda, o append é O(n).`, { ok: true, done: true });
     return out;
   }
 
   if (op === "remover") {
     if (n === 0) {
-      push(0, `A lista está vazia: não existe posição ${pos} para remover. O sentinela evita o if da cabeça, mas não te livra de validar a posição.`, { fim: true });
+      push(0, `A lista está vazia: não existe posição ${pos} para remover. O sentinela evita o if da cabeça, mas não te livra de validar a posição.`, { done: true });
       return out;
     }
     const p = Math.max(0, Math.min(pos, n - 1));
 
-    if (sentinela) {
-      ant = 0;
-      visitados = 1;
+    if (sentinel) {
+      prev = 0;
+      visited = 1;
       push(1, `anterior começa no sentinela, e nem preciso perguntar se a posição é a 0.`);
       for (let h = 0; h < p; h++) {
-        ant = (ant as number) + 1;
-        visitados++;
-        push(3, `Avanço para ${nome(ant)}. Preciso parar no nó ANTERIOR ao que vou remover: numa lista simplesmente encadeada, ninguém sabe quem aponta para ele.`);
+        prev = (prev as number) + 1;
+        visited++;
+        push(3, `Avanço para ${nodeName(prev)}. Preciso parar no nó ANTERIOR ao que vou remover: numa lista simplesmente encadeada, ninguém sabe quem aponta para ele.`);
       }
-      solto = p + off;
+      loose = p + off;
       bypass = true;
-      religados++;
-      push(4, `anterior.prox = anterior.prox.prox: ${nome(ant)} passa a apontar direto para ${nome(p + off + 1)}. O nó ${valores[p]} ficou sem ninguém apontando para ele e vira lixo. Nenhum outro nó se moveu.`, { ok: true, fim: true });
+      relinked++;
+      push(4, `anterior.prox = anterior.prox.prox: ${nodeName(prev)} passa a apontar direto para ${nodeName(p + off + 1)}. O nó ${values[p]} ficou sem ninguém apontando para ele e vira lixo. Nenhum outro nó se moveu.`, { ok: true, done: true });
       return out;
     }
 
     if (p === 0) {
       push(1, `pos = 0: de novo o caso especial, porque quem aponta para o primeiro nó é a variável cabeça.`);
-      solto = 0;
-      cabecaPara = 1;
-      religados++;
-      push(2, `cabeca = cabeca.prox: a lista passa a começar em ${nome(1)} e o nó ${valores[0]} sai. Remover o primeiro é O(1), enquanto num array seria deslocar todo o resto.`);
-      push(3, `Fim, com 1 ponteiro religado.`, { ok: true, fim: true });
+      loose = 0;
+      headTo = 1;
+      relinked++;
+      push(2, `cabeca = cabeca.prox: a lista passa a começar em ${nodeName(1)} e o nó ${values[0]} sai. Remover o primeiro é O(1), enquanto num array seria deslocar todo o resto.`);
+      push(3, `Fim, com 1 ponteiro religado.`, { ok: true, done: true });
       return out;
     }
 
     push(1, `pos = ${p}, não é 0: sigo pelo caminho de baixo.`);
-    ant = 0;
-    visitados = 1;
-    push(4, `anterior começa na cabeça, ${nome(0)}.`);
+    prev = 0;
+    visited = 1;
+    push(4, `anterior começa na cabeça, ${nodeName(0)}.`);
     for (let h = 0; h < p - 1; h++) {
-      ant = (ant as number) + 1;
-      visitados++;
-      push(6, `Avanço para ${nome(ant)}. Preciso parar no nó ANTERIOR ao que vou remover: numa lista simplesmente encadeada, ninguém sabe quem aponta para ele.`);
+      prev = (prev as number) + 1;
+      visited++;
+      push(6, `Avanço para ${nodeName(prev)}. Preciso parar no nó ANTERIOR ao que vou remover: numa lista simplesmente encadeada, ninguém sabe quem aponta para ele.`);
     }
-    solto = p;
+    loose = p;
     bypass = true;
-    religados++;
-    push(7, `anterior.prox = anterior.prox.prox: ${nome(ant)} passa a apontar direto para ${nome(p + 1)}. O nó ${valores[p]} ficou solto na memória. Percorri ${visitados} nós e religuei 1 ponteiro.`, { ok: true, fim: true });
+    relinked++;
+    push(7, `anterior.prox = anterior.prox.prox: ${nodeName(prev)} passa a apontar direto para ${nodeName(p + 1)}. O nó ${values[p]} ficou solto na memória. Percorri ${visited} nós e religuei 1 ponteiro.`, { ok: true, done: true });
     return out;
   }
 
   // buscar
   push(1, nVis === 0
     ? `atual começa na cabeça, que é None: a lista está vazia.`
-    : `atual começa na cabeça, ${nome(0)}. Este é o ponteiro auxiliar que só existe para caminhar, a cabeça continua parada onde estava.`);
+    : `atual começa na cabeça, ${nodeName(0)}. Este é o ponteiro auxiliar que só existe para caminhar, a cabeça continua parada onde estava.`);
   if (nVis > 0) {
-    ant = 0;
-    visitados = 1;
+    prev = 0;
+    visited = 1;
   }
   let i = 0;
   while (i < nVis) {
-    ant = i;
+    prev = i;
     push(2, `atual não é None, então tenho nó para olhar.`);
-    const ehSentinela = sentinela && i === 0;
-    const v = ehSentinela ? null : valores[i - off];
-    if (v === valor) {
-      alvo = i;
-      push(4, `${v} == ${valor}: achei, depois de visitar ${visitados} ${visitados === 1 ? "nó" : "nós"}. Devolvo a referência do nó, e quem tiver essa referência remove ou insere ao lado dela em O(1).`, { ok: true, fim: true });
+    const isSentinel = sentinel && i === 0;
+    const v = isSentinel ? null : values[i - off];
+    if (v === value) {
+      found = i;
+      push(4, `${v} == ${value}: achei, depois de visitar ${visited} ${visited === 1 ? "nó" : "nós"}. Devolvo a referência do nó, e quem tiver essa referência remove ou insere ao lado dela em O(1).`, { ok: true, done: true });
       return out;
     }
-    push(3, ehSentinela
+    push(3, isSentinel
       ? `O sentinela não guarda valor de verdade, então ele nunca casa com a busca. Sigo em frente.`
-      : `${v} != ${valor}: não é este.`);
+      : `${v} != ${value}: não é este.`);
     i++;
     if (i < nVis) {
-      ant = i;
-      visitados++;
-      push(5, `Avanço para ${nome(i)}. ${visitados} nós visitados.`);
+      prev = i;
+      visited++;
+      push(5, `Avanço para ${nodeName(i)}. ${visited} nós visitados.`);
     } else {
-      ant = null;
+      prev = null;
       push(5, `Avanço, e caio no None: a lista acabou.`);
     }
   }
   push(2, `atual é None: não sobrou nó para olhar.`);
-  push(6, `O valor ${valor} não está na lista. Buscar numa lista encadeada é sempre O(n): não existe pular para o meio, como o array faz com um índice.`, { fim: true });
+  push(6, `O valor ${value} não está na lista. Buscar numa lista encadeada é sempre O(n): não existe pular para o meio, como o array faz com um índice.`, { done: true });
   return out;
 }
 
@@ -355,53 +355,53 @@ const BOX_H = 42;
 const STEP = 96;
 const PAD_X = 16;
 const CY = 92; // linha principal
-const Y_NOVO = 180; // linha do nó recém-criado
+const Y_NEW = 180; // linha do nó recém-criado
 const X0 = -74; // sobra à esquerda: cabe a etiqueta "cabeça"
-const VB_TOPO = 6;
-const VB_ALTURA = 206; // com a linha do nó novo
-const VB_ALTURA_CURTA = 148; // sem ela (remover e buscar não criam nó)
+const VB_TOP = 6;
+const VB_HEIGHT = 206; // com a linha do nó novo
+const VB_HEIGHT_SHORT = 148; // sem ela (remover e buscar não criam nó)
 
-type Preset = { key: string; rotulo: string; op: Op; pos: number; valor: number; valores?: number[] };
+type Preset = { key: string; label: string; op: Op; pos: number; value: number; values?: number[] };
 
-const LISTA_PADRAO = [10, 20, 30, 40, 50];
+const DEFAULT_LIST = [10, 20, 30, 40, 50];
 
 const PRESETS: Preset[] = [
-  { key: "meio", rotulo: "Inserir 35 na posição 3", op: "inserir", pos: 3, valor: 35 },
-  { key: "cabeca", rotulo: "Inserir 5 na cabeça", op: "inserir", pos: 0, valor: 5 },
-  { key: "fim", rotulo: "Inserir 60 no fim", op: "append", pos: 5, valor: 60 },
-  { key: "remove", rotulo: "Remover a posição 2", op: "remover", pos: 2, valor: 35 },
-  { key: "remove0", rotulo: "Remover o primeiro", op: "remover", pos: 0, valor: 35 },
-  { key: "removeFim", rotulo: "Remover o último", op: "remover", pos: 4, valor: 35 },
-  { key: "busca", rotulo: "Buscar o valor 40", op: "buscar", pos: 0, valor: 40 },
-  { key: "busca404", rotulo: "Buscar um valor que não existe", op: "buscar", pos: 0, valor: 99 },
+  { key: "meio", label: "Inserir 35 na posição 3", op: "inserir", pos: 3, value: 35 },
+  { key: "cabeca", label: "Inserir 5 na cabeça", op: "inserir", pos: 0, value: 5 },
+  { key: "fim", label: "Inserir 60 no fim", op: "append", pos: 5, value: 60 },
+  { key: "remove", label: "Remover a posição 2", op: "remover", pos: 2, value: 35 },
+  { key: "remove0", label: "Remover o primeiro", op: "remover", pos: 0, value: 35 },
+  { key: "removeFim", label: "Remover o último", op: "remover", pos: 4, value: 35 },
+  { key: "busca", label: "Buscar o valor 40", op: "buscar", pos: 0, value: 40 },
+  { key: "busca404", label: "Buscar um valor que não existe", op: "buscar", pos: 0, value: 99 },
   // Os três casos de borda que o artigo manda testar antes de qualquer código.
-  { key: "vazia", rotulo: "Lista vazia + inserir", op: "inserir", pos: 0, valor: 7, valores: [] },
-  { key: "um", rotulo: "Um nó só + remover", op: "remover", pos: 0, valor: 35, valores: [42] },
-  { key: "dois", rotulo: "Dois nós + inserir no meio", op: "inserir", pos: 1, valor: 15, valores: [10, 20] },
+  { key: "vazia", label: "Lista vazia + inserir", op: "inserir", pos: 0, value: 7, values: [] },
+  { key: "um", label: "Um nó só + remover", op: "remover", pos: 0, value: 35, values: [42] },
+  { key: "dois", label: "Dois nós + inserir no meio", op: "inserir", pos: 1, value: 15, values: [10, 20] },
 ];
 
-const OPS: { key: Op; rotulo: string }[] = [
-  { key: "inserir", rotulo: "Inserir na posição" },
-  { key: "append", rotulo: "Inserir no fim" },
-  { key: "remover", rotulo: "Remover a posição" },
-  { key: "buscar", rotulo: "Buscar o valor" },
+const OPS: { key: Op; label: string }[] = [
+  { key: "inserir", label: "Inserir na posição" },
+  { key: "append", label: "Inserir no fim" },
+  { key: "remover", label: "Remover a posição" },
+  { key: "buscar", label: "Buscar o valor" },
 ];
 
 export function LinkedListVisualizer() {
-  const [valores, setValores] = useState<number[]>(LISTA_PADRAO);
-  const [entrada, setEntrada] = useState(LISTA_PADRAO.join(", "));
+  const [values, setValues] = useState<number[]>(DEFAULT_LIST);
+  const [input, setInput] = useState(DEFAULT_LIST.join(", "));
   const [op, setOp] = useState<Op>("inserir");
   const [pos, setPos] = useState(3);
-  const [valor, setValor] = useState(35);
-  const [sentinela, setSentinela] = useState(false);
-  const [temCauda, setTemCauda] = useState(false);
+  const [value, setValue] = useState(35);
+  const [sentinel, setSentinel] = useState(false);
+  const [hasTail, setHasTail] = useState(false);
   const [preset, setPreset] = useState("meio");
 
-  const passos = useMemo(
-    () => gerarPassos(valores, sentinela, temCauda, op, pos, valor),
-    [valores, sentinela, temCauda, op, pos, valor]
+  const steps = useMemo(
+    () => generateSteps(values, sentinel, hasTail, op, pos, value),
+    [values, sentinel, hasTail, op, pos, value]
   );
-  const total = passos.length;
+  const total = steps.length;
 
   const viz = useVisualizer({
     title: "Visualizador · religando ponteiros: inserir, remover e buscar",
@@ -411,91 +411,91 @@ export function LinkedListVisualizer() {
     // estrutura (que trocam a variante do código), o tamanho da lista (o
     // viewBox alarga e o desenho encolhe junto) e o número de passos — remover
     // de uma lista vazia devolve UM passo, e aí o rodapé inteiro some.
-    measureOn: [op, sentinela, temCauda, valores.length, total],
+    measureOn: [op, sentinel, hasTail, values.length, total],
   });
 
   const idx = viz.step;
-  const p = passos[idx];
+  const p = steps[idx];
 
-  const reiniciar = viz.reset;
+  const reset = viz.reset;
 
-  const aoMudarEntrada = (v: string) => {
+  const onInputChange = (v: string) => {
     const arr = v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 7);
-    reiniciar(); setPreset("");
-    setEntrada(v); setValores(arr);
+    reset(); setPreset("");
+    setInput(v); setValues(arr);
   };
-  const aoMudarOp = (novaOp: Op) => { reiniciar(); setPreset(""); setOp(novaOp); };
-  const aoMudarPos = (v: string) => { reiniciar(); setPreset(""); setPos(Math.max(0, parseInt(v, 10) || 0)); };
-  const aoMudarValor = (v: string) => { reiniciar(); setPreset(""); setValor(parseInt(v, 10) || 0); };
-  const alternarSentinela = () => { reiniciar(); setSentinela((s) => !s); };
-  const alternarCauda = () => { reiniciar(); setTemCauda((s) => !s); };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar(); setPreset(pr.key);
-    const novos = pr.valores ?? LISTA_PADRAO;
-    setValores(novos); setEntrada(novos.join(", "));
-    setOp(pr.op); setPos(pr.pos); setValor(pr.valor);
+  const onOpChange = (nextOp: Op) => { reset(); setPreset(""); setOp(nextOp); };
+  const onPosChange = (v: string) => { reset(); setPreset(""); setPos(Math.max(0, parseInt(v, 10) || 0)); };
+  const onValueChange = (v: string) => { reset(); setPreset(""); setValue(parseInt(v, 10) || 0); };
+  const toggleSentinel = () => { reset(); setSentinel((s) => !s); };
+  const toggleTail = () => { reset(); setHasTail((s) => !s); };
+  const applyPreset = (pr: Preset) => {
+    reset(); setPreset(pr.key);
+    const novos = pr.values ?? DEFAULT_LIST;
+    setValues(novos); setInput(novos.join(", "));
+    setOp(pr.op); setPos(pr.pos); setValue(pr.value);
   };
-  const sortear = () => {
+  const shuffle = () => {
     const n = 4 + Math.floor(Math.random() * 3);
     const arr = Array.from({ length: n }, () => 5 + Math.floor(Math.random() * 90));
-    reiniciar(); setPreset("");
-    setValores(arr); setEntrada(arr.join(", "));
+    reset(); setPreset("");
+    setValues(arr); setInput(arr.join(", "));
     setPos(Math.floor(Math.random() * (n + 1)));
-    setValor(5 + Math.floor(Math.random() * 90));
+    setValue(5 + Math.floor(Math.random() * 90));
   };
 
   // --- geometria ------------------------------------------------------------
-  const off = sentinela ? 1 : 0;
-  const n = valores.length;
+  const off = sentinel ? 1 : 0;
+  const n = values.length;
   const nVis = n + off;
-  const xNo = (i: number) => PAD_X + i * STEP;
-  const xNovo = p.novoDepoisDe < 0 ? PAD_X - 48 : xNo(p.novoDepoisDe) + 48;
+  const xNode = (i: number) => PAD_X + i * STEP;
+  const xNew = p.newAfter < 0 ? PAD_X - 48 : xNode(p.newAfter) + 48;
   // Piso na largura: com a lista quase vazia o viewBox ficaria estreito e o
   // desenho seria esticado até virar caricatura dentro do container.
-  const larguraVB = Math.max(560, PAD_X + nVis * STEP + 52 - X0);
-  const xNone = xNo(nVis) - 2;
+  const vbWidth = Math.max(560, PAD_X + nVis * STEP + 52 - X0);
+  const xNone = xNode(nVis) - 2;
   // A altura é fixa por operação (nunca por passo), senão o desenho pularia de
   // tamanho no meio da animação.
-  const alturaVB = op === "inserir" || op === "append" ? VB_ALTURA : VB_ALTURA_CURTA;
+  const vbHeight = op === "inserir" || op === "append" ? VB_HEIGHT : VB_HEIGHT_SHORT;
 
-  const valorDe = (i: number): string => (sentinela && i === 0 ? "None" : String(valores[i - off]));
+  const valueAt = (i: number): string => (sentinel && i === 0 ? "None" : String(values[i - off]));
 
   // Uma seta morta é a ligação que deixou de existir neste passo (tracejada) ou
   // a que sobrou pendurada no nó solto (apagada).
-  const setaMorta = (i: number): "quebrada" | "fantasma" | null => {
-    if (p.solto !== null && i === p.solto) return "fantasma";
-    if (p.ant !== null && i === p.ant && (p.ligaEntrada || p.bypass)) return "quebrada";
+  const deadArrow = (i: number): "quebrada" | "fantasma" | null => {
+    if (p.loose !== null && i === p.loose) return "fantasma";
+    if (p.prev !== null && i === p.prev && (p.linkedIn || p.bypass)) return "quebrada";
     return null;
   };
 
-  const codigo = CODIGO[chaveCodigo(op, sentinela, temCauda)];
+  const code = CODE[codeKey(op, sentinel, hasTail)];
 
-  const rotuloPonteiro =
-    op === "buscar" ? "atual" : op === "append" ? (temCauda ? null : "ultimo") : "anterior";
+  const pointerLabel =
+    op === "buscar" ? "atual" : op === "append" ? (hasTail ? null : "ultimo") : "anterior";
 
-  const variaveis = [
-    { nome: rotuloPonteiro ?? "cauda", valor: p.ant === null ? "None" : sentinela && p.ant === 0 ? "sentinela" : `nó ${valores[p.ant - off]}` },
-    { nome: "cabeça", valor: p.cabecaNoNovo ? `nó ${valor}` : sentinela ? "sentinela" : p.cabecaPara >= nVis ? "None" : `nó ${valores[p.cabecaPara]}` },
-    { nome: "nós na lista", valor: `${n}` },
-    { nome: "custo", valor: custoDaOperacao(op, pos, n, temCauda), best: custoDaOperacao(op, pos, n, temCauda) === "O(1)" },
+  const vars = [
+    { name: pointerLabel ?? "cauda", value: p.prev === null ? "None" : sentinel && p.prev === 0 ? "sentinela" : `nó ${values[p.prev - off]}` },
+    { name: "cabeça", value: p.headOnNew ? `nó ${value}` : sentinel ? "sentinela" : p.headTo >= nVis ? "None" : `nó ${values[p.headTo]}` },
+    { name: "nós na lista", value: `${n}` },
+    { name: "custo", value: operationCost(op, pos, n, hasTail), best: operationCost(op, pos, n, hasTail) === "O(1)" },
   ];
 
-  const deslocamentos =
+  const shifts =
     op === "inserir" ? Math.max(0, n - Math.min(pos, n))
       : op === "remover" ? (n === 0 ? 0 : Math.max(0, n - 1 - Math.min(pos, n - 1)))
         : 0;
 
-  const estatisticas = [
-    { k: "vis", rot: "nós percorridos", val: `${p.visitados}` },
-    { k: "rel", rot: "ponteiros religados", val: `${p.religados}` },
-    { k: "arr", rot: "deslocamentos num array", val: `${deslocamentos}` },
-    { k: "mem", rot: "memória extra", val: op === "buscar" || op === "remover" ? "O(1)" : "1 nó" },
+  const stats = [
+    { k: "vis", label: "nós percorridos", value: `${p.visited}` },
+    { k: "rel", label: "ponteiros religados", value: `${p.relinked}` },
+    { k: "arr", label: "deslocamentos num array", value: `${shifts}` },
+    { k: "mem", label: "memória extra", value: op === "buscar" || op === "remover" ? "O(1)" : "1 nó" },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const descricao = `Lista encadeada com ${n} ${n === 1 ? "nó" : "nós"}${n ? `: ${valores.join(", ")}` : " (vazia)"}${sentinela ? ", com nó sentinela" : ""}. ${p.nota}`;
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
+  const description = `Lista encadeada com ${n} ${n === 1 ? "nó" : "nós"}${n ? `: ${values.join(", ")}` : " (vazia)"}${sentinel ? ", com nó sentinela" : ""}. ${p.note}`;
 
-  const quadro = (
+  const frame = (
     <figure {...viz.figureProps} style={{ margin: 0 }}>
       <VizHeader viz={viz} />
 
@@ -507,10 +507,10 @@ export function LinkedListVisualizer() {
               <button
                 key={o.key}
                 className={`bigo-chip${op === o.key ? " on" : ""}`}
-                onClick={() => aoMudarOp(o.key)}
+                onClick={() => onOpChange(o.key)}
                 aria-pressed={op === o.key}
               >
-                {o.rotulo}
+                {o.label}
               </button>
             ))}
           </div>
@@ -519,12 +519,12 @@ export function LinkedListVisualizer() {
         <div className="ll-grupo">
           <span className="ll-grupo-rot">Estrutura</span>
           <div className="bigo-chips">
-            <button className={`bigo-chip${sentinela ? " on" : ""}`} onClick={alternarSentinela} aria-pressed={sentinela}>
-              <span className="sw" style={{ background: sentinela ? "#a78bfa" : "#3a4a60" }} />
+            <button className={`bigo-chip${sentinel ? " on" : ""}`} onClick={toggleSentinel} aria-pressed={sentinel}>
+              <span className="sw" style={{ background: sentinel ? "#a78bfa" : "#3a4a60" }} />
               nó sentinela
             </button>
-            <button className={`bigo-chip${temCauda ? " on" : ""}`} onClick={alternarCauda} aria-pressed={temCauda}>
-              <span className="sw" style={{ background: temCauda ? "#34d399" : "#3a4a60" }} />
+            <button className={`bigo-chip${hasTail ? " on" : ""}`} onClick={toggleTail} aria-pressed={hasTail}>
+              <span className="sw" style={{ background: hasTail ? "#34d399" : "#3a4a60" }} />
               ponteiro de cauda
             </button>
           </div>
@@ -537,10 +537,10 @@ export function LinkedListVisualizer() {
               <button
                 key={pr.key}
                 className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-                onClick={() => aplicarPreset(pr)}
+                onClick={() => applyPreset(pr)}
                 aria-pressed={preset === pr.key}
               >
-                {pr.rotulo}
+                {pr.label}
               </button>
             ))}
           </div>
@@ -549,25 +549,25 @@ export function LinkedListVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Valores da lista (até 7)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
           {op !== "append" && op !== "buscar" ? (
             <label className="viz-field">
               <span>posição</span>
-              <input className="viz-input k" type="number" min={0} value={pos} onChange={(e) => aoMudarPos(e.target.value)} />
+              <input className="viz-input k" type="number" min={0} value={pos} onChange={(e) => onPosChange(e.target.value)} />
             </label>
           ) : null}
           {op !== "remover" ? (
             <label className="viz-field">
               <span>valor</span>
-              <input className="viz-input k" type="number" value={valor} onChange={(e) => aoMudarValor(e.target.value)} />
+              <input className="viz-input k" type="number" value={value} onChange={(e) => onValueChange(e.target.value)} />
             </label>
           ) : null}
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="ll-svg-wrap">
-          <svg className="ll-svg" viewBox={`${X0} ${VB_TOPO} ${larguraVB} ${alturaVB}`} role="img" aria-label={descricao}>
+          <svg className="ll-svg" viewBox={`${X0} ${VB_TOP} ${vbWidth} ${vbHeight}`} role="img" aria-label={description}>
             <defs>
               <marker id="llop-seta" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
                 <path d="M0,0 L6,3 L0,6 z" fill="#4c5f79" />
@@ -585,53 +585,53 @@ export function LinkedListVisualizer() {
             <text x={-40} y={CY} fill="#93bbfd" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11.5} fontWeight={600} textAnchor="middle" dominantBaseline="central">
               cabeça
             </text>
-            {p.cabecaNoNovo ? (
+            {p.headOnNew ? (
               <path
-                d={`M -40,${CY + 14} C -40,${CY + 70} ${xNovo + 14},${Y_NOVO - 70} ${xNovo + 14},${Y_NOVO - BOX_H / 2 - 4}`}
+                d={`M -40,${CY + 14} C -40,${CY + 70} ${xNew + 14},${Y_NEW - 70} ${xNew + 14},${Y_NEW - BOX_H / 2 - 4}`}
                 fill="none" stroke="#34d399" strokeWidth={1.8} markerEnd="url(#llop-seta-ok)"
               />
-            ) : p.cabecaPara === 0 ? (
-              <line x1={-10} y1={CY} x2={xNo(0) - 7} y2={CY} stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#llop-seta)" />
+            ) : p.headTo === 0 ? (
+              <line x1={-10} y1={CY} x2={xNode(0) - 7} y2={CY} stroke="#3a4a60" strokeWidth={1.6} markerEnd="url(#llop-seta)" />
             ) : (
               <path
-                d={`M -40,${CY - 15} Q ${(xNo(p.cabecaPara) - 40) / 2},${CY - 66} ${xNo(p.cabecaPara) - 6},${CY - 14}`}
+                d={`M -40,${CY - 15} Q ${(xNode(p.headTo) - 40) / 2},${CY - 66} ${xNode(p.headTo) - 6},${CY - 14}`}
                 fill="none" stroke="#34d399" strokeWidth={1.8} markerEnd="url(#llop-seta-ok)"
               />
             )}
 
             {/* ponteiro de cauda */}
-            {temCauda && nVis > 0 ? (
+            {hasTail && nVis > 0 ? (
               <g>
-                <rect x={xNo(nVis - 1) + 5} y={16} width={56} height={24} rx={8} fill="#0e1725" stroke="rgba(52,211,153,0.4)" />
-                <text x={xNo(nVis - 1) + 33} y={28} fill="#6ee7b7" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11} fontWeight={600} textAnchor="middle" dominantBaseline="central">
+                <rect x={xNode(nVis - 1) + 5} y={16} width={56} height={24} rx={8} fill="#0e1725" stroke="rgba(52,211,153,0.4)" />
+                <text x={xNode(nVis - 1) + 33} y={28} fill="#6ee7b7" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11} fontWeight={600} textAnchor="middle" dominantBaseline="central">
                   cauda
                 </text>
-                <line x1={xNo(nVis - 1) + 33} y1={41} x2={xNo(nVis - 1) + 33} y2={CY - BOX_H / 2 - 5} stroke="rgba(52,211,153,0.5)" strokeWidth={1.5} markerEnd="url(#llop-seta-ok)" />
+                <line x1={xNode(nVis - 1) + 33} y1={41} x2={xNode(nVis - 1) + 33} y2={CY - BOX_H / 2 - 5} stroke="rgba(52,211,153,0.5)" strokeWidth={1.5} markerEnd="url(#llop-seta-ok)" />
               </g>
             ) : null}
 
             {/* setas entre os nós, e a última apontando para None */}
             {Array.from({ length: nVis }, (_, i) => {
-              const morta = setaMorta(i);
-              const x1 = xNo(i) + 55;
-              const x2 = xNo(i + 1) - 7;
+              const dead = deadArrow(i);
+              const x1 = xNode(i) + 55;
+              const x2 = xNode(i + 1) - 7;
               return (
                 <line
                   key={`s${i}`}
                   x1={x1} y1={CY} x2={x2} y2={CY}
-                  stroke={morta === "quebrada" ? "#7d5560" : "#3a4a60"}
+                  stroke={dead === "quebrada" ? "#7d5560" : "#3a4a60"}
                   strokeWidth={1.6}
-                  strokeDasharray={morta ? "4 4" : undefined}
-                  opacity={morta === "fantasma" ? 0.3 : 1}
-                  markerEnd={morta ? "url(#llop-seta-off)" : "url(#llop-seta)"}
+                  strokeDasharray={dead ? "4 4" : undefined}
+                  opacity={dead === "fantasma" ? 0.3 : 1}
+                  markerEnd={dead ? "url(#llop-seta-off)" : "url(#llop-seta)"}
                 />
               );
             })}
 
             {/* arco que pula o nó removido */}
-            {p.bypass && p.ant !== null && p.solto !== null ? (
+            {p.bypass && p.prev !== null && p.loose !== null ? (
               <path
-                d={`M ${xNo(p.ant) + 55},${CY - 16} Q ${(xNo(p.ant) + 55 + xNo(p.solto + 1) - 7) / 2},${CY - 62} ${xNo(p.solto + 1) - 7},${CY - 14}`}
+                d={`M ${xNode(p.prev) + 55},${CY - 16} Q ${(xNode(p.prev) + 55 + xNode(p.loose + 1) - 7) / 2},${CY - 62} ${xNode(p.loose + 1) - 7},${CY - 14}`}
                 fill="none" stroke="#34d399" strokeWidth={1.8} markerEnd="url(#llop-seta-ok)"
               />
             ) : null}
@@ -642,44 +642,44 @@ export function LinkedListVisualizer() {
 
             {/* os nós */}
             {Array.from({ length: nVis }, (_, i) => {
-              const x = xNo(i);
-              const ehSentinela = sentinela && i === 0;
-              const solto = p.solto === i;
-              const marcado = p.ant === i;
-              const achou = p.alvo === i;
-              const borda = achou ? "#34d399" : marcado ? "#f59e0b" : ehSentinela ? "rgba(167,139,250,0.55)" : "rgba(255,255,255,0.14)";
-              const fundo = achou ? "rgba(52,211,153,0.18)" : marcado ? "rgba(245,158,11,0.14)" : "#0f1826";
+              const x = xNode(i);
+              const isSentinel = sentinel && i === 0;
+              const isLoose = p.loose === i;
+              const marked = p.prev === i;
+              const isFound = p.found === i;
+              const stroke = isFound ? "#34d399" : marked ? "#f59e0b" : isSentinel ? "rgba(167,139,250,0.55)" : "rgba(255,255,255,0.14)";
+              const fill = isFound ? "rgba(52,211,153,0.18)" : marked ? "rgba(245,158,11,0.14)" : "#0f1826";
               return (
-                <g key={`n${i}`} opacity={solto ? 0.34 : 1}>
+                <g key={`n${i}`} opacity={isLoose ? 0.34 : 1}>
                   <rect
                     x={x} y={CY - BOX_H / 2} width={BOX_W} height={BOX_H} rx={9}
-                    fill={fundo} stroke={borda} strokeWidth={1.8}
-                    strokeDasharray={ehSentinela || solto ? "5 4" : undefined}
+                    fill={fill} stroke={stroke} strokeWidth={1.8}
+                    strokeDasharray={isSentinel || isLoose ? "5 4" : undefined}
                   />
                   <line x1={x + 44} y1={CY - BOX_H / 2} x2={x + 44} y2={CY + BOX_H / 2} stroke="rgba(255,255,255,0.12)" strokeWidth={1.2} />
                   <text
                     x={x + 22} y={CY}
-                    fill={achou ? "#d1fae5" : marcado ? "#fff" : ehSentinela ? "#c4b5fd" : "#b9c9dd"}
+                    fill={isFound ? "#d1fae5" : marked ? "#fff" : isSentinel ? "#c4b5fd" : "#b9c9dd"}
                     fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
-                    fontSize={ehSentinela ? 10.5 : 15} fontWeight={600}
+                    fontSize={isSentinel ? 10.5 : 15} fontWeight={600}
                     textAnchor="middle" dominantBaseline="central"
                   >
-                    {valorDe(i)}
+                    {valueAt(i)}
                   </text>
                   <circle cx={x + 55} cy={CY} r={3.2} fill="#4c5f79" />
-                  {ehSentinela ? (
+                  {isSentinel ? (
                     <text x={x + 33} y={60} fill="#a78bfa" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={10.5} fontWeight={700} textAnchor="middle" dominantBaseline="central">
                       sentinela
                     </text>
                   ) : null}
-                  {marcado && rotuloPonteiro ? (
+                  {marked && pointerLabel ? (
                     // deslocado para a esquerda de propósito: no x + 33 o rótulo
                     // encostaria na curva que sai do campo prox deste nó.
                     <text x={x + 22} y={CY + BOX_H / 2 + 16} fill="#fcd34d" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11.5} fontWeight={700} textAnchor="middle" dominantBaseline="central">
-                      {rotuloPonteiro}
+                      {pointerLabel}
                     </text>
                   ) : null}
-                  {solto ? (
+                  {isLoose ? (
                     <text x={x + 33} y={CY + BOX_H / 2 + 16} fill="#fca5a5" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11} fontWeight={700} textAnchor="middle" dominantBaseline="central">
                       solto
                     </text>
@@ -689,26 +689,26 @@ export function LinkedListVisualizer() {
             })}
 
             {/* o nó novo, desenhado fora da linha: nada na lista sai do lugar */}
-            {p.mostraNovo ? (
+            {p.showsNew ? (
               <g>
-                <text x={xNovo - 8} y={Y_NOVO} fill="#6ee7b7" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11} fontWeight={700} textAnchor="end" dominantBaseline="central">
+                <text x={xNew - 8} y={Y_NEW} fill="#6ee7b7" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={11} fontWeight={700} textAnchor="end" dominantBaseline="central">
                   novo
                 </text>
-                <rect x={xNovo} y={Y_NOVO - BOX_H / 2} width={BOX_W} height={BOX_H} rx={9} fill="rgba(52,211,153,0.14)" stroke="#34d399" strokeWidth={1.8} />
-                <line x1={xNovo + 44} y1={Y_NOVO - BOX_H / 2} x2={xNovo + 44} y2={Y_NOVO + BOX_H / 2} stroke="rgba(255,255,255,0.12)" strokeWidth={1.2} />
-                <text x={xNovo + 22} y={Y_NOVO} fill="#d1fae5" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={15} fontWeight={600} textAnchor="middle" dominantBaseline="central">
-                  {valor}
+                <rect x={xNew} y={Y_NEW - BOX_H / 2} width={BOX_W} height={BOX_H} rx={9} fill="rgba(52,211,153,0.14)" stroke="#34d399" strokeWidth={1.8} />
+                <line x1={xNew + 44} y1={Y_NEW - BOX_H / 2} x2={xNew + 44} y2={Y_NEW + BOX_H / 2} stroke="rgba(255,255,255,0.12)" strokeWidth={1.2} />
+                <text x={xNew + 22} y={Y_NEW} fill="#d1fae5" fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace" fontSize={15} fontWeight={600} textAnchor="middle" dominantBaseline="central">
+                  {value}
                 </text>
-                <circle cx={xNovo + 55} cy={Y_NOVO} r={3.2} fill="#34d399" />
-                {p.ligaSaida ? (
+                <circle cx={xNew + 55} cy={Y_NEW} r={3.2} fill="#34d399" />
+                {p.linkedOut ? (
                   <path
-                    d={`M ${xNovo + 55},${Y_NOVO} C ${xNovo + 55},${Y_NOVO - 40} ${xNo(p.novoDepoisDe + 1) + 14},${CY + 58} ${xNo(p.novoDepoisDe + 1) + 14},${CY + BOX_H / 2 + 4}`}
+                    d={`M ${xNew + 55},${Y_NEW} C ${xNew + 55},${Y_NEW - 40} ${xNode(p.newAfter + 1) + 14},${CY + 58} ${xNode(p.newAfter + 1) + 14},${CY + BOX_H / 2 + 4}`}
                     fill="none" stroke="#34d399" strokeWidth={1.8} markerEnd="url(#llop-seta-ok)"
                   />
                 ) : null}
-                {p.ligaEntrada && p.novoDepoisDe >= 0 ? (
+                {p.linkedIn && p.newAfter >= 0 ? (
                   <path
-                    d={`M ${xNo(p.novoDepoisDe) + 55},${CY} C ${xNo(p.novoDepoisDe) + 55},${CY + 50} ${xNovo + 14},${Y_NOVO - 50} ${xNovo + 14},${Y_NOVO - BOX_H / 2 - 4}`}
+                    d={`M ${xNode(p.newAfter) + 55},${CY} C ${xNode(p.newAfter) + 55},${CY + 50} ${xNew + 14},${Y_NEW - 50} ${xNew + 14},${Y_NEW - BOX_H / 2 - 4}`}
                     fill="none" stroke="#34d399" strokeWidth={1.8} markerEnd="url(#llop-seta-ok)"
                   />
                 ) : null}
@@ -724,7 +724,7 @@ export function LinkedListVisualizer() {
           <span><i style={{ background: "#f59e0b" }} /> nó sob o ponteiro que caminha</span>
         </p>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
           {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
@@ -737,8 +737,8 @@ export function LinkedListVisualizer() {
             <div className="viz-code" {...viz.blockProps}>
               <div className="viz-code-head">lista_encadeada.py</div>
               <div className="viz-code-body">
-                {codigo.map((txt, i) => (
-                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
                     <span className="ln">{i + 1}</span>
                     {txt}
                   </div>
@@ -748,20 +748,20 @@ export function LinkedListVisualizer() {
           </div>
           <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
@@ -773,13 +773,13 @@ export function LinkedListVisualizer() {
     </figure>
   );
 
-  return viz.inPanel(quadro);
+  return viz.inPanel(frame);
 }
 
 // O custo assintótico da operação escolhida, do jeito que ele aparece no artigo.
-function custoDaOperacao(op: Op, pos: number, n: number, temCauda: boolean): string {
+function operationCost(op: Op, pos: number, n: number, hasTail: boolean): string {
   if (op === "buscar") return "O(n)";
-  if (op === "append") return temCauda ? "O(1)" : "O(n)";
+  if (op === "append") return hasTail ? "O(1)" : "O(n)";
   if (n === 0 || pos <= 0) return "O(1)";
   return "O(n)";
 }

--- a/content/visualizers/LinkedListVisualizer.tsx
+++ b/content/visualizers/LinkedListVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // LinkedListVisualizer, as operações de uma lista simplesmente encadeada.
@@ -121,9 +122,6 @@ function chaveCodigo(op: Op, sentinela: boolean, temCauda: boolean): string {
   if (op === "append") return temCauda ? "append-cauda" : "append";
   return "buscar";
 }
-
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 function gerarPassos(
   valores: number[],
@@ -398,47 +396,28 @@ export function LinkedListVisualizer() {
   const [sentinela, setSentinela] = useState(false);
   const [temCauda, setTemCauda] = useState(false);
   const [preset, setPreset] = useState("meio");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   const passos = useMemo(
     () => gerarPassos(valores, sentinela, temCauda, op, pos, valor),
     [valores, sentinela, temCauda, op, pos, valor]
   );
   const total = passos.length;
-  const idx = Math.min(passo, total - 1);
+
+  const viz = useVisualizer({
+    title: "Visualizador · religando ponteiros: inserir, remover e buscar",
+    total,
+    // O que muda a altura da peça: a operação (o desenho ganha a linha do nó
+    // novo, e o bloco de código vai de 5 a 11 linhas), os dois interruptores de
+    // estrutura (que trocam a variante do código), o tamanho da lista (o
+    // viewBox alarga e o desenho encolhe junto) e o número de passos — remover
+    // de uma lista vazia devolve UM passo, e aí o rodapé inteiro some.
+    measureOn: [op, sentinela, temCauda, valores.length, total],
+  });
+
+  const idx = viz.step;
   const p = passos[idx];
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
+  const reiniciar = viz.reset;
 
   const aoMudarEntrada = (v: string) => {
     const arr = v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 7);
@@ -514,25 +493,13 @@ export function LinkedListVisualizer() {
   ];
 
   const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
   const descricao = `Lista encadeada com ${n} ${n === 1 ? "nó" : "nós"}${n ? `: ${valores.join(", ")}` : " (vazia)"}${sentinela ? ", com nó sentinela" : ""}. ${p.nota}`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · religando ponteiros: inserir, remover e buscar</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const quadro = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="ll-grupo">
           <span className="ll-grupo-rot">Operação</span>
           <div className="bigo-chips">
@@ -760,18 +727,26 @@ export function LinkedListVisualizer() {
         <p className={notaCls}>{p.nota}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">lista_encadeada.py</div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso;
+              `inert` tira ele do teclado enquanto está fora de vista. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">lista_encadeada.py</div>
+              <div className="viz-code-body">
+                {codigo.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {variaveis.map((v) => (
               <div className="viz-var" key={v.nome}>
@@ -790,34 +765,15 @@ export function LinkedListVisualizer() {
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(quadro);
 }
 
 // O custo assintótico da operação escolhida, do jeito que ele aparece no artigo.

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -183,6 +183,39 @@ Três regras que só apareceram medindo:
   "Mostrar código" e expande espera continuar vendo o código. Se não couber, o
   miolo rola, que é para isso que o cabeçalho e o rodapé ficam parados.
 
+### O estado mais alto não é "encher a entrada até o máximo"
+
+Você mede a peça no pior caso para saber se ela cabe. O jeito óbvio de achar
+esse pior caso — encher todo campo até o limite — **errou nas três peças em que
+foi tentado numa mesma rodada, e nas três por um motivo diferente**:
+
+| peça | o que "encher tudo" deu | por quê |
+|---|---|---|
+| busca da hash table | **833px, menos** que os 847 do padrão | a corrente longa cabe numa linha que já existia, e a nota que explica o estado padrão é mais comprida |
+| busca da skip list | **0px de diferença** com 14 elementos | a altura vem dos NÍVEIS, que têm teto (`MAX_LEVELS = 4`), e o padrão já batia nele; mais elementos só alargam o SVG, e o wrapper rola na horizontal |
+| reversão da lista | 4 nós = **979px**, 5 nós = 954px | o viewBox tem piso de largura, então menos nós = razão altura/largura maior = mais altura no esticão até a largura do corpo |
+
+O que fazer em vez disso, na ordem:
+
+1. **Ache o que gera as LINHAS do desenho** — o `while`, o `Array.from`, o
+   `map` sobre buckets ou níveis. É esse eixo que vira altura; os outros viram
+   largura, e largura rola sozinha quando o wrapper tem `overflow-x: auto`.
+2. **Verifique se ele tem teto.** Um eixo com limite já pode estar no máximo no
+   estado padrão, e aí encher devolve o mesmo número e você conclui "não tem
+   pior caso" com uma medição que não confirmou nada.
+3. **Cheque se o extremo é combinação.** Na pirâmide de níveis o pior caso exige
+   dois controles no máximo **ao mesmo tempo** (o `n` e o `p`); mexer só num deles
+   dá metade da altura — 21 linhas em vez de 40.
+4. **Se o pior caso construído der um número MENOR que o padrão, o padrão é o
+   pior caso.** Troque o número, não a narrativa.
+
+E o corolário que fecha a §3: **a régua de 1512x900 responde "a camada 3 é
+necessária?", não "a camada 1 é necessária?"**. Peça que parece sadia nela pode
+estar desenhando o botão de reprodução fora da janela em 1440x700 — foi o caso
+da busca da hash table (104px abaixo do pé visível) e do trade-off do prefix sum
+(135px). Meça também abaixo de 900 antes de dizer que uma peça não precisa de
+nada.
+
 ## 4. A API de CSS
 
 Tudo em `src/app/globals.css`, e tudo **opt-in**: um visualizador sem `viz-fit`

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -69,6 +69,21 @@ Os dois da 2ª versão não são casos exóticos: o Prettier quebra a linha de
 qualquer elemento cujos atributos não cabem, e ternário dentro de interpolação
 é como metade das notas deste repo escolhe entre singular e plural.
 
+**Mais dois buracos, medidos no `listas-ligadas`, e os dois continuam
+abertos** — porque tapá-los é reescrever o guarda com um analisador de verdade,
+e isso é PR de plataforma, não carona numa adaptação de tópico:
+
+| o que não olha | o que passa |
+|---|---|
+| **template dentro de `${...}`**: o casamento da crase é regex, então uma crase aninhada tira o pareamento de sincronia | o `LinkedListFloyd` tem 6 delas (``` `… ${cycle > 0 ? `, e ${cycle}…` : ""}` ```), e daí em diante o guarda compara **código** como se fosse tela: dezenas de linhas de ruído, e uma troca de rótulo de verdade some no meio |
+| **texto de tela que divide a linha com uma interpolação**: o padrão exige `>texto<`, e um `{` no meio corta o casamento | `<span>Nós no ciclo: {cycle === 0 ? … }</span>` — "Nós no ciclo: " não está em string nenhuma, não é visto pelo guarda, e um rename cego o estragaria **sem nenhum aviso** |
+
+O segundo é o mais perigoso dos dois, porque é silencioso: o primeiro pelo
+menos grita. E os dois têm a mesma consequência prática — **quando o arquivo
+tiver crase aninhada ou rótulo colado numa interpolação, o guarda não é prova;
+a prova é comparar o texto renderizado dos ESTADOS** (§8), que é o que pegou
+os dois aqui.
+
 **E um buraco continua aberto, por construção: ele compara o CONJUNTO de textos,
 não onde cada um aparece.** Trocar dois campos de lugar num rename (o subtítulo
 de um cartão indo para o corpo e vice-versa) mantém o conjunto idêntico e passa

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -445,12 +445,12 @@ os dois passando contra a quebra antes de serem consertados:
 
 ---
 
-## 9. Dois limites medidos da casca
+## 9. Limites medidos da casca
 
-Ambos apareceram adaptando o tópico `intervals`, e ambos são do comportamento
-da casca — não do componente. Estão aqui porque um explica um número que o
-relatório de qualquer adaptação vai encontrar, e o outro é um recurso que o hook
-não tem.
+Todos são do comportamento da casca — não do componente — e estão aqui porque
+explicam números que o relatório de qualquer adaptação vai encontrar, ou
+recursos que o hook não tem. A seção cresce: acrescente no fim em vez de
+renumerar.
 
 ### A compressão da camada 2 não alcança o fluxo do artigo
 
@@ -494,3 +494,29 @@ o `out/` congela o passo 1 e só o cliente corrige — conferido no HTML do buil
 Uma consequência a assumir: o `↺` do `VizFooter` é `viz.reset()`, que volta ao
 passo **0**, e não ao passo inicial escolhido. Se o estado de partida for para
 valer, ele precisa de um botão próprio — ver a nota do `↺` na §6.
+
+### Adotar a casca deixa a peça mais ALTA no artigo, e quem não tem bloco paga
+
+O `.viz-foot` sai do `.viz-body` — é isso que o deixa parado no pé do painel — e
+traz o respiro dele: uma linha divisória e o padding dos controles. No painel
+expandido isso não custa nada, porque lá a régua é a janela e o miolo rola. **No
+fluxo do artigo custa altura**, e quem tem bloco recolhível paga com o bloco.
+
+Quem não tem, não paga: com `collapsible: false` não existe a camada 3, e a
+camada 2 não alcança o artigo (limite acima). Medido:
+
+| peça | artigo antes | artigo depois |
+|---|---|---|
+| `HashTableBuscaVisualizer` (`collapsible: false`, com linha do tempo) | 847px | **875px** (+28) |
+| `PrefixSumTradeoff` (`collapsible: false`, `total: 1`, rodapé à mão) | 731px | **741px** (+10) |
+
+Nos dois a adaptação valeu, porque o que ela conserta é outra coisa — e só
+aparece **abaixo** da régua de 1512x900. Na busca da hash table, o `▶ Rodar` era
+desenhado 104px (1440x700) e 204px (1440x600) abaixo do pé visível da peça; no
+trade-off, o `↺ Reiniciar` ficava 135px e 235px abaixo. Nos quatro casos o
+controle voltou para dentro da janela e o cabeçalho parou de subir.
+
+Mas o número no artigo piora, e o relatório tem que dizer isso **com o
+número**, não arredondar para "sem mudança". A pergunta certa ao decidir o
+escopo de uma peça sem bloco não é "quanto ela encolhe", é "onde ficam os
+controles quando ela rola".

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -281,14 +281,18 @@ Reprodução, quando você precisa mexer nela de fora: `viz.step` (já limitado 
 | ritmo próprio | `speeds: [...]` — um passo de sudoku e uma troca de array não pedem o mesmo tempo |
 | só passo a passo, sem animação contínua | `<VizFooter noSpeed />` |
 | botões extras nos controles | `<VizFooter>{seus botões}</VizFooter>` |
-| **sem linha do tempo E com botões extras** | escreva o rodapé à mão (abaixo) |
+| **sem linha do tempo E com botões extras** | `<VizFooter>{seus botões}</VizFooter>` também: o rodapé sai com os seus botões e sem nada de reprodução |
 
-A linha do `total: 1` e a dos **botões extras** se contradizem, e a contradição é
-real: **`VizFooter` é o rodapé de REPRODUÇÃO e retorna `null` quando
-`total <= 1`, descartando os `children` em silêncio.** Um classificador com
-presets — que é o caso do `SubTypesVisualizer` — cai exatamente aí, e passar os
-botões para o `VizFooter` some com eles sem erro nenhum. Nesse caso os controles
-são seus e o `.viz-foot` também:
+A última linha já foi a contradição desta tabela, e **não é mais**: `VizFooter`
+retornava `null` sempre que `total <= 1`, **descartando os `children` em
+silêncio**, e dois visualizadores (`SubTypesVisualizer` e `PrefixSumTradeoff`)
+escreveram o rodapé à mão por causa disso. O hook foi consertado: com
+`total <= 1` ele descarta os controles de reprodução — que um visualizador sem
+linha do tempo não tem —, mas desenha o `.viz-foot` com os seus `children`. Só
+quando não há `children` é que ele some inteiro.
+
+Escrever o rodapé à mão continua sendo API pública, e é o que você usa quando
+precisa de um `.viz-foot` que o hook não monta:
 
 ```tsx
 {/* Fora do `.viz-body` de propósito: é o que os deixa parados no pé do
@@ -307,12 +311,12 @@ um visualizador sem linha do tempo não tem.
 não há decisão a tomar e o hook nem espera as fontes. Passar a lista ali é ruído
 que sugere uma medição que não acontece.
 
-**`total` que vem da entrada do aluno pode cair para 1, e aí o rodapé some
-inteiro** — com ele, os `children` que você pôs lá dentro. No visualizador de
+**`total` que vem da entrada do aluno pode cair para 1, e aí somem o contador, os
+atalhos, a barra de progresso e os botões de reprodução** — os seus `children`
+ficam, mas sozinhos numa linha que era de outra coisa. No visualizador de
 memória contígua o passo É o índice, então um array de um elemento zera a linha
-do tempo; se o preset "20 inteiros" morasse no rodapé, o aluno que digitasse um
-número só ficaria sem o caminho de volta. Preset e botão de estado ficam no
-miolo; no rodapé só o que é reprodução.
+do tempo. Preset e botão de estado ficam no miolo; no rodapé só o que é
+reprodução — assim a linha não muda de sentido quando a linha do tempo some.
 
 E o `↺` do `VizFooter` é `viz.reset()`: ele volta ao passo 0 e **não** desfaz o
 estado que o aluno montou (array, modo, parâmetros). Se o seu visualizador tinha

--- a/content/visualizers/SkipListInsercao.tsx
+++ b/content/visualizers/SkipListInsercao.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // SkipListInsercao, as duas operações que mexem na estrutura: inserir e remover.
@@ -9,13 +10,13 @@ import { createPortal } from "react-dom";
 // A busca (SkipListVisualizer) mostra o benefício dos níveis. Este mostra o
 // preço e o truque: para inserir ou remover é preciso guardar, nível a nível,
 // quem é o vizinho da esquerda do nó afetado (o vetor `update`, o "bread crumb"
-// que a galera batizou no encontro), e só então religar os ponteiros.
+// da implementação), e só então religar os ponteiros.
 //
 // Quatro coisas que o aluno precisa enxergar acontecendo:
 //   1. o update[] enchendo, um candidato por nível, sempre que a busca desce;
 //   2. a moeda decidindo a altura, e a altura sendo sorteada UMA vez só;
-//   3. os níveis acima do topo atual, onde o candidato já era o head. Foi a
-//      dúvida que mais tomou tempo do encontro, e ela só fecha vendo;
+//   3. os níveis acima do topo atual, onde o candidato já era o head. É a
+//      dúvida mais comum do tema, e ela só fecha vendo;
 //   4. na remoção, o `break`: o primeiro nível em que o candidato não aponta
 //      para o alvo encerra o trabalho, porque a altura é contínua de baixo
 //      para cima. E a assimetria do custo: inserir reescreve 2 ponteiros por
@@ -24,33 +25,37 @@ import { createPortal } from "react-dom";
 // O gerador é puro: recebe (modo, valor, altura) e devolve sempre os mesmos
 // passos. O sorteio real de altura acontece num handler de clique, nunca no
 // render.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Contrato
+// em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Modo = "inserir" | "remover";
-type Item = { valor: number; altura: number; novo?: boolean };
+type Mode = "inserir" | "remover";
+type Item = { value: number; height: number; isNew?: boolean };
 type Face = "cara" | "coroa" | "teto";
 
-type Passo = {
-  nivel: number;
-  atual: number; // índice em `itens`, -1 = head
-  olhando: number | null;
+type Step = {
+  level: number;
+  current: number; // índice em `items`, -1 = head
+  looking: number | null;
   update: number[]; // por nível: índice do candidato, -1 = head (o valor inicial)
-  escrito: boolean[]; // se a busca já passou por aquele nível e gravou o candidato
-  ligados: number; // quantos níveis do nó novo já foram religados (inserção)
-  desligados: number; // quantos níveis do nó alvo já saíram (remoção)
-  moedas: Face[];
-  emCena: boolean; // o nó em foco já apareceu (criado na inserção, achado na remoção)
-  nivelMax: number;
-  linha: number;
-  fim?: boolean;
+  written: boolean[]; // se a busca já passou por aquele nível e gravou o candidato
+  linked: number; // quantos níveis do nó novo já foram religados (inserção)
+  unlinked: number; // quantos níveis do nó alvo já saíram (remoção)
+  coins: Face[];
+  onStage: boolean; // o nó em foco já apareceu (criado na inserção, achado na remoção)
+  maxLevel: number;
+  line: number;
+  done?: boolean;
   ok?: boolean;
-  erro?: boolean;
-  nota: string;
+  error?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO_INSERIR = [
+const CODE_INSERT = [
   "def inserir(self, valor):",
   "    atual = self.head",
   "    update = [self.head] * MAX_NIVEL",
@@ -68,7 +73,7 @@ const CODIGO_INSERIR = [
   "        update[nivel].forward[nivel] = novo",
 ];
 
-const CODIGO_REMOVER = [
+const CODE_REMOVE = [
   "def remover(self, valor):",
   "    atual = self.head",
   "    update = [self.head] * MAX_NIVEL",
@@ -90,421 +95,418 @@ const CODIGO_REMOVER = [
   "    return True",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-const MAX_NIVEL = 5; // teto de altura de um nó: níveis 0 a 4
+const MAX_LEVEL = 5; // teto de altura de um nó: níveis 0 a 4
 
 // Base com a pirâmide de livro: 10 nós no nível 0, 6 no 1, 3 no 2 e 1 no 3.
 // O 33, o 80 e o 1 ficam de fora de propósito, são os buracos para inserir.
 const BASE: Item[] = [
-  { valor: 3, altura: 1 },
-  { valor: 9, altura: 3 },
-  { valor: 17, altura: 1 },
-  { valor: 23, altura: 2 },
-  { valor: 31, altura: 1 },
-  { valor: 42, altura: 4 },
-  { valor: 50, altura: 1 },
-  { valor: 59, altura: 2 },
-  { valor: 73, altura: 3 },
-  { valor: 92, altura: 2 },
+  { value: 3, height: 1 },
+  { value: 9, height: 3 },
+  { value: 17, height: 1 },
+  { value: 23, height: 2 },
+  { value: 31, height: 1 },
+  { value: 42, height: 4 },
+  { value: 50, height: 1 },
+  { value: 59, height: 2 },
+  { value: 73, height: 3 },
+  { value: 92, height: 2 },
 ];
 
-const NIVEL_MAX_BASE = Math.max(...BASE.map((b) => b.altura)) - 1; // 3
+const BASE_MAX_LEVEL = Math.max(...BASE.map((b) => b.height)) - 1; // 3
 
 // A sequência de moedas que produz aquela altura: (altura - 1) caras e uma
 // coroa. Quando a altura bate no teto, a última moeda nem é lançada.
-function moedasDe(altura: number): Face[] {
+function coinsFor(height: number): Face[] {
   const out: Face[] = [];
-  for (let i = 1; i < altura; i++) out.push("cara");
-  out.push(altura >= MAX_NIVEL ? "teto" : "coroa");
+  for (let i = 1; i < height; i++) out.push("cara");
+  out.push(height >= MAX_LEVEL ? "teto" : "coroa");
   return out;
 }
 
-function nomeDe(itens: Item[], i: number): string {
-  return i < 0 ? "o head" : `o ${itens[i].valor}`;
+function nameOf(items: Item[], i: number): string {
+  return i < 0 ? "o head" : `o ${items[i].value}`;
 }
 
-function rotuloUpdate(itens: Item[], v: number): string {
-  return v < 0 ? "head" : `${itens[v].valor}`;
+function updateLabel(items: Item[], v: number): string {
+  return v < 0 ? "head" : `${items[v].value}`;
 }
 
 // Estado de visibilidade do nó em foco, que é o que faz o desenho animar a
-// religação. Na inserção ele ainda não existe nos níveis acima de `ligados`;
-// na remoção ele já saiu dos níveis abaixo de `desligados`.
-type Vis = { alvo: number; modo: Modo; ligados: number; desligados: number };
+// religação. Na inserção ele ainda não existe nos níveis acima de `linked`;
+// na remoção ele já saiu dos níveis abaixo de `unlinked`.
+type Vis = { target: number; mode: Mode; linked: number; unlinked: number };
 
-function escondido(j: number, nivel: number, v: Vis): boolean {
-  if (j !== v.alvo) return false;
-  return v.modo === "inserir" ? nivel >= v.ligados : nivel < v.desligados;
+function isHidden(j: number, level: number, v: Vis): boolean {
+  if (j !== v.target) return false;
+  return v.mode === "inserir" ? level >= v.linked : level < v.unlinked;
 }
 
-// O próximo nó de `i` no nível `nivel`, respeitando o que já está ligado.
-function proximo(itens: Item[], i: number, nivel: number, v: Vis): number | null {
-  for (let j = i + 1; j < itens.length; j++) {
-    if (escondido(j, nivel, v)) continue;
-    if (itens[j].altura > nivel) return j;
+// O próximo nó de `i` no nível `level`, respeitando o que já está ligado.
+function nextFrom(items: Item[], i: number, level: number, v: Vis): number | null {
+  for (let j = i + 1; j < items.length; j++) {
+    if (isHidden(j, level, v)) continue;
+    if (items[j].height > level) return j;
   }
   return null;
 }
 
-type Saida = { itens: Item[]; idxAlvo: number; alturaAlvo: number; passos: Passo[] };
+type Result = { items: Item[]; targetIdx: number; targetHeight: number; steps: Step[] };
 
-function gerarPassos(modo: Modo, valor: number, altura: number): Saida {
-  const jaExiste = BASE.some((b) => b.valor === valor);
-  const inserindo = modo === "inserir";
+function generateSteps(mode: Mode, value: number, height: number): Result {
+  const exists = BASE.some((b) => b.value === value);
+  const inserting = mode === "inserir";
 
   // Na inserção o nó entra na lista; na remoção ele já estava lá.
-  const idxAlvo = inserindo
-    ? jaExiste
+  const targetIdx = inserting
+    ? exists
       ? -1
-      : BASE.filter((b) => b.valor < valor).length
-    : BASE.findIndex((b) => b.valor === valor);
+      : BASE.filter((b) => b.value < value).length
+    : BASE.findIndex((b) => b.value === value);
 
-  const itens: Item[] =
-    inserindo && !jaExiste
+  const items: Item[] =
+    inserting && !exists
       ? [
-          ...BASE.slice(0, idxAlvo).map((b) => ({ ...b })),
-          { valor, altura, novo: true },
-          ...BASE.slice(idxAlvo).map((b) => ({ ...b })),
+          ...BASE.slice(0, targetIdx).map((b) => ({ ...b })),
+          { value, height, isNew: true },
+          ...BASE.slice(targetIdx).map((b) => ({ ...b })),
         ]
       : BASE.map((b) => ({ ...b }));
 
-  const alturaAlvo = inserindo ? altura : idxAlvo >= 0 ? BASE[idxAlvo].altura : 0;
+  const targetHeight = inserting ? height : targetIdx >= 0 ? BASE[targetIdx].height : 0;
 
   // Nasce todo apontando para o head, igual ao `[self.head] * MAX_NIVEL` do código.
-  const update: number[] = Array.from({ length: MAX_NIVEL }, () => -1);
-  const escrito: boolean[] = Array.from({ length: MAX_NIVEL }, () => false);
-  const moedas: Face[] = [];
-  let nivel = NIVEL_MAX_BASE;
-  let atual = -1;
-  let ligados = 0;
-  let desligados = 0;
-  let emCena = false;
-  let nivelMax = NIVEL_MAX_BASE;
+  const update: number[] = Array.from({ length: MAX_LEVEL }, () => -1);
+  const written: boolean[] = Array.from({ length: MAX_LEVEL }, () => false);
+  const coins: Face[] = [];
+  let level = BASE_MAX_LEVEL;
+  let current = -1;
+  let linked = 0;
+  let unlinked = 0;
+  let onStage = false;
+  let maxLevel = BASE_MAX_LEVEL;
 
-  const vis = (): Vis => ({ alvo: idxAlvo, modo, ligados, desligados });
+  const vis = (): Vis => ({ target: targetIdx, mode, linked, unlinked });
   const base = () => ({
-    nivel,
-    atual,
+    level,
+    current,
     update: [...update],
-    escrito: [...escrito],
-    ligados,
-    desligados,
-    moedas: [...moedas],
-    emCena,
-    nivelMax,
+    written: [...written],
+    linked,
+    unlinked,
+    coins: [...coins],
+    onStage,
+    maxLevel,
   });
 
-  if (inserindo && jaExiste) {
+  if (inserting && exists) {
     return {
-      itens,
-      idxAlvo,
-      alturaAlvo,
-      passos: [
+      items,
+      targetIdx,
+      targetHeight,
+      steps: [
         {
           ...base(),
-          olhando: null,
-          linha: 0,
-          fim: true,
-          erro: true,
-          nota: `O ${valor} já está nesta lista, e esta implementação didática não aceita repetidos. Troque o valor: o 33, o 80 e o 1 são os buracos interessantes.`,
+          looking: null,
+          line: 0,
+          done: true,
+          error: true,
+          note: `O ${value} já está nesta lista, e esta implementação didática não aceita repetidos. Troque o valor: o 33, o 80 e o 1 são os buracos interessantes.`,
         },
       ],
     };
   }
 
-  const passos: Passo[] = [];
-  passos.push({
+  const steps: Step[] = [];
+  steps.push({
     ...base(),
-    olhando: null,
-    linha: 2,
-    nota: inserindo
-      ? `Antes de andar, crio o vetor update com ${MAX_NIVEL} posições, todas apontando para o head. Ele vai guardar, nível a nível, quem é o vizinho da esquerda do ${valor}.`
-      : `Remover começa com a mesma busca da inserção, e pelo mesmo motivo: preciso do update, um candidato por nível, para saber quem vai passar a apontar por cima do ${valor} depois que ele sair.`,
+    looking: null,
+    line: 2,
+    note: inserting
+      ? `Antes de andar, crio o vetor update com ${MAX_LEVEL} posições, todas apontando para o head. Ele vai guardar, nível a nível, quem é o vizinho da esquerda do ${value}.`
+      : `Remover começa com a mesma busca da inserção, e pelo mesmo motivo: preciso do update, um candidato por nível, para saber quem vai passar a apontar por cima do ${value} depois que ele sair.`,
   });
 
   // --- a busca, idêntica nas duas operações --------------------------------
-  let guarda = 0;
-  while (nivel >= 0 && guarda++ < 300) {
-    const prox = proximo(itens, atual, nivel, vis());
-    if (prox === null) {
-      passos.push({
+  let guard = 0;
+  while (level >= 0 && guard++ < 300) {
+    const next = nextFrom(items, current, level, vis());
+    if (next === null) {
+      steps.push({
         ...base(),
-        olhando: null,
-        linha: 4,
-        nota: `No nível ${nivel} não há ninguém depois de ${nomeDe(itens, atual)}: o ponteiro é None. Não dá para andar mais aqui.`,
+        looking: null,
+        line: 4,
+        note: `No nível ${level} não há ninguém depois de ${nameOf(items, current)}: o ponteiro é None. Não dá para andar mais aqui.`,
       });
-    } else if (itens[prox].valor < valor) {
-      passos.push({
+    } else if (items[next].value < value) {
+      steps.push({
         ...base(),
-        olhando: prox,
-        linha: 5,
-        nota: `${itens[prox].valor} < ${valor}: ainda dá para avançar no nível ${nivel} sem passar do lugar do ${valor}.`,
+        looking: next,
+        line: 5,
+        note: `${items[next].value} < ${value}: ainda dá para avançar no nível ${level} sem passar do lugar do ${value}.`,
       });
-      atual = prox;
-      passos.push({
+      current = next;
+      steps.push({
         ...base(),
-        olhando: null,
-        linha: 6,
-        nota: `Avancei para ${nomeDe(itens, atual)} no nível ${nivel}.`,
+        looking: null,
+        line: 6,
+        note: `Avancei para ${nameOf(items, current)} no nível ${level}.`,
       });
       continue;
     } else {
-      passos.push({
+      steps.push({
         ...base(),
-        olhando: prox,
-        linha: 5,
-        nota: `${itens[prox].valor} não é menor que ${valor}: se eu avançasse, passaria do ponto. Paro de andar no nível ${nivel}.`,
+        looking: next,
+        line: 5,
+        note: `${items[next].value} não é menor que ${value}: se eu avançasse, passaria do ponto. Paro de andar no nível ${level}.`,
       });
     }
 
-    update[nivel] = atual;
-    escrito[nivel] = true;
-    passos.push({
+    update[level] = current;
+    written[level] = true;
+    steps.push({
       ...base(),
-      olhando: null,
-      linha: 8,
-      nota: inserindo
-        ? `Gravo update[${nivel}] = ${nomeDe(itens, atual)}. Se o ${valor} for promovido até o nível ${nivel}, é ${nomeDe(itens, atual)} que vai apontar para ele.`
-        : `Gravo update[${nivel}] = ${nomeDe(itens, atual)}. Se o ${valor} viver no nível ${nivel}, é ${nomeDe(itens, atual)} que vai ter que costurar por cima dele.`,
+      looking: null,
+      line: 8,
+      note: inserting
+        ? `Gravo update[${level}] = ${nameOf(items, current)}. Se o ${value} for promovido até o nível ${level}, é ${nameOf(items, current)} que vai apontar para ele.`
+        : `Gravo update[${level}] = ${nameOf(items, current)}. Se o ${value} viver no nível ${level}, é ${nameOf(items, current)} que vai ter que costurar por cima dele.`,
     });
 
-    if (nivel === 0) break;
-    nivel--;
-    passos.push({
+    if (level === 0) break;
+    level--;
+    steps.push({
       ...base(),
-      olhando: null,
-      linha: 3,
-      nota: `Desço para o nível ${nivel}, sem sair de ${nomeDe(itens, atual)}. Cada descida deixa um candidato para trás: é esse o rastro que o update guarda.`,
-    });
-  }
-
-  if (MAX_NIVEL > NIVEL_MAX_BASE + 1) {
-    passos.push({
-      ...base(),
-      olhando: null,
-      linha: 2,
-      nota: `A busca parou no nível ${NIVEL_MAX_BASE}, o topo atual. Do ${NIVEL_MAX_BASE + 1} para cima o update nunca foi tocado, e continua valendo o head que estava lá desde o começo. É por isso que o head nasce com ${MAX_NIVEL} ponteiros, e os outros nós não.`,
+      looking: null,
+      line: 3,
+      note: `Desço para o nível ${level}, sem sair de ${nameOf(items, current)}. Cada descida deixa um candidato para trás: é esse o rastro que o update guarda.`,
     });
   }
 
-  const estado: Estado = {
-    set: (l, d, c, nm) => {
-      ligados = l;
-      desligados = d;
-      emCena = c;
-      nivelMax = nm;
+  if (MAX_LEVEL > BASE_MAX_LEVEL + 1) {
+    steps.push({
+      ...base(),
+      looking: null,
+      line: 2,
+      note: `A busca parou no nível ${BASE_MAX_LEVEL}, o topo atual. Do ${BASE_MAX_LEVEL + 1} para cima o update nunca foi tocado, e continua valendo o head que estava lá desde o começo. É por isso que o head nasce com ${MAX_LEVEL} ponteiros, e os outros nós não.`,
+    });
+  }
+
+  const state: State = {
+    set: (l, u, c, ml) => {
+      linked = l;
+      unlinked = u;
+      onStage = c;
+      maxLevel = ml;
     },
-    get: () => ({ ligados, desligados, emCena, nivelMax }),
+    get: () => ({ linked, unlinked, onStage, maxLevel }),
   };
 
-  if (inserindo) {
-    montarInsercao(passos, itens, idxAlvo, valor, altura, moedas, update, base, estado);
+  if (inserting) {
+    buildInsert(steps, items, targetIdx, value, height, coins, update, base, state);
   } else {
-    montarRemocao(passos, itens, idxAlvo, valor, update, base, vis, estado);
+    buildRemove(steps, items, targetIdx, value, update, base, vis, state);
   }
 
-  return { itens, idxAlvo, alturaAlvo, passos };
+  return { items, targetIdx, targetHeight, steps };
 }
 
 // Handles de escrita do estado mutável do gerador. Existem só para as duas
 // montagens abaixo poderem empurrar passos sem duplicar o corpo da busca.
-type Estado = {
-  set: (ligados: number, desligados: number, emCena: boolean, nivelMax: number) => void;
-  get: () => { ligados: number; desligados: number; emCena: boolean; nivelMax: number };
+type State = {
+  set: (linked: number, unlinked: number, onStage: boolean, maxLevel: number) => void;
+  get: () => { linked: number; unlinked: number; onStage: boolean; maxLevel: number };
 };
-type Base = () => Omit<Passo, "olhando" | "linha" | "nota">;
+type BaseStep = () => Omit<Step, "looking" | "line" | "note">;
 
-function montarInsercao(
-  passos: Passo[],
-  itens: Item[],
-  idxNovo: number,
-  valor: number,
-  altura: number,
-  moedas: Face[],
+function buildInsert(
+  steps: Step[],
+  items: Item[],
+  newIdx: number,
+  value: number,
+  height: number,
+  coins: Face[],
   update: number[],
-  base: Base,
-  st: Estado
+  base: BaseStep,
+  st: State
 ) {
   // A moeda: uma face por passo. A altura já veio decidida de fora para o
   // gerador continuar puro, mas a sequência de faces é a que produziria ela.
-  for (const f of moedasDe(altura)) {
-    moedas.push(f);
-    const n = moedas.length;
-    passos.push({
+  for (const f of coinsFor(height)) {
+    coins.push(f);
+    const tossed = coins.length;
+    steps.push({
       ...base(),
-      olhando: null,
-      linha: 9,
-      nota:
+      looking: null,
+      line: 9,
+      note:
         f === "cara"
-          ? `Lanço a moeda: cara. O ${valor} sobe mais um degrau e já vai ocupar o nível ${n}. Jogo de novo.`
+          ? `Lanço a moeda: cara. O ${value} sobe mais um degrau e já vai ocupar o nível ${tossed}. Jogo de novo.`
           : f === "coroa"
-            ? `Lanço a moeda: coroa. Parei de subir. O ${valor} vai ter altura ${altura}, ou seja, ${altura === 1 ? "só o nível 0" : `os níveis 0 a ${altura - 1}`}.`
-            : `Bati no teto de ${MAX_NIVEL} níveis, então nem lanço de novo. O ${valor} fica com altura ${altura}. O teto existe para a altura não fugir para o infinito.`,
+            ? `Lanço a moeda: coroa. Parei de subir. O ${value} vai ter altura ${height}, ou seja, ${height === 1 ? "só o nível 0" : `os níveis 0 a ${height - 1}`}.`
+            : `Bati no teto de ${MAX_LEVEL} níveis, então nem lanço de novo. O ${value} fica com altura ${height}. O teto existe para a altura não fugir para o infinito.`,
     });
   }
 
-  const antes = st.get();
-  const novoTopo = Math.max(antes.nivelMax, altura - 1);
-  const subiu = novoTopo > antes.nivelMax;
-  st.set(antes.ligados, antes.desligados, antes.emCena, novoTopo);
-  passos.push({
+  const before = st.get();
+  const newTop = Math.max(before.maxLevel, height - 1);
+  const grew = newTop > before.maxLevel;
+  st.set(before.linked, before.unlinked, before.onStage, newTop);
+  steps.push({
     ...base(),
-    olhando: null,
-    linha: 10,
-    nota: subiu
-      ? `A altura ${altura} passou do topo que a lista tinha: nivel_max sobe de ${antes.nivelMax} para ${novoTopo}. Os níveis novos nascem com o head apontando direto para o ${valor}, porque não existe mais ninguém lá em cima.`
-      : `A altura ${altura} cabe nos níveis que já existiam, então nivel_max continua ${novoTopo}. Nada mais muda na estrutura.`,
+    looking: null,
+    line: 10,
+    note: grew
+      ? `A altura ${height} passou do topo que a lista tinha: nivel_max sobe de ${before.maxLevel} para ${newTop}. Os níveis novos nascem com o head apontando direto para o ${value}, porque não existe mais ninguém lá em cima.`
+      : `A altura ${height} cabe nos níveis que já existiam, então nivel_max continua ${newTop}. Nada mais muda na estrutura.`,
   });
 
-  st.set(0, 0, true, novoTopo);
-  passos.push({
+  st.set(0, 0, true, newTop);
+  steps.push({
     ...base(),
-    olhando: idxNovo,
-    linha: 11,
-    nota: `Crio o nó do ${valor} com ${altura} ${altura === 1 ? "ponteiro" : "ponteiros"} forward, um por nível em que ele vai participar. Essa altura nunca mais muda: é sorteada uma vez, na inserção, e pronto.`,
+    looking: newIdx,
+    line: 11,
+    note: `Crio o nó do ${value} com ${height} ${height === 1 ? "ponteiro" : "ponteiros"} forward, um por nível em que ele vai participar. Essa altura nunca mais muda: é sorteada uma vez, na inserção, e pronto.`,
   });
 
-  for (let nv = 0; nv < altura; nv++) {
-    const cand = update[nv];
-    const depois = proximo(itens, cand, nv, { alvo: idxNovo, modo: "inserir", ligados: nv, desligados: 0 });
-    passos.push({
+  for (let lv = 0; lv < height; lv++) {
+    const cand = update[lv];
+    const after = nextFrom(items, cand, lv, { target: newIdx, mode: "inserir", linked: lv, unlinked: 0 });
+    steps.push({
       ...base(),
-      olhando: cand < 0 ? null : cand,
-      linha: 13,
-      nota: `Nível ${nv}, ponteiro 1 de 2: o ${valor} passa a apontar para ${depois === null ? "None" : `o ${itens[depois].valor}`}, que era o próximo de ${nomeDe(itens, cand)} neste nível.`,
+      looking: cand < 0 ? null : cand,
+      line: 13,
+      note: `Nível ${lv}, ponteiro 1 de 2: o ${value} passa a apontar para ${after === null ? "None" : `o ${items[after].value}`}, que era o próximo de ${nameOf(items, cand)} neste nível.`,
     });
-    st.set(nv + 1, 0, true, novoTopo);
-    passos.push({
+    st.set(lv + 1, 0, true, newTop);
+    steps.push({
       ...base(),
-      olhando: idxNovo,
-      linha: 14,
-      nota: `Nível ${nv}, ponteiro 2 de 2: agora ${nomeDe(itens, cand)} aponta para o ${valor}. Religado. Repare que só dois ponteiros mudaram, e nada mais na lista precisou se mexer.`,
+      looking: newIdx,
+      line: 14,
+      note: `Nível ${lv}, ponteiro 2 de 2: agora ${nameOf(items, cand)} aponta para o ${value}. Religado. Repare que só dois ponteiros mudaram, e nada mais na lista precisou se mexer.`,
     });
   }
 
-  const ponteiros = BASE.reduce((s, b) => s + b.altura, 0) + altura;
-  passos.push({
+  const pointers = BASE.reduce((s, b) => s + b.height, 0) + height;
+  steps.push({
     ...base(),
-    olhando: idxNovo,
-    linha: 14,
-    fim: true,
+    looking: newIdx,
+    line: 14,
+    done: true,
     ok: true,
-    nota: `Pronto: ${valor} inserido com altura ${altura}, mexendo em ${altura * 2} ${altura * 2 === 1 ? "ponteiro" : "ponteiros"}, dois por nível. Nenhuma rotação, nenhum rebalanceamento, e a lista continua ordenada com ${BASE.length + 1} elementos e ${ponteiros} ponteiros no total.`,
+    note: `Pronto: ${value} inserido com altura ${height}, mexendo em ${height * 2} ${height * 2 === 1 ? "ponteiro" : "ponteiros"}, dois por nível. Nenhuma rotação, nenhum rebalanceamento, e a lista continua ordenada com ${BASE.length + 1} elementos e ${pointers} ponteiros no total.`,
   });
 }
 
-function montarRemocao(
-  passos: Passo[],
-  itens: Item[],
-  idxAlvo: number,
-  valor: number,
+function buildRemove(
+  steps: Step[],
+  items: Item[],
+  targetIdx: number,
+  value: number,
   update: number[],
-  base: Base,
+  base: BaseStep,
   vis: () => Vis,
-  st: Estado
+  st: State
 ) {
-  const antes = st.get();
-  const candidato = proximo(itens, update[0], 0, vis());
-  const achou = candidato !== null && candidato === idxAlvo;
+  const before = st.get();
+  const candidate = nextFrom(items, update[0], 0, vis());
+  const found = candidate !== null && candidate === targetIdx;
 
-  passos.push({
+  steps.push({
     ...base(),
-    olhando: candidato,
-    linha: 9,
-    nota:
-      candidato === null
-        ? `Depois de ${nomeDe(itens, update[0])} não há mais nada no nível 0. O ${valor} não está na lista.`
-        : `Saí do laço em ${nomeDe(itens, update[0])}. O único candidato possível é o vizinho dele no nível 0, o ${itens[candidato].valor}.`,
+    looking: candidate,
+    line: 9,
+    note:
+      candidate === null
+        ? `Depois de ${nameOf(items, update[0])} não há mais nada no nível 0. O ${value} não está na lista.`
+        : `Saí do laço em ${nameOf(items, update[0])}. O único candidato possível é o vizinho dele no nível 0, o ${items[candidate].value}.`,
   });
 
-  if (!achou) {
-    passos.push({
+  if (!found) {
+    steps.push({
       ...base(),
-      olhando: candidato,
-      linha: 11,
-      fim: true,
-      erro: true,
-      nota: `${candidato === null ? "Não há candidato" : `O candidato é o ${itens[candidato].valor}, e não o ${valor}`}: o ${valor} não está na lista, então devolvo False sem tocar em ponteiro nenhum. Remover o que não existe custa a mesma busca e mais nada.`,
+      looking: candidate,
+      line: 11,
+      done: true,
+      error: true,
+      note: `${candidate === null ? "Não há candidato" : `O candidato é o ${items[candidate].value}, e não o ${value}`}: o ${value} não está na lista, então devolvo False sem tocar em ponteiro nenhum. Remover o que não existe custa a mesma busca e mais nada.`,
     });
     return;
   }
 
-  st.set(antes.ligados, 0, true, antes.nivelMax);
-  passos.push({
+  st.set(before.linked, 0, true, before.maxLevel);
+  steps.push({
     ...base(),
-    olhando: idxAlvo,
-    linha: 12,
-    nota: `Achei o ${valor}, que vive nos níveis 0 a ${itens[idxAlvo].altura - 1}. Agora desligo ele de baixo para cima, um nível por vez, usando os candidatos que o update guardou.`,
+    looking: targetIdx,
+    line: 12,
+    note: `Achei o ${value}, que vive nos níveis 0 a ${items[targetIdx].height - 1}. Agora desligo ele de baixo para cima, um nível por vez, usando os candidatos que o update guardou.`,
   });
 
-  let desligados = 0;
-  for (let nv = 0; nv <= antes.nivelMax; nv++) {
-    const cand = update[nv];
-    const v: Vis = { alvo: idxAlvo, modo: "remover", ligados: 0, desligados };
-    if (proximo(itens, cand, nv, v) !== idxAlvo) {
-      const outro = proximo(itens, cand, nv, v);
-      passos.push({
+  let unlinked = 0;
+  for (let lv = 0; lv <= before.maxLevel; lv++) {
+    const cand = update[lv];
+    const v: Vis = { target: targetIdx, mode: "remover", linked: 0, unlinked };
+    if (nextFrom(items, cand, lv, v) !== targetIdx) {
+      const other = nextFrom(items, cand, lv, v);
+      steps.push({
         ...base(),
-        olhando: cand < 0 ? null : cand,
-        linha: 14,
-        nota: `No nível ${nv}, quem vem depois de ${nomeDe(itens, cand)} é ${outro === null ? "None" : `o ${itens[outro].valor}`}, e não o ${valor}. Sinal de que o ${valor} nunca chegou a este andar, e como a altura é contínua de baixo para cima, também não chegou a nenhum acima. break: nada mais a desligar.`,
+        looking: cand < 0 ? null : cand,
+        line: 14,
+        note: `No nível ${lv}, quem vem depois de ${nameOf(items, cand)} é ${other === null ? "None" : `o ${items[other].value}`}, e não o ${value}. Sinal de que o ${value} nunca chegou a este andar, e como a altura é contínua de baixo para cima, também não chegou a nenhum acima. break: nada mais a desligar.`,
       });
       break;
     }
-    const depois = proximo(itens, idxAlvo, nv, v);
-    desligados = nv + 1;
-    st.set(antes.ligados, desligados, true, antes.nivelMax);
-    passos.push({
+    const after = nextFrom(items, targetIdx, lv, v);
+    unlinked = lv + 1;
+    st.set(before.linked, unlinked, true, before.maxLevel);
+    steps.push({
       ...base(),
-      olhando: cand < 0 ? null : cand,
-      linha: 15,
-      nota: `Nível ${nv}: ${nomeDe(itens, cand)} deixa de apontar para o ${valor} e passa a apontar para ${depois === null ? "None" : `o ${itens[depois].valor}`}. Um ponteiro reescrito, e o ${valor} sumiu deste nível.`,
+      looking: cand < 0 ? null : cand,
+      line: 15,
+      note: `Nível ${lv}: ${nameOf(items, cand)} deixa de apontar para o ${value} e passa a apontar para ${after === null ? "None" : `o ${items[after].value}`}. Um ponteiro reescrito, e o ${value} sumiu deste nível.`,
     });
   }
 
   // Encolher o topo: enquanto o nível mais alto ficar sem ninguém, ele some.
-  let nivelMax = antes.nivelMax;
-  const vazio = (nv: number) =>
-    proximo(itens, -1, nv, { alvo: idxAlvo, modo: "remover", ligados: 0, desligados }) === null;
-  const topoAntes = nivelMax;
-  while (nivelMax > 0 && vazio(nivelMax)) nivelMax--;
-  st.set(antes.ligados, desligados, true, nivelMax);
-  passos.push({
+  let maxLevel = before.maxLevel;
+  const isEmpty = (lv: number) =>
+    nextFrom(items, -1, lv, { target: targetIdx, mode: "remover", linked: 0, unlinked }) === null;
+  const topBefore = maxLevel;
+  while (maxLevel > 0 && isEmpty(maxLevel)) maxLevel--;
+  st.set(before.linked, unlinked, true, maxLevel);
+  steps.push({
     ...base(),
-    olhando: idxAlvo,
-    linha: 16,
-    nota:
-      nivelMax < topoAntes
-        ? `O ${valor} era o único morador do nível ${topoAntes}: agora head.forward[${topoAntes}] é None e o andar ficou vazio, então nivel_max cai de ${topoAntes} para ${nivelMax}. A lista encolheu de altura sem nenhum rebalanceamento.`
-        : `O nível ${topoAntes} continua com moradores, então nivel_max fica em ${nivelMax}. Só encolho o topo quando o andar mais alto esvazia.`,
+    looking: targetIdx,
+    line: 16,
+    note:
+      maxLevel < topBefore
+        ? `O ${value} era o único morador do nível ${topBefore}: agora head.forward[${topBefore}] é None e o andar ficou vazio, então nivel_max cai de ${topBefore} para ${maxLevel}. A lista encolheu de altura sem nenhum rebalanceamento.`
+        : `O nível ${topBefore} continua com moradores, então nivel_max fica em ${maxLevel}. Só encolho o topo quando o andar mais alto esvazia.`,
   });
 
-  const ponteiros = BASE.reduce((s, b) => s + b.altura, 0) - itens[idxAlvo].altura;
-  passos.push({
+  const pointers = BASE.reduce((s, b) => s + b.height, 0) - items[targetIdx].height;
+  steps.push({
     ...base(),
-    olhando: idxAlvo,
-    linha: 18,
-    fim: true,
+    looking: targetIdx,
+    line: 18,
+    done: true,
     ok: true,
-    nota: `Pronto: ${valor} removido reescrevendo ${desligados} ${desligados === 1 ? "ponteiro" : "ponteiros"}, um por nível em que ele vivia. Repare na assimetria: inserir custa dois ponteiros por nível, remover custa um, porque o nó que sai não precisa ser religado a nada. Sobraram ${BASE.length - 1} elementos e ${ponteiros} ponteiros.`,
+    note: `Pronto: ${value} removido reescrevendo ${unlinked} ${unlinked === 1 ? "ponteiro" : "ponteiros"}, um por nível em que ele vivia. Repare na assimetria: inserir custa dois ponteiros por nível, remover custa um, porque o nó que sai não precisa ser religado a nada. Sobraram ${BASE.length - 1} elementos e ${pointers} ponteiros.`,
   });
 }
 
-type Preset = { key: string; rotulo: string; valor: number; altura: number };
-const PRESETS: Record<Modo, Preset[]> = {
+type Preset = { key: string; label: string; value: number; height: number };
+const PRESETS: Record<Mode, Preset[]> = {
   inserir: [
-    { key: "meio", rotulo: "Do encontro: inserir o 33 (altura 2)", valor: 33, altura: 2 },
-    { key: "raso", rotulo: "Só no nível 0: inserir o 80 (altura 1)", valor: 80, altura: 1 },
-    { key: "teto", rotulo: "Andar novo: inserir o 33 (altura 5)", valor: 33, altura: 5 },
-    { key: "menor", rotulo: "Menor que todos: inserir o 1 (altura 3)", valor: 1, altura: 3 },
+    { key: "meio", label: "Do encontro: inserir o 33 (altura 2)", value: 33, height: 2 },
+    { key: "raso", label: "Só no nível 0: inserir o 80 (altura 1)", value: 80, height: 1 },
+    { key: "teto", label: "Andar novo: inserir o 33 (altura 5)", value: 33, height: 5 },
+    { key: "menor", label: "Menor que todos: inserir o 1 (altura 3)", value: 1, height: 3 },
   ],
   remover: [
-    { key: "r-meio", rotulo: "Do encontro: remover o 59 (altura 2)", valor: 59, altura: 2 },
-    { key: "r-alto", rotulo: "O mais alto: remover o 42 (altura 4)", valor: 42, altura: 4 },
-    { key: "r-raso", rotulo: "Só no nível 0: remover o 3", valor: 3, altura: 1 },
-    { key: "r-nao", rotulo: "Não existe: remover o 33", valor: 33, altura: 1 },
+    { key: "r-meio", label: "Do encontro: remover o 59 (altura 2)", value: 59, height: 2 },
+    { key: "r-alto", label: "O mais alto: remover o 42 (altura 4)", value: 42, height: 4 },
+    { key: "r-raso", label: "Só no nível 0: remover o 3", value: 3, height: 1 },
+    { key: "r-nao", label: "Não existe: remover o 33", value: 33, height: 1 },
   ],
 };
 
@@ -519,260 +521,212 @@ const RH = 38;
 const TOP = 12;
 
 export function SkipListInsercao() {
-  const [modo, setModo] = useState<Modo>("inserir");
-  const [valor, setValor] = useState(33);
-  const [altura, setAltura] = useState(2);
+  const [mode, setMode] = useState<Mode>("inserir");
+  const [value, setValue] = useState(33);
+  const [height, setHeight] = useState(2);
   const [preset, setPreset] = useState("meio");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
-
-  const { itens, idxAlvo, alturaAlvo, passos } = useMemo(
-    () => gerarPassos(modo, valor, altura),
-    [modo, valor, altura]
+  const { items, targetIdx, targetHeight, steps } = useMemo(
+    () => generateSteps(mode, value, height),
+    [mode, value, height]
   );
-  const CODIGO = modo === "inserir" ? CODIGO_INSERIR : CODIGO_REMOVER;
-  const total = Math.max(1, passos.length);
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const CODE = mode === "inserir" ? CODE_INSERT : CODE_REMOVE;
+  const total = Math.max(1, steps.length);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  // --- desenho -------------------------------------------------------------
+  const inserting = mode === "inserir";
+  const top = inserting ? Math.max(BASE_MAX_LEVEL, height - 1) : BASE_MAX_LEVEL;
+  const levels = top + 1;
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+  const viz = useVisualizer({
+    title: `Visualizador · ${inserting ? "inserção: o rastro de candidatos e a moeda" : "remoção: o rastro, o break e o topo que encolhe"}`,
+    total,
+    // O que MAIS muda a altura da peça: o modo (troca o bloco da moeda pelo
+    // texto da remoção e o código de 15 para 19 linhas), o número de níveis
+    // desenhados, e o tamanho da linha do tempo, que liga e desliga o rodapé.
+    measureOn: [mode, levels, total],
+  });
 
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const aoMudarValor = (v: string) => {
-    reiniciar();
+  const onValueChange = (v: string) => {
+    viz.reset();
     setPreset("");
-    setValor(parseInt(v, 10) || 0);
+    setValue(parseInt(v, 10) || 0);
   };
-  const aoMudarAltura = (v: number) => {
-    reiniciar();
+  const onHeightChange = (v: number) => {
+    viz.reset();
     setPreset("");
-    setAltura(Math.min(MAX_NIVEL, Math.max(1, v)));
+    setHeight(Math.min(MAX_LEVEL, Math.max(1, v)));
   };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
-    setValor(pr.valor);
-    setAltura(pr.altura);
+    setValue(pr.value);
+    setHeight(pr.height);
   };
-  const trocarModo = (m: Modo) => {
-    if (m === modo) return;
-    reiniciar();
-    setModo(m);
-    aplicarPreset(PRESETS[m][0]);
+  const switchMode = (m: Mode) => {
+    if (m === mode) return;
+    setMode(m);
+    applyPreset(PRESETS[m][0]);
   };
   // Math.random só aqui, num handler de clique. No render ele quebraria a
   // hidratação (o HTML do build sairia diferente do HTML do cliente).
-  const sortearAltura = () => {
+  const rollHeight = () => {
     let h = 1;
-    while (Math.random() < 0.5 && h < MAX_NIVEL) h++;
-    reiniciar();
+    while (Math.random() < 0.5 && h < MAX_LEVEL) h++;
+    viz.reset();
     setPreset("");
-    setAltura(h);
+    setHeight(h);
   };
 
-  // --- desenho -------------------------------------------------------------
-  const inserindo = modo === "inserir";
-  const topo = inserindo ? Math.max(NIVEL_MAX_BASE, altura - 1) : NIVEL_MAX_BASE;
-  const niveis = topo + 1;
-  const larguraSvg = X0 + itens.length * COL + 44;
-  const alturaSvg = TOP + topo * RH + H + 14;
+  const svgWidth = X0 + items.length * COL + 44;
+  const svgHeight = TOP + top * RH + H + 14;
 
-  const yDe = (nivel: number) => TOP + (topo - nivel) * RH;
-  const cyDe = (nivel: number) => yDe(nivel) + H / 2;
-  const xDe = (i: number) => (i < 0 ? GUT : X0 + i * COL);
-  const larDe = (i: number) => (i < 0 ? HEAD_W : W);
-  const cxDe = (i: number) => xDe(i) + larDe(i) / 2;
+  const yOf = (level: number) => TOP + (top - level) * RH;
+  const cyOf = (level: number) => yOf(level) + H / 2;
+  const xOf = (i: number) => (i < 0 ? GUT : X0 + i * COL);
+  const widthOf = (i: number) => (i < 0 ? HEAD_W : W);
+  const cxOf = (i: number) => xOf(i) + widthOf(i) / 2;
 
-  const visAtual: Vis = { alvo: idxAlvo, modo, ligados: p.ligados, desligados: p.desligados };
+  const vis: Vis = { target: targetIdx, mode, linked: p.linked, unlinked: p.unlinked };
 
-  type Seta = { k: string; x1: number; x2: number; y: number; novo: boolean };
-  const setas: Seta[] = [];
+  type Arrow = { k: string; x1: number; x2: number; y: number; isNew: boolean };
+  const arrows: Arrow[] = [];
   const nones: { k: string; x: number; y: number }[] = [];
-  for (let nv = 0; nv <= topo; nv++) {
-    const y = cyDe(nv);
-    let anterior = -1;
-    let seguinte = proximo(itens, -1, nv, visAtual);
-    let volta = 0;
-    while (seguinte !== null && volta++ < 40) {
-      const tocaAlvo = inserindo && (seguinte === idxAlvo || anterior === idxAlvo);
-      setas.push({
-        k: `s${nv}-${seguinte}`,
-        x1: xDe(anterior) + larDe(anterior),
-        x2: xDe(seguinte) - 5,
+  for (let lv = 0; lv <= top; lv++) {
+    const y = cyOf(lv);
+    let previous = -1;
+    let next = nextFrom(items, -1, lv, vis);
+    let turns = 0;
+    while (next !== null && turns++ < 40) {
+      const touchesTarget = inserting && (next === targetIdx || previous === targetIdx);
+      arrows.push({
+        k: `s${lv}-${next}`,
+        x1: xOf(previous) + widthOf(previous),
+        x2: xOf(next) - 5,
         y,
-        novo: tocaAlvo,
+        isNew: touchesTarget,
       });
-      anterior = seguinte;
-      seguinte = proximo(itens, anterior, nv, visAtual);
+      previous = next;
+      next = nextFrom(items, previous, lv, vis);
     }
-    const fim = xDe(anterior) + larDe(anterior);
-    setas.push({ k: `n${nv}`, x1: fim, x2: fim + 14, y, novo: inserindo && anterior === idxAlvo });
-    nones.push({ k: `none${nv}`, x: fim + 18, y });
+    const end = xOf(previous) + widthOf(previous);
+    arrows.push({ k: `n${lv}`, x1: end, x2: end + 14, y, isNew: inserting && previous === targetIdx });
+    nones.push({ k: `none${lv}`, x: end + 18, y });
   }
 
-  const corDoNo = (i: number, nv: number) => {
-    const neutro = { fill: "#0f1826", stroke: "rgba(255,255,255,0.13)", txt: "#8ba0bb", tracejado: false };
-    if (i === idxAlvo) {
-      if (inserindo) {
-        return nv >= p.ligados
-          ? { fill: "rgba(124,58,237,0.12)", stroke: "#7c3aed", txt: "#c4b5fd", tracejado: true }
-          : { fill: "rgba(52,211,153,0.24)", stroke: "#34d399", txt: "#eafff5", tracejado: false };
+  const nodeColor = (i: number, lv: number) => {
+    const neutral = { fill: "#0f1826", stroke: "rgba(255,255,255,0.13)", txt: "#8ba0bb", dashed: false };
+    if (i === targetIdx) {
+      if (inserting) {
+        return lv >= p.linked
+          ? { fill: "rgba(124,58,237,0.12)", stroke: "#7c3aed", txt: "#c4b5fd", dashed: true }
+          : { fill: "rgba(52,211,153,0.24)", stroke: "#34d399", txt: "#eafff5", dashed: false };
       }
-      if (nv < p.desligados) return { fill: "transparent", stroke: "rgba(248,113,113,0.35)", txt: "#5b6b82", tracejado: true };
-      if (p.emCena) return { fill: "rgba(248,113,113,0.2)", stroke: "#f87171", txt: "#fecaca", tracejado: false };
+      if (lv < p.unlinked) return { fill: "transparent", stroke: "rgba(248,113,113,0.35)", txt: "#5b6b82", dashed: true };
+      if (p.onStage) return { fill: "rgba(248,113,113,0.2)", stroke: "#f87171", txt: "#fecaca", dashed: false };
     }
-    if (p.olhando === i && p.atual !== i)
-      return { fill: "rgba(245,158,11,0.22)", stroke: "#f59e0b", txt: "#fff", tracejado: false };
-    if (p.atual === i && p.nivel === nv)
-      return { fill: "rgba(59,130,246,0.3)", stroke: "#3b82f6", txt: "#fff", tracejado: false };
-    if (p.update[nv] === i)
-      return { fill: "rgba(59,130,246,0.12)", stroke: "rgba(59,130,246,0.6)", txt: "#cbd9ea", tracejado: false };
-    return neutro;
+    if (p.looking === i && p.current !== i)
+      return { fill: "rgba(245,158,11,0.22)", stroke: "#f59e0b", txt: "#fff", dashed: false };
+    if (p.current === i && p.level === lv)
+      return { fill: "rgba(59,130,246,0.3)", stroke: "#3b82f6", txt: "#fff", dashed: false };
+    if (p.update[lv] === i)
+      return { fill: "rgba(59,130,246,0.12)", stroke: "rgba(59,130,246,0.6)", txt: "#cbd9ea", dashed: false };
+    return neutral;
   };
 
-  const headMarcado =
-    p.atual < 0 || (inserindo && p.emCena && p.update.some((u, nv) => u === -1 && nv < altura));
+  const headMarked =
+    p.current < 0 || (inserting && p.onStage && p.update.some((u, lv) => u === -1 && lv < height));
 
-  const variaveis = inserindo
+  const variables = inserting
     ? [
-        { nome: "nivel", valor: `${p.nivel}` },
-        { nome: "atual", valor: p.atual < 0 ? "head" : `${itens[p.atual].valor}` },
-        { nome: "altura", valor: p.emCena || p.moedas.length ? `${altura}` : "?" },
-        { nome: "nivel_max", valor: `${p.nivelMax}`, best: true },
+        { name: "nivel", value: `${p.level}` },
+        { name: "atual", value: p.current < 0 ? "head" : `${items[p.current].value}` },
+        { name: "altura", value: p.onStage || p.coins.length ? `${height}` : "?" },
+        { name: "nivel_max", value: `${p.maxLevel}`, best: true },
       ]
     : [
-        { nome: "nivel", valor: `${p.nivel}` },
-        { nome: "atual", valor: p.atual < 0 ? "head" : `${itens[p.atual].valor}` },
-        { nome: "alvo", valor: p.emCena ? `${valor}` : "?" },
-        { nome: "nivel_max", valor: `${p.nivelMax}`, best: true },
+        { name: "nivel", value: `${p.level}` },
+        { name: "atual", value: p.current < 0 ? "head" : `${items[p.current].value}` },
+        { name: "alvo", value: p.onStage ? `${value}` : "?" },
+        { name: "nivel_max", value: `${p.maxLevel}`, best: true },
       ];
 
-  const estatisticas = inserindo
+  const stats = inserting
     ? [
-        { k: "n", rot: "elementos depois", val: `${BASE.length + (idxAlvo >= 0 ? 1 : 0)}` },
-        { k: "alt", rot: "altura sorteada", val: p.moedas.length ? `${altura}` : "?" },
-        { k: "pt", rot: "ponteiros reescritos", val: `${p.ligados * 2}` },
-        { k: "niv", rot: "níveis da lista", val: `${p.nivelMax + 1}` },
+        { k: "n", label: "elementos depois", value: `${BASE.length + (targetIdx >= 0 ? 1 : 0)}` },
+        { k: "alt", label: "altura sorteada", value: p.coins.length ? `${height}` : "?" },
+        { k: "pt", label: "ponteiros reescritos", value: `${p.linked * 2}` },
+        { k: "niv", label: "níveis da lista", value: `${p.maxLevel + 1}` },
       ]
     : [
-        { k: "n", rot: "elementos depois", val: `${BASE.length - (idxAlvo >= 0 ? 1 : 0)}` },
-        { k: "alt", rot: "altura do nó removido", val: idxAlvo >= 0 ? `${alturaAlvo}` : "não existe" },
-        { k: "pt", rot: "ponteiros reescritos", val: `${p.desligados}` },
-        { k: "niv", rot: "níveis da lista", val: `${p.nivelMax + 1}` },
+        { k: "n", label: "elementos depois", value: `${BASE.length - (targetIdx >= 0 ? 1 : 0)}` },
+        { k: "alt", label: "altura do nó removido", value: targetIdx >= 0 ? `${targetHeight}` : "não existe" },
+        { k: "pt", label: "ponteiros reescritos", value: `${p.unlinked}` },
+        { k: "niv", label: "níveis da lista", value: `${p.maxLevel + 1}` },
       ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.erro ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const descricao = inserindo
-    ? `Skip list com ${BASE.length} elementos, inserindo o ${valor} com altura ${altura}. A operação está no nível ${p.nivel}, em ${p.atual < 0 ? "head" : itens[p.atual].valor}, com ${p.ligados} de ${altura} níveis religados.`
-    : `Skip list com ${BASE.length} elementos, removendo o ${valor}. A operação está no nível ${p.nivel}, em ${p.atual < 0 ? "head" : itens[p.atual].valor}, com ${p.desligados} de ${alturaAlvo} níveis desligados.`;
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.error ? " invalid" : "");
+  const description = inserting
+    ? `Skip list com ${BASE.length} elementos, inserindo o ${value} com altura ${height}. A operação está no nível ${p.level}, em ${p.current < 0 ? "head" : items[p.current].value}, com ${p.linked} de ${height} níveis religados.`
+    : `Skip list com ${BASE.length} elementos, removendo o ${value}. A operação está no nível ${p.level}, em ${p.current < 0 ? "head" : items[p.current].value}, com ${p.unlinked} de ${targetHeight} níveis desligados.`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>
-            Visualizador · {inserindo ? "inserção: o rastro de candidatos e a moeda" : "remoção: o rastro, o break e o topo que encolhe"}
-          </span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="arr-tabs" style={{ marginBottom: 16 }}>
           <button
-            className={`arr-tab${inserindo ? " on" : ""}`}
-            onClick={() => trocarModo("inserir")}
-            aria-pressed={inserindo}
+            className={`arr-tab${inserting ? " on" : ""}`}
+            onClick={() => switchMode("inserir")}
+            aria-pressed={inserting}
           >
             Inserir
           </button>
           <button
-            className={`arr-tab${!inserindo ? " on" : ""}`}
-            onClick={() => trocarModo("remover")}
-            aria-pressed={!inserindo}
+            className={`arr-tab${!inserting ? " on" : ""}`}
+            onClick={() => switchMode("remover")}
+            aria-pressed={!inserting}
           >
             Remover
           </button>
         </div>
 
         <div className="bigo-chips">
-          {PRESETS[modo].map((pr) => (
+          {PRESETS[mode].map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
         <div className="viz-inputs">
           <label className="viz-field">
-            <span>{inserindo ? "inserir" : "remover"}</span>
-            <input className="viz-input k" type="number" value={valor} onChange={(e) => aoMudarValor(e.target.value)} />
+            <span>{inserting ? "inserir" : "remover"}</span>
+            <input className="viz-input k" type="number" value={value} onChange={(e) => onValueChange(e.target.value)} />
           </label>
-          {inserindo ? (
+          {inserting ? (
             <>
               <label className="viz-field">
-                <span>altura sorteada: {altura}</span>
+                <span>altura sorteada: {height}</span>
                 <input
                   type="range"
                   min={1}
-                  max={MAX_NIVEL}
+                  max={MAX_LEVEL}
                   step={1}
-                  value={altura}
-                  onChange={(e) => aoMudarAltura(parseInt(e.target.value, 10))}
+                  value={height}
+                  onChange={(e) => onHeightChange(parseInt(e.target.value, 10))}
                   style={{ accentColor: "var(--ccc-accent)", width: 150 }}
                 />
               </label>
-              <button className="viz-btn" onClick={sortearAltura}>
+              <button className="viz-btn" onClick={rollHeight}>
                 Lançar a moeda
               </button>
             </>
@@ -780,7 +734,7 @@ export function SkipListInsercao() {
             <div className="viz-field">
               <span>altura do nó</span>
               <span className="viz-var-val">
-                {idxAlvo >= 0 ? `${alturaAlvo} (níveis 0 a ${alturaAlvo - 1})` : "o valor não está na lista"}
+                {targetIdx >= 0 ? `${targetHeight} (níveis 0 a ${targetHeight - 1})` : "o valor não está na lista"}
               </span>
             </div>
           )}
@@ -789,11 +743,11 @@ export function SkipListInsercao() {
         <div className="sl-wrap">
           <svg
             className="sl-svg"
-            width={Math.round(larguraSvg)}
-            height={Math.round(alturaSvg)}
-            viewBox={`0 0 ${Math.round(larguraSvg)} ${Math.round(alturaSvg)}`}
+            width={Math.round(svgWidth)}
+            height={Math.round(svgHeight)}
+            viewBox={`0 0 ${Math.round(svgWidth)} ${Math.round(svgHeight)}`}
             role="img"
-            aria-label={descricao}
+            aria-label={description}
           >
             <defs>
               <marker id="sli-seta" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
@@ -804,16 +758,16 @@ export function SkipListInsercao() {
               </marker>
             </defs>
 
-            {setas.map((s) => (
+            {arrows.map((s) => (
               <line
                 key={s.k}
                 x1={s.x1}
                 y1={s.y}
                 x2={s.x2}
                 y2={s.y}
-                stroke={s.novo ? "#34d399" : "#3a4a60"}
-                strokeWidth={s.novo ? 2 : 1.5}
-                markerEnd={s.novo ? "url(#sli-seta-nova)" : "url(#sli-seta)"}
+                stroke={s.isNew ? "#34d399" : "#3a4a60"}
+                strokeWidth={s.isNew ? 2 : 1.5}
+                markerEnd={s.isNew ? "url(#sli-seta-nova)" : "url(#sli-seta)"}
               />
             ))}
 
@@ -831,39 +785,39 @@ export function SkipListInsercao() {
               </text>
             ))}
 
-            {Array.from({ length: niveis }, (_, k) => {
-              const nv = topo - k;
+            {Array.from({ length: levels }, (_, k) => {
+              const lv = top - k;
               return (
                 <text
-                  key={`r${nv}`}
+                  key={`r${lv}`}
                   x={GUT - 9}
-                  y={cyDe(nv)}
-                  fill={nv > p.nivelMax ? "#33455c" : "#61748c"}
+                  y={cyOf(lv)}
+                  fill={lv > p.maxLevel ? "#33455c" : "#61748c"}
                   fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
                   fontSize={10.5}
                   textAnchor="end"
                   dominantBaseline="central"
                 >
-                  nível {nv}
+                  nível {lv}
                 </text>
               );
             })}
 
             {/* head: o sentinela, sempre com MAX_NIVEL ponteiros forward. */}
             <rect
-              x={xDe(-1)}
-              y={yDe(topo)}
+              x={xOf(-1)}
+              y={yOf(top)}
               width={HEAD_W}
-              height={topo * RH + H}
+              height={top * RH + H}
               rx={7}
-              fill={headMarcado ? "rgba(59,130,246,0.22)" : "#111c2b"}
-              stroke={headMarcado ? "#3b82f6" : "rgba(255,255,255,0.16)"}
+              fill={headMarked ? "rgba(59,130,246,0.22)" : "#111c2b"}
+              stroke={headMarked ? "#3b82f6" : "rgba(255,255,255,0.16)"}
               strokeWidth={1.6}
             />
             <text
-              x={cxDe(-1)}
-              y={cyDe(topo) + (topo * RH) / 2}
-              fill={headMarcado ? "#fff" : "#7d8fa8"}
+              x={cxOf(-1)}
+              y={cyOf(top) + (top * RH) / 2}
+              fill={headMarked ? "#fff" : "#7d8fa8"}
               fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
               fontSize={10.5}
               fontWeight={700}
@@ -873,26 +827,26 @@ export function SkipListInsercao() {
               head
             </text>
 
-            {itens.map((no, i) =>
-              Array.from({ length: no.altura }, (_, nv) => {
-                if (inserindo && i === idxAlvo && !p.emCena && nv >= p.ligados) return null;
-                const c = corDoNo(i, nv);
+            {items.map((node, i) =>
+              Array.from({ length: node.height }, (_, lv) => {
+                if (inserting && i === targetIdx && !p.onStage && lv >= p.linked) return null;
+                const c = nodeColor(i, lv);
                 return (
-                  <g key={`${i}-${nv}`}>
+                  <g key={`${i}-${lv}`}>
                     <rect
-                      x={xDe(i)}
-                      y={yDe(nv)}
+                      x={xOf(i)}
+                      y={yOf(lv)}
                       width={W}
                       height={H}
                       rx={6}
                       fill={c.fill}
                       stroke={c.stroke}
                       strokeWidth={1.6}
-                      strokeDasharray={c.tracejado ? "4 3" : undefined}
+                      strokeDasharray={c.dashed ? "4 3" : undefined}
                     />
                     <text
-                      x={cxDe(i)}
-                      y={cyDe(nv)}
+                      x={cxOf(i)}
+                      y={cyOf(lv)}
                       fill={c.txt}
                       fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
                       fontSize={12.5}
@@ -900,7 +854,7 @@ export function SkipListInsercao() {
                       textAnchor="middle"
                       dominantBaseline="central"
                     >
-                      {no.valor}
+                      {node.value}
                     </text>
                   </g>
                 );
@@ -915,32 +869,32 @@ export function SkipListInsercao() {
             <em>o rastro que a busca deixa ao descer</em>
           </div>
           <div className="sl-update">
-            {Array.from({ length: MAX_NIVEL }, (_, k) => {
-              const nv = MAX_NIVEL - 1 - k;
-              const v = p.update[nv];
-              const usado = inserindo ? p.emCena && nv < altura : nv < p.desligados;
-              const pendente = !p.escrito[nv] && nv <= NIVEL_MAX_BASE;
+            {Array.from({ length: MAX_LEVEL }, (_, k) => {
+              const lv = MAX_LEVEL - 1 - k;
+              const v = p.update[lv];
+              const used = inserting ? p.onStage && lv < height : lv < p.unlinked;
+              const pending = !p.written[lv] && lv <= BASE_MAX_LEVEL;
               return (
-                <span key={nv} className={`sl-slot${pendente ? " pendente" : ""}${usado ? " usado" : ""}`}>
-                  <b>update[{nv}]</b>
-                  {rotuloUpdate(itens, v)}
+                <span key={lv} className={`sl-slot${pending ? " pendente" : ""}${used ? " usado" : ""}`}>
+                  <b>update[{lv}]</b>
+                  {updateLabel(items, v)}
                 </span>
               );
             })}
           </div>
         </div>
 
-        {inserindo ? (
+        {inserting ? (
           <div className="sl-painel">
             <div className="sl-painel-tit">
               A moeda · random() &lt; 0.5 sobe um nível
-              <em>p = 0.5, teto de {MAX_NIVEL} níveis</em>
+              <em>p = 0.5, teto de {MAX_LEVEL} níveis</em>
             </div>
             <div className="sl-moedas">
-              {p.moedas.length === 0 ? (
+              {p.coins.length === 0 ? (
                 <span className="sl-moeda vazia">ainda não lancei</span>
               ) : (
-                p.moedas.map((f, i) => (
+                p.coins.map((f, i) => (
                   <span key={i} className={`sl-moeda ${f}`}>
                     {f === "cara" ? "cara · sobe" : f === "coroa" ? "coroa · para" : "teto · para"}
                   </span>
@@ -961,111 +915,46 @@ export function SkipListInsercao() {
           </div>
         )}
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">skip_list.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">skip_list.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {variables.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/SkipListNiveis.tsx
+++ b/content/visualizers/SkipListNiveis.tsx
@@ -1,15 +1,16 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // SkipListNiveis, a aritmética da moeda: de onde sai o log n.
 //
-// A busca e a inserção mostram a estrutura funcionando. Falta a pergunta que o
-// encontro deixou no ar: por que confiar num sorteio? Aqui o aluno mexe em n e
-// em p e vê a pirâmide se formar sozinha (100%, 50%, 25%, 12,5%...), a altura
-// esperada da lista virar log de n e o preço em memória subir junto.
+// A busca e a inserção mostram a estrutura funcionando. Falta a pergunta que
+// fica no ar: por que confiar num sorteio? Aqui o aluno mexe em n e em p e vê a
+// pirâmide se formar sozinha (100%, 50%, 25%, 12,5%...), a altura esperada da
+// lista virar log de n e o preço em memória subir junto.
 //
 // Tudo que aparece é calculado, não estimado:
 //   nós esperados no nível k .... n * p^k
@@ -21,13 +22,18 @@ import { createPortal } from "react-dom";
 // O botão "Sortear n moedas" roda a simulação de verdade e põe o observado ao
 // lado do esperado. Math.random só ali, num handler de clique: no render ele
 // quebraria a hidratação.
+//
+// Da casca vêm as camadas 1 e 2: o painel expandido com o cabeçalho e os
+// controles parados enquanto a pirâmide rola. `collapsible: false` porque não
+// há bloco dispensável — a pirâmide É o conteúdo, e ela é justamente o que
+// cresce (medido: 40 linhas com n = 1.048.576 e p = 0,75).
 // ---------------------------------------------------------------------------
 
-const ENTRADAS = [16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576];
+const INPUTS = [16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576];
 const PS = [
-  { valor: 0.25, rotulo: "p = 0,25", nota: "sobe 1 a cada 4" },
-  { valor: 0.5, rotulo: "p = 0,5", nota: "a moeda, o padrão" },
-  { valor: 0.75, rotulo: "p = 0,75", nota: "sobe 3 a cada 4" },
+  { value: 0.25, label: "p = 0,25", note: "sobe 1 a cada 4" },
+  { value: 0.5, label: "p = 0,5", note: "a moeda, o padrão" },
+  { value: 0.75, label: "p = 0,75", note: "sobe 3 a cada 4" },
 ];
 
 // Formatação determinística: nada de Intl, para o HTML do build bater com o do
@@ -38,12 +44,12 @@ function num(v: number): string {
 
 // Zeros à direita saem fora: "p = 0,5" e "2 ponteiros", nunca "0,50" e "2,00".
 // É o mesmo número que o artigo escreve, e o aluno compara os dois.
-function dec(v: number, casas: number): string {
-  const r = v.toFixed(casas);
+function dec(v: number, places: number): string {
+  const r = v.toFixed(places);
   const [i, f] = r.split(".");
-  const inteiro = i.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+  const whole = i.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
   const frac = (f ?? "").replace(/0+$/, "");
-  return frac ? `${inteiro},${frac}` : inteiro;
+  return frac ? `${whole},${frac}` : whole;
 }
 
 function pct(v: number): string {
@@ -60,121 +66,110 @@ function chance(log10: number): string {
   return `1 em 10^${String(Math.round(-log10))}`;
 }
 
-type Linha = { nivel: number; esperado: number; fracao: number };
+type Row = { level: number; expected: number; fraction: number };
 
 export function SkipListNiveis() {
   const [iN, setIN] = useState(3); // 1.024
   const [p, setP] = useState(0.5);
   const [sim, setSim] = useState<number[] | null>(null);
   const [simN, setSimN] = useState(0);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
 
-  useEffect(() => setMounted(true), []);
+  const n = INPUTS[iN];
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const n = ENTRADAS[iN];
-
-  const linhas = useMemo<Linha[]>(() => {
-    const out: Linha[] = [];
+  const rows = useMemo<Row[]>(() => {
+    const out: Row[] = [];
     let k = 0;
-    let fracao = 1;
-    while (n * fracao >= 1 && k < 40) {
-      out.push({ nivel: k, esperado: n * fracao, fracao });
+    let fraction = 1;
+    while (n * fraction >= 1 && k < 40) {
+      out.push({ level: k, expected: n * fraction, fraction });
       k++;
-      fracao *= p;
+      fraction *= p;
     }
     return out.reverse();
   }, [n, p]);
 
-  const niveis = linhas.length;
-  const topo = niveis - 1;
-  const ponteirosPorNo = 1 / (1 - p);
-  const ponteirosTotais = n * ponteirosPorNo;
+  const levels = rows.length;
+  const top = levels - 1;
+  const pointersPerNode = 1 / (1 - p);
+  const totalPointers = n * pointersPerNode;
   const logBase = Math.log(n) / Math.log(1 / p);
-  const comparacoes = logBase / p + ponteirosPorNo;
-  const log10Azar = n * Math.log10(1 - p);
+  const comparisons = logBase / p + pointersPerNode;
+  const log10BadLuck = n * Math.log10(1 - p);
 
-  const sortear = () => {
-    const contagem = Array.from({ length: 41 }, () => 0);
+  // Sem linha do tempo (`total: 1`) e sem bloco dispensável: a peça ganha o
+  // painel com cabeçalho e controles parados, e nada mais.
+  const viz = useVisualizer({
+    title: "Visualizador · a aritmética da moeda: de onde sai o log n",
+    total: 1,
+    collapsible: false,
+  });
+
+  const rollCoins = () => {
+    const counts = Array.from({ length: 41 }, () => 0);
     for (let i = 0; i < n; i++) {
       let h = 0;
       while (Math.random() < p && h < 39) h++;
-      for (let lv = 0; lv <= h; lv++) contagem[lv]++;
+      for (let lv = 0; lv <= h; lv++) counts[lv]++;
     }
-    setSim(contagem);
+    setSim(counts);
     setSimN(n);
   };
-  const limpar = () => {
+  const clearSim = () => {
     setSim(null);
     setSimN(0);
   };
 
-  const simValida = sim !== null && simN === n;
-  const maiorNivelSorteado = simValida ? sim.reduce((m, q, k) => (q > 0 ? k : m), 0) : 0;
+  const simValid = sim !== null && simN === n;
+  const highestRolledLevel = simValid ? sim.reduce((m, q, k) => (q > 0 ? k : m), 0) : 0;
 
-  const estatisticas = [
-    { k: "niv", rot: "níveis esperados", val: `${niveis}` },
-    { k: "cmp", rot: "comparações na busca", val: `${num(comparacoes)}` },
-    { k: "pt", rot: "ponteiros por nó", val: dec(ponteirosPorNo, 2) },
-    { k: "mem", rot: "ponteiros no total", val: num(ponteirosTotais) },
+  const stats = [
+    { k: "niv", label: "níveis esperados", value: `${levels}` },
+    { k: "cmp", label: "comparações na busca", value: `${num(comparisons)}` },
+    { k: "pt", label: "ponteiros por nó", value: dec(pointersPerNode, 2) },
+    { k: "mem", label: "ponteiros no total", value: num(totalPointers) },
   ];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a aritmética da moeda: de onde sai o log n</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            n = {num(n)} · p = {dec(p, 2)}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo não há "passo N de M", e o lugar dele guarda o
+          número que resume a peça — com o rótulo junto, senão ele perde o
+          contexto que o explicava. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          n = {num(n)} · p = {dec(p, 2)}
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PS.map((op) => (
             <button
-              key={op.valor}
-              className={`bigo-chip${p === op.valor ? " on" : ""}`}
+              key={op.value}
+              className={`bigo-chip${p === op.value ? " on" : ""}`}
               onClick={() => {
-                setP(op.valor);
-                limpar();
+                setP(op.value);
+                clearSim();
               }}
-              aria-pressed={p === op.valor}
+              aria-pressed={p === op.value}
             >
-              {op.rotulo} · {op.nota}
+              {op.label} · {op.note}
             </button>
           ))}
         </div>
 
         <div className="sl-piramide">
-          {linhas.map((l) => {
-            const obs = simValida ? sim[l.nivel] : null;
+          {rows.map((l) => {
+            const obs = simValid ? sim[l.level] : null;
             return (
-              <div className="sl-plinha" key={l.nivel}>
-                <span className="sl-prot">nível {l.nivel}</span>
+              <div className="sl-plinha" key={l.level}>
+                <span className="sl-prot">nível {l.level}</span>
                 <span className="sl-pbarra">
-                  <i style={{ width: `${Math.max(0.35, l.fracao * 100)}%` }} />
+                  <i style={{ width: `${Math.max(0.35, l.fraction * 100)}%` }} />
                   {obs !== null ? <b style={{ width: `${Math.max(0.35, (obs / n) * 100)}%` }} /> : null}
                 </span>
                 <span className="sl-pval">
-                  {num(l.esperado)}
-                  <em>{pct(l.fracao)}</em>
+                  {num(l.expected)}
+                  <em>{pct(l.fraction)}</em>
                   {obs !== null ? <span className="obs">{num(obs)} sorteados</span> : null}
                 </span>
               </div>
@@ -184,27 +179,27 @@ export function SkipListNiveis() {
 
         <p className="viz-note">
           Com <strong>n = {num(n)}</strong> e <strong>p = {dec(p, 2)}</strong>, cada nível guarda{" "}
-          <strong>{pct(p)}</strong> do nível de baixo. A conta para o nível {topo} ainda ter pelo menos 1 nó é{" "}
+          <strong>{pct(p)}</strong> do nível de baixo. A conta para o nível {top} ainda ter pelo menos 1 nó é{" "}
           <strong>
             {num(n)} × {dec(p, 2)}
-            <sup>{topo}</sup> ≥ 1
+            <sup>{top}</sup> ≥ 1
           </strong>
-          , e é daí que sai a altura de <strong>{niveis} níveis</strong>: é o logaritmo de {num(n)} na base{" "}
+          , e é daí que sai a altura de <strong>{levels} níveis</strong>: é o logaritmo de {num(n)} na base{" "}
           {dec(1 / p, 2)}, arredondado para cima.
-          {simValida ? (
+          {simValid ? (
             <>
               {" "}
-              O sorteio de verdade chegou ao nível <strong>{maiorNivelSorteado}</strong>: a barra azul é o esperado, a
+              O sorteio de verdade chegou ao nível <strong>{highestRolledLevel}</strong>: a barra azul é o esperado, a
               verde é o que a moeda entregou.
             </>
           ) : null}
         </p>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
@@ -217,58 +212,48 @@ export function SkipListNiveis() {
           <p className="sl-azar">
             Para a skip list virar uma lista encadeada comum, os {num(n)} nós teriam que tirar coroa de primeira, todos.
             A chance disso é <strong>(1 − {dec(p, 2)})</strong>
-            <sup>{num(n)}</sup> = <strong>{chance(log10Azar)}</strong>. O pior caso é O(n) de verdade, mas ele não é uma
-            entrada ruim que alguém pode escolher: é azar puro, e o tamanho dessa fração é o motivo de dar para confiar
-            no sorteio.
+            <sup>{num(n)}</sup> = <strong>{chance(log10BadLuck)}</strong>. O pior caso é O(n) de verdade, mas ele não é
+            uma entrada ruim que alguém pode escolher: é azar puro, e o tamanho dessa fração é o motivo de dar para
+            confiar no sorteio.
           </p>
         </div>
-
-        <div className="viz-controls">
-          <div className="viz-field grow">
-            <span>Elementos: n = {num(n)}</span>
-            <input
-              type="range"
-              min={0}
-              max={ENTRADAS.length - 1}
-              step={1}
-              value={iN}
-              onChange={(e) => {
-                setIN(parseInt(e.target.value, 10));
-                limpar();
-              }}
-              style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
-            />
-          </div>
-          <button className="viz-btn" onClick={sortear}>
-            Sortear {num(n)} moedas
-          </button>
-          <button
-            className="viz-btn"
-            onClick={() => {
-              setIN(3);
-              setP(0.5);
-              limpar();
-            }}
-          >
-            ↺ Reiniciar
-          </button>
-        </div>
       </div>
+
+      {/* Os controles são deste visualizador, não de reprodução — mas moram no
+          `.viz-foot` do `VizFooter` pelo mesmo motivo de sempre: é o que os
+          deixa parados no pé do painel enquanto a pirâmide rola. */}
+      <VizFooter viz={viz}>
+        <div className="viz-field grow">
+          <span>Elementos: n = {num(n)}</span>
+          <input
+            type="range"
+            min={0}
+            max={INPUTS.length - 1}
+            step={1}
+            value={iN}
+            onChange={(e) => {
+              setIN(parseInt(e.target.value, 10));
+              clearSim();
+            }}
+            style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
+          />
+        </div>
+        <button className="viz-btn" onClick={rollCoins}>
+          Sortear {num(n)} moedas
+        </button>
+        <button
+          className="viz-btn"
+          onClick={() => {
+            setIN(3);
+            setP(0.5);
+            clearSim();
+          }}
+        >
+          ↺ Reiniciar
+        </button>
+      </VizFooter>
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/SkipListVisualizer.tsx
+++ b/content/visualizers/SkipListVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // SkipListVisualizer, a busca descendo em escada pelos níveis.
@@ -18,27 +19,31 @@ import { createPortal } from "react-dom";
 //      mesma busca feita só no nível 0, que é uma lista encadeada comum.
 //
 // As alturas padrão dão a pirâmide de livro (12 / 6 / 3 / 1 nós por nível) e o
-// botão "Sortear alturas" mostra o que o encontro repetiu o tempo todo: a mesma
-// entrada gera estruturas diferentes, mas o resultado da busca não muda.
+// botão "Sortear alturas" mostra que a mesma entrada gera estruturas
+// diferentes, mas o resultado da busca não muda.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type No = { valor: number; altura: number };
+type SkipNode = { value: number; height: number };
 
-type Passo = {
-  nivel: number;
-  atual: number; // índice do nó atual, -1 = head (o sentinela)
-  olhando: number | null; // nó comparado neste passo
-  comparacoes: number;
-  visitados: string[]; // "nivel:indice", na ordem em que a busca passou
-  linha: number;
-  encontrou?: boolean;
-  fim?: boolean;
-  nota: string;
+type Step = {
+  level: number;
+  current: number; // índice do nó atual, -1 = head (o sentinela)
+  looking: number | null; // nó comparado neste passo
+  comparisons: number;
+  visited: string[]; // "nivel:indice", na ordem em que a busca passou
+  line: number;
+  found?: boolean;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO = [
+const CODE = [
   "def buscar(self, alvo):",
   "    atual = self.head",
   "    for nivel in range(self.nivel_max, -1, -1):",
@@ -50,205 +55,202 @@ const CODIGO = [
   "    return atual is not None and atual.valor == alvo",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-const MAX_NIVEIS = 4; // altura máxima de um nó, o `MAX_NIVEL` da implementação
+const MAX_LEVELS = 4; // altura máxima de um nó, o `MAX_NIVEL` da implementação
 
 // Doze elementos com a pirâmide exata da teoria: 12 nós no nível 0, 6 no
-// nível 1, 3 no nível 2 e 1 no nível 3. São os números do desenho do encontro.
-const VALORES_PADRAO = [3, 9, 17, 23, 31, 42, 50, 59, 73, 80, 92, 98];
-const CICLO_PADRAO = [1, 3, 1, 2, 1, 4, 1, 2, 3, 1, 2, 1];
+// nível 1, 3 no nível 2 e 1 no nível 3.
+const DEFAULT_VALUES = [3, 9, 17, 23, 31, 42, 50, 59, 73, 80, 92, 98];
+const DEFAULT_CYCLE = [1, 3, 1, 2, 1, 4, 1, 2, 3, 1, 2, 1];
 
-// Alturas determinísticas: o mesmo padrão do encontro, repetido em ciclo quando
-// o aluno digita um array maior. Nada de Math.random no caminho de render.
-function alturasPadrao(n: number): number[] {
-  return Array.from({ length: n }, (_, i) => CICLO_PADRAO[i % CICLO_PADRAO.length]);
+// Alturas determinísticas: o mesmo padrão, repetido em ciclo quando o aluno
+// digita um array maior. Nada de Math.random no caminho de render.
+function defaultHeights(n: number): number[] {
+  return Array.from({ length: n }, (_, i) => DEFAULT_CYCLE[i % DEFAULT_CYCLE.length]);
 }
 
-function limpar(texto: string): number[] {
-  const vistos = new Set<number>();
-  const saida: number[] = [];
-  for (const bruto of texto.split(",")) {
-    const v = parseInt(bruto.trim(), 10);
-    if (isNaN(v) || vistos.has(v)) continue;
-    vistos.add(v);
-    saida.push(v);
+function parseValues(text: string): number[] {
+  const seen = new Set<number>();
+  const out: number[] = [];
+  for (const raw of text.split(",")) {
+    const v = parseInt(raw.trim(), 10);
+    if (isNaN(v) || seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
   }
-  return saida.sort((a, b) => a - b).slice(0, 14);
+  return out.sort((a, b) => a - b).slice(0, 14);
 }
 
-// O próximo nó de `i` no nível `nivel`: o primeiro à direita que chega lá.
+// O próximo nó de `i` no nível `level`: o primeiro à direita que chega lá.
 // Com i = -1 a busca começa no head, que participa de todos os níveis.
-function forwardDe(nos: No[], i: number, nivel: number): number | null {
-  for (let j = i + 1; j < nos.length; j++) {
-    if (nos[j].altura > nivel) return j;
+function forwardFrom(nodes: SkipNode[], i: number, level: number): number | null {
+  for (let j = i + 1; j < nodes.length; j++) {
+    if (nodes[j].height > level) return j;
   }
   return null;
 }
 
-function nomeDe(nos: No[], i: number): string {
-  return i < 0 ? "o head" : `o ${nos[i].valor}`;
+function nameOf(nodes: SkipNode[], i: number): string {
+  return i < 0 ? "o head" : `o ${nodes[i].value}`;
 }
 
 // A mesma busca, mas andando só pelo nível 0: é exatamente o que uma lista
 // encadeada comum faria. Conta do mesmo jeito (cada `<` avaliado, mais a
 // comparação final de igualdade) para os dois números serem comparáveis.
-function comparacoesLista(nos: No[], alvo: number): number {
+function listComparisons(nodes: SkipNode[], target: number): number {
   let c = 0;
   let i = 0;
-  while (i < nos.length && nos[i].valor < alvo) {
+  while (i < nodes.length && nodes[i].value < target) {
     c++;
     i++;
   }
-  if (i < nos.length) c += 2; // o `<` que deu falso + o `==` do final
+  if (i < nodes.length) c += 2; // o `<` que deu falso + o `==` do final
   return c;
 }
 
-function gerarPassos(nos: No[], alvo: number): Passo[] {
-  const out: Passo[] = [];
-  if (!nos.length) return out;
-  const topo = Math.max(1, ...nos.map((n) => n.altura)) - 1;
-  let nivel = topo;
-  let atual = -1;
-  let comparacoes = 0;
-  const visitados: string[] = [`${topo}:-1`];
-  const base = () => ({ nivel, atual, comparacoes, visitados: [...visitados] });
+function generateSteps(nodes: SkipNode[], target: number): Step[] {
+  const out: Step[] = [];
+  if (!nodes.length) return out;
+  const top = Math.max(1, ...nodes.map((n) => n.height)) - 1;
+  let level = top;
+  let current = -1;
+  let comparisons = 0;
+  const visited: string[] = [`${top}:-1`];
+  const base = () => ({ level, current, comparisons, visited: [...visited] });
 
   out.push({
     ...base(),
-    olhando: null,
-    linha: 1,
-    nota: `Começo no head, no nível ${topo}, o mais alto que esta lista tem. É de lá que saem os maiores saltos, e por isso toda busca começa no topo, à esquerda.`,
+    looking: null,
+    line: 1,
+    note: `Começo no head, no nível ${top}, o mais alto que esta lista tem. É de lá que saem os maiores saltos, e por isso toda busca começa no topo, à esquerda.`,
   });
 
-  let guarda = 0;
-  while (nivel >= 0 && guarda++ < 300) {
-    const prox = forwardDe(nos, atual, nivel);
-    if (prox === null) {
+  let guard = 0;
+  while (level >= 0 && guard++ < 300) {
+    const next = forwardFrom(nodes, current, level);
+    if (next === null) {
       out.push({
         ...base(),
-        olhando: null,
-        linha: 3,
-        nota: `No nível ${nivel} não existe ninguém depois de ${nomeDe(nos, atual)}: o ponteiro aponta para None. Não dá para avançar, então só me resta descer.`,
+        looking: null,
+        line: 3,
+        note: `No nível ${level} não existe ninguém depois de ${nameOf(nodes, current)}: o ponteiro aponta para None. Não dá para avançar, então só me resta descer.`,
       });
     } else {
-      const v = nos[prox].valor;
-      comparacoes++;
-      if (v < alvo) {
-        const pulados = prox - atual - 1;
+      const v = nodes[next].value;
+      comparisons++;
+      if (v < target) {
+        const skipped = next - current - 1;
         out.push({
           ...base(),
-          olhando: prox,
-          linha: 4,
-          nota: `${v} < ${alvo}: o próximo do nível ${nivel} ainda é menor que o alvo, então dá para pular até ele sem risco de passar do ponto.`,
+          looking: next,
+          line: 4,
+          note: `${v} < ${target}: o próximo do nível ${level} ainda é menor que o alvo, então dá para pular até ele sem risco de passar do ponto.`,
         });
-        atual = prox;
-        visitados.push(`${nivel}:${atual}`);
+        current = next;
+        visited.push(`${level}:${current}`);
         out.push({
           ...base(),
-          olhando: null,
-          linha: 5,
-          nota:
-            pulados === 0
-              ? `Avancei para o ${v}. Neste salto não pulei ninguém: no nível ${nivel} ele já era o vizinho imediato.`
-              : `Avancei para o ${v} de uma vez só, sem nem olhar ${pulados === 1 ? "o elemento que ficou" : `os ${pulados} elementos que ficaram`} para trás no nível 0. É isso que o atalho compra.`,
+          looking: null,
+          line: 5,
+          note:
+            skipped === 0
+              ? `Avancei para o ${v}. Neste salto não pulei ninguém: no nível ${level} ele já era o vizinho imediato.`
+              : `Avancei para o ${v} de uma vez só, sem nem olhar ${skipped === 1 ? "o elemento que ficou" : `os ${skipped} elementos que ficaram`} para trás no nível 0. É isso que o atalho compra.`,
         });
         continue;
       }
       out.push({
         ...base(),
-        olhando: prox,
-        linha: 4,
-        nota: `${v} não é menor que ${alvo}: se eu avançasse, passaria do ponto. Paro de andar no nível ${nivel}.`,
+        looking: next,
+        line: 4,
+        note: `${v} não é menor que ${target}: se eu avançasse, passaria do ponto. Paro de andar no nível ${level}.`,
       });
     }
 
-    if (nivel === 0) break;
-    nivel--;
-    visitados.push(`${nivel}:${atual}`);
+    if (level === 0) break;
+    level--;
+    visited.push(`${level}:${current}`);
     out.push({
       ...base(),
-      olhando: null,
-      linha: 2,
-      nota: `Desço um degrau, para o nível ${nivel}, sem sair de ${nomeDe(nos, atual)}. Tudo que ficou à esquerda está descartado de vez: já sei que é menor que ${alvo}.`,
+      looking: null,
+      line: 2,
+      note: `Desço um degrau, para o nível ${level}, sem sair de ${nameOf(nodes, current)}. Tudo que ficou à esquerda está descartado de vez: já sei que é menor que ${target}.`,
     });
   }
 
-  const candidato = forwardDe(nos, atual, 0);
-  if (candidato !== null) visitados.push(`0:${candidato}`);
+  const candidate = forwardFrom(nodes, current, 0);
+  if (candidate !== null) visited.push(`0:${candidate}`);
   out.push({
     ...base(),
-    olhando: candidato,
-    linha: 7,
-    nota:
-      candidato === null
-        ? `Saí do laço em ${nomeDe(nos, atual)}, e depois dele não há mais nada no nível 0. O ${alvo} não está na lista.`
-        : `Saí do laço em ${nomeDe(nos, atual)}. O único candidato possível é o vizinho dele no nível 0, o ${nos[candidato].valor}: se o ${alvo} existisse, estaria exatamente aí.`,
+    looking: candidate,
+    line: 7,
+    note:
+      candidate === null
+        ? `Saí do laço em ${nameOf(nodes, current)}, e depois dele não há mais nada no nível 0. O ${target} não está na lista.`
+        : `Saí do laço em ${nameOf(nodes, current)}. O único candidato possível é o vizinho dele no nível 0, o ${nodes[candidate].value}: se o ${target} existisse, estaria exatamente aí.`,
   });
 
-  if (candidato !== null) comparacoes++;
-  const achou = candidato !== null && nos[candidato].valor === alvo;
-  const naLista = comparacoesLista(nos, alvo);
+  if (candidate !== null) comparisons++;
+  const hit = candidate !== null && nodes[candidate].value === target;
+  const inPlainList = listComparisons(nodes, target);
   out.push({
     ...base(),
-    olhando: candidato,
-    linha: 8,
-    encontrou: achou,
-    fim: true,
-    nota: achou
-      ? `Achei o ${alvo} com ${comparacoes} ${comparacoes === 1 ? "comparação" : "comparações"}. A mesma busca andando só pelo nível 0, que é uma lista encadeada comum, gastaria ${naLista}.`
-      : `O ${alvo} não está na lista, e para saber disso bastaram ${comparacoes} ${comparacoes === 1 ? "comparação" : "comparações"}. Percorrendo só o nível 0 seriam ${naLista}.`,
+    looking: candidate,
+    line: 8,
+    found: hit,
+    done: true,
+    note: hit
+      ? `Achei o ${target} com ${comparisons} ${comparisons === 1 ? "comparação" : "comparações"}. A mesma busca andando só pelo nível 0, que é uma lista encadeada comum, gastaria ${inPlainList}.`
+      : `O ${target} não está na lista, e para saber disso bastaram ${comparisons} ${comparisons === 1 ? "comparação" : "comparações"}. Percorrendo só o nível 0 seriam ${inPlainList}.`,
   });
   return out;
 }
 
-type Preset = { key: string; rotulo: string; alvo: number; valores: number[]; alturas: number[] };
+type Preset = { key: string; label: string; target: number; values: number[]; heights: number[] };
 const PRESETS: Preset[] = [
   {
     key: "encontro",
-    rotulo: "Do encontro: procurar o 73",
-    alvo: 73,
-    valores: VALORES_PADRAO,
-    alturas: alturasPadrao(VALORES_PADRAO.length),
+    label: "Do encontro: procurar o 73",
+    target: 73,
+    values: DEFAULT_VALUES,
+    heights: defaultHeights(DEFAULT_VALUES.length),
   },
   {
     key: "longe",
-    rotulo: "Lá no fim: procurar o 92",
-    alvo: 92,
-    valores: VALORES_PADRAO,
-    alturas: alturasPadrao(VALORES_PADRAO.length),
+    label: "Lá no fim: procurar o 92",
+    target: 92,
+    values: DEFAULT_VALUES,
+    heights: defaultHeights(DEFAULT_VALUES.length),
   },
   {
     key: "ausente",
-    rotulo: "Não existe: procurar o 44",
-    alvo: 44,
-    valores: VALORES_PADRAO,
-    alturas: alturasPadrao(VALORES_PADRAO.length),
+    label: "Não existe: procurar o 44",
+    target: 44,
+    values: DEFAULT_VALUES,
+    heights: defaultHeights(DEFAULT_VALUES.length),
   },
   {
     key: "plano",
-    rotulo: "Azar total: ninguém passou do nível 0",
-    alvo: 92,
-    valores: VALORES_PADRAO,
-    alturas: VALORES_PADRAO.map(() => 1),
+    label: "Azar total: ninguém passou do nível 0",
+    target: 92,
+    values: DEFAULT_VALUES,
+    heights: DEFAULT_VALUES.map(() => 1),
   },
   // Os dois casos de borda que o artigo manda prever antes de rodar. O "antes
   // de todos" é o único em que a skip list perde para a lista comum, e é por
   // isso que ele merece um botão em vez de ficar escondido no texto.
   {
     key: "antes",
-    rotulo: "Antes de todos: procurar o 1",
-    alvo: 1,
-    valores: VALORES_PADRAO,
-    alturas: alturasPadrao(VALORES_PADRAO.length),
+    label: "Antes de todos: procurar o 1",
+    target: 1,
+    values: DEFAULT_VALUES,
+    heights: defaultHeights(DEFAULT_VALUES.length),
   },
   {
     key: "unico",
-    rotulo: "Um elemento só: procurar o 42",
-    alvo: 42,
-    valores: [42],
-    alturas: [1],
+    label: "Um elemento só: procurar o 42",
+    target: 42,
+    values: [42],
+    heights: [1],
   },
 ];
 
@@ -263,196 +265,151 @@ const RH = 38; // distância entre níveis
 const TOP = 12;
 
 export function SkipListVisualizer() {
-  const [valores, setValores] = useState<number[]>(VALORES_PADRAO);
-  const [entrada, setEntrada] = useState(VALORES_PADRAO.join(", "));
-  const [alturas, setAlturas] = useState<number[]>(alturasPadrao(VALORES_PADRAO.length));
-  const [alvo, setAlvo] = useState(73);
+  const [values, setValues] = useState<number[]>(DEFAULT_VALUES);
+  const [input, setInput] = useState(DEFAULT_VALUES.join(", "));
+  const [heights, setHeights] = useState<number[]>(defaultHeights(DEFAULT_VALUES.length));
+  const [target, setTarget] = useState(73);
   const [preset, setPreset] = useState("encontro");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
-
-  const nos = useMemo<No[]>(
-    () => valores.map((valor, i) => ({ valor, altura: Math.min(MAX_NIVEIS, alturas[i] ?? 1) })),
-    [valores, alturas]
+  const nodes = useMemo<SkipNode[]>(
+    () => values.map((value, i) => ({ value, height: Math.min(MAX_LEVELS, heights[i] ?? 1) })),
+    [values, heights]
   );
-  const passos = useMemo(() => gerarPassos(nos, alvo), [nos, alvo]);
-  const total = Math.max(1, passos.length);
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(nodes, target), [nodes, target]);
+  const total = Math.max(1, steps.length);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  // --- desenho -------------------------------------------------------------
+  const top = Math.max(1, ...nodes.map((n) => n.height)) - 1;
+  const levels = top + 1;
+  const n = nodes.length;
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+  const viz = useVisualizer({
+    title: "Visualizador · a busca descendo em escada pelos níveis",
+    total,
+    // O que MAIS muda a altura da peça: o número de níveis (cada um é uma
+    // linha do SVG e uma ficha a mais na linha de ocupação) e o tamanho da
+    // linha do tempo, que liga e desliga o rodapé inteiro.
+    measureOn: [levels, total],
+  });
 
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const aoMudarAlvo = (v: string) => {
-    reiniciar();
+  const onTargetChange = (v: string) => {
+    viz.reset();
     setPreset("");
-    setAlvo(parseInt(v, 10) || 0);
+    setTarget(parseInt(v, 10) || 0);
   };
-  const aoMudarEntrada = (v: string) => {
-    const novos = limpar(v);
-    reiniciar();
+  const onInputChange = (v: string) => {
+    const parsed = parseValues(v);
+    viz.reset();
     setPreset("");
-    setEntrada(v);
-    setValores(novos.length ? novos : [1]);
-    setAlturas(alturasPadrao(Math.max(1, novos.length)));
+    setInput(v);
+    setValues(parsed.length ? parsed : [1]);
+    setHeights(defaultHeights(Math.max(1, parsed.length)));
   };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
-    setValores(pr.valores);
-    setEntrada(pr.valores.join(", "));
-    setAlturas(pr.alturas);
-    setAlvo(pr.alvo);
+    setValues(pr.values);
+    setInput(pr.values.join(", "));
+    setHeights(pr.heights);
+    setTarget(pr.target);
   };
   // Math.random só aqui, num handler de clique: no caminho de render ele faria
   // o HTML do build divergir do cliente e quebrar a hidratação.
-  const sortear = () => {
-    const novas = valores.map(() => {
+  const shuffleHeights = () => {
+    const rolled = values.map(() => {
       let h = 1;
-      while (Math.random() < 0.5 && h < MAX_NIVEIS) h++;
+      while (Math.random() < 0.5 && h < MAX_LEVELS) h++;
       return h;
     });
-    reiniciar();
+    viz.reset();
     setPreset("");
-    setAlturas(novas);
+    setHeights(rolled);
   };
 
-  // --- desenho -------------------------------------------------------------
-  const topo = Math.max(1, ...nos.map((n) => n.altura)) - 1;
-  const niveis = topo + 1;
-  const n = nos.length;
-  const larguraSvg = X0 + n * COL + 44;
-  const alturaSvg = TOP + topo * RH + H + 14;
+  const svgWidth = X0 + n * COL + 44;
+  const svgHeight = TOP + top * RH + H + 14;
 
-  const yDe = (nivel: number) => TOP + (topo - nivel) * RH;
-  const cyDe = (nivel: number) => yDe(nivel) + H / 2;
-  const xDe = (i: number) => (i < 0 ? GUT : X0 + i * COL);
-  const larDe = (i: number) => (i < 0 ? HEAD_W : W);
-  const cxDe = (i: number) => xDe(i) + larDe(i) / 2;
+  const yOf = (level: number) => TOP + (top - level) * RH;
+  const cyOf = (level: number) => yOf(level) + H / 2;
+  const xOf = (i: number) => (i < 0 ? GUT : X0 + i * COL);
+  const widthOf = (i: number) => (i < 0 ? HEAD_W : W);
+  const cxOf = (i: number) => xOf(i) + widthOf(i) / 2;
 
-  const visitadosSet = useMemo(() => new Set(p ? p.visitados : []), [p]);
+  const visitedSet = useMemo(() => new Set(p ? p.visited : []), [p]);
 
   // A escada: uma polilinha ligando, na ordem, cada posição por onde o ponteiro
   // `atual` passou. Trechos horizontais são saltos, trechos verticais são
   // descidas de nível.
-  const escada = (p ? p.visitados : [])
+  const ladder = (p ? p.visited : [])
     .map((k) => {
-      const [nv, ix] = k.split(":").map((s) => parseInt(s, 10));
-      return `${cxDe(ix).toFixed(1)},${cyDe(nv).toFixed(1)}`;
+      const [lv, ix] = k.split(":").map((s) => parseInt(s, 10));
+      return `${cxOf(ix).toFixed(1)},${cyOf(lv).toFixed(1)}`;
     })
     .join(" ");
 
   // Setas de cada nível: head -> nós daquele nível -> None. A última seta de
   // cada linha morre no rótulo None, que é o `forward[nivel] is None` do código.
-  type Seta = { k: string; x1: number; x2: number; y: number };
-  const setas: Seta[] = [];
+  type Arrow = { k: string; x1: number; x2: number; y: number };
+  const arrows: Arrow[] = [];
   const nones: { k: string; x: number; y: number }[] = [];
-  const ocupacao: number[] = [];
-  for (let nv = 0; nv <= topo; nv++) {
-    const participantes = nos.map((no, i) => ({ no, i })).filter((c) => c.no.altura > nv);
-    ocupacao.push(participantes.length);
-    let anterior = -1;
-    const y = cyDe(nv);
-    for (const c of participantes) {
-      setas.push({ k: `s${nv}-${c.i}`, x1: xDe(anterior) + larDe(anterior), x2: xDe(c.i) - 5, y });
-      anterior = c.i;
+  const occupancy: number[] = [];
+  for (let lv = 0; lv <= top; lv++) {
+    const members = nodes.map((node, i) => ({ node, i })).filter((c) => c.node.height > lv);
+    occupancy.push(members.length);
+    let previous = -1;
+    const y = cyOf(lv);
+    for (const c of members) {
+      arrows.push({ k: `s${lv}-${c.i}`, x1: xOf(previous) + widthOf(previous), x2: xOf(c.i) - 5, y });
+      previous = c.i;
     }
-    const fim = xDe(anterior) + larDe(anterior);
-    setas.push({ k: `n${nv}`, x1: fim, x2: fim + 14, y });
-    nones.push({ k: `none${nv}`, x: fim + 18, y });
+    const end = xOf(previous) + widthOf(previous);
+    arrows.push({ k: `n${lv}`, x1: end, x2: end + 14, y });
+    nones.push({ k: `none${lv}`, x: end + 18, y });
   }
 
-  const corDoNo = (i: number, nv: number) => {
+  const nodeColor = (i: number, lv: number) => {
     if (!p) return { fill: "#0f1826", stroke: "rgba(255,255,255,0.13)", txt: "#8ba0bb" };
-    if (p.encontrou && p.olhando === i) return { fill: "rgba(52,211,153,0.26)", stroke: "#34d399", txt: "#eafff5" };
-    if (p.olhando === i && p.atual !== i) return { fill: "rgba(245,158,11,0.22)", stroke: "#f59e0b", txt: "#fff" };
-    if (p.atual === i && p.nivel === nv) return { fill: "rgba(59,130,246,0.3)", stroke: "#3b82f6", txt: "#fff" };
-    if (visitadosSet.has(`${nv}:${i}`)) return { fill: "rgba(59,130,246,0.12)", stroke: "rgba(59,130,246,0.55)", txt: "#cbd9ea" };
+    if (p.found && p.looking === i) return { fill: "rgba(52,211,153,0.26)", stroke: "#34d399", txt: "#eafff5" };
+    if (p.looking === i && p.current !== i) return { fill: "rgba(245,158,11,0.22)", stroke: "#f59e0b", txt: "#fff" };
+    if (p.current === i && p.level === lv) return { fill: "rgba(59,130,246,0.3)", stroke: "#3b82f6", txt: "#fff" };
+    if (visitedSet.has(`${lv}:${i}`)) return { fill: "rgba(59,130,246,0.12)", stroke: "rgba(59,130,246,0.55)", txt: "#cbd9ea" };
     return { fill: "#0f1826", stroke: "rgba(255,255,255,0.13)", txt: "#8ba0bb" };
   };
 
-  const variaveis = [
-    { nome: "nivel", valor: p ? `${p.nivel}` : "-" },
-    { nome: "atual", valor: !p || p.atual < 0 ? "head" : `${nos[p.atual].valor}` },
-    { nome: "prox", valor: !p || p.olhando === null ? "None" : `${nos[p.olhando].valor}` },
-    { nome: "alvo", valor: `${alvo}`, best: true },
+  const variables = [
+    { name: "nivel", value: p ? `${p.level}` : "-" },
+    { name: "atual", value: !p || p.current < 0 ? "head" : `${nodes[p.current].value}` },
+    { name: "prox", value: !p || p.looking === null ? "None" : `${nodes[p.looking].value}` },
+    { name: "alvo", value: `${target}`, best: true },
   ];
 
-  const naLista = comparacoesLista(nos, alvo);
-  const estatisticas = [
-    { k: "n", rot: "elementos (n)", val: `${n}` },
-    { k: "niv", rot: "níveis", val: `${niveis}` },
-    { k: "cmp", rot: "comparações na skip list", val: p ? `${p.comparacoes}` : "0" },
-    { k: "lst", rot: "comparações numa lista comum", val: `${naLista}` },
+  const inPlainList = listComparisons(nodes, target);
+  const stats = [
+    { k: "n", label: "elementos (n)", value: `${n}` },
+    { k: "niv", label: "níveis", value: `${levels}` },
+    { k: "cmp", label: "comparações na skip list", value: p ? `${p.comparisons}` : "0" },
+    { k: "lst", label: "comparações numa lista comum", value: `${inPlainList}` },
   ];
 
-  const notaCls = "viz-note" + (p && p.encontrou ? " ok" : p && p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const descricao = `Skip list com ${n} elementos e ${niveis} ${niveis === 1 ? "nível" : "níveis"}, procurando o ${alvo}. A busca está no nível ${p ? p.nivel : 0}, em ${!p || p.atual < 0 ? "head" : nos[p.atual].valor}, com ${p ? p.comparacoes : 0} comparações feitas.`;
+  const noteClass = "viz-note" + (p && p.found ? " ok" : p && p.done ? " invalid" : "");
+  const description = `Skip list com ${n} elementos e ${levels} ${levels === 1 ? "nível" : "níveis"}, procurando o ${target}. A busca está no nível ${p ? p.level : 0}, em ${!p || p.current < 0 ? "head" : nodes[p.current].value}, com ${p ? p.comparisons : 0} comparações feitas.`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a busca descendo em escada pelos níveis</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -460,13 +417,13 @@ export function SkipListVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Lista (ordenada sozinha, sem repetidos)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>procurar</span>
-            <input className="viz-input k" type="number" value={alvo} onChange={(e) => aoMudarAlvo(e.target.value)} />
+            <input className="viz-input k" type="number" value={target} onChange={(e) => onTargetChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={shuffleHeights}>
             Sortear alturas
           </button>
         </div>
@@ -474,11 +431,11 @@ export function SkipListVisualizer() {
         <div className="sl-wrap">
           <svg
             className="sl-svg"
-            width={Math.round(larguraSvg)}
-            height={Math.round(alturaSvg)}
-            viewBox={`0 0 ${Math.round(larguraSvg)} ${Math.round(alturaSvg)}`}
+            width={Math.round(svgWidth)}
+            height={Math.round(svgHeight)}
+            viewBox={`0 0 ${Math.round(svgWidth)} ${Math.round(svgHeight)}`}
             role="img"
-            aria-label={descricao}
+            aria-label={description}
           >
             <defs>
               <marker id="sl-seta" markerWidth="7" markerHeight="7" refX="6" refY="3" orient="auto">
@@ -486,7 +443,7 @@ export function SkipListVisualizer() {
               </marker>
             </defs>
 
-            {setas.map((s) => (
+            {arrows.map((s) => (
               <line
                 key={s.k}
                 x1={s.x1}
@@ -513,39 +470,39 @@ export function SkipListVisualizer() {
               </text>
             ))}
 
-            {Array.from({ length: niveis }, (_, k) => {
-              const nv = topo - k;
+            {Array.from({ length: levels }, (_, k) => {
+              const lv = top - k;
               return (
                 <text
-                  key={`r${nv}`}
+                  key={`r${lv}`}
                   x={GUT - 9}
-                  y={cyDe(nv)}
+                  y={cyOf(lv)}
                   fill="#61748c"
                   fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
                   fontSize={10.5}
                   textAnchor="end"
                   dominantBaseline="central"
                 >
-                  nível {nv}
+                  nível {lv}
                 </text>
               );
             })}
 
             {/* head: um nó só, com um ponteiro por nível. É o sentinela. */}
             <rect
-              x={xDe(-1)}
-              y={yDe(topo)}
+              x={xOf(-1)}
+              y={yOf(top)}
               width={HEAD_W}
-              height={topo * RH + H}
+              height={top * RH + H}
               rx={7}
-              fill={p && p.atual < 0 ? "rgba(59,130,246,0.22)" : "#111c2b"}
-              stroke={p && p.atual < 0 ? "#3b82f6" : "rgba(255,255,255,0.16)"}
+              fill={p && p.current < 0 ? "rgba(59,130,246,0.22)" : "#111c2b"}
+              stroke={p && p.current < 0 ? "#3b82f6" : "rgba(255,255,255,0.16)"}
               strokeWidth={1.6}
             />
             <text
-              x={cxDe(-1)}
-              y={cyDe(topo) + (topo * RH) / 2}
-              fill={p && p.atual < 0 ? "#fff" : "#7d8fa8"}
+              x={cxOf(-1)}
+              y={cyOf(top) + (top * RH) / 2}
+              fill={p && p.current < 0 ? "#fff" : "#7d8fa8"}
               fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
               fontSize={10.5}
               fontWeight={700}
@@ -555,14 +512,14 @@ export function SkipListVisualizer() {
               head
             </text>
 
-            {nos.map((no, i) =>
-              Array.from({ length: no.altura }, (_, nv) => {
-                const c = corDoNo(i, nv);
+            {nodes.map((node, i) =>
+              Array.from({ length: node.height }, (_, lv) => {
+                const c = nodeColor(i, lv);
                 return (
-                  <g key={`${i}-${nv}`}>
+                  <g key={`${i}-${lv}`}>
                     <rect
-                      x={xDe(i)}
-                      y={yDe(nv)}
+                      x={xOf(i)}
+                      y={yOf(lv)}
                       width={W}
                       height={H}
                       rx={6}
@@ -571,8 +528,8 @@ export function SkipListVisualizer() {
                       strokeWidth={1.6}
                     />
                     <text
-                      x={cxDe(i)}
-                      y={cyDe(nv)}
+                      x={cxOf(i)}
+                      y={cyOf(lv)}
                       fill={c.txt}
                       fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
                       fontSize={12.5}
@@ -580,7 +537,7 @@ export function SkipListVisualizer() {
                       textAnchor="middle"
                       dominantBaseline="central"
                     >
-                      {no.valor}
+                      {node.value}
                     </text>
                   </g>
                 );
@@ -589,7 +546,7 @@ export function SkipListVisualizer() {
 
             {/* a escada: o caminho que o ponteiro `atual` já percorreu */}
             <polyline
-              points={escada}
+              points={ladder}
               fill="none"
               stroke="#60a5fa"
               strokeWidth={2.4}
@@ -601,9 +558,9 @@ export function SkipListVisualizer() {
         </div>
 
         <p className="sl-ocupacao">
-          {ocupacao.map((q, nv) => (
-            <span key={nv}>
-              nível {nv}: <strong>{q}</strong> {q === 1 ? "nó" : "nós"}
+          {occupancy.map((q, lv) => (
+            <span key={lv}>
+              nível {lv}: <strong>{q}</strong> {q === 1 ? "nó" : "nós"}
             </span>
           ))}
         </p>
@@ -623,111 +580,46 @@ export function SkipListVisualizer() {
           </span>
         </p>
 
-        <p className={notaCls}>{p ? p.nota : ""}</p>
+        <p className={noteClass}>{p ? p.note : ""}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">skip_list.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${p && i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">skip_list.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${p && i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {variables.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -558,6 +558,23 @@ html { scroll-behavior: smooth; }
 .ll-svg-wrap { margin: 6px 0 2px; border: 1px solid var(--ccc-line); border-radius: 10px; background: var(--ccc-panel); overflow-x: auto; }
 .ll-svg { display: block; width: 100%; min-width: 460px; height: auto; }
 
+/* Camada 2 da casca adaptativa, para ESTES desenhos: com `width: 100%` o SVG é
+   esticado até a largura do corpo e a altura vai junto, e o que cresce no
+   esticão é o vazio entre os nós — respiro, que é o que a camada 2 negocia
+   antes de esconder qualquer coisa. Medido em 1512x900, no fluxo do artigo,
+   com o código já recolhido pela medição: o rho do Floyd renderiza a 800x337px
+   a partir de um viewBox de 504x212, e a peça pede 870px contra 816 de
+   orçamento. O teto devolve 73px e ela passa a caber (797px).
+   264px é o teto porque o viewBox mais alto desta família tem 260px de altura
+   (o ciclo de 8 nós): nenhum estado é desenhado menor que o tamanho natural
+   dele, o teto só corta o esticão.
+   No expandido o teto sai: lá o miolo rola, e o painel existe justamente para
+   ver o desenho maior. Vence por especificidade, não por ordem de arquivo. */
+@media (max-height: 950px) {
+  .ll-svg { max-height: 264px; }
+  .viz-overlay-fit .ll-svg { max-height: none; }
+}
+
 .ll-legenda { display: flex; flex-wrap: wrap; gap: 8px 18px; margin: 10px 0 0; font-size: 12px; line-height: 1.5; color: var(--ccc-muted); }
 .ll-legenda span { display: inline-flex; align-items: center; gap: 7px; }
 .ll-legenda i { width: 11px; height: 11px; border-radius: 3px; flex: none; }

--- a/tests/viz-hash-table.spec.ts
+++ b/tests/viz-hash-table.spec.ts
@@ -1,0 +1,322 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa dos visualizadores de hash-table.
+//
+// A página tem duas peças com overlay, nesta ordem:
+//   0 · HashTableVisualizer      — inserir chaves, com as três camadas
+//   1 · HashTableBuscaVisualizer — busca linear x hash, `collapsible: false`
+//                                  (não há bloco dispensável: os dois painéis,
+//                                  a fita de buckets e os cartões de pior caso
+//                                  são todos conteúdo)
+//
+// O `HashTableOperacoes` não entra: é uma tabela estática, sem overlay e sem
+// controles, então não há painel para arrumar.
+//
+// Todo teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada, e comportamento certo debaixo do rótulo errado ensina errado do mesmo
+// jeito — por isso os cartões de comparação são lidos com nome e valor juntos,
+// no mesmo cartão: é exatamente o que o guarda de idioma, que compara o
+// CONJUNTO de textos e não onde cada um aparece, não consegue ver.
+
+const URL = "/topico/hash-table/";
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+/** Congela a animação e espera as fontes: medir antes disso mede o fallback. */
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Abre o painel expandido da peça `i` e devolve o `<figure>` do painel. */
+async function expandir(page: Page, i: number) {
+  await page.goto(URL);
+  await preparar(page);
+  await page.locator("article figure.viz").nth(i).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+/** Orçamento de altura do fluxo do artigo: janela menos cabeçalho e respiro. */
+function orcamento(page: Page) {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+        60) -
+      24
+  );
+}
+
+/**
+ * Altura que parou de mudar. O `data-anim` do hook congela a transição da
+ * MEDIÇÃO dele, e não a do clique do aluno: ler no meio dos 0,32s devolve o
+ * layout a caminho e conclui "cabe" para uma peça que não cabe.
+ */
+async function alturaEstavel(alvo: Locator) {
+  let anterior = -1;
+  for (let k = 0; k < 40; k++) {
+    const h = await alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    if (h === anterior) return h;
+    anterior = h;
+    await alvo.page().waitForTimeout(60);
+  }
+  return anterior;
+}
+
+/**
+ * Rola o MIOLO até o fim e diz quanto o cabeçalho e o rodapé se mexeram.
+ *
+ * Devolve também a sobra da FIGURA: sem isso o teste aprova justamente a quebra
+ * que a camada 1 conserta. Se a rolagem voltar para a figura inteira, o
+ * `.viz-body` não tem o que rolar, `scrollTop` fica em zero, o cabeçalho não se
+ * mexe em relação à figura — e um teste que só olhasse `headMoveu` passaria.
+ */
+async function rolarAteOFim(painel: Locator) {
+  return painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const foot = f.querySelector<HTMLElement>(".viz-foot")!;
+    const headAntes = Math.round(head.getBoundingClientRect().top);
+    const footAntes = Math.round(foot.getBoundingClientRect().top);
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return {
+      sobra,
+      rolou: Math.round(body.scrollTop),
+      sobraFigura: f.scrollHeight - f.clientHeight,
+      headMoveu: Math.round(head.getBoundingClientRect().top) - headAntes,
+      footMoveu: Math.round(foot.getBoundingClientRect().top) - footAntes,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 0 · HashTableVisualizer — as três camadas
+// ---------------------------------------------------------------------------
+
+test("no expandido da inserção, o ▶ Rodar fica parado enquanto o miolo rola", async ({ page }) => {
+  // 1440x600: medido, o miolo da inserção sobra 104px. Antes da casca a figura
+  // inteira rolava (594px de sobra), o cabeçalho subia 593px e a linha de
+  // controles era desenhada com a base em 1135px numa janela de 600 — o aluno
+  // perdia de vista justamente o botão que faz o algoritmo andar.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 0);
+
+  const r = await rolarAteOFim(painel);
+  // Sem sobra o teste não testaria nada, e sem provar que é o MIOLO que rola
+  // ele aprovaria a quebra que devolve a rolagem para a figura.
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.sobraFigura).toBeLessThanOrEqual(8);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // E os dois continuam LEGÍVEIS, com o rótulo deles, depois de rolar até o fim.
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · inserindo chaves numa tabela hash")
+  ).toBeInViewport();
+});
+
+test("em 1512x900 o código da inserção vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const codigo = peca.locator(".viz-code");
+
+  // O rótulo diz o que o botão FAZ, e o bloco está mesmo sem altura (2px de
+  // borda). Rótulo sem medida, ou medida sem rótulo, deixaria passar o caso em
+  // que o botão promete uma coisa e a peça faz outra.
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // A premissa medida, dentro do teste: com o código à mostra a peça pede
+  // 1076px contra 816px de orçamento. Sem isto o teste ficaria verde no dia em
+  // que a peça encolhesse e o recolhimento deixasse de ter motivo.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em janela alta o código da inserção já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra a peça pede 1076px. Em 1300px de janela o
+  // orçamento é 1216px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1300 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  // E o código é o DESTE visualizador, não um bloco qualquer.
+  await expect(peca.locator(".viz-code-head")).toHaveText("tabela_hash.py");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+});
+
+test("a escolha de mostrar o código sobrevive à troca de capacidade", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // A capacidade está no `measureOn` do hook e é o que mais muda a altura:
+  // cada bucket é uma linha da coluna. A troca precisa aparecer NA TELA, senão
+  // o teste "sobrevive" a uma medição que nunca foi pedida.
+  await expect(peca.locator(".ht-table .ht-row")).toHaveCount(5);
+  await peca.locator("select").selectOption("16");
+  await expect(peca.locator(".ht-table .ht-row")).toHaveCount(16);
+
+  // Premissa medida: neste estado, com o código à mostra, a peça estoura o
+  // orçamento — ou seja, uma medição sem a escolha do aluno recolheria.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+
+  // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+});
+
+test("no expandido da inserção, seta e espaço andam a animação e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 0);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 18");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 18");
+  // O rótulo e o número contam a mesma coisa: o passo 2 é o da soma ASCII.
+  await expect(painel.locator(".viz-note").first()).toContainText("Somo os códigos ASCII");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 18");
+
+  // Espaço roda e pausa, e o rótulo do botão diz em qual dos dois estados está.
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Com o cursor num campo, espaço é espaço e seta é cursor. Sequestrar isso
+  // deixaria a lista de chaves impossível de editar, que é pior que não ter
+  // atalho. Afirmo DEPOIS DE CADA TECLA: duas setas opostas se cancelam e um
+  // teste que só olhasse o fim aprovaria a quebra.
+  const campo = painel.locator("input.viz-input").first();
+  await campo.fill("Ana, Bob");
+  await expect(passo).toHaveText("passo 1 de 8");
+
+  await campo.press("Space");
+  await expect(campo).toHaveValue("Ana, Bob ");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+  await expect(passo).toHaveText("passo 1 de 8");
+
+  // `fill` deixa o cursor no fim sem depender de `End`, que no macOS não leva o
+  // cursor ao fim de um input. Comparo o cursor com ele mesmo.
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(passo).toHaveText("passo 1 de 8");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 1 · HashTableBuscaVisualizer — camadas 1 e 2, sem bloco recolhível
+// ---------------------------------------------------------------------------
+
+test("no expandido da busca, o cabeçalho fica parado enquanto o miolo rola", async ({ page }) => {
+  // 1440x600: medido, o miolo da busca sobra 254px. Antes da casca a figura
+  // inteira rolava (263px), o cabeçalho subia 262px e o ▶ Rodar era desenhado
+  // com a base em 804px numa janela de 600 — 204px abaixo do pé visível.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 1);
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.sobraFigura).toBeLessThanOrEqual(8);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(painel.getByText("Visualizador · busca linear x busca por hash")).toBeInViewport();
+
+  // O contador vive no cabeçalho e o botão no rodapé: se qualquer um dos dois
+  // tivesse ido junto com a rolagem, este passo a passo seria impossível de
+  // acompanhar. Clico no botão que ficou à vista e leio o contador que ficou.
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeInViewport();
+  await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 9");
+});
+
+test("a busca não promete esconder um bloco que ela não tem", async ({ page }) => {
+  // Com `collapsible: false` os itens 2, 3 e 4 do mínimo do contrato não
+  // existem. No lugar deles: nenhum botão pode prometer esconder um bloco que
+  // o visualizador não tem — `collapsible: true` aqui desenharia "Ocultar
+  // código" sobre nada.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  await expect(peca.getByRole("button", { name: /c(ó|o)digo/i })).toHaveCount(0);
+  await expect(peca.locator(".viz-code")).toHaveCount(0);
+  await expect(peca.locator(".viz-code-slot")).toHaveCount(0);
+
+  // E o que ela TEM continua lá: a casca, o Expandir e a linha do tempo.
+  await expect(peca).toHaveClass(/viz-fit/);
+  await expect(peca.getByRole("button", { name: "⤢ Expandir" })).toBeVisible();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 9");
+});
+
+test("os cartões da busca leem rótulo e valor juntos, no mesmo cartão", async ({ page }) => {
+  // O guarda de idioma compara o CONJUNTO de textos de tela, não onde cada um
+  // aparece: trocar dois campos de lugar num rename mantém o conjunto idêntico
+  // e passa verde com a tela mentindo. Quem pega isso é ler rótulo e valor
+  // juntos — e aqui os dois números são diferentes de propósito, que é a aula
+  // inteira desta peça.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  // Passo 3: a lista já gastou 2 comparações e o hash gastou 1.
+  await peca.getByRole("button", { name: "Próximo ›" }).click();
+  await peca.getByRole("button", { name: "Próximo ›" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 3 de 9");
+
+  const cartao = (rotulo: string) =>
+    peca.locator(".bigo-stat").filter({ hasText: rotulo }).locator("strong");
+  await expect(cartao("comparações · lista")).toHaveText("2");
+  await expect(cartao("comparações · hash")).toHaveText("1");
+  await expect(cartao("pior caso · lista com 1 milhão")).toHaveText("1.000.000");
+  await expect(cartao("pior caso · hash com 1 milhão")).toHaveText("1");
+
+  // O título de cada painel carrega o mesmo número do cartão dele.
+  await expect(peca.locator(".ht-painel-tit").first()).toContainText("2 comparações");
+  await expect(peca.locator(".ht-painel-tit").nth(1)).toContainText("1 comparação");
+
+  // E com o hash ruim os dois empatam: é o O(n) do pior caso aparecendo.
+  await peca.getByRole("button", { name: "Com hash ruim" }).click();
+  await peca.getByRole("button", { name: "Próximo ›" }).click();
+  await peca.getByRole("button", { name: "Próximo ›" }).click();
+  await expect(cartao("pior caso · hash com 1 milhão")).toHaveText("1.000.000");
+});

--- a/tests/viz-listas-ligadas.spec.ts
+++ b/tests/viz-listas-ligadas.spec.ts
@@ -1,0 +1,417 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa nos três visualizadores de Listas Ligadas.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura. Então a régua aqui é sempre um número medido no
+// navegador (altura, posição, deslocamento) ou o texto que o aluno lê.
+//
+// Antes da casca, as três peças rolavam INTEIRAS dentro do painel expandido: o
+// cabeçalho subia 505, 248 e 538px e o `▶ Rodar` era desenhado até 446px
+// abaixo de uma janela de 900 (medido em 1512x900).
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/listas-ligadas/";
+
+// Janela de notebook de 16", que é o caso que motivou a casca.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para as três peças caberem com o código à mostra.
+const ALTA = { width: 1512, height: 1600 };
+// Apertada de propósito: garante que o miolo do painel tem o que rolar nas três
+// peças, e que a medição REALMENTE discordaria de quem abre o código na mão.
+const APERTADA = { width: 1512, height: 700 };
+
+const VISUALIZADORES = [
+  {
+    i: 0,
+    nome: "operações",
+    arquivo: "lista_encadeada.py",
+    // Um preset que muda o que está em `measureOn` (o tamanho da lista e, com
+    // ele, a altura do desenho) — e não só o alvo da operação.
+    preset: "Lista vazia + inserir",
+    // A prova, na tela, de que a entrada da medição mudou mesmo.
+    provaRotulo: "nós na lista",
+    provaValor: "0",
+    // Esta peça continua acima do orçamento do artigo com o código já
+    // recolhido: 990px contra 816. Ver o comentário do teste de tela baixa.
+    cabeNoOrcamento: false,
+  },
+  {
+    i: 1,
+    nome: "reversão",
+    arquivo: "reverter.py",
+    preset: "Cinco nós: 1 a 5",
+    provaRotulo: "nós na lista",
+    provaValor: "5",
+    cabeNoOrcamento: true,
+  },
+  {
+    i: 2,
+    nome: "Floyd",
+    arquivo: "floyd.py",
+    preset: "Tudo é ciclo: 6 nós em roda",
+    provaRotulo: "nós na lista",
+    provaValor: "6",
+    cabeNoOrcamento: true,
+  },
+];
+
+/** A peça no fluxo do artigo. */
+function noArtigo(page: Page, i: number): Locator {
+  return page.locator("article figure.viz").nth(i);
+}
+
+/** A peça depois de expandida: ela é portada para fora do artigo. */
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto(URL);
+  // As fontes chegam com `display: swap`: medir antes é medir o fallback, e a
+  // casca só decide depois delas.
+  await page.evaluate(() => document.fonts.ready);
+  await expect(page.locator("article figure.viz-fit").first()).toBeVisible();
+  // `data-anim` volta para "on" quando a casca terminou de medir e decidir. É o
+  // sinal que ela já publica; esperar por ele custa menos que um sono fixo e
+  // não vira flake com a máquina cheia.
+  await expect(page.locator("article figure.viz-fit").first()).toHaveAttribute("data-anim", "on");
+}
+
+async function expandir(page: Page, i: number): Promise<Locator> {
+  await noArtigo(page, i).getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = noPainel(page);
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+async function altura(loc: Locator): Promise<number> {
+  return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+/** O orçamento do artigo: a janela menos o cabeçalho fixo e um respiro. */
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const h = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+    return window.innerHeight - h - 24;
+  });
+}
+
+/**
+ * Amostra o estado do bloco recolhível N vezes ao longo de `ms` e devolve as
+ * amostras que falharam.
+ *
+ * Quando a promessa é PERMANÊNCIA ("a escolha do aluno sobrevive"), uma espera
+ * fixa seguida de uma leitura olha um instante só. Amostrar responde a pergunta
+ * certa: nenhum instante da janela pode ter falhado.
+ */
+async function amostrarAberto(page: Page, fig: Locator, ms = 900, n = 9): Promise<string[]> {
+  const falhas: string[] = [];
+  for (let k = 0; k < n; k++) {
+    const alturaSlot = await altura(fig.locator(".viz-code-slot"));
+    const rotulo = (await fig.locator("button.viz-toggle-codigo").textContent()) ?? "";
+    if (alturaSlot <= 100 || rotulo !== "Ocultar código") {
+      falhas.push(`aos ${Math.round((k * ms) / n)}ms: slot=${alturaSlot}px, rótulo=${JSON.stringify(rotulo)}`);
+    }
+    await page.waitForTimeout(ms / n);
+  }
+  return falhas;
+}
+
+for (const v of VISUALIZADORES) {
+  test.describe(`listas-ligadas · ${v.nome}`, () => {
+    // §8.1: no expandido o cabeçalho e o rodapé ficam parados, e o botão que faz
+    // o algoritmo andar nunca sai da tela.
+    //
+    // As duas primeiras asserções não são cerimônia: um teste que rola o
+    // `.viz-body` sem provar que é ELE quem rola aprova justamente a quebra que
+    // devolve a rolagem para a figura inteira — ali o `scrollTop` do miolo fica
+    // em zero, o cabeçalho não se mexe, e o teste passa feliz.
+    test("expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({ page }) => {
+      await abrir(page, APERTADA);
+      const painel = await expandir(page, v.i);
+
+      const mostrar = painel.locator("button.viz-toggle-codigo");
+      if ((await mostrar.textContent()) === "Mostrar código") await mostrar.click();
+      await expect(mostrar).toHaveText("Ocultar código");
+
+      const miolo = painel.locator(".viz-body");
+      const cabeca = painel.locator(".viz-head");
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+      // 1. o miolo é o que estoura...
+      await expect
+        .poll(() => miolo.evaluate((el) => el.scrollHeight - el.clientHeight))
+        .toBeGreaterThan(8);
+
+      const topoAntes = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+      // O rótulo importa tanto quanto a posição: um botão no lugar certo
+      // dizendo a coisa errada ensina errado do mesmo jeito.
+      await expect(rodar).toHaveText("▶ Rodar");
+      await expect(rodar).toBeInViewport();
+
+      // 2. ...e é ele que rola, não a figura inteira.
+      await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+      await expect.poll(() => miolo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(8);
+      expect(await painel.evaluate((f) => Math.round(f.scrollTop))).toBe(0);
+
+      // 3. e o cabeçalho não saiu do lugar.
+      const topoDepois = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+      expect(Math.abs(topoDepois - topoAntes)).toBeLessThanOrEqual(1);
+      await expect(rodar).toBeInViewport();
+      await expect(rodar).toHaveText("▶ Rodar");
+
+      // E o rodapé está colado no pé da figura, não empurrado para fora dela.
+      const folga = await painel.evaluate((f) => {
+        const foot = f.querySelector(".viz-foot") as HTMLElement;
+        return Math.round(f.getBoundingClientRect().bottom - foot.getBoundingClientRect().bottom);
+      });
+      expect(folga).toBeLessThanOrEqual(2);
+    });
+
+    // §8.2: em tela baixa a peça não cabe com o código à mostra, então ele
+    // recolhe — e o botão passa a dizer o que faria aparecer.
+    test("tela baixa: o botão diz 'Mostrar código' e o bloco está recolhido", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Mostrar código");
+      await expect(botao).toHaveAttribute("aria-expanded", "false");
+      // Recolhido de verdade: o slot perde a ALTURA, não só a largura. Zerar a
+      // trilha da coluna deixava a linha do grid com a altura do código.
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeLessThanOrEqual(4);
+
+      const recolhida = await altura(fig);
+      const orc = await orcamento(page);
+
+      // A premissa medida DENTRO do teste: com o código à mostra a peça não
+      // cabe. Sem ela, no dia em que a peça encolher isto vira decoração verde.
+      await botao.click();
+      await expect(botao).toHaveText("Ocultar código");
+      await expect.poll(() => altura(fig)).toBeGreaterThan(orc);
+      const aberta = await altura(fig);
+      expect(aberta - recolhida).toBeGreaterThan(150);
+
+      if (v.cabeNoOrcamento) {
+        // E recolhida a peça inteira passa a caber, que é o ponto de tudo isto.
+        expect(recolhida).toBeLessThanOrEqual(orc);
+      } else {
+        // A peça de operações NÃO cabe nem recolhida: medido 990px contra 816
+        // de orçamento em 1512x900. O que sobra não é bloco dispensável — são
+        // três fileiras de chips (228px), o desenho (266px), as fichas de
+        // estatística (78px) e ~130px de respiro do miolo, que a camada 2
+        // apertaria se ela alcançasse o fluxo do artigo (contrato §9).
+        // O teto aqui é regressão: recolher tem que continuar valendo a pena.
+        expect(recolhida).toBeLessThan(1050);
+      }
+    });
+
+    // §8.3: onde cabe, o código já vem à mostra — a medição decide, não um
+    // breakpoint de largura.
+    test("tela alta: o código já vem aberto e o botão diz 'Ocultar código'", async ({ page }) => {
+      await abrir(page, ALTA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Ocultar código");
+      await expect(botao).toHaveAttribute("aria-expanded", "true");
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+      // O bloco é mesmo o código DESTE visualizador, não um bloco qualquer.
+      await expect(fig.locator(".viz-code-head")).toHaveText(v.arquivo);
+    });
+
+    // §8.4: a escolha explícita do aluno vence a medição e não é desfeita por
+    // uma troca de estado que pediria medição nova.
+    test("a escolha do aluno sobrevive a uma troca de estado que pede medição nova", async ({ page }) => {
+      await abrir(page, APERTADA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Mostrar código");
+      await botao.click();
+      await expect(botao).toHaveText("Ocultar código");
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+
+      await fig.getByRole("button", { name: v.preset, exact: true }).click();
+
+      // A entrada da medição mudou MESMO — e a leitura é do rótulo junto com o
+      // valor, no mesmo cartão: comportamento certo com rótulo errado ensina
+      // errado do mesmo jeito. ("nós na lista" é ficha de estatística em duas
+      // peças e linha do painel de variáveis na outra; o filtro pelo rótulo
+      // acha uma só em qualquer um dos casos.)
+      const ficha = fig.locator(".bigo-stat, .viz-var").filter({ hasText: v.provaRotulo });
+      await expect(ficha).toHaveCount(1);
+      await expect(ficha.locator("strong, .viz-var-val")).toHaveText(v.provaValor);
+
+      // A janela amostrada cobre a medição E a transição de 0,32s que viria
+      // depois dela. Exigir que NENHUMA amostra tenha falhado é o que separa
+      // "está aberto" de "continua aberto".
+      expect(await amostrarAberto(page, fig)).toEqual([]);
+    });
+
+    // §8.5: as teclas dirigem a animação dentro do painel.
+    test("expandido: as setas andam o passo e o espaço roda", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const painel = await expandir(page, v.i);
+      const passo = painel.locator(".viz-step");
+
+      const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+      await expect(passo).toHaveText(`passo 1 de ${total}`);
+
+      // Uma asserção DEPOIS DE CADA TECLA: `→` seguido de `←` se cancelam, e um
+      // teste que só olha o fim aprova a quebra que ignora as duas.
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 2 de ${total}`);
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 3 de ${total}`);
+      await page.keyboard.press("ArrowLeft");
+      await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("❚❚ Pausar");
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("▶ Rodar");
+    });
+  });
+}
+
+// A regra mais importante dos atalhos é o inverso deles: com o cursor num campo,
+// espaço é espaço e seta é cursor. Sequestrar isso deixa a entrada impossível de
+// editar, o que é pior que não ter atalho.
+for (const v of [
+  { i: 0, nome: "operações" },
+  { i: 1, nome: "reversão" },
+]) {
+  test(`listas-ligadas · ${v.nome}: o campo em edição manda no espaço`, async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page, v.i);
+    const campo = painel.locator("input.viz-input").first();
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+    await campo.click();
+    // `End` não leva o cursor ao fim de um input no macOS, então a régua é o
+    // valor comparado consigo mesmo, não a posição do cursor.
+    const antes = await campo.inputValue();
+    await page.keyboard.press("Space");
+
+    await expect(campo).not.toHaveValue(antes);
+    expect((await campo.inputValue()).length).toBe(antes.length + 1);
+    // E a animação NÃO começou.
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+}
+
+// O Floyd não tem campo de texto: a entrada dele são dois sliders. Num slider a
+// seta é do próprio slider, e sequestrá-la deixaria a lista impossível de
+// configurar pelo teclado.
+test("listas-ligadas · Floyd: no slider a seta é do slider, não do passo", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const painel = await expandir(page, 2);
+  const slider = painel.locator('input[type="range"]').first();
+  const passo = painel.locator(".viz-step");
+
+  const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+  await expect(passo).toHaveText(`passo 1 de ${total}`);
+
+  await slider.click();
+  const antes = await slider.inputValue();
+  await page.keyboard.press("ArrowRight");
+
+  await expect(slider).not.toHaveValue(antes);
+  // E o rótulo do campo acompanha o slider, que é como o aluno confere.
+  await expect(painel.locator("label.viz-field").first()).toContainText(
+    `Nós antes do ciclo: ${Number(antes) + 1}`
+  );
+  // O passo não andou junto (o `total` muda com a lista, então a régua é o "1").
+  await expect(passo).toContainText("passo 1 de ");
+});
+
+// ---------------------------------------------------------------------------
+// O teto de altura do desenho (camada 2, específica destes visualizadores).
+// Medido em 1512x900: o rho do Floyd ia a 337px e a peça a 870, contra 816 de
+// orçamento. O teto devolve a peça para dentro da janela sem esconder nada, e
+// NÃO vale no expandido, que existe justamente para ver o desenho maior.
+// ---------------------------------------------------------------------------
+test("listas-ligadas · o desenho tem teto no artigo e não tem no expandido", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const fig = noArtigo(page, 2);
+
+  // A régua não é o valor do `max-height` (isso só repetiria o CSS aqui): é a
+  // altura SEM teto, medida em 1512x900 antes deste conserto, que era 337px.
+  const SEM_TETO = 337;
+  const svgNoArtigo = await altura(fig.locator(".ll-svg"));
+  expect(svgNoArtigo).toBeLessThan(SEM_TETO * 0.85);
+
+  // E o desenho continua inteiro: nenhum nó foi cortado pelo teto.
+  const cabeInteiro = await fig.locator(".ll-svg").evaluate((svg) => {
+    const caixa = svg.getBoundingClientRect();
+    return [...svg.querySelectorAll("circle")].every((c) => {
+      const r = c.getBoundingClientRect();
+      return r.top >= caixa.top - 1 && r.bottom <= caixa.bottom + 1;
+    });
+  });
+  expect(cabeInteiro).toBe(true);
+
+  // No painel o teto sai. A régua é o próprio desenho do artigo, não um número
+  // solto.
+  const painel = await expandir(page, 2);
+  await expect.poll(() => altura(painel.locator(".ll-svg"))).toBeGreaterThan(svgNoArtigo);
+  expect(await painel.locator(".ll-svg").evaluate((el) => getComputedStyle(el).maxHeight)).toBe("none");
+});
+
+// ---------------------------------------------------------------------------
+// `total` que vem da entrada pode cair para 1: remover de uma lista vazia
+// devolve UM passo. Aí o contador, o rodapé e os atalhos somem inteiros — cerca
+// de 90px a menos de peça —, e é por isso que `steps.length` entra no
+// `measureOn`. O que não pode é sobrar um controle prometendo animação que não
+// existe.
+// ---------------------------------------------------------------------------
+test("listas-ligadas · lista vazia + remover: sem linha do tempo, sem rodapé", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const fig = noArtigo(page, 0);
+
+  await fig.getByRole("button", { name: "Remover a posição", exact: true }).click();
+  await fig.locator("input.viz-input").first().fill("");
+
+  await expect(fig.locator(".viz-note")).toHaveText(/A lista está vazia: não existe posição/);
+  await expect(fig.locator(".viz-step")).toHaveCount(0);
+  await expect(fig.locator(".viz-foot")).toHaveCount(0);
+  await expect(fig.getByRole("button", { name: /Rodar|Pausar/ })).toHaveCount(0);
+  // O botão do bloco continua lá, porque o bloco continua existindo.
+  await expect(fig.locator("button.viz-toggle-codigo")).toHaveCount(1);
+});
+
+// ---------------------------------------------------------------------------
+// O guarda de idioma, agora como teste: identificador em inglês, tela em
+// português (contrato §0). Um `find & replace` de `lento` → `slow` traduz o
+// identificador e estraga a aula junto — e o `tsc` não reclama de nada.
+// ---------------------------------------------------------------------------
+test("listas-ligadas · o Python da tela e os rótulos seguem em português", async ({ page }) => {
+  await abrir(page, ALTA);
+
+  await expect(noArtigo(page, 0).locator(".viz-code-body")).toContainText("def inserir(self, pos, valor):");
+  await expect(noArtigo(page, 0).locator(".viz-code-body")).toContainText("anterior = self.cabeca");
+  await expect(noArtigo(page, 1).locator(".viz-code-body")).toContainText("atual.prox = anterior  # viro a seta");
+  await expect(noArtigo(page, 2).locator(".viz-code-body")).toContainText("lento = rapido = cabeca");
+
+  // Os rótulos do painel de variáveis explicam justamente aquelas linhas: se um
+  // lado vira inglês e o outro não, o aluno perde a correspondência.
+  const rotulos = async (i: number) => noArtigo(page, i).locator(".viz-var-name").allTextContents();
+  expect(await rotulos(0)).toEqual(["anterior", "cabeça", "nós na lista", "custo"]);
+  expect(await rotulos(1)).toEqual(["anterior", "atual", "proximo", "setas viradas"]);
+  expect(await rotulos(2)).toEqual(["lento", "rapido", "fase", "retorno"]);
+
+  // E as fichas de estatística, que são o argumento do artigo em números.
+  const fichas = async (i: number) => noArtigo(page, i).locator(".bigo-stat span").allTextContents();
+  expect(await fichas(0)).toEqual([
+    "nós percorridos", "ponteiros religados", "deslocamentos num array", "memória extra",
+  ]);
+  expect(await fichas(2)).toEqual([
+    "nós na lista", "iterações da fase 1", "passos da fase 2", "início do ciclo",
+  ]);
+});

--- a/tests/viz-skip-list.spec.ts
+++ b/tests/viz-skip-list.spec.ts
@@ -1,0 +1,323 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa dos três visualizadores de skip-list.
+//
+// A página tem três peças, nesta ordem:
+//   0 · SkipListVisualizer — a busca descendo em escada pelos níveis
+//   1 · SkipListInsercao   — inserir e remover, com o update[] e a moeda
+//   2 · SkipListNiveis     — a aritmética da moeda: `total: 1` e
+//                            `collapsible: false` (sem passos, sem bloco)
+//
+// O defeito que estes testes protegem não era altura: no painel expandido a
+// FIGURA inteira rolava, e o cabeçalho ia junto. Medido em 1512x900, antes:
+// o cabeçalho subia 176px (busca), 563px (inserção) e 1.171px (níveis, com a
+// pirâmide no pior caso), levando embora os botões que fazem a peça andar.
+//
+// Todo teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada, e comportamento certo debaixo do rótulo errado ensina errado do mesmo
+// jeito.
+
+const URL = "/topico/skip-list/";
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+/** Congela a animação e espera as fontes: medir antes disso mede o fallback. */
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Abre o painel expandido da peça `i` SEM recarregar: o estado montado fica. */
+async function expandirAqui(page: Page, i: number) {
+  await page.locator("article figure.viz").nth(i).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+/** Abre a página e o painel expandido da peça `i`. */
+async function expandir(page: Page, i: number) {
+  await page.goto(URL);
+  await preparar(page);
+  return expandirAqui(page, i);
+}
+
+/** Orçamento de altura do fluxo do artigo: janela menos cabeçalho e respiro. */
+function orcamento(page: Page) {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+        60) -
+      24
+  );
+}
+
+/**
+ * Altura que parou de mudar. O `data-anim` do hook congela a transição da
+ * MEDIÇÃO dele, e não a do clique do aluno: ler no meio dos 0,32s devolve o
+ * layout a caminho e conclui "cabe" para uma peça que não cabe.
+ */
+async function alturaEstavel(alvo: Locator) {
+  let anterior = -1;
+  for (let k = 0; k < 40; k++) {
+    const h = await alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    if (h === anterior) return h;
+    anterior = h;
+    await alvo.page().waitForTimeout(60);
+  }
+  return anterior;
+}
+
+/**
+ * Rola o miolo até o fim e diz quanto o cabeçalho e o rodapé se mexeram, e se
+ * quem rolou foi mesmo o miolo. As três coisas juntas são o teste: com a
+ * rolagem devolvida à figura, `sobra` e `rolou` ficam em zero, o cabeçalho não
+ * se mexe, e um teste que só olhasse `headMoveu` aprovaria a quebra.
+ */
+async function rolarAteOFim(painel: Locator) {
+  return painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const foot = f.querySelector<HTMLElement>(".viz-foot")!;
+    const headAntes = Math.round(head.getBoundingClientRect().top);
+    const footAntes = Math.round(foot.getBoundingClientRect().top);
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    f.scrollTop = f.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return {
+      sobra,
+      rolou: Math.round(body.scrollTop),
+      figuraRolou: Math.round(f.scrollTop),
+      headMoveu: Math.round(head.getBoundingClientRect().top) - headAntes,
+      footMoveu: Math.round(foot.getBoundingClientRect().top) - footAntes,
+    };
+  });
+}
+
+test("no expandido da busca, o ▶ Rodar fica parado enquanto o miolo rola", async ({ page }) => {
+  // 1440x600: medido, o miolo da busca sobra 139px. Antes da casca o `.viz`
+  // inteiro rolava, o cabeçalho subia 476px e o `▶ Rodar` era desenhado com a
+  // base em 1017px numa janela de 600 — o aluno perdia de vista justamente o
+  // botão que faz o algoritmo andar.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 0);
+
+  const r = await rolarAteOFim(painel);
+  // Sem sobra o teste não testaria nada: ele precisa de miolo para rolar.
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  // E quem rola tem que ser o miolo, não a figura.
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // O botão continua LEGÍVEL, com o rótulo dele, depois de rolar até o fim.
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · a busca descendo em escada pelos níveis")
+  ).toBeInViewport();
+});
+
+test("no expandido da inserção, o Próximo › anda o passo depois da rolagem", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 1);
+
+  await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 28");
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // O contador vive no cabeçalho e o botão no rodapé: se qualquer um dos dois
+  // tivesse ido junto com a rolagem, este passo a passo seria impossível de
+  // acompanhar. Clico no botão que ficou à vista e leio o contador que ficou.
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeInViewport();
+  await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 28");
+  // O passo 2 é a primeira comparação da busca: o contador e a nota contam a
+  // mesma coisa, e a nota nomeia o nível que o painel de variáveis mostra.
+  await expect(painel.locator(".viz-note")).toContainText(
+    "42 não é menor que 33: se eu avançasse, passaria do ponto. Paro de andar no nível 3."
+  );
+  await expect(painel.locator(".viz-var").filter({ hasText: "nivel" }).first()).toContainText("3");
+});
+
+test("no expandido dos níveis, a pirâmide gigante rola sozinha sob o cabeçalho parado", async ({
+  page,
+}) => {
+  // O pior caso da ENTRADA, que o estado padrão esconde: com n = 1.048.576 e
+  // p = 0,75 a pirâmide vai a 40 linhas. Medido antes da casca: 2.067px de peça,
+  // o cabeçalho subindo 1.171px ao rolar e o "↺ Reiniciar" desenhado com a base
+  // em 2.027px numa janela de 900.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  await peca.getByRole("button", { name: /p = 0,75/ }).click();
+  await peca.locator('input[type="range"]').fill("8");
+  // A entrada mudou mesmo, e o cabeçalho diz qual é: sem esta asserção o teste
+  // mediria a pirâmide pequena e ficaria verde à toa.
+  await expect(peca.locator(".viz-step")).toHaveText("n = 1.048.576 · p = 0,75");
+  await expect(peca.locator(".sl-plinha")).toHaveCount(40);
+
+  const painel = await expandirAqui(page, 2);
+  await expect(painel.locator(".sl-plinha")).toHaveCount(40);
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(900);
+  expect(r.rolou).toBeGreaterThan(900);
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // Com 1.148px de pirâmide passando por baixo, os controles seguem à vista e
+  // sob o rótulo certo.
+  await expect(painel.getByRole("button", { name: "↺ Reiniciar" })).toBeInViewport();
+  await expect(painel.getByRole("button", { name: "Sortear 1.048.576 moedas" })).toBeInViewport();
+  await expect(painel.locator(".viz-step")).toBeInViewport();
+});
+
+test("os níveis não prometem esconder bloco nenhum, e o número resume a peça", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  // Sem bloco dispensável não existe botão de recolher: `collapsible: true`
+  // aqui renderizaria "Ocultar código" sobre nada. A pirâmide É o conteúdo.
+  await expect(peca.getByRole("button", { name: /código/ })).toHaveCount(0);
+  await expect(peca.locator(".viz-code")).toHaveCount(0);
+  // Sem linha do tempo, o lugar do "passo N de M" guarda o número que resume a
+  // peça — com o rótulo junto, senão o número perde o que o explicava.
+  await expect(peca.locator(".viz-step")).toHaveText("n = 1.024 · p = 0,5");
+  await expect(peca.locator(".viz-progress")).toHaveCount(0);
+  await expect(peca.getByRole("button", { name: "▶ Rodar" })).toHaveCount(0);
+
+  // E o número acompanha a entrada, os dois pedaços dele.
+  await peca.getByRole("button", { name: /p = 0,25/ }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("n = 1.024 · p = 0,25");
+  await peca.locator('input[type="range"]').fill("0");
+  await expect(peca.locator(".viz-step")).toHaveText("n = 16 · p = 0,25");
+});
+
+test("em 1512x900 o código da busca vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const codigo = peca.locator(".viz-code");
+
+  // O rótulo diz o que o botão FAZ, e o bloco está mesmo sem altura (2px de
+  // borda). Rótulo sem medida, ou medida sem rótulo, deixaria passar o caso em
+  // que o botão promete uma coisa e a peça faz outra.
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // A premissa medida, dentro do teste: com o código à mostra a peça NÃO cabe
+  // no orçamento da janela (1.028px contra 816). Sem isto o teste ficaria verde
+  // no dia em que o recolhimento fosse decidido por engano.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em janela alta o código da busca já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra a peça pede 1.028px. Em 1300px de janela o
+  // orçamento é 1.216px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1300 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  // E o código é o deste visualizador, não um bloco qualquer.
+  await expect(peca.locator(".viz-code-head")).toHaveText("skip_list.py");
+  await expect(peca.locator(".viz-line").first()).toContainText("def buscar(self, alvo):");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+});
+
+test("a escolha de mostrar o código sobrevive à troca do preset da busca", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // O preset "Azar total" derruba a lista de 4 níveis para 1, e o número de
+  // níveis é justamente o que está no `measureOn`: a medição roda de novo.
+  await peca.getByRole("button", { name: "Azar total: ninguém passou do nível 0" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 24");
+  await expect(peca.locator(".sl-ocupacao span")).toHaveCount(1);
+
+  // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
+  // Esta é a asserção que carrega o sentido do teste, e por isso vem ANTES da
+  // premissa: com a escolha do aluno desfeita, é ela que tem de reprovar.
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  // Premissa medida: neste estado, com o código à mostra, a peça estoura o
+  // orçamento (914px contra 816) — ou seja, uma medição sem a escolha do aluno
+  // recolheria. Sem esta asserção o teste passaria mesmo se o estado escolhido
+  // coubesse, e nada teria ameaçado a escolha.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("no expandido, seta e espaço andam a busca e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 0);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 14");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 14");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 14");
+
+  // Espaço roda e pausa, e o rótulo do botão diz em qual dos dois estados está.
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Com o cursor num campo, espaço é espaço e seta é cursor. Sequestrar isso
+  // deixaria a lista impossível de editar, que é pior que não ter atalho.
+  const campo = painel.locator("input.viz-input").first();
+  await campo.fill("10, 20, 30");
+  await expect(passo).toHaveText("passo 1 de 12");
+
+  await campo.press("Space");
+  await expect(campo).toHaveValue("10, 20, 30 ");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // `fill` deixa o cursor no fim sem depender de `End`, que no macOS não leva o
+  // cursor ao fim de um input. Comparo o cursor com ele mesmo.
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(passo).toHaveText("passo 1 de 12");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores dos grupos **Hashing**
e **Listas Encadeadas**: três tópicos, **oito visualizadores adaptados**, com um
agente por tópico em paralelo e consolidação num PR só.

## O que entrou, e o que ficou de fora

| tópico | adaptados | fora do escopo | por quê |
|---|---|---|---|
| `hash-table` | `HashTableVisualizer` (3 camadas), `HashTableBuscaVisualizer` (1 e 2, `collapsible: false`) | `HashTableOperacoes` | estático, sem `"use client"`; vira `<figure class="ht-tab">` no build, sem overlay nem controles |
| `listas-ligadas` | `LinkedListVisualizer`, `LinkedListReversao`, `LinkedListFloyd` (3 camadas cada) | `LinkedListOperacoes` | tabela de custos na moldura `.bigo-fam`; não é `figure.viz` |
| `skip-list` | `SkipListVisualizer`, `SkipListInsercao` (3 camadas), `SkipListNiveis` (1 e 2, `collapsible: false` + `total: 1`) | — | nenhum |

**8 de 10 entraram.** Os dois de fora não têm painel expandido, então não há o
que arrumar. Ambos foram conferidos lendo o arquivo, não só a coluna do
inventário.

## Medições

Janela **1512x900**, fontes carregadas (`document.fonts.ready`), animação
congelada. Orçamento no fluxo do artigo = 900 − 60 − 24 = **816px**. "Cabeça" é
quanto o `.viz-head` sobe ao rolar o painel expandido até o fim.

| peça | artigo antes | artigo depois | cabeça antes → depois | base do controle |
|---|---|---|---|---|
| hash table · inserção | 1076 | **758** | −293 → **0** | 1135 → 753 |
| hash table · inserção, pior caso | 1604 | 1286 | −821 → **0** | 1663 → 843 |
| hash table · busca | 847 | 875 | 1 → 1 | 823 → 828 |
| listas · operações | 1276 | **990** | −505 → **0** | 1346 → 843 |
| listas · reversão | 979 | **744** | −248 → **0** | 1089 → 843 |
| listas · Floyd | 1181 | **797** | −538 → **0** | 1379 → 843 |
| skip list · busca | 1018 | **783** | −176 → **0** | 1017 → 770 |
| skip list · inserção | 1360 | 972 | −563 → **0** | 1404 → 843 |
| skip list · níveis | 915 | 925 | −40 → **0** | 896 → 858 |
| skip list · níveis, pior caso | **2067** | 2077 | **−1171 → 0** | **2027** → 858 |

**Nas dez, o cabeçalho para de sair da tela ao rolar o expandido.** Era esse o
defeito maior: não altura do miolo, mas a figura inteira rolando e levando
cabeçalho e controles junto.

### O que não fechou, com número em vez de arredondamento

- **hash table · busca: +28px** e **skip list · níveis: +10px** no fluxo do
  artigo. O `.viz-foot` sai do `.viz-body` — é o que o deixa parado no pé do
  painel — e traz o respiro dele. Quem tem bloco recolhível paga com o bloco;
  quem tem `collapsible: false` não tem camada 3 e a camada 2 não alcança o
  artigo. Promovido ao contrato (§9).
- **listas · operações: 990 contra 816**, com o código já recolhido. A altura
  foi quebrada por bloco: três fileiras de chips (228px, sendo 154 só a de casos
  de borda), o desenho (266px), as fichas (78px) e ~130px de respiro. Não é
  bloco dispensável — é conteúdo.
- **hash table · inserção, pior caso: 1286 contra 816.** São 16 buckets
  desenhados, cada um uma linha.
- **skip list · inserção: +156px** (+194 no pior caso). Limite do §9.

### Onde o ganho estava escondido

Duas peças pareciam sadias em 1512x900 e não estavam. Em **1440x700** a busca da
hash table desenhava o `▶ Rodar` **104px abaixo do pé visível** (204px em
1440x600), e o pior caso da pirâmide de níveis punha o `↺ Reiniciar` **1127px
fora da janela**. Nos dois, o controle voltou para dentro.

## Testes

**37 testes novos**, em três arquivos disjuntos (`tests/viz-hash-table.spec.ts`,
`tests/viz-listas-ligadas.spec.ts`, `tests/viz-skip-list.spec.ts`), todos medindo
comportamento e **lendo rótulo** além de número.

**26 quebras provadas**, cada uma compilando e chegando ao navegador antes de
reprovar o seu teste: rodapé de volta ao `.viz-body`, `.viz-code-slot`
renomeado, medição invertida, escolha manual zerada, `stepBy(0)`, espaço e seta
ignorando campo em edição e slider, `.ll-svg` sem teto, `VizFooter` com
`total: 1`, rótulo `lento` → `slow`.

**Suíte completa na branch integrada: 205 passed, 0 failed** (`--workers=2`, com
a máquina livre). No padrão de workers, três testes de tópicos da rodada
anterior estouram `page.goto` por saturação do servidor de teste local — `git
diff origin/main` vazio nos arquivos e nos componentes que eles exercitam, e
passam 32/32 em isolamento. O CI roda com 1 worker e não é afetado.

## Verificação cruzada da consolidação

O que nenhum tópico sozinho podia provar:

- **Diff do texto renderizado do build inteiro**, `origin/main` contra esta
  branch, 35.886 linhas em todas as páginas: **uma única linha removida**, e ela
  reaparece na linha seguinte com um espaço duplo do JSX colapsado — invisível na
  tela, porque HTML colapsa espaço em branco. Zero texto didático perdido. As
  únicas adições são as afordâncias novas da casca ("Ocultar código" nas seis
  peças com bloco, a dica de teclado nas sete com linha do tempo), e a ausência
  delas nas peças `collapsible: false` / `total: 1` confirma no build o que os
  testes afirmam.
- **Varredura da classe de bug do #28** (`stepBy` com aritmética, o "vá para o
  passo k" que apareceu em dois tópicos): nenhuma ocorrência.
- **Rodapé escrito à mão que o hook já dispensa**: nenhum sobrou.
- **O padrão do esticão de SVG**, que motivou o teto do `.ll-svg`: conferido nas
  outras famílias. `.sl-svg` usa tamanho natural com `overflow-x` no wrapper e
  não estica; `HashTable*` não desenha SVG. O teto é específico do `.ll-*`.

## Contrato (`content/visualizers/README.md`)

Quatro correções, três delas achadas por agentes diferentes:

1. **§6 estava descrevendo um bug morto.** Dizia que `VizFooter` retorna `null`
   com `total <= 1` "descartando os `children` em silêncio" e mandava escrever o
   rodapé à mão — mas o hook foi consertado no #28 e o texto ficou para trás.
   Foi essa linha que fez `SubTypesVisualizer` e `PrefixSumTradeoff` contornarem.
   `SkipListNiveis` é exatamente esse caso e usou o `VizFooter` direto.
2. **§9 ganha o preço de adotar a casca no artigo**, medido em dois tópicos
   independentes (busca da hash table +28px, `PrefixSumTradeoff` +10px).
3. **§0 ganha dois buracos do `guarda-idioma.py`**, medidos: crase aninhada
   dentro de `${...}` tira o pareamento de sincronia (o `LinkedListFloyd` tem
   seis), e texto de tela colado numa interpolação (`<span>Nós no ciclo:
   {…}</span>`) não é visto por ninguém — este é o silencioso.
4. **§3 ganha como achar o estado mais alto**, porque "encher a entrada até o
   máximo" errou nas três peças em que foi tentado, cada uma por um motivo
   diferente (detalhe na mensagem do commit).

## CSS

Uma regra nova, no bloco temático `.ll-*`, **fora do bloco `viz-fit`
compartilhado**: `@media (max-height: 950px) { .ll-svg { max-height: 264px } }`
com isenção no expandido. Motivo medido: o rho do Floyd renderiza a 800x337px a
partir de um viewBox de 504x212 — 125px de esticão puro — e a peça pedia 870
contra 816 de orçamento; com o teto, 797. O valor 264 é o viewBox mais alto da
família (260px), então nenhum estado é desenhado menor que o natural.

## Idioma

Identificadores traduzidos para inglês nos oito componentes, com o texto de tela
intacto — provado varrendo **910 estados** no navegador (282 + 311 + 317),
comparando `innerText`, `title`, `aria-label` e `aria-pressed` antes e depois, e
confirmado pelo diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
