### PR TITLE
feat(viz): casca adaptativa em Pilhas e Filas e em Recursão

### DIFF
--- a/content/visualizers/QueueDequeMonotonico.tsx
+++ b/content/visualizers/QueueDequeMonotonico.tsx
@@ -1,42 +1,46 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // QueueDequeMonotonico, o deque decrescente resolvendo o máximo de cada janela
 // (LeetCode 239). É a ponte entre este tópico e a Sliding Window.
 //
-// Mesmo padrão do TwoPointersVisualizer: gerador PURO de passos + a mesma casca.
-// O desenho central tem três andares: a fita do array com a janela atual, o
-// deque de ÍNDICES (o detalhe que mais confunde: guarda índice, não valor) e a
-// saída sendo montada.
+// Gerador PURO de passos + a casca compartilhada. O desenho central tem três
+// andares: a fita do array com a janela atual, o deque de ÍNDICES (o detalhe
+// que mais confunde: guarda índice, não valor) e a saída sendo montada.
 //
 // A única coisa que o aluno precisa ver acontecendo: quando um valor maior
 // chega, todo mundo menor que ele sai pelo fundo do deque de uma vez, porque
 // nenhum deles pode voltar a ser máximo enquanto o novo estiver na janela. Os
 // dois contadores (comparações do deque x comparações da força bruta) mostram
 // por que isso vira O(n) em vez de O(n·k): aumente o k e só um dos dois cresce.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   i: number; // índice sendo lido, -1 no passo de preparação
   dq: number[]; // índices no deque, da frente para o fundo
-  saida: number[];
-  linha: number;
-  saindo: number | null; // índice que acabou de sair do deque
-  porFrente?: boolean; // a saída foi pela frente (venceu a validade)
+  output: number[];
+  line: number;
+  leaving: number | null; // índice que acabou de sair do deque
+  fromFront?: boolean; // a saída foi pela frente (venceu a validade)
   comp: number; // comparações de valores feitas até aqui
   ops: number; // entradas e saídas no deque
-  maiorDq: number;
-  fecha?: boolean; // este passo fechou uma janela
-  fim?: boolean;
-  nota: string;
+  maxDq: number;
+  closes?: boolean; // este passo fechou uma janela
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO = [
+const CODE = [
   "from collections import deque",
   "",
   "def maximos_da_janela(nums, k):",
@@ -53,65 +57,64 @@ const CODIGO = [
   "    return saida",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-function gerarPassos(nums: number[], k: number): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(nums: number[], k: number): Step[] {
+  const out: Step[] = [];
   const dq: number[] = [];
-  const saida: number[] = [];
+  const output: number[] = [];
   let comp = 0;
   let ops = 0;
-  let maiorDq = 0;
+  let maxDq = 0;
 
-  const reg = (p: { i: number; linha: number; nota: string; saindo?: number; porFrente?: boolean; fecha?: boolean; fim?: boolean }) => {
+  const reg = (p: { i: number; line: number; note: string; leaving?: number; fromFront?: boolean; closes?: boolean; done?: boolean }) => {
     out.push({
       i: p.i,
       dq: [...dq],
-      saida: [...saida],
-      linha: p.linha,
-      saindo: p.saindo ?? null,
-      porFrente: p.porFrente,
+      output: [...output],
+      line: p.line,
+      leaving: p.leaving ?? null,
+      fromFront: p.fromFront,
       comp,
       ops,
-      maiorDq,
-      fecha: p.fecha,
-      fim: p.fim,
-      nota: p.nota,
+      maxDq,
+      closes: p.closes,
+      done: p.done,
+      note: p.note,
     });
   };
 
   reg({
     i: -1,
-    linha: 3,
-    nota: `Deque vazio, saída vazia. Vou passar uma vez só pelo array, com janelas de ${k} ${k === 1 ? "elemento" : "elementos"}.`,
+    line: 3,
+    note: `Deque vazio, saída vazia. Vou passar uma vez só pelo array, com janelas de ${k} ${k === 1 ? "elemento" : "elementos"}.`,
   });
 
-  let guarda = 0;
-  for (let i = 0; i < nums.length && guarda++ < 80; i++) {
+  let guard = 0;
+  for (let i = 0; i < nums.length && guard++ < 80; i++) {
     const v = nums[i];
-    const ini = Math.max(0, i - k + 1);
+    const windowStart = Math.max(0, i - k + 1);
     reg({
       i,
-      linha: 5,
-      nota: `Leio nums[${i}] = ${v}. A janela agora vai de ${ini} a ${i}${i < k - 1 ? ", ainda incompleta" : ""}.`,
+      line: 5,
+      note: `Leio nums[${i}] = ${v}. A janela agora vai de ${windowStart} a ${i}${i < k - 1 ? ", ainda incompleta" : ""}.`,
     });
 
     while (dq.length && nums[dq[dq.length - 1]] <= v) {
       comp++;
-      const fora = dq[dq.length - 1];
+      const dropped = dq[dq.length - 1];
       reg({
         i,
-        linha: 6,
-        saindo: fora,
-        nota: `nums[${fora}] = ${nums[fora]} é menor ou igual a ${v}, e entrou antes. Enquanto ${v} estiver na janela, ${nums[fora]} nunca mais vai ser o máximo: descarto pelo fundo.`,
+        line: 6,
+        leaving: dropped,
+        note: `nums[${dropped}] = ${nums[dropped]} é menor ou igual a ${v}, e entrou antes. Enquanto ${v} estiver na janela, ${nums[dropped]} nunca mais vai ser o máximo: descarto pelo fundo.`,
       });
       dq.pop();
       ops++;
       reg({
         i,
-        linha: 7,
-        nota: `Fora o índice ${fora}. O deque fica com ${dq.length} ${dq.length === 1 ? "índice" : "índices"}.`,
+        line: 7,
+        note: `Fora o índice ${dropped}. O deque fica com ${dq.length} ${dq.length === 1 ? "índice" : "índices"}.`,
       });
     }
     if (dq.length) comp++;
@@ -120,8 +123,8 @@ function gerarPassos(nums: number[], k: number): Passo[] {
     ops++;
     reg({
       i,
-      linha: 8,
-      nota:
+      line: 8,
+      note:
         dq.length > 1
           ? `nums[${dq[dq.length - 2]}] = ${nums[dq[dq.length - 2]]} é maior que ${v}, então paro de descartar e guardo o índice ${i} no fundo. O deque continua decrescente: ${dq
               .map((j) => nums[j])
@@ -130,218 +133,171 @@ function gerarPassos(nums: number[], k: number): Passo[] {
     });
 
     if (dq[0] <= i - k) {
-      const velho = dq[0];
+      const stale = dq[0];
       reg({
         i,
-        linha: 9,
-        saindo: velho,
-        porFrente: true,
-        nota: `O índice ${velho} está na frente, mas a janela começa em ${ini}: ele venceu a validade. O maior valor da janela anterior ficou para trás.`,
+        line: 9,
+        leaving: stale,
+        fromFront: true,
+        note: `O índice ${stale} está na frente, mas a janela começa em ${windowStart}: ele venceu a validade. O maior valor da janela anterior ficou para trás.`,
       });
       dq.shift();
       ops++;
       reg({
         i,
-        linha: 10,
-        nota: `Tiro o ${velho} pela frente. Agora quem manda é o índice ${dq[0]}, com valor ${nums[dq[0]]}.`,
+        line: 10,
+        note: `Tiro o ${stale} pela frente. Agora quem manda é o índice ${dq[0]}, com valor ${nums[dq[0]]}.`,
       });
     }
     // O maior deque é medido depois da validade: por um instante ele chega a ter
     // k + 1 índices, mas o tamanho que sustenta o O(k) de memória é o que sobra
     // quando o passo termina.
-    maiorDq = Math.max(maiorDq, dq.length);
+    maxDq = Math.max(maxDq, dq.length);
 
     if (i >= k - 1) {
-      saida.push(nums[dq[0]]);
+      output.push(nums[dq[0]]);
       reg({
         i,
-        linha: 12,
-        fecha: true,
-        nota: `Janela [${ini}..${i}] fechada. O máximo é nums[${dq[0]}] = ${nums[dq[0]]}, que está na frente do deque: leio sem comparar nada.`,
+        line: 12,
+        closes: true,
+        note: `Janela [${windowStart}..${i}] fechada. O máximo é nums[${dq[0]}] = ${nums[dq[0]]}, que está na frente do deque: leio sem comparar nada.`,
       });
     } else {
       reg({
         i,
-        linha: 11,
-        nota: `Ainda não tenho ${k} elementos lidos, então esta janela não conta. Sigo para o próximo índice.`,
+        line: 11,
+        note: `Ainda não tenho ${k} elementos lidos, então esta janela não conta. Sigo para o próximo índice.`,
       });
     }
   }
 
-  const janelas = Math.max(0, nums.length - k + 1);
-  const bruta = janelas * Math.max(0, k - 1);
+  const windows = Math.max(0, nums.length - k + 1);
+  const brute = windows * Math.max(0, k - 1);
   reg({
     i: nums.length - 1,
-    linha: 13,
-    fim: true,
-    nota: `Fim: saída = [${saida.join(", ")}]. Foram ${comp} ${comp === 1 ? "comparação" : "comparações"} de valores, contra ${bruta} que a força bruta faria para reolhar as ${janelas} ${
-      janelas === 1 ? "janela" : "janelas"
+    line: 13,
+    done: true,
+    note: `Fim: saída = [${output.join(", ")}]. Foram ${comp} ${comp === 1 ? "comparação" : "comparações"} de valores, contra ${brute} que a força bruta faria para reolhar as ${windows} ${
+      windows === 1 ? "janela" : "janelas"
     }.`,
   });
   return out;
 }
 
-type Preset = { key: string; rotulo: string; nums: number[]; k: number };
+type Preset = { key: string; label: string; nums: number[]; k: number };
 const PRESETS: Preset[] = [
-  { key: "lc239", rotulo: "LeetCode 239", nums: [1, 3, -1, -3, 5, 3, 6, 7], k: 3 },
-  { key: "validade", rotulo: "O máximo vence a validade", nums: [8, 1, 2, 3, 4, 5], k: 3 },
-  { key: "desc", rotulo: "Decrescente (deque cheio)", nums: [9, 8, 7, 6, 5, 4, 3, 2], k: 3 },
-  { key: "cresc", rotulo: "Crescente (deque de um)", nums: [1, 2, 3, 4, 5, 6, 7, 8], k: 3 },
-  { key: "iguais", rotulo: "Tudo igual", nums: [5, 5, 5, 5, 5, 5], k: 3 },
+  { key: "lc239", label: "LeetCode 239", nums: [1, 3, -1, -3, 5, 3, 6, 7], k: 3 },
+  { key: "validade", label: "O máximo vence a validade", nums: [8, 1, 2, 3, 4, 5], k: 3 },
+  { key: "desc", label: "Decrescente (deque cheio)", nums: [9, 8, 7, 6, 5, 4, 3, 2], k: 3 },
+  { key: "cresc", label: "Crescente (deque de um)", nums: [1, 2, 3, 4, 5, 6, 7, 8], k: 3 },
+  { key: "iguais", label: "Tudo igual", nums: [5, 5, 5, 5, 5, 5], k: 3 },
 ];
 
-const PADRAO = PRESETS[0];
+const DEFAULT_PRESET = PRESETS[0];
 
 export function QueueDequeMonotonico() {
-  const [nums, setNums] = useState<number[]>(PADRAO.nums);
-  const [entrada, setEntrada] = useState(PADRAO.nums.join(", "));
-  const [k, setK] = useState(PADRAO.k);
-  const [preset, setPreset] = useState(PADRAO.key);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [nums, setNums] = useState<number[]>(DEFAULT_PRESET.nums);
+  const [text, setText] = useState(DEFAULT_PRESET.nums.join(", "));
+  const [k, setK] = useState(DEFAULT_PRESET.k);
+  const [preset, setPreset] = useState(DEFAULT_PRESET.key);
 
-  useEffect(() => setMounted(true), []);
+  const kUsed = Math.min(Math.max(1, k), Math.max(1, nums.length));
+  const steps = useMemo(() => generateSteps(nums.length ? nums : [0], kUsed), [nums, kUsed]);
 
-  const kUsado = Math.min(Math.max(1, k), Math.max(1, nums.length));
-  const passos = useMemo(() => gerarPassos(nums.length ? nums : [0], kUsado), [nums, kUsado]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · deque monotônico: o máximo de cada janela",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o tamanho do array (as células e as fichas
+    // da saída quebram linha) e o k, que decide quantas janelas fecham. O
+    // número de passos entra porque ele liga e desliga o rodapé inteiro.
+    measureOn: [nums.length, kUsed, steps.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const zerar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aoMudarEntrada = (v: string) => {
+  const onTextChange = (v: string) => {
     const arr = v
       .split(",")
       .map((x) => parseInt(x.trim(), 10))
       .filter((x) => !isNaN(x))
       .slice(0, 14);
-    zerar();
+    viz.reset();
     setPreset("");
-    setEntrada(v);
+    setText(v);
     setNums(arr.length ? arr : [0]);
   };
-  const aoMudarK = (v: string) => {
+  const onKChange = (v: string) => {
     const n = parseInt(v, 10);
-    zerar();
+    viz.reset();
     setPreset("");
     setK(isNaN(n) ? 1 : Math.max(1, Math.min(12, n)));
   };
-  const aplicarPreset = (pr: Preset) => {
-    zerar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
     setNums(pr.nums);
-    setEntrada(pr.nums.join(", "));
+    setText(pr.nums.join(", "));
     setK(pr.k);
   };
-  const sortear = () => {
-    const n = 8;
-    const arr = Array.from({ length: n }, () => 1 + Math.floor(Math.random() * 20));
-    zerar();
+  const shuffle = () => {
+    const size = 8;
+    const arr = Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 20));
+    viz.reset();
     setPreset("");
     setNums(arr);
-    setEntrada(arr.join(", "));
+    setText(arr.join(", "));
     setK(2 + Math.floor(Math.random() * 3));
   };
 
-  const iniJanela = p.i < 0 ? 0 : Math.max(0, p.i - kUsado + 1);
-  const frente = p.dq.length ? p.dq[0] : null;
+  const windowStart = p.i < 0 ? 0 : Math.max(0, p.i - kUsed + 1);
+  const front = p.dq.length ? p.dq[0] : null;
 
   const cells = nums.map((v, i) => {
     let cls = "viz-cell";
-    if (p.i >= 0 && i >= iniJanela && i <= p.i) cls += " in";
-    if (p.i >= 0 && i < iniJanela) cls += " drop";
+    if (p.i >= 0 && i >= windowStart && i <= p.i) cls += " in";
+    if (p.i >= 0 && i < windowStart) cls += " drop";
     if (i === p.i) cls += " entra";
-    if (p.saindo === i) cls += " sai";
-    let marca = "";
-    if (i === p.i) marca = "i";
-    if (frente !== null && i === frente) marca = marca ? "i máx" : "máx";
-    return { i, v, cls, marca };
+    if (p.leaving === i) cls += " sai";
+    let mark = "";
+    if (i === p.i) mark = "i";
+    if (front !== null && i === front) mark = mark ? "i máx" : "máx";
+    return { i, v, cls, mark };
   });
 
-  const janelas = Math.max(0, nums.length - kUsado + 1);
-  const bruta = janelas * Math.max(0, kUsado - 1);
+  const windows = Math.max(0, nums.length - kUsed + 1);
+  const brute = windows * Math.max(0, kUsed - 1);
 
-  const variaveis = [
-    { nome: "i", valor: p.i < 0 ? "-" : `${p.i}` },
-    { nome: "nums[i]", valor: p.i < 0 ? "-" : `${nums[p.i]}` },
-    { nome: "dq[0]", valor: frente === null ? "-" : `${frente}` },
-    { nome: "máximo", valor: frente === null ? "-" : `${nums[frente]}`, best: true },
+  const vars = [
+    { name: "i", value: p.i < 0 ? "-" : `${p.i}` },
+    { name: "nums[i]", value: p.i < 0 ? "-" : `${nums[p.i]}` },
+    { name: "dq[0]", value: front === null ? "-" : `${front}` },
+    { name: "máximo", value: front === null ? "-" : `${nums[front]}`, best: true },
   ];
 
-  const estatisticas = [
-    { k: "comp", rot: "comparações (deque)", val: `${p.comp}` },
-    { k: "bruta", rot: "comparações (força bruta)", val: `${bruta}` },
-    { k: "ops", rot: "entradas e saídas no deque", val: `${p.ops}` },
-    { k: "maior", rot: "maior deque", val: `${p.maiorDq}` },
+  const stats = [
+    { k: "comp", label: "comparações (deque)", value: `${p.comp}` },
+    { k: "bruta", label: "comparações (força bruta)", value: `${brute}` },
+    { k: "ops", label: "entradas e saídas no deque", value: `${p.ops}` },
+    { k: "maior", label: "maior deque", value: `${p.maxDq}` },
   ];
 
-  const notaCls = "viz-note" + (p.fim || p.fecha ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.done || p.closes ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · deque monotônico: o máximo de cada janela</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -349,13 +305,13 @@ export function QueueDequeMonotonico() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Array</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={text} onChange={(e) => onTextChange(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>k</span>
-            <input className="viz-input k" type="number" min={1} max={12} value={k} onChange={(e) => aoMudarK(e.target.value)} />
+            <input className="viz-input k" type="number" min={1} max={12} value={k} onChange={(e) => onKChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={shuffle}>
             Sortear
           </button>
         </div>
@@ -365,7 +321,7 @@ export function QueueDequeMonotonico() {
             <div className="viz-cell-wrap" key={c.i}>
               <span className="viz-cell-idx">{c.i}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
@@ -376,7 +332,7 @@ export function QueueDequeMonotonico() {
           <div className="fila-itens">
             {p.dq.length === 0 && <span className="fila-vazio">vazio</span>}
             {p.dq.map((j, pos) => (
-              <span key={j} className={`fila-item${pos === 0 ? " frente" : ""}${p.saindo === j ? " saindo" : ""}`}>
+              <span key={j} className={`fila-item${pos === 0 ? " frente" : ""}${p.leaving === j ? " saindo" : ""}`}>
                 <b>{nums[j]}</b>
                 <i>idx {j}</i>
               </span>
@@ -388,118 +344,66 @@ export function QueueDequeMonotonico() {
         <div className="fila-fila">
           <span className="fila-rot">saída</span>
           <div className="fila-itens">
-            {p.saida.length === 0 && <span className="fila-vazio">nenhuma janela fechada ainda</span>}
-            {p.saida.map((v, i) => (
-              <span key={i} className={`fila-item saida${p.fecha && i === p.saida.length - 1 ? " novo" : ""}`}>
+            {p.output.length === 0 && <span className="fila-vazio">nenhuma janela fechada ainda</span>}
+            {p.output.map((v, i) => (
+              <span key={i} className={`fila-item saida${p.closes && i === p.output.length - 1 ? " novo" : ""}`}>
                 <b>{v}</b>
               </span>
             ))}
           </div>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">maximos_da_janela.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">maximos_da_janela.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
             <p className="fila-resumo">
-              n = {nums.length}, k = {kUsado}: são {janelas} {janelas === 1 ? "janela" : "janelas"} para resolver.
-              {k > nums.length ? ` Você pediu k = ${k}, mas não existe janela maior que o array: usei k = ${kUsado}.` : ""}
-              {kUsado === 1 ? " Com k = 1 a resposta é o próprio array, e a força bruta não compara nada: o deque vira só custo." : ""}
+              n = {nums.length}, k = {kUsed}: são {windows} {windows === 1 ? "janela" : "janelas"} para resolver.
+              {k > nums.length ? ` Você pediu k = ${k}, mas não existe janela maior que o array: usei k = ${kUsed}.` : ""}
+              {kUsed === 1 ? " Com k = 1 a resposta é o próprio array, e a força bruta não compara nada: o deque vira só custo." : ""}
             </p>
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={zerar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/QueueDuasPilhas.tsx
+++ b/content/visualizers/QueueDuasPilhas.tsx
@@ -1,42 +1,46 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
-// QueueDuasPilhas, a fila montada com duas pilhas (LeetCode 232), que foi a
-// tarefa de casa deixada no encontro.
+// QueueDuasPilhas, a fila montada com duas pilhas (LeetCode 232).
 //
-// Mesmo padrão do TwoPointersVisualizer: gerador PURO de passos + a mesma casca.
-// O desenho central são duas torres, porque o truque é geométrico: despejar a
-// pilha de ENTRADA na de SAÍDA inverte a ordem, e LIFO invertido é FIFO.
+// Gerador PURO de passos + a casca compartilhada. O desenho central são duas
+// torres, porque o truque é geométrico: despejar a pilha de ENTRADA na de SAÍDA
+// inverte a ordem, e LIFO invertido é FIFO.
 //
 // A única coisa que o aluno precisa ver acontecendo: a virada é cara, mas
 // acontece raramente, e cada elemento é empurrado e retirado no máximo duas
 // vezes em cada pilha. Por isso o contador "operações por elemento" nunca passa
 // de 4, mexa-se no roteiro o quanto quiser: é O(1) amortizado na tela.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Op = { tipo: "enq"; valor: string } | { tipo: "deq" };
+type Op = { kind: "enq"; value: string } | { kind: "deq" };
 
-type Passo = {
-  entrada: string[]; // fundo -> topo
-  saida: string[]; // fundo -> topo
-  linha: number;
+type Step = {
+  input: string[]; // fundo -> topo
+  output: string[]; // fundo -> topo
+  line: number;
   op: number;
-  movendo: string | null; // valor que acabou de trocar de pilha
+  moving: string | null; // valor que acabou de trocar de pilha
   ops: number; // pushes e pops nas duas pilhas
-  enfileirados: number;
-  entregues: number;
-  viradas: number;
-  ultimo: string | null;
-  alerta?: boolean;
-  nota: string;
+  enqueued: number;
+  delivered: number;
+  flips: number;
+  last: string | null;
+  warn?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO = [
+const CODE = [
   "class FilaComDuasPilhas:",
   "    def __init__(self):",
   "        self.entrada = []   # todo mundo chega aqui",
@@ -54,124 +58,123 @@ const CODIGO = [
   "        return self.saida.pop()",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-const LETRAS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-function roteiroDe(s: string): Op[] {
-  return Array.from(s).map((c) => (c === "-" ? { tipo: "deq" } : { tipo: "enq", valor: c }));
+function scriptOf(s: string): Op[] {
+  return Array.from(s).map((c) => (c === "-" ? { kind: "deq" } : { kind: "enq", value: c }));
 }
 
-function proximaLetra(roteiro: Op[]): string {
+function nextLetter(script: Op[]): string {
   let n = 0;
-  for (const o of roteiro) if (o.tipo === "enq") n++;
-  return LETRAS[n % LETRAS.length];
+  for (const o of script) if (o.kind === "enq") n++;
+  return LETTERS[n % LETTERS.length];
 }
 
-function gerarPassos(roteiro: Op[]): Passo[] {
-  const out: Passo[] = [];
-  const entrada: string[] = [];
-  const saida: string[] = [];
+function generateSteps(script: Op[]): Step[] {
+  const out: Step[] = [];
+  const input: string[] = [];
+  const output: string[] = [];
   let ops = 0;
-  let enfileirados = 0;
-  let entregues = 0;
-  let viradas = 0;
-  let ultimo: string | null = null;
+  let enqueued = 0;
+  let delivered = 0;
+  let flips = 0;
+  let last: string | null = null;
 
-  const reg = (p: { linha: number; op: number; nota: string; movendo?: string; alerta?: boolean }) => {
+  const reg = (p: { line: number; op: number; note: string; moving?: string; warn?: boolean }) => {
     out.push({
-      entrada: [...entrada],
-      saida: [...saida],
-      linha: p.linha,
+      input: [...input],
+      output: [...output],
+      line: p.line,
       op: p.op,
-      movendo: p.movendo ?? null,
+      moving: p.moving ?? null,
       ops,
-      enfileirados,
-      entregues,
-      viradas,
-      ultimo,
-      alerta: p.alerta,
-      nota: p.nota,
+      enqueued,
+      delivered,
+      flips,
+      last,
+      warn: p.warn,
+      note: p.note,
     });
   };
 
-  reg({ linha: 3, op: -1, nota: "As duas pilhas começam vazias. Uma só recebe, a outra só entrega." });
+  reg({ line: 3, op: -1, note: "As duas pilhas começam vazias. Uma só recebe, a outra só entrega." });
 
-  let guarda = 0;
-  for (let k = 0; k < roteiro.length && guarda++ < 60; k++) {
-    const op = roteiro[k];
+  let guard = 0;
+  for (let k = 0; k < script.length && guard++ < 60; k++) {
+    const op = script[k];
 
-    if (op.tipo === "enq") {
-      entrada.push(op.valor);
+    if (op.kind === "enq") {
+      input.push(op.value);
       ops++;
-      enfileirados++;
+      enqueued++;
       reg({
-        linha: 6,
+        line: 6,
         op: k,
-        movendo: op.valor,
-        nota: `Enfileirar ${op.valor} é só empilhar na entrada, sem olhar para mais nada. Uma operação, sempre: O(1) de verdade, não amortizado.`,
+        moving: op.value,
+        note: `Enfileirar ${op.value} é só empilhar na entrada, sem olhar para mais nada. Uma operação, sempre: O(1) de verdade, não amortizado.`,
       });
       continue;
     }
 
-    if (!entrada.length && !saida.length) {
+    if (!input.length && !output.length) {
       reg({
-        linha: 10,
+        line: 10,
         op: k,
-        alerta: true,
-        nota: "As duas pilhas estão vazias: não tem ninguém para entregar. É o único caso em que o desenfileirar falha.",
+        warn: true,
+        note: "As duas pilhas estão vazias: não tem ninguém para entregar. É o único caso em que o desenfileirar falha.",
       });
       continue;
     }
     reg({
-      linha: 9,
+      line: 9,
       op: k,
-      nota: `Pediram um desenfileirar. Tem ${entrada.length} na entrada e ${saida.length} na saída, então alguém vai sair.`,
+      note: `Pediram um desenfileirar. Tem ${input.length} na entrada e ${output.length} na saída, então alguém vai sair.`,
     });
     // Guardado para a nota final dizer quanto ESTE desenfileirar custou: é o
     // contraste entre o passo caro (a virada) e os baratos que vêm depois, que
     // é a definição de amortizado.
-    const opsAntes = ops;
+    const opsBefore = ops;
 
-    if (!saida.length) {
-      viradas++;
+    if (!output.length) {
+      flips++;
       reg({
-        linha: 11,
+        line: 11,
         op: k,
-        nota: `A saída está vazia, então é hora da virada: vou despejar os ${entrada.length} da entrada, um por um. O topo da entrada é o mais NOVO, e ele vai para o fundo da saída.`,
+        note: `A saída está vazia, então é hora da virada: vou despejar os ${input.length} da entrada, um por um. O topo da entrada é o mais NOVO, e ele vai para o fundo da saída.`,
       });
       let g2 = 0;
-      while (entrada.length && g2++ < 40) {
-        const v = entrada.pop() as string;
-        saida.push(v);
+      while (input.length && g2++ < 40) {
+        const v = input.pop() as string;
+        output.push(v);
         ops += 2;
         reg({
-          linha: 13,
+          line: 13,
           op: k,
-          movendo: v,
-          nota: `${v} sai do topo da entrada e vai para o topo da saída. Como saiu por último, entra por primeiro: a ordem está sendo invertida.`,
+          moving: v,
+          note: `${v} sai do topo da entrada e vai para o topo da saída. Como saiu por último, entra por primeiro: a ordem está sendo invertida.`,
         });
       }
     } else {
       reg({
-        linha: 11,
+        line: 11,
         op: k,
-        nota: `A saída ainda tem ${saida.length} ${saida.length === 1 ? "elemento" : "elementos"}, então não viro nada: o próximo da fila já está no topo dela.`,
+        note: `A saída ainda tem ${output.length} ${output.length === 1 ? "elemento" : "elementos"}, então não viro nada: o próximo da fila já está no topo dela.`,
       });
     }
 
-    const v = saida.pop() as string;
+    const v = output.pop() as string;
     ops++;
-    entregues++;
-    ultimo = v;
-    const custo = ops - opsAntes;
+    delivered++;
+    last = v;
+    const cost = ops - opsBefore;
     reg({
-      linha: 14,
+      line: 14,
       op: k,
-      movendo: v,
-      nota: `Desempilho ${v} da saída e devolvo. Foi o primeiro que entrou na fila, e saiu do topo de uma pilha: LIFO virado do avesso é FIFO. Este desenfileirar custou ${custo} ${
-        custo === 1 ? "operação de pilha (o mínimo possível)" : "operações de pilha, porque pagou a virada"
+      moving: v,
+      note: `Desempilho ${v} da saída e devolvo. Foi o primeiro que entrou na fila, e saiu do topo de uma pilha: LIFO virado do avesso é FIFO. Este desenfileirar custou ${cost} ${
+        cost === 1 ? "operação de pilha (o mínimo possível)" : "operações de pilha, porque pagou a virada"
       }.`,
     });
   }
@@ -179,154 +182,107 @@ function gerarPassos(roteiro: Op[]): Passo[] {
   return out;
 }
 
-type Preset = { key: string; rotulo: string; roteiro: string };
+type Preset = { key: string; label: string; script: string };
 const PRESETS: Preset[] = [
-  { key: "tudo", rotulo: "Enche e esvazia", roteiro: "ABCD----" },
-  { key: "misto", rotulo: "Intercalado", roteiro: "AB-C-D-" },
-  { key: "duas", rotulo: "Duas viradas", roteiro: "ABC--DE--" },
-  { key: "vazia", rotulo: "Esvazia demais", roteiro: "A--" },
+  { key: "tudo", label: "Enche e esvazia", script: "ABCD----" },
+  { key: "misto", label: "Intercalado", script: "AB-C-D-" },
+  { key: "duas", label: "Duas viradas", script: "ABC--DE--" },
+  { key: "vazia", label: "Esvazia demais", script: "A--" },
 ];
 
-const PADRAO = PRESETS[0];
+const DEFAULT_PRESET = PRESETS[0];
 
 // Custo amortizado: operações de pilha divididas por elemento que passou pela
 // fila. Nunca passa de 4, que é o teto do truque (cada elemento é empurrado e
 // retirado uma vez em cada pilha).
-function media(ops: number, elementos: number): string {
-  if (!elementos) return "-";
-  const v = Math.round((ops / elementos) * 10) / 10;
+function average(ops: number, elements: number): string {
+  if (!elements) return "-";
+  const v = Math.round((ops / elements) * 10) / 10;
   return v.toFixed(1).replace(".", ",");
 }
 
 export function QueueDuasPilhas() {
-  const [roteiro, setRoteiro] = useState<Op[]>(roteiroDe(PADRAO.roteiro));
-  const [preset, setPreset] = useState(PADRAO.key);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [script, setScript] = useState<Op[]>(scriptOf(DEFAULT_PRESET.script));
+  const [preset, setPreset] = useState(DEFAULT_PRESET.key);
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(script), [script]);
 
-  const passos = useMemo(() => gerarPassos(roteiro), [roteiro]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · fila com duas pilhas: a virada que inverte a ordem",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o tamanho do roteiro (as fichas quebram
+    // linha e as torres crescem) e o número de passos, porque um roteiro vazio
+    // gera UM passo só e aí o rodapé inteiro some.
+    measureOn: [script.length, steps.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const zerar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aplicarPreset = (pr: Preset) => {
-    zerar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
-    setRoteiro(roteiroDe(pr.roteiro));
+    setScript(scriptOf(pr.script));
   };
-  const acrescentar = (op: Op) => {
-    zerar();
+  const append = (op: Op) => {
+    viz.reset();
     setPreset("");
-    setRoteiro((r) => (r.length >= 16 ? r : [...r, op]));
+    setScript((r) => (r.length >= 16 ? r : [...r, op]));
   };
-  const desfazer = () => {
-    zerar();
+  const undo = () => {
+    viz.reset();
     setPreset("");
-    setRoteiro((r) => r.slice(0, -1));
+    setScript((r) => r.slice(0, -1));
   };
 
-  const torre = (itens: string[], qual: "entrada" | "saida") => {
-    const doTopoParaBaixo = [...itens].reverse();
+  const tower = (items: string[], which: "entrada" | "saida") => {
+    const topDown = [...items].reverse();
     return (
       <div className="fila-torre">
-        <div className="fila-torre-rot">{qual === "entrada" ? "entrada · só empilha" : "saída · só desempilha"}</div>
+        <div className="fila-torre-rot">{which === "entrada" ? "entrada · só empilha" : "saída · só desempilha"}</div>
         <div className="fila-torre-corpo">
-          {doTopoParaBaixo.length === 0 && <span className="fila-vazio">vazia</span>}
-          {doTopoParaBaixo.map((v, i) => (
-            <div key={`${v}-${i}`} className={`viz-cell${i === 0 ? " in" : ""}${p.movendo === v ? " entra" : ""}`}>
+          {topDown.length === 0 && <span className="fila-vazio">vazia</span>}
+          {topDown.map((v, i) => (
+            <div key={`${v}-${i}`} className={`viz-cell${i === 0 ? " in" : ""}${p.moving === v ? " entra" : ""}`}>
               {v}
             </div>
           ))}
         </div>
-        <div className="fila-torre-base">{doTopoParaBaixo.length ? `topo: ${doTopoParaBaixo[0]}` : "sem topo"}</div>
+        <div className="fila-torre-base">{topDown.length ? `topo: ${topDown[0]}` : "sem topo"}</div>
       </div>
     );
   };
 
-  const variaveis = [
-    { nome: "entrada", valor: p.entrada.length ? p.entrada.join(" ") : "[]" },
-    { nome: "saida", valor: p.saida.length ? p.saida.join(" ") : "[]" },
-    { nome: "viradas", valor: `${p.viradas}` },
-    { nome: "devolvido", valor: p.ultimo ?? "-", best: true },
+  const vars = [
+    { name: "entrada", value: p.input.length ? p.input.join(" ") : "[]" },
+    { name: "saida", value: p.output.length ? p.output.join(" ") : "[]" },
+    { name: "viradas", value: `${p.flips}` },
+    { name: "devolvido", value: p.last ?? "-", best: true },
   ];
 
-  const estatisticas = [
-    { k: "ops", rot: "operações de pilha", val: `${p.ops}` },
-    { k: "ent", rot: "elementos entregues", val: `${p.entregues}` },
-    { k: "med", rot: "operações por elemento", val: media(p.ops, p.enfileirados) },
-    { k: "custo", rot: "custo do desenfileirar", val: "O(1) amortizado" },
+  const stats = [
+    { k: "ops", label: "operações de pilha", value: `${p.ops}` },
+    { k: "ent", label: "elementos entregues", value: `${p.delivered}` },
+    { k: "med", label: "operações por elemento", value: average(p.ops, p.enqueued) },
+    { k: "custo", label: "custo do desenfileirar", value: "O(1) amortizado" },
   ];
 
-  const notaCls = "viz-note" + (p.alerta ? " invalid" : idx === total - 1 ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.warn ? " invalid" : viz.step === steps.length - 1 ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · fila com duas pilhas: a virada que inverte a ordem</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -335,13 +291,13 @@ export function QueueDuasPilhas() {
           <div className="viz-field grow">
             <span>roteiro de operações</span>
             <div className="fila-botoes">
-              <button className="viz-btn" onClick={() => acrescentar({ tipo: "enq", valor: proximaLetra(roteiro) })}>
-                + enfileirar {proximaLetra(roteiro)}
+              <button className="viz-btn" onClick={() => append({ kind: "enq", value: nextLetter(script) })}>
+                + enfileirar {nextLetter(script)}
               </button>
-              <button className="viz-btn" onClick={() => acrescentar({ tipo: "deq" })}>
+              <button className="viz-btn" onClick={() => append({ kind: "deq" })}>
                 + desenfileirar
               </button>
-              <button className="viz-btn" disabled={!roteiro.length} onClick={desfazer}>
+              <button className="viz-btn" disabled={!script.length} onClick={undo}>
                 ← desfazer
               </button>
             </div>
@@ -349,43 +305,49 @@ export function QueueDuasPilhas() {
         </div>
 
         <div className="fila-roteiro">
-          {roteiro.length === 0 && <span className="fila-vazio">roteiro vazio: use os botões acima</span>}
-          {roteiro.map((o, i) => (
+          {script.length === 0 && <span className="fila-vazio">roteiro vazio: use os botões acima</span>}
+          {script.map((o, i) => (
             <span key={i} className={`fila-op${i === p.op ? " on" : ""}${i < p.op ? " feito" : ""}`}>
-              {o.tipo === "enq" ? `↓ ${o.valor}` : "↑ deq"}
+              {o.kind === "enq" ? `↓ ${o.value}` : "↑ deq"}
             </span>
           ))}
         </div>
 
         <div className="fila-torres">
-          {torre(p.entrada, "entrada")}
+          {tower(p.input, "entrada")}
           <div className="fila-vira">
             <span>↻</span>
             <em>a virada só acontece quando a saída esvazia</em>
           </div>
-          {torre(p.saida, "saida")}
+          {tower(p.output, "saida")}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">fila_com_duas_pilhas.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">fila_com_duas_pilhas.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
             <p className="fila-resumo">Nas duas pilhas, o topo é o primeiro item de cima para baixo.</p>
@@ -393,78 +355,20 @@ export function QueueDuasPilhas() {
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={zerar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/QueueVisualizer.tsx
+++ b/content/visualizers/QueueVisualizer.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // QueueVisualizer, a fila sobre array nas duas versões: a ingênua e o buffer
 // circular. É o "aha" do tópico.
 //
-// Mesmo padrão do TwoPointersVisualizer: um gerador PURO de passos + a mesma
-// casca (células, código sincronizado, variáveis, controles, Expandir). O que
-// muda é que aqui existem DOIS códigos, um por implementação, e o campo `linha`
-// aponta para o código do modo atual (as duas listas têm 19 linhas e só diferem
-// no laço do desenfileirar, que é justamente o assunto).
+// Gerador PURO de passos + a casca compartilhada. O que muda em relação aos
+// outros é que aqui existem DOIS códigos, um por implementação, e o campo
+// `line` aponta para o código do modo atual (as duas listas têm 19 linhas e só
+// diferem no laço do desenfileirar, que é justamente o assunto).
 //
 // A única coisa que o aluno precisa ver acontecendo: na fila ingênua QUEM ANDA
 // SÃO OS ELEMENTOS (o shift left, O(n)); no buffer circular quem anda são os
@@ -23,30 +23,34 @@ import { createPortal } from "react-dom";
 // fita de cima. Ele existe para o momento em que o fim passa da última posição
 // e reaparece no zero, que no desenho linear parece um pulo e no anel é só o
 // próximo passo. A legenda usa .tp-legenda, que já é genérica no globals.css.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Op = { tipo: "enq"; valor: string } | { tipo: "deq" };
-type Modo = "ingenua" | "circular";
+type Op = { kind: "enq"; value: string } | { kind: "deq" };
+type Mode = "ingenua" | "circular";
 
-type Passo = {
+type Step = {
   slots: (string | null)[];
-  inicio: number;
-  fim: number;
-  tamanho: number;
-  linha: number;
+  start: number;
+  end: number;
+  size: number;
+  line: number;
   op: number; // índice da operação no roteiro, -1 no passo de preparação
-  foco: number | null; // posição que acabou de ser escrita
-  saiu: number | null; // posição que acabou de ser lida
-  movidos: number[]; // posições que receberam valor no shift left
-  movs: number; // movimentações de elementos acumuladas
-  ultimo: string | null; // último valor devolvido pelo desenfileirar
-  alerta?: boolean;
-  nota: string;
+  wroteAt: number | null; // posição que acabou de ser escrita
+  readAt: number | null; // posição que acabou de ser lida
+  moved: number[]; // posições que receberam valor no shift left
+  moves: number; // movimentações de elementos acumuladas
+  last: string | null; // último valor devolvido pelo desenfileirar
+  warn?: boolean;
+  note: string;
 };
 
-// As duas listas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e
+// As duas listas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e
 // a quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO: Record<Modo, string[]> = {
+const CODE: Record<Mode, string[]> = {
   ingenua: [
     "class FilaIngenua:",
     "    def __init__(self, cap):",
@@ -93,188 +97,187 @@ const CODIGO: Record<Modo, string[]> = {
 
 // Linhas de interesse, por modo (as duas implementações desencontram a partir
 // do desenfileirar, que é onde uma tem o laço e a outra não).
-const L: Record<Modo, Record<string, number>> = {
-  ingenua: { init: 3, guardCheia: 6, cheia: 7, escrita: 8, mais: 9, guardVazia: 12, vazia: 13, leitura: 14, shift: 16, menos: 17 },
-  circular: { init: 3, guardCheia: 6, cheia: 7, escrita: 8, mais: 10, guardVazia: 13, vazia: 14, leitura: 15, andaInicio: 16, menos: 17 },
+const L: Record<Mode, Record<string, number>> = {
+  ingenua: { init: 3, guardFull: 6, full: 7, write: 8, inc: 9, guardEmpty: 12, empty: 13, read: 14, shift: 16, dec: 17 },
+  circular: { init: 3, guardFull: 6, full: 7, write: 8, inc: 10, guardEmpty: 13, empty: 14, read: 15, moveStart: 16, dec: 17 },
 };
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-const LETRAS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 // Roteiro compacto: cada letra é um enfileirar, cada "-" é um desenfileirar.
-function roteiroDe(s: string): Op[] {
-  return Array.from(s).map((c) => (c === "-" ? { tipo: "deq" } : { tipo: "enq", valor: c }));
+function scriptOf(s: string): Op[] {
+  return Array.from(s).map((c) => (c === "-" ? { kind: "deq" } : { kind: "enq", value: c }));
 }
 
-function proximaLetra(roteiro: Op[]): string {
+function nextLetter(script: Op[]): string {
   let n = 0;
-  for (const o of roteiro) if (o.tipo === "enq") n++;
-  return LETRAS[n % LETRAS.length];
+  for (const o of script) if (o.kind === "enq") n++;
+  return LETTERS[n % LETTERS.length];
 }
 
-function gerarPassos(roteiro: Op[], cap: number, modo: Modo): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(script: Op[], cap: number, mode: Mode): Step[] {
+  const out: Step[] = [];
   const slots: (string | null)[] = new Array(cap).fill(null);
-  const ln = L[modo];
-  let inicio = 0;
-  let fim = 0;
-  let tamanho = 0;
-  let movs = 0;
-  let ultimo: string | null = null;
+  const ln = L[mode];
+  let start = 0;
+  let end = 0;
+  let size = 0;
+  let moves = 0;
+  let last: string | null = null;
 
-  const reg = (p: { linha: number; op: number; nota: string; foco?: number; saiu?: number; movidos?: number[]; alerta?: boolean }) => {
+  const reg = (p: { line: number; op: number; note: string; wroteAt?: number; readAt?: number; moved?: number[]; warn?: boolean }) => {
     out.push({
       slots: [...slots],
-      inicio,
-      fim,
-      tamanho,
-      movs,
-      ultimo,
-      foco: p.foco ?? null,
-      saiu: p.saiu ?? null,
-      movidos: p.movidos ?? [],
-      linha: p.linha,
+      start,
+      end,
+      size,
+      moves,
+      last,
+      wroteAt: p.wroteAt ?? null,
+      readAt: p.readAt ?? null,
+      moved: p.moved ?? [],
+      line: p.line,
       op: p.op,
-      nota: p.nota,
-      alerta: p.alerta,
+      note: p.note,
+      warn: p.warn,
     });
   };
 
   reg({
-    linha: ln.init,
+    line: ln.init,
     op: -1,
-    nota: `Array de ${cap} posições, nenhuma ocupada: início, fim e tamanho começam todos em 0.`,
+    note: `Array de ${cap} posições, nenhuma ocupada: início, fim e tamanho começam todos em 0.`,
   });
 
-  let guarda = 0;
-  for (let k = 0; k < roteiro.length && guarda++ < 60; k++) {
-    const op = roteiro[k];
+  let guard = 0;
+  for (let k = 0; k < script.length && guard++ < 60; k++) {
+    const op = script[k];
 
-    if (op.tipo === "enq") {
-      if (tamanho === cap) {
+    if (op.kind === "enq") {
+      if (size === cap) {
         reg({
-          linha: ln.cheia,
+          line: ln.full,
           op: k,
-          alerta: true,
-          nota: `Chegou ${op.valor}, mas tamanho (${tamanho}) já bateu na capacidade (${cap}): a fila está cheia. Aqui o guard rail recusa; as outras saídas seriam descartar o mais antigo ou dobrar o array.`,
+          warn: true,
+          note: `Chegou ${op.value}, mas tamanho (${size}) já bateu na capacidade (${cap}): a fila está cheia. Aqui o guard rail recusa; as outras saídas seriam descartar o mais antigo ou dobrar o array.`,
         });
         continue;
       }
       reg({
-        linha: ln.guardCheia,
+        line: ln.guardFull,
         op: k,
-        nota: `Chegou ${op.valor}. tamanho (${tamanho}) ainda é menor que a capacidade (${cap}), então cabe mais um.`,
+        note: `Chegou ${op.value}. tamanho (${size}) ainda é menor que a capacidade (${cap}), então cabe mais um.`,
       });
 
-      const pos = modo === "circular" ? fim : tamanho;
-      const reaproveita = slots[pos] !== null;
-      slots[pos] = op.valor;
+      const pos = mode === "circular" ? end : size;
+      const reused = slots[pos] !== null;
+      slots[pos] = op.value;
       reg({
-        linha: ln.escrita,
+        line: ln.write,
         op: k,
-        foco: pos,
-        nota:
-          modo === "circular"
-            ? `Escrevo ${op.valor} na posição ${pos}, que é exatamente para onde o fim aponta.${
-                reaproveita ? " Essa posição já tinha sido usada e ficou livre, então foi reaproveitada." : ""
+        wroteAt: pos,
+        note:
+          mode === "circular"
+            ? `Escrevo ${op.value} na posição ${pos}, que é exatamente para onde o fim aponta.${
+                reused ? " Essa posição já tinha sido usada e ficou livre, então foi reaproveitada." : ""
               }`
-            : `Escrevo ${op.valor} na posição ${pos}. Na ingênua o fim da fila é sempre o próprio tamanho, então nem preciso de um ponteiro para ele.`,
+            : `Escrevo ${op.value} na posição ${pos}. Na ingênua o fim da fila é sempre o próprio tamanho, então nem preciso de um ponteiro para ele.`,
       });
 
-      if (modo === "circular") {
-        const antigo = fim;
-        fim = (fim + 1) % cap;
-        tamanho++;
+      if (mode === "circular") {
+        const previous = end;
+        end = (end + 1) % cap;
+        size++;
         reg({
-          linha: ln.mais,
+          line: ln.inc,
           op: k,
-          foco: pos,
-          nota: `fim = (${antigo} + 1) % ${cap} = ${fim}${
-            fim === 0 ? ": dei a volta, o fim reaparece na posição 0" : ""
-          }. O tamanho vai para ${tamanho}${tamanho === cap ? " e a fila está cheia" : ""}.`,
+          wroteAt: pos,
+          note: `fim = (${previous} + 1) % ${cap} = ${end}${
+            end === 0 ? ": dei a volta, o fim reaparece na posição 0" : ""
+          }. O tamanho vai para ${size}${size === cap ? " e a fila está cheia" : ""}.`,
         });
       } else {
-        tamanho++;
+        size++;
         reg({
-          linha: ln.mais,
+          line: ln.inc,
           op: k,
-          foco: pos,
-          nota: `O tamanho vai para ${tamanho}${tamanho === cap ? " e a fila está cheia" : ""}. Nenhum elemento se mexeu: enfileirar é O(1) nas duas implementações.`,
+          wroteAt: pos,
+          note: `O tamanho vai para ${size}${size === cap ? " e a fila está cheia" : ""}. Nenhum elemento se mexeu: enfileirar é O(1) nas duas implementações.`,
         });
       }
       continue;
     }
 
     // desenfileirar
-    if (tamanho === 0) {
+    if (size === 0) {
       reg({
-        linha: ln.vazia,
+        line: ln.empty,
         op: k,
-        alerta: true,
-        nota: `Pedi para desenfileirar com tamanho 0: não tem ninguém na fila. Sem esse guard rail eu devolveria lixo de uma posição que nunca foi escrita.`,
+        warn: true,
+        note: `Pedi para desenfileirar com tamanho 0: não tem ninguém na fila. Sem esse guard rail eu devolveria lixo de uma posição que nunca foi escrita.`,
       });
       continue;
     }
     reg({
-      linha: ln.guardVazia,
+      line: ln.guardEmpty,
       op: k,
-      nota: `Vou desenfileirar. tamanho é ${tamanho}, então tem gente na fila e a operação pode acontecer.`,
+      note: `Vou desenfileirar. tamanho é ${size}, então tem gente na fila e a operação pode acontecer.`,
     });
 
-    const lido = modo === "circular" ? inicio : 0;
-    const valor = slots[lido];
+    const readPos = mode === "circular" ? start : 0;
+    const value = slots[readPos];
     reg({
-      linha: ln.leitura,
+      line: ln.read,
       op: k,
-      saiu: lido,
-      nota:
-        modo === "circular"
-          ? `Leio ${valor} da posição ${lido}, onde o início está parado. É o mais antigo da fila, o primeiro que entrou.`
-          : `Leio ${valor} da posição 0. Na ingênua o primeiro da fila é sempre a posição 0, e é isso que vai custar caro daqui a pouco.`,
+      readAt: readPos,
+      note:
+        mode === "circular"
+          ? `Leio ${value} da posição ${readPos}, onde o início está parado. É o mais antigo da fila, o primeiro que entrou.`
+          : `Leio ${value} da posição 0. Na ingênua o primeiro da fila é sempre a posição 0, e é isso que vai custar caro daqui a pouco.`,
     });
 
-    if (modo === "circular") {
-      const antigo = inicio;
-      inicio = (inicio + 1) % cap;
-      tamanho--;
-      ultimo = valor;
+    if (mode === "circular") {
+      const previous = start;
+      start = (start + 1) % cap;
+      size--;
+      last = value;
       reg({
-        linha: ln.andaInicio,
+        line: ln.moveStart,
         op: k,
-        nota: `início = (${antigo} + 1) % ${cap} = ${inicio}${
-          inicio === 0 ? ": o início também dá a volta" : ""
+        note: `início = (${previous} + 1) % ${cap} = ${start}${
+          start === 0 ? ": o início também dá a volta" : ""
         }. Zero elemento se mexeu, só o ponteiro andou.`,
       });
       reg({
-        linha: ln.menos,
+        line: ln.dec,
         op: k,
-        nota: `O tamanho volta para ${tamanho} e eu devolvo ${valor}. Custo do desenfileirar: uma leitura, uma soma e um resto. O(1).`,
+        note: `O tamanho volta para ${size} e eu devolvo ${value}. Custo do desenfileirar: uma leitura, uma soma e um resto. O(1).`,
       });
     } else {
-      const movidos: number[] = [];
-      for (let i = 1; i < tamanho; i++) {
+      const moved: number[] = [];
+      for (let i = 1; i < size; i++) {
         slots[i - 1] = slots[i];
-        movidos.push(i - 1);
+        moved.push(i - 1);
       }
-      movs += Math.max(0, tamanho - 1);
+      moves += Math.max(0, size - 1);
       reg({
-        linha: ln.shift,
+        line: ln.shift,
         op: k,
-        movidos,
-        nota: movidos.length
-          ? `Agora o pedágio: empurro os ${movidos.length} que sobraram uma casa para a esquerda (${movidos
+        moved,
+        note: moved.length
+          ? `Agora o pedágio: empurro os ${moved.length} que sobraram uma casa para a esquerda (${moved
               .map((i) => `${slots[i]} para ${i}`)
-              .join(", ")}). Foram ${movidos.length} movimentações só para tirar um elemento.`
+              .join(", ")}). Foram ${moved.length} movimentações só para tirar um elemento.`
           : `A fila tinha um só, então não sobrou ninguém para empurrar. Esse é o único caso em que o shift sai de graça.`,
       });
-      tamanho--;
-      ultimo = valor;
+      size--;
+      last = value;
       reg({
-        linha: ln.menos,
+        line: ln.dec,
         op: k,
-        nota: `O tamanho volta para ${tamanho} e eu devolvo ${valor}. Repare no resíduo: a última posição ainda guarda uma cópia, e só some quando alguém escrever por cima.`,
+        note: `O tamanho volta para ${size} e eu devolvo ${value}. Repare no resíduo: a última posição ainda guarda uma cópia, e só some quando alguém escrever por cima.`,
       });
     }
   }
@@ -282,232 +285,186 @@ function gerarPassos(roteiro: Op[], cap: number, modo: Modo): Passo[] {
   return out;
 }
 
-type Preset = { key: string; rotulo: string; cap: number; roteiro: string };
+type Preset = { key: string; label: string; cap: number; script: string };
 const PRESETS: Preset[] = [
-  { key: "volta", rotulo: "Dá a volta", cap: 5, roteiro: "ABCD-EF-" },
-  { key: "duas", rotulo: "Duas voltas", cap: 4, roteiro: "ABC-D-E-F-G-" },
-  { key: "cheia", rotulo: "Enche e recusa", cap: 4, roteiro: "ABCDE" },
-  { key: "vazia", rotulo: "Esvazia demais", cap: 4, roteiro: "AB---" },
+  { key: "volta", label: "Dá a volta", cap: 5, script: "ABCD-EF-" },
+  { key: "duas", label: "Duas voltas", cap: 4, script: "ABC-D-E-F-G-" },
+  { key: "cheia", label: "Enche e recusa", cap: 4, script: "ABCDE" },
+  { key: "vazia", label: "Esvazia demais", cap: 4, script: "AB---" },
 ];
 
-const PADRAO = PRESETS[0];
+const DEFAULT_PRESET = PRESETS[0];
 
 // Geometria do anel: cada posição do array vira um ponto da circunferência,
 // com o zero no topo e o índice crescendo no sentido horário.
 const CX = 170;
 const CY = 170;
 const R_SLOT = 108;
-const R_CELULA = 26;
+const R_CELL = 26;
 
-function ponto(i: number, cap: number, raio: number, desvioGraus = 0): [number, number] {
-  const ang = ((-90 + (360 * i) / cap + desvioGraus) * Math.PI) / 180;
-  return [CX + raio * Math.cos(ang), CY + raio * Math.sin(ang)];
+function point(i: number, cap: number, radius: number, offsetDeg = 0): [number, number] {
+  const angle = ((-90 + (360 * i) / cap + offsetDeg) * Math.PI) / 180;
+  return [CX + radius * Math.cos(angle), CY + radius * Math.sin(angle)];
 }
 
 export function QueueVisualizer() {
   // Abre na ingênua de propósito: é a ordem em que o artigo apresenta as duas,
   // e o contador de movimentações só faz sentido depois de ver o shift left.
-  const [modo, setModo] = useState<Modo>("ingenua");
-  const [cap, setCap] = useState(PADRAO.cap);
-  const [roteiro, setRoteiro] = useState<Op[]>(roteiroDe(PADRAO.roteiro));
-  const [preset, setPreset] = useState(PADRAO.key);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [mode, setMode] = useState<Mode>("ingenua");
+  const [cap, setCap] = useState(DEFAULT_PRESET.cap);
+  const [script, setScript] = useState<Op[]>(scriptOf(DEFAULT_PRESET.script));
+  const [preset, setPreset] = useState(DEFAULT_PRESET.key);
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(script, cap, mode), [script, cap, mode]);
 
-  const passos = useMemo(() => gerarPassos(roteiro, cap, modo), [roteiro, cap, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · a fila no array: ingênua x buffer circular",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o modo (o circular ganha uma quinta ficha de
+    // estatística), a capacidade (as células da fita), o tamanho do roteiro (as
+    // fichas quebram linha) e o número de passos, porque um roteiro vazio gera
+    // UM passo só e aí o rodapé inteiro some.
+    measureOn: [mode, cap, script.length, steps.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
     setCap(pr.cap);
-    setRoteiro(roteiroDe(pr.roteiro));
+    setScript(scriptOf(pr.script));
   };
-  const acrescentar = (op: Op) => {
-    reiniciar();
+  const append = (op: Op) => {
+    viz.reset();
     setPreset("");
-    setRoteiro((r) => (r.length >= 16 ? r : [...r, op]));
+    setScript((r) => (r.length >= 16 ? r : [...r, op]));
   };
-  const desfazer = () => {
-    reiniciar();
+  const undo = () => {
+    viz.reset();
     setPreset("");
-    setRoteiro((r) => r.slice(0, -1));
+    setScript((r) => r.slice(0, -1));
   };
-  const limpar = () => {
-    reiniciar();
+  const clear = () => {
+    viz.reset();
     setPreset("");
-    setRoteiro([]);
+    setScript([]);
   };
-  const trocarCap = (v: string) => {
+  const changeCap = (v: string) => {
     const n = parseInt(v, 10);
     if (isNaN(n)) return;
-    reiniciar();
+    viz.reset();
     setPreset("");
     setCap(Math.min(8, Math.max(3, n)));
   };
-  const trocarModo = (m: Modo) => {
-    reiniciar();
-    setModo(m);
+  const changeMode = (m: Mode) => {
+    viz.reset();
+    setMode(m);
   };
 
   // Uma posição está OCUPADA se pertence à fila lógica agora. Fora disso ela
   // pode estar vazia (nunca escrita) ou guardar um resíduo, um valor que já foi
   // consumido e continua gravado até alguém escrever por cima.
-  const ocupada = (i: number): boolean => {
-    if (p.tamanho === 0) return false;
-    if (modo === "ingenua") return i < p.tamanho;
-    const rel = (i - p.inicio + cap) % cap;
-    return rel < p.tamanho;
+  const occupied = (i: number): boolean => {
+    if (p.size === 0) return false;
+    if (mode === "ingenua") return i < p.size;
+    const rel = (i - p.start + cap) % cap;
+    return rel < p.size;
   };
 
-  const classeDe = (i: number): string => {
+  const classOf = (i: number): string => {
     let cls = "viz-cell";
-    if (ocupada(i)) cls += " in";
+    if (occupied(i)) cls += " in";
     else if (p.slots[i] !== null) cls += " drop fila-fantasma";
     else cls += " fila-vaga";
-    if (p.saiu === i) cls += " sai";
-    if (p.foco === i || p.movidos.includes(i)) cls += " entra";
+    if (p.readAt === i) cls += " sai";
+    if (p.wroteAt === i || p.moved.includes(i)) cls += " entra";
     return cls;
   };
 
-  const marcaDe = (i: number): string => {
-    const ehInicio = i === (modo === "ingenua" ? 0 : p.inicio);
-    const ehFim = i === (modo === "ingenua" ? p.tamanho : p.fim);
-    if (ehInicio && ehFim) return "iní fim";
-    if (ehInicio) return "iní";
-    if (ehFim) return "fim";
+  const markOf = (i: number): string => {
+    const isStart = i === (mode === "ingenua" ? 0 : p.start);
+    const isEnd = i === (mode === "ingenua" ? p.size : p.end);
+    if (isStart && isEnd) return "iní fim";
+    if (isStart) return "iní";
+    if (isEnd) return "fim";
     return "";
   };
 
-  const codigo = CODIGO[modo];
+  const code = CODE[mode];
 
-  const variaveis = [
-    { nome: "inicio", valor: modo === "ingenua" ? "0 (fixo)" : `${p.inicio}` },
-    { nome: "fim", valor: modo === "ingenua" ? `${p.tamanho} (= tamanho)` : `${p.fim}` },
-    { nome: "tamanho", valor: `${p.tamanho} / ${cap}` },
-    { nome: "devolvido", valor: p.ultimo ?? "-", best: true },
+  const vars = [
+    { name: "inicio", value: mode === "ingenua" ? "0 (fixo)" : `${p.start}` },
+    { name: "fim", value: mode === "ingenua" ? `${p.size} (= tamanho)` : `${p.end}` },
+    { name: "tamanho", value: `${p.size} / ${cap}` },
+    { name: "devolvido", value: p.last ?? "-", best: true },
   ];
 
-  const enfileirados = roteiro.filter((o) => o.tipo === "enq").length;
-  const desenfileirados = roteiro.length - enfileirados;
-  const estatisticas = [
-    { k: "cap", rot: "capacidade", val: `${cap}` },
-    { k: "ocup", rot: "ocupadas agora", val: `${p.tamanho}` },
-    { k: "movs", rot: "movimentações de elementos", val: `${p.movs}` },
-    { k: "custo", rot: "custo do desenfileirar", val: modo === "ingenua" ? "O(n)" : "O(1)" },
+  const enqueued = script.filter((o) => o.kind === "enq").length;
+  const dequeued = script.length - enqueued;
+  const stats = [
+    { k: "cap", label: "capacidade", value: `${cap}` },
+    { k: "ocup", label: "ocupadas agora", value: `${p.size}` },
+    { k: "movs", label: "movimentações de elementos", value: `${p.moves}` },
+    { k: "custo", label: "custo do desenfileirar", value: mode === "ingenua" ? "O(n)" : "O(1)" },
   ];
   // No circular, início e fim caindo na mesma posição é o estado ambíguo da
   // seção "cheia ou vazia": só o tamanho desempata, e este card mostra isso
   // acontecendo (no anel, as duas mãos se separam alguns graus para aparecer).
-  if (modo === "circular") {
-    estatisticas.push({
+  if (mode === "circular") {
+    stats.push({
       k: "ambiguo",
-      rot: "início == fim?",
-      val: p.inicio === p.fim ? (p.tamanho === cap ? "sim, e cheia" : "sim, e vazia") : "não",
+      label: "início == fim?",
+      value: p.start === p.end ? (p.size === cap ? "sim, e cheia" : "sim, e vazia") : "não",
     });
   }
 
-  const notaCls = "viz-note" + (p.alerta ? " invalid" : idx === total - 1 ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.warn ? " invalid" : viz.step === steps.length - 1 ? " ok" : "");
 
   // O anel: o mesmo array, dobrado. Quando início e fim caem na mesma posição
   // as duas mãos são desviadas alguns graus para nenhuma sumir atrás da outra.
-  const juntos = modo === "circular" && p.inicio === p.fim;
-  const mao = (i: number, cor: string, desvio: number) => {
-    const [x, y] = ponto(i, cap, R_SLOT - R_CELULA - 3, desvio);
-    const [bx, by] = ponto(i, cap, 30, desvio);
-    const [px, py] = ponto(i, cap, R_SLOT - R_CELULA - 17, desvio);
-    const ang = ((-90 + (360 * i) / cap + desvio) * Math.PI) / 180;
-    const nx = -Math.sin(ang) * 6;
-    const ny = Math.cos(ang) * 6;
+  const together = mode === "circular" && p.start === p.end;
+  const hand = (i: number, color: string, offset: number) => {
+    const [x, y] = point(i, cap, R_SLOT - R_CELL - 3, offset);
+    const [bx, by] = point(i, cap, 30, offset);
+    const [px, py] = point(i, cap, R_SLOT - R_CELL - 17, offset);
+    const angle = ((-90 + (360 * i) / cap + offset) * Math.PI) / 180;
+    const nx = -Math.sin(angle) * 6;
+    const ny = Math.cos(angle) * 6;
     return (
-      <g key={cor}>
-        <line x1={bx} y1={by} x2={px} y2={py} stroke={cor} strokeWidth={2.5} strokeLinecap="round" />
-        <polygon points={`${x},${y} ${px + nx},${py + ny} ${px - nx},${py - ny}`} fill={cor} />
+      <g key={color}>
+        <line x1={bx} y1={by} x2={px} y2={py} stroke={color} strokeWidth={2.5} strokeLinecap="round" />
+        <polygon points={`${x},${y} ${px + nx},${py + ny} ${px - nx},${py - ny}`} fill={color} />
       </g>
     );
   };
 
-  const descricaoAnel =
-    modo === "circular"
-      ? `Anel de ${cap} posições. Início na posição ${p.inicio}, fim na posição ${p.fim}, ${p.tamanho} de ${cap} ocupadas.`
-      : `Array de ${cap} posições. O início fica preso na posição 0 e o fim está na posição ${p.tamanho}, com ${p.tamanho} de ${cap} ocupadas.`;
+  const ringDescription =
+    mode === "circular"
+      ? `Anel de ${cap} posições. Início na posição ${p.start}, fim na posição ${p.end}, ${p.size} de ${cap} ocupadas.`
+      : `Array de ${cap} posições. O início fica preso na posição 0 e o fim está na posição ${p.size}, com ${p.size} de ${cap} ocupadas.`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a fila no array: ingênua x buffer circular</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           <button
-            className={`bigo-chip${modo === "ingenua" ? " on" : ""}`}
-            onClick={() => trocarModo("ingenua")}
-            aria-pressed={modo === "ingenua"}
+            className={`bigo-chip${mode === "ingenua" ? " on" : ""}`}
+            onClick={() => changeMode("ingenua")}
+            aria-pressed={mode === "ingenua"}
           >
-            <span className="sw" style={{ background: modo === "ingenua" ? "#fbbf24" : "#3a4a60" }} />
+            <span className="sw" style={{ background: mode === "ingenua" ? "#fbbf24" : "#3a4a60" }} />
             fila ingênua
           </button>
           <button
-            className={`bigo-chip${modo === "circular" ? " on" : ""}`}
-            onClick={() => trocarModo("circular")}
-            aria-pressed={modo === "circular"}
+            className={`bigo-chip${mode === "circular" ? " on" : ""}`}
+            onClick={() => changeMode("circular")}
+            aria-pressed={mode === "circular"}
           >
-            <span className="sw" style={{ background: modo === "circular" ? "#34d399" : "#3a4a60" }} />
+            <span className="sw" style={{ background: mode === "circular" ? "#34d399" : "#3a4a60" }} />
             buffer circular
           </button>
         </div>
@@ -517,10 +474,10 @@ export function QueueVisualizer() {
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -528,21 +485,21 @@ export function QueueVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field">
             <span>capacidade</span>
-            <input className="viz-input k" type="number" min={3} max={8} value={cap} onChange={(e) => trocarCap(e.target.value)} />
+            <input className="viz-input k" type="number" min={3} max={8} value={cap} onChange={(e) => changeCap(e.target.value)} />
           </label>
           <div className="viz-field grow">
             <span>roteiro de operações</span>
             <div className="fila-botoes">
-              <button className="viz-btn" onClick={() => acrescentar({ tipo: "enq", valor: proximaLetra(roteiro) })}>
-                + enfileirar {proximaLetra(roteiro)}
+              <button className="viz-btn" onClick={() => append({ kind: "enq", value: nextLetter(script) })}>
+                + enfileirar {nextLetter(script)}
               </button>
-              <button className="viz-btn" onClick={() => acrescentar({ tipo: "deq" })}>
+              <button className="viz-btn" onClick={() => append({ kind: "deq" })}>
                 + desenfileirar
               </button>
-              <button className="viz-btn" disabled={!roteiro.length} onClick={desfazer}>
+              <button className="viz-btn" disabled={!script.length} onClick={undo}>
                 ← desfazer
               </button>
-              <button className="viz-btn" disabled={!roteiro.length} onClick={limpar}>
+              <button className="viz-btn" disabled={!script.length} onClick={clear}>
                 limpar
               </button>
             </div>
@@ -550,57 +507,57 @@ export function QueueVisualizer() {
         </div>
 
         <div className="fila-roteiro">
-          {roteiro.length === 0 && <span className="fila-vazio">roteiro vazio: use os botões acima para montar a sequência</span>}
-          {roteiro.map((o, i) => (
+          {script.length === 0 && <span className="fila-vazio">roteiro vazio: use os botões acima para montar a sequência</span>}
+          {script.map((o, i) => (
             <span key={i} className={`fila-op${i === p.op ? " on" : ""}${i < p.op ? " feito" : ""}`}>
-              {o.tipo === "enq" ? `↓ ${o.valor}` : "↑ deq"}
+              {o.kind === "enq" ? `↓ ${o.value}` : "↑ deq"}
             </span>
           ))}
         </div>
 
         <div className="viz-cells">
           {p.slots.map((v, i) => {
-            const marca = marcaDe(i);
+            const mark = markOf(i);
             return (
               <div className="viz-cell-wrap" key={i}>
                 <span className="viz-cell-idx">{i}</span>
-                <div className={classeDe(i)}>{v ?? "·"}</div>
-                <span className={`viz-mark${marca ? " show" : ""}`}>{marca || "·"}</span>
+                <div className={classOf(i)}>{v ?? "·"}</div>
+                <span className={`viz-mark${mark ? " show" : ""}`}>{mark || "·"}</span>
               </div>
             );
           })}
         </div>
 
         <div className="fila-anel-wrap">
-          <svg className="fila-anel" viewBox="0 0 340 340" role="img" aria-label={descricaoAnel}>
+          <svg className="fila-anel" viewBox="0 0 340 340" role="img" aria-label={ringDescription}>
             <circle cx={CX} cy={CY} r={R_SLOT} fill="none" stroke="rgba(255,255,255,0.07)" strokeWidth={1} />
             {p.slots.map((v, i) => {
-              const [x, y] = ponto(i, cap, R_SLOT);
-              const [ix, iy] = ponto(i, cap, R_SLOT + R_CELULA + 12);
-              const dentro = ocupada(i);
-              const residuo = !dentro && v !== null;
+              const [x, y] = point(i, cap, R_SLOT);
+              const [ix, iy] = point(i, cap, R_SLOT + R_CELL + 12);
+              const inside = occupied(i);
+              const residue = !inside && v !== null;
               return (
                 <g key={i}>
                   <circle
                     cx={x}
                     cy={y}
-                    r={R_CELULA}
-                    fill={dentro ? "rgba(59,130,246,0.18)" : "#0f1826"}
-                    stroke={dentro ? "#3b82f6" : "rgba(255,255,255,0.12)"}
+                    r={R_CELL}
+                    fill={inside ? "rgba(59,130,246,0.18)" : "#0f1826"}
+                    stroke={inside ? "#3b82f6" : "rgba(255,255,255,0.12)"}
                     strokeWidth={1.5}
-                    strokeDasharray={dentro ? undefined : "4 3"}
-                    opacity={residuo ? 0.6 : 1}
+                    strokeDasharray={inside ? undefined : "4 3"}
+                    opacity={residue ? 0.6 : 1}
                   />
                   <text
                     x={x}
                     y={y}
                     textAnchor="middle"
                     dominantBaseline="central"
-                    fill={dentro ? "#ffffff" : "#61748c"}
+                    fill={inside ? "#ffffff" : "#61748c"}
                     fontFamily="ui-monospace, SFMono-Regular, Menlo, monospace"
                     fontSize={17}
                     fontWeight={600}
-                    opacity={residuo ? 0.7 : 1}
+                    opacity={residue ? 0.7 : 1}
                   >
                     {v ?? "·"}
                   </text>
@@ -618,8 +575,8 @@ export function QueueVisualizer() {
                 </g>
               );
             })}
-            {mao(modo === "ingenua" ? 0 : p.inicio, "#3b82f6", juntos ? -7 : 0)}
-            {(modo === "circular" || p.tamanho < cap) && mao(modo === "ingenua" ? p.tamanho : p.fim, "#fbbf24", juntos ? 7 : 0)}
+            {hand(mode === "ingenua" ? 0 : p.start, "#3b82f6", together ? -7 : 0)}
+            {(mode === "circular" || p.size < cap) && hand(mode === "ingenua" ? p.size : p.end, "#fbbf24", together ? 7 : 0)}
             <circle cx={CX} cy={CY} r={4} fill="#4c5f79" />
           </svg>
           <p className="tp-legenda">
@@ -635,109 +592,57 @@ export function QueueVisualizer() {
           </p>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo === "ingenua" ? "fila_ingenua.py" : "fila_circular.py"}</div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode === "ingenua" ? "fila_ingenua.py" : "fila_circular.py"}</div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
             <p className="fila-resumo">
-              Roteiro com {enfileirados} {enfileirados === 1 ? "entrada" : "entradas"} e {desenfileirados}{" "}
-              {desenfileirados === 1 ? "saída" : "saídas"}. Até aqui, {p.movs}{" "}
-              {p.movs === 1 ? "movimentação de elemento" : "movimentações de elementos"}.
+              Roteiro com {enqueued} {enqueued === 1 ? "entrada" : "entradas"} e {dequeued}{" "}
+              {dequeued === 1 ? "saída" : "saídas"}. Até aqui, {p.moves}{" "}
+              {p.moves === 1 ? "movimentação de elemento" : "movimentações de elementos"}.
             </p>
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -157,6 +157,20 @@ A camada 3 é a única condicional. Visualizador sem bloco de código — um SVG
 árvore, um canvas, uma tabela — recebe 1 e 2 e para por aí. Não invente um bloco
 para recolher só para ter a camada 3.
 
+E o inverso também acontece: **existir um bloco não quer dizer que ele seja
+dispensável.** Antes de ligar a camada 3, procure no componente uma frase de tela
+que fale do bloco **na segunda pessoa** — «Leia o código acima», «compare com a
+tabela ao lado». Se existe, o bloco é o conteúdo, e recolhê-lo transforma essa
+frase em mentira toda vez que a medição decidir esconder. Medido no classificador
+de posição de cauda (`TailRecursionForma`): a nota do modo treino manda ler o
+código, a medição recolheria a 1440x700, e mesmo recolhido ele pediria 533px de
+um orçamento de 516 a 1440x600 — esconderia o conteúdo e continuaria sem caber.
+Ele saiu com `collapsible: false`.
+
+O `inventario.sh` responde `code = sim` para esse arquivo, e responde certo: a
+pergunta dele é *existe um bloco?*, não *o bloco é dispensável?*. A segunda é
+sua.
+
 ## 3. Quem decide é a medição, não um breakpoint
 
 O hook mede se a peça cabe e decide. Nada de `if (largura < 768)`. Você não
@@ -194,6 +208,7 @@ foi tentado numa mesma rodada, e nas três por um motivo diferente**:
 | busca da hash table | **833px, menos** que os 847 do padrão | a corrente longa cabe numa linha que já existia, e a nota que explica o estado padrão é mais comprida |
 | busca da skip list | **0px de diferença** com 14 elementos | a altura vem dos NÍVEIS, que têm teto (`MAX_LEVELS = 4`), e o padrão já batia nele; mais elementos só alargam o SVG, e o wrapper rola na horizontal |
 | reversão da lista | 4 nós = **979px**, 5 nós = 954px | o viewBox tem piso de largura, então menos nós = razão altura/largura maior = mais altura no esticão até a largura do corpo |
+| árvore do Fibonacci | `fib(8)` **com** cache (15 nós) é **81px mais alta** que sem cache (67 nós) | o eixo da altura é a PROFUNDIDADE, `n − 1`, igual nos dois; os nós viram largura. Desligar o cache — o movimento óbvio — dá o caso mais baixo |
 
 O que fazer em vez disso, na ordem:
 
@@ -209,12 +224,53 @@ O que fazer em vez disso, na ordem:
 4. **Se o pior caso construído der um número MENOR que o padrão, o padrão é o
    pior caso.** Troque o número, não a narrativa.
 
-E o corolário que fecha a §3: **a régua de 1512x900 responde "a camada 3 é
-necessária?", não "a camada 1 é necessária?"**. Peça que parece sadia nela pode
-estar desenhando o botão de reprodução fora da janela em 1440x700 — foi o caso
-da busca da hash table (104px abaixo do pé visível) e do trade-off do prefix sum
-(135px). Meça também abaixo de 900 antes de dizer que uma peça não precisa de
-nada.
+### E o estado mais alto não é o último passo: pode ser o do meio
+
+Quando o desenho cresce e depois desfaz — uma torre de pilha, uma recursão que
+desce e volta —, a altura máxima acontece **no pico**, e tanto o passo 0 quanto o
+passo final mostram a peça vazia. Medido nas três peças de `pilhas`: os máximos
+estão nos passos 13 de 26, 15 de 24 e 37 de 38, e ler o passo 0 com a entrada já
+cheia erra por **218, 301 e 87px para baixo**. Na recursão, o passo 0 mente por
+até 85px.
+
+**Ande a animação inteira registrando a altura de cada passo** e use o maior. E
+escreva o teste de rolagem **naquele** passo: a asserção "existe sobra para
+rolar" reprova sozinha no passo 1, onde o miolo ainda não tem o que rolar —
+custou dois testes verdes que não testavam nada.
+
+Isso volta na decisão de `measureOn`, com uma segunda pergunta além da do
+`hash-table` ("os dois extremos caem do mesmo lado do orçamento?"): **se a
+decisão mudasse, a peça passaria a CABER?** Na pilha de chamadas não passaria — o
+passo mais alto pede 1.060px com o código aberto e 896 recolhido, contra 816 de
+orçamento —, então medir por passo trocaria 164px por um bloco de código abrindo
+e fechando durante a reprodução.
+
+### "O desenho é grande" não é "o desenho está esticado"
+
+A receita de devolver altura com um `max-height` no bloco temático (§7) só
+recupera **vazio**, e só existe vazio quando o tamanho **renderizado é maior que
+o natural do `viewBox`**. Isso vale para SVG com `width: 100%` e `height: auto`,
+onde o esticão até a largura do corpo infla o espaço entre os elementos.
+
+Fora desse caso o teto **destrói**, porque o `preserveAspectRatio` escala tudo,
+texto junto. Dois desenhos grandes desta série pareciam o mesmo caso e não eram:
+
+| desenho | renderizado | natural (`viewBox`) | o que um teto faria |
+|---|---|---|---|
+| anel do `QueueVisualizer` | 320px (`max-width: 320px`) | 340px | encolheria conteúdo: já está **abaixo** do natural |
+| árvore do `RecursionArvore` | 426px (`width`/`height` de atributo) | 426px | levaria a fonte dos nós de 10,5px para **6,5px** |
+
+**Compare os dois números antes de escrever o teto.** Se forem iguais, ou se o
+renderizado for menor, não há vazio a devolver — o caminho é outro.
+
+### O corolário que fecha a §3
+
+**A régua de 1512x900 responde "a camada 3 é necessária?", não "a camada 1 é
+necessária?"**. Peça que parece sadia nela pode estar desenhando o botão de
+reprodução fora da janela em 1440x700 — foi o caso da busca da hash table (104px
+abaixo do pé visível), do trade-off do prefix sum (135px) e do classificador de
+cauda (94px de figura rolando a 1440x600, com o cabeçalho subindo junto). Meça
+também abaixo de 900 antes de dizer que uma peça não precisa de nada.
 
 ## 4. A API de CSS
 
@@ -423,6 +479,13 @@ resolveu foi `measureOn: [n, steps.length]`.
   rola, e o painel existe justamente para ver o desenho maior; deixe a regra do
   painel ganhar por especificidade, não por ordem de arquivo.
 
+  **Mas confirme que existe esticão antes de escrever o teto.** Esta receita só
+  devolve **vazio**, e só há vazio quando o renderizado é maior que o natural do
+  `viewBox`. Dois desenhos grandes desta série pareciam o mesmo caso e não eram
+  — o teto teria encolhido conteúdo num e a fonte no outro. Os números e o
+  critério estão na §3, em *"O desenho é grande" não é "o desenho está
+  esticado"*.
+
 ## 8. Como provar que funcionou
 
 Contar elemento não testa nada — já passaram por uma suíte verde um visualizador
@@ -572,3 +635,20 @@ Mas o número no artigo piora, e o relatório tem que dizer isso **com o
 número**, não arredondar para "sem mudança". A pergunta certa ao decidir o
 escopo de uma peça sem bloco não é "quanto ela encolhe", é "onde ficam os
 controles quando ela rola".
+
+### `measureOn` não enxerga o passo, e há peça cujo bloco mais alto cresce com ele
+
+A medição roda ao expandir, ao redimensionar e quando `measureOn` muda — **nunca
+a cada passo**, e isso é deliberado: remedir por passo abriria e fecharia o bloco
+enquanto o aluno assiste.
+
+A consequência a assumir é que uma peça cujo bloco mais alto cresce ao longo da
+animação é medida no seu estado mais **baixo**. Medido na pilha de chamadas da
+recursão: a fileira de frames vai de 168px (um frame, o `min-height`) a 662px
+(treze frames) na mesma execução, e a peça de 885px no passo 0 chega a 970px no
+passo 12.
+
+Quando o passo 0 já estoura o orçamento, a peça recolhe de saída e o problema não
+aparece. Quando ele cabe por pouco, o código fica aberto e a peça passa do
+orçamento no meio da animação. **Não tente resolver pelo componente** — pôr o
+passo em `measureOn` é o remédio pior que a doença, pelo critério da §3.

--- a/content/visualizers/RecursionArvoreVisualizer.tsx
+++ b/content/visualizers/RecursionArvoreVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // RecursionArvoreVisualizer, a árvore de chamadas do Fibonacci.
@@ -15,47 +16,53 @@ import { createPortal } from "react-dom";
 // O gerador é puro: monta a árvore inteira em pré-ordem (que é exatamente a
 // ordem das chamadas) e depois só revela um nó por passo. Como a pré-ordem já
 // coloca a subárvore de um nó em posições contíguas, o índice do último
-// descendente (`fim`) diz de graça em que passo o valor daquele nó fica
+// descendente (`end`) diz de graça em que passo o valor daquele nó fica
 // pronto: nada de estado externo.
 //
 // Com o cache ligado, um fib(k) já calculado vira folha roxa e poda a
 // subárvore inteira. É a mesma função, e a contagem sai de 21.891 chamadas
 // para 39 em fib(20).
+//
+// A casca vem do `useVisualizer`. Uma nota de medição que vale para quem mexer
+// aqui: o número de NÓS explode com n, mas ele vira LARGURA — o SVG mantém o
+// tamanho natural (`.rec-arv { display: block }`, sem `width: 100%`) e
+// `.rec-arv-wrap` rola na horizontal. O eixo que vira ALTURA é a
+// PROFUNDIDADE, que é n − 1 e não muda com o cache: medido, fib(8) sem cache
+// (67 nós) e com cache (15 nós) desenham o MESMO SVG de 426px de altura.
 // ---------------------------------------------------------------------------
 
-type Tipo = "base" | "expande" | "memo";
+type NodeKind = "base" | "expand" | "memo";
 
-type No = {
+type TreeNode = {
   id: number;
   k: number;
-  prof: number;
-  pai: number | null;
-  filhos: number[];
-  tipo: Tipo;
-  valor: number;
-  repetido: boolean;
-  fim: number; // índice do último nó da subárvore em pré-ordem
-  x: number;   // slot horizontal (em unidades de PASSO_X)
+  depth: number;
+  parent: number | null;
+  children: number[];
+  kind: NodeKind;
+  value: number;
+  repeated: boolean;
+  end: number; // índice do último nó da subárvore em pré-ordem
+  x: number;   // slot horizontal (em unidades de STEP_X)
 };
 
-type Passo = {
-  no: number;      // -1 no passo final
-  linha: number;
-  repetidas: number;
-  podadas: number;
-  nota: string;
+type Step = {
+  node: number;    // -1 no passo final
+  line: number;
+  repeats: number;
+  pruned: number;
+  note: string;
   ok?: boolean;
-  erro?: boolean;
 };
 
-const CODIGO_INGENUO = [
+const NAIVE_CODE = [
   "def fib(n):",
   "    if n <= 1:",
   "        return n",
   "    return fib(n - 1) + fib(n - 2)",
 ];
 
-const CODIGO_MEMO = [
+const MEMO_CODE = [
   "memo = {}",
   "",
   "def fib(n):",
@@ -67,17 +74,16 @@ const CODIGO_MEMO = [
   "    return memo[n]",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
 // Geometria da árvore. O SVG rola dentro do próprio container quando fica mais
 // largo que a tela, então dá para abrir n = 8 sem a página rolar na horizontal.
-const NO_L = 46;
-const NO_A = 34;
-const PASSO_X = 52;
-const PASSO_Y = 52;
-const MARGEM = 16;
-const TOPO = 14;
+const NODE_W = 46;
+const NODE_H = 34;
+const STEP_X = 52;
+const STEP_Y = 52;
+const MARGIN = 16;
+const TOP = 14;
 
 // Formatação determinística (nada de Intl, para o HTML do servidor bater com o
 // do cliente na hidratação).
@@ -94,250 +100,220 @@ function fibNum(n: number): number {
 
 // Contagem EXATA de chamadas do fib recursivo ingênuo: T(n) = 2·fib(n+1) - 1.
 // (T(0) = T(1) = 1, T(n) = 1 + T(n-1) + T(n-2).)
-function chamadasIngenuo(n: number): number {
+function naiveCalls(n: number): number {
   return 2 * fibNum(n + 1) - 1;
 }
 
 // Com memoização top-down cada k acima de 1 é expandido uma vez só e acerta o
 // cache uma vez: T(n) = 2n - 1 para n >= 2.
-function chamadasMemo(n: number): number {
+function memoCalls(n: number): number {
   return n <= 1 ? 1 : 2 * n - 1;
 }
 
-function construir(n0: number, comMemo: boolean): No[] {
-  const nos: No[] = [];
+function build(n0: number, withMemo: boolean): TreeNode[] {
+  const nodes: TreeNode[] = [];
   const memo = new Map<number, number>();
-  const jaVisto = new Set<number>();
+  const seen = new Set<number>();
 
-  const visita = (k: number, pai: number | null, prof: number): number => {
-    const id = nos.length;
-    const no: No = {
-      id, k, prof, pai, filhos: [], tipo: "expande", valor: 0,
-      repetido: jaVisto.has(k), fim: id, x: 0,
+  const visit = (k: number, parent: number | null, depth: number): number => {
+    const id = nodes.length;
+    const node: TreeNode = {
+      id, k, depth, parent, children: [], kind: "expand", value: 0,
+      repeated: seen.has(k), end: id, x: 0,
     };
-    nos.push(no);
+    nodes.push(node);
 
     if (k <= 1) {
-      no.tipo = "base";
-      no.valor = k;
-    } else if (comMemo && memo.has(k)) {
-      no.tipo = "memo";
-      no.valor = memo.get(k) as number;
-    } else if (nos.length < 400) {
-      const a = visita(k - 1, id, prof + 1);
-      const b = visita(k - 2, id, prof + 1);
-      no.filhos = [a, b];
-      no.valor = nos[a].valor + nos[b].valor;
-      if (comMemo) memo.set(k, no.valor);
+      node.kind = "base";
+      node.value = k;
+    } else if (withMemo && memo.has(k)) {
+      node.kind = "memo";
+      node.value = memo.get(k) as number;
+    } else if (nodes.length < 400) {
+      const a = visit(k - 1, id, depth + 1);
+      const b = visit(k - 2, id, depth + 1);
+      node.children = [a, b];
+      node.value = nodes[a].value + nodes[b].value;
+      if (withMemo) memo.set(k, node.value);
     }
 
-    jaVisto.add(k);
-    no.fim = nos.length - 1;
+    seen.add(k);
+    node.end = nodes.length - 1;
     return id;
   };
 
-  visita(n0, null, 0);
+  visit(n0, null, 0);
 
   // Layout: cada folha ganha um slot, cada nó interno senta no meio dos filhos.
   let slot = 0;
-  const posicionar = (id: number) => {
-    const no = nos[id];
-    if (no.filhos.length === 0) { no.x = slot++; return; }
-    posicionar(no.filhos[0]);
-    posicionar(no.filhos[1]);
-    no.x = (nos[no.filhos[0]].x + nos[no.filhos[1]].x) / 2;
+  const place = (id: number) => {
+    const node = nodes[id];
+    if (node.children.length === 0) { node.x = slot++; return; }
+    place(node.children[0]);
+    place(node.children[1]);
+    node.x = (nodes[node.children[0]].x + nodes[node.children[1]].x) / 2;
   };
-  posicionar(0);
+  place(0);
 
-  return nos;
+  return nodes;
 }
 
-function gerarPassos(nos: No[], n0: number, comMemo: boolean): Passo[] {
-  const out: Passo[] = [];
-  let repetidas = 0;
-  let podadas = 0;
-  let primeiraBase = true;
+function generateSteps(nodes: TreeNode[], n0: number, withMemo: boolean): Step[] {
+  const out: Step[] = [];
+  let repeats = 0;
+  let pruned = 0;
+  let firstBase = true;
 
-  for (const no of nos) {
-    if (no.repetido) repetidas++;
-    let linha: number;
-    let nota: string;
+  for (const node of nodes) {
+    if (node.repeated) repeats++;
+    let line: number;
+    let note: string;
 
-    if (no.tipo === "base") {
-      linha = comMemo ? 4 : 2;
-      if (no.repetido) {
-        nota = comMemo
-          ? `fib(${no.k}) outra vez. O caso base é testado ANTES do cache, então fib(1) e fib(0) continuam sendo recalculados: são as únicas repetições que a memoização não elimina.`
-          : `fib(${no.k}) de novo. É caso base, então custa uma chamada só, mas repare quantas folhas iguais a esta a árvore já acumulou.`;
-      } else if (primeiraBase) {
-        nota = `fib(${no.k}) bate no caso base: devolvo ${no.k} na hora, sem chamar mais ninguém. É a primeira resposta concreta da execução inteira.`;
-        primeiraBase = false;
+    if (node.kind === "base") {
+      line = withMemo ? 4 : 2;
+      if (node.repeated) {
+        note = withMemo
+          ? `fib(${node.k}) outra vez. O caso base é testado ANTES do cache, então fib(1) e fib(0) continuam sendo recalculados: são as únicas repetições que a memoização não elimina.`
+          : `fib(${node.k}) de novo. É caso base, então custa uma chamada só, mas repare quantas folhas iguais a esta a árvore já acumulou.`;
+      } else if (firstBase) {
+        note = `fib(${node.k}) bate no caso base: devolvo ${node.k} na hora, sem chamar mais ninguém. É a primeira resposta concreta da execução inteira.`;
+        firstBase = false;
       } else {
-        nota = `fib(${no.k}) também é caso base: devolvo ${no.k} direto. Com os dois casos base resolvidos, o nó de cima já consegue somar.`;
+        note = `fib(${node.k}) também é caso base: devolvo ${node.k} direto. Com os dois casos base resolvidos, o nó de cima já consegue somar.`;
       }
-    } else if (no.tipo === "memo") {
-      linha = 6;
+    } else if (node.kind === "memo") {
+      line = 6;
       // Comparação honesta: o ramo que a versão INGÊNUA teria que refazer aqui.
       // (Com o cache ligado, reexpandir fib(k) custaria só mais 2 chamadas,
       // porque fib(k-1) e fib(k-2) já estariam guardados.)
-      const evitadas = chamadasIngenuo(no.k) - 1;
-      podadas++;
-      nota = `fib(${no.k}) já está no cache valendo ${num(no.valor)}. Devolvo na hora e podo a subárvore inteira: sem cache, este mesmo ramo custaria ${num(evitadas)} ${evitadas === 1 ? "chamada" : "chamadas"} abaixo dele.`;
+      const avoided = naiveCalls(node.k) - 1;
+      pruned++;
+      note = `fib(${node.k}) já está no cache valendo ${num(node.value)}. Devolvo na hora e podo a subárvore inteira: sem cache, este mesmo ramo custaria ${num(avoided)} ${avoided === 1 ? "chamada" : "chamadas"} abaixo dele.`;
     } else {
-      linha = comMemo ? 7 : 3;
-      const tam = no.fim - no.id + 1;
-      nota = no.repetido
-        ? `fib(${no.k}) outra vez, e sem cache eu não tenho como saber disso. Vou refazer a subárvore inteira, mais ${num(tam - 1)} ${tam - 1 === 1 ? "chamada" : "chamadas"}, para chegar de novo no mesmo ${num(no.valor)}.`
-        : `Entro em fib(${no.k}). Não sei responder direto, então quebro em fib(${no.k - 1}) e fib(${no.k - 2}) e desço mais um nível.`;
+      line = withMemo ? 7 : 3;
+      const size = node.end - node.id + 1;
+      note = node.repeated
+        ? `fib(${node.k}) outra vez, e sem cache eu não tenho como saber disso. Vou refazer a subárvore inteira, mais ${num(size - 1)} ${size - 1 === 1 ? "chamada" : "chamadas"}, para chegar de novo no mesmo ${num(node.value)}.`
+        : `Entro em fib(${node.k}). Não sei responder direto, então quebro em fib(${node.k - 1}) e fib(${node.k - 2}) e desço mais um nível.`;
     }
 
-    out.push({ no: no.id, linha, repetidas, podadas, nota });
+    out.push({ node: node.id, line, repeats, pruned, note });
   }
 
-  const total = nos.length;
-  const resposta = nos[0].valor;
-  const fecho = comMemo
-    ? `fib(${n0}) = ${num(resposta)} com ${num(total)} ${total === 1 ? "chamada" : "chamadas"}. Cada valor foi calculado uma vez só: o cache transformou a árvore numa espinha, e a complexidade caiu de exponencial para O(n).`
-    : `fib(${n0}) = ${num(resposta)} depois de ${num(total)} ${total === 1 ? "chamada" : "chamadas"}, das quais ${num(repetidas)} ${repetidas === 1 ? "foi" : "foram"} para valores que a árvore já tinha calculado. Com cache seriam ${num(chamadasMemo(n0))}.`;
+  const total = nodes.length;
+  const answer = nodes[0].value;
+  const closing = withMemo
+    ? `fib(${n0}) = ${num(answer)} com ${num(total)} ${total === 1 ? "chamada" : "chamadas"}. Cada valor foi calculado uma vez só: o cache transformou a árvore numa espinha, e a complexidade caiu de exponencial para O(n).`
+    : `fib(${n0}) = ${num(answer)} depois de ${num(total)} ${total === 1 ? "chamada" : "chamadas"}, das quais ${num(repeats)} ${repeats === 1 ? "foi" : "foram"} para valores que a árvore já tinha calculado. Com cache seriam ${num(memoCalls(n0))}.`;
 
-  out.push({ no: -1, linha: comMemo ? 8 : 3, repetidas, podadas, nota: fecho, ok: true });
+  out.push({ node: -1, line: withMemo ? 8 : 3, repeats, pruned, note: closing, ok: true });
   return out;
 }
 
-type Preset = { key: string; rotulo: string; n: number; memo: boolean };
+type Preset = { key: string; label: string; n: number; memo: boolean };
 
 const PRESETS: Preset[] = [
-  { key: "quatro", rotulo: "fib(4): a primeira subárvore refeita", n: 4, memo: false },
-  { key: "seis", rotulo: "fib(6): 25 chamadas", n: 6, memo: false },
-  { key: "seisMemo", rotulo: "fib(6) com cache: 11 chamadas", n: 6, memo: true },
-  { key: "oito", rotulo: "fib(8): o retrabalho fica óbvio", n: 8, memo: false },
+  { key: "quatro", label: "fib(4): a primeira subárvore refeita", n: 4, memo: false },
+  { key: "seis", label: "fib(6): 25 chamadas", n: 6, memo: false },
+  { key: "seisMemo", label: "fib(6) com cache: 11 chamadas", n: 6, memo: true },
+  { key: "oito", label: "fib(8): o retrabalho fica óbvio", n: 8, memo: false },
 ];
 
 export function RecursionArvoreVisualizer() {
   const [n, setN] = useState(6);
-  const [comMemo, setComMemo] = useState(false);
+  const [withMemo, setWithMemo] = useState(false);
   const [preset, setPreset] = useState("seis");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const nodes = useMemo(() => build(n, withMemo), [n, withMemo]);
+  const steps = useMemo(() => generateSteps(nodes, n, withMemo), [nodes, n, withMemo]);
 
-  const nos = useMemo(() => construir(n, comMemo), [n, comMemo]);
-  const passos = useMemo(() => gerarPassos(nos, n, comMemo), [nos, n, comMemo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · a árvore de chamadas do Fibonacci e o retrabalho",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: `n`, porque a altura do desenho é a
+    // PROFUNDIDADE (n − 1) e não o número de nós; e o cache, que troca um
+    // código de 4 linhas por um de 9 e acrescenta uma tarja na legenda. Medido:
+    // com o cache LIGADO a peça é 81px mais alta (1496 contra 1415 em n = 8),
+    // apesar de ter 52 nós a menos.
+    measureOn: [n, withMemo],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const aoMudarN = (v: string) => {
+  const onChangeN = (v: string) => {
     const x = parseInt(v, 10);
-    reiniciar(); setPreset("");
+    viz.reset();
+    setPreset("");
     setN(isNaN(x) ? 2 : Math.min(8, Math.max(2, x)));
   };
-  const alternarMemo = () => { reiniciar(); setPreset(""); setComMemo((v) => !v); };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar(); setPreset(pr.key);
-    setN(pr.n); setComMemo(pr.memo);
+  const toggleMemo = () => { viz.reset(); setPreset(""); setWithMemo((v) => !v); };
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setPreset(pr.key);
+    setN(pr.n);
+    setWithMemo(pr.memo);
   };
 
   // Geometria do desenho
-  const folhas = nos.filter((no) => no.filhos.length === 0).length;
-  const maxProf = nos.reduce((m, no) => Math.max(m, no.prof), 0);
-  const W = MARGEM * 2 + Math.max(0, folhas - 1) * PASSO_X + NO_L;
-  const H = TOPO * 2 + maxProf * PASSO_Y + NO_A;
-  const cx = (no: No) => MARGEM + NO_L / 2 + no.x * PASSO_X;
-  const cyTopo = (no: No) => TOPO + no.prof * PASSO_Y;
+  const leaves = nodes.filter((node) => node.children.length === 0).length;
+  const maxDepth = nodes.reduce((m, node) => Math.max(m, node.depth), 0);
+  const W = MARGIN * 2 + Math.max(0, leaves - 1) * STEP_X + NODE_W;
+  const H = TOP * 2 + maxDepth * STEP_Y + NODE_H;
+  const cx = (node: TreeNode) => MARGIN + NODE_W / 2 + node.x * STEP_X;
+  const cyTop = (node: TreeNode) => TOP + node.depth * STEP_Y;
 
   // Cadeia da raiz até o nó atual, para acender o caminho da chamada.
-  const atual = p.no >= 0 ? nos[p.no] : null;
-  const caminho = useMemo(() => {
+  const current = p.node >= 0 ? nodes[p.node] : null;
+  const path = useMemo(() => {
     const s = new Set<number>();
-    let cur = atual;
+    let cur = current;
     while (cur) {
       s.add(cur.id);
-      cur = cur.pai === null ? null : nos[cur.pai];
+      cur = cur.parent === null ? null : nodes[cur.parent];
     }
     return s;
-  }, [atual, nos]);
+  }, [current, nodes]);
 
-  const classeNo = (no: No) => {
-    if (idx < no.id) return "rec-no futuro";
-    if (no.id === p.no) return "rec-no on";
-    if (no.tipo === "memo") return "rec-no memo";
-    if (no.repetido) return "rec-no rep";
-    if (no.tipo === "base") return "rec-no base";
+  const nodeClass = (node: TreeNode) => {
+    if (viz.step < node.id) return "rec-no futuro";
+    if (node.id === p.node) return "rec-no on";
+    if (node.kind === "memo") return "rec-no memo";
+    if (node.repeated) return "rec-no rep";
+    if (node.kind === "base") return "rec-no base";
     return "rec-no";
   };
 
-  const chamadasAte = p.no >= 0 ? p.no + 1 : nos.length;
-  const totalIngenuo = chamadasIngenuo(n);
-  const totalMemo = chamadasMemo(n);
+  const callsSoFar = p.node >= 0 ? p.node + 1 : nodes.length;
+  const naiveTotal = naiveCalls(n);
+  const memoTotal = memoCalls(n);
 
-  const variaveis = [
-    { nome: "n (chamada atual)", valor: atual ? `${atual.k}` : "-" },
-    { nome: "profundidade", valor: atual ? `${atual.prof}` : "0" },
-    { nome: "devolve", valor: atual && idx >= atual.fim ? num(atual.valor) : "pendente" },
-    { nome: "chamadas", valor: num(chamadasAte), best: true },
+  const vars = [
+    { name: "n (chamada atual)", value: current ? `${current.k}` : "-" },
+    { name: "profundidade", value: current ? `${current.depth}` : "0" },
+    { name: "devolve", value: current && viz.step >= current.end ? num(current.value) : "pendente" },
+    { name: "chamadas", value: num(callsSoFar), best: true },
   ];
 
-  const linhas = [n, 10, 20, 30];
+  const tableRows = [n, 10, 20, 30];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const codigo = comMemo ? CODIGO_MEMO : CODIGO_INGENUO;
+  const noteClass = "viz-note" + (p.ok ? " ok" : "");
+  const code = withMemo ? MEMO_CODE : NAIVE_CODE;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a árvore de chamadas do Fibonacci e o retrabalho</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -345,15 +321,15 @@ export function RecursionArvoreVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field">
             <span>n</span>
-            <input className="viz-input k" type="number" min={2} max={8} value={n} onChange={(e) => aoMudarN(e.target.value)} />
+            <input className="viz-input k" type="number" min={2} max={8} value={n} onChange={(e) => onChangeN(e.target.value)} />
           </label>
           <div className="viz-field">
             <span>Memoização</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${comMemo ? "" : " on"}`} onClick={() => { if (comMemo) alternarMemo(); }} aria-pressed={!comMemo}>
+              <button className={`sub-modo-btn${withMemo ? "" : " on"}`} onClick={() => { if (withMemo) toggleMemo(); }} aria-pressed={!withMemo}>
                 desligada
               </button>
-              <button className={`sub-modo-btn${comMemo ? " on" : ""}`} onClick={() => { if (!comMemo) alternarMemo(); }} aria-pressed={comMemo}>
+              <button className={`sub-modo-btn${withMemo ? " on" : ""}`} onClick={() => { if (!withMemo) toggleMemo(); }} aria-pressed={withMemo}>
                 ligada
               </button>
             </div>
@@ -367,39 +343,39 @@ export function RecursionArvoreVisualizer() {
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`Árvore de chamadas de fib(${n}) ${comMemo ? "com" : "sem"} memoização. Passo ${idx + 1} de ${total}. ${p.nota}`}
+            aria-label={`Árvore de chamadas de fib(${n}) ${withMemo ? "com" : "sem"} memoização. Passo ${viz.step + 1} de ${viz.total}. ${p.note}`}
           >
-            {nos.map((no) =>
-              no.filhos.map((fid) => {
-                const f = nos[fid];
-                const aceso = caminho.has(fid) && caminho.has(no.id);
-                const cls = "rec-aresta" + (idx < f.id ? " futuro" : aceso ? " on" : "");
+            {nodes.map((node) =>
+              node.children.map((childId) => {
+                const child = nodes[childId];
+                const lit = path.has(childId) && path.has(node.id);
+                const cls = "rec-aresta" + (viz.step < child.id ? " futuro" : lit ? " on" : "");
                 return (
                   <line
-                    key={`${no.id}-${fid}`}
+                    key={`${node.id}-${childId}`}
                     className={cls}
-                    x1={cx(no)}
-                    y1={cyTopo(no) + NO_A}
-                    x2={cx(f)}
-                    y2={cyTopo(f)}
+                    x1={cx(node)}
+                    y1={cyTop(node) + NODE_H}
+                    x2={cx(child)}
+                    y2={cyTop(child)}
                   />
                 );
               })
             )}
-            {nos.map((no) => {
-              const resolvido = idx >= no.fim;
+            {nodes.map((node) => {
+              const resolved = viz.step >= node.end;
               return (
-                <g key={no.id} className={classeNo(no)}>
+                <g key={node.id} className={nodeClass(node)}>
                   <rect
-                    x={cx(no) - NO_L / 2}
-                    y={cyTopo(no)}
-                    width={NO_L}
-                    height={NO_A}
+                    x={cx(node) - NODE_W / 2}
+                    y={cyTop(node)}
+                    width={NODE_W}
+                    height={NODE_H}
                     rx={8}
                   />
-                  <text x={cx(no)} y={cyTopo(no) + 13} textAnchor="middle">fib({no.k})</text>
-                  <text x={cx(no)} y={cyTopo(no) + 26} textAnchor="middle" className="rec-no-val">
-                    {resolvido ? `= ${num(no.valor)}` : "= ?"}
+                  <text x={cx(node)} y={cyTop(node) + 13} textAnchor="middle">fib({node.k})</text>
+                  <text x={cx(node)} y={cyTop(node) + 26} textAnchor="middle" className="rec-no-val">
+                    {resolved ? `= ${num(node.value)}` : "= ?"}
                   </text>
                 </g>
               );
@@ -411,29 +387,35 @@ export function RecursionArvoreVisualizer() {
           <span><i style={{ background: "rgba(59,130,246,0.7)" }} />chamada atual</span>
           <span><i style={{ background: "rgba(52,211,153,0.5)" }} />caso base novo</span>
           <span><i style={{ background: "rgba(251,191,36,0.55)" }} />valor já calculado antes</span>
-          {comMemo ? <span><i style={{ background: "rgba(167,139,250,0.6)" }} />acerto no cache, subárvore podada</span> : null}
+          {withMemo ? <span><i style={{ background: "rgba(167,139,250,0.6)" }} />acerto no cache, subárvore podada</span> : null}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{comMemo ? "fib_memo.py" : "fib.py"}</div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` recolhe a ALTURA (grid 1fr→0fr); zerar a trilha
+              da coluna só tiraria a largura. O bloco continua no DOM para a
+              medição enxergar o pior caso, com `inert` tirando ele do teclado e
+              dos leitores de tela enquanto está fora de vista. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{withMemo ? "fib_memo.py" : "fib.py"}</div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
@@ -442,25 +424,25 @@ export function RecursionArvoreVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>chamadas até aqui</span>
-            <strong>{num(chamadasAte)}</strong>
+            <strong>{num(callsSoFar)}</strong>
           </div>
           <div className="bigo-stat">
             <span>chamadas no total</span>
-            <strong>{num(nos.length)}</strong>
+            <strong>{num(nodes.length)}</strong>
           </div>
           <div className="bigo-stat">
-            <span>{comMemo ? "acertos no cache" : "chamadas repetidas"}</span>
-            <strong>{num(comMemo ? p.podadas : p.repetidas)}</strong>
+            <span>{withMemo ? "acertos no cache" : "chamadas repetidas"}</span>
+            <strong>{num(withMemo ? p.pruned : p.repeats)}</strong>
           </div>
           {/* O contraste que fecha a seção: a árvore tem dezenas de nós, mas a
               pilha nunca passa da profundidade. Tempo exponencial, espaço linear. */}
           <div className="bigo-stat">
             <span>pico da pilha</span>
-            <strong>{num(maxProf + 1)}</strong>
+            <strong>{num(maxDepth + 1)}</strong>
           </div>
           <div className="bigo-stat">
             <span>fib({n})</span>
-            <strong>{num(nos[0].valor)}</strong>
+            <strong>{num(nodes[0].value)}</strong>
           </div>
         </div>
 
@@ -476,48 +458,29 @@ export function RecursionArvoreVisualizer() {
               </tr>
             </thead>
             <tbody>
-              {linhas.map((v, i) => (
+              {tableRows.map((v, i) => (
                 <tr key={`${v}-${i}`} className={i === 0 ? "on" : undefined}>
                   <td>{v}{i === 0 ? " (o seu)" : ""}</td>
-                  <td>{num(chamadasIngenuo(v))}</td>
-                  <td>{num(chamadasMemo(v))}</td>
-                  <td>{num(Math.round(chamadasIngenuo(v) / chamadasMemo(v)))}×</td>
+                  <td>{num(naiveCalls(v))}</td>
+                  <td>{num(memoCalls(v))}</td>
+                  <td>{num(Math.round(naiveCalls(v) / memoCalls(v)))}×</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
 
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
-
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
-          Sem cache, fib({n}) custa {num(totalIngenuo)} chamadas; com cache, {num(totalMemo)}. Em fib(20) a diferença
+          Sem cache, fib({n}) custa {num(naiveTotal)} chamadas; com cache, {num(memoTotal)}. Em fib(20) a diferença
           é 21.891 contra 39.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/RecursionArvoreVisualizer.tsx
+++ b/content/visualizers/RecursionArvoreVisualizer.tsx
@@ -231,6 +231,10 @@ export function RecursionArvoreVisualizer() {
     title: "Visualizador · a árvore de chamadas do Fibonacci e o retrabalho",
     total: steps.length,
     speeds: SPEEDS,
+    // A marcha inicial desta peça é a 4 ("1.5x"), não a 3 do hook: a árvore tem
+    // dezenas de nós e no 1x a reprodução inteira fica longa demais para quem
+    // só quer ver a forma do retrabalho. Era o valor que o componente já tinha.
+    initialSpeed: 4,
     // O que muda a altura da peça: `n`, porque a altura do desenho é a
     // PROFUNDIDADE (n − 1) e não o número de nós; e o cache, que troca um
     // código de 4 linhas por um de 9 e acrescenta uma tarja na legenda. Medido:

--- a/content/visualizers/RecursionVisualizer.tsx
+++ b/content/visualizers/RecursionVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // RecursionVisualizer, a pilha de chamadas.
@@ -12,7 +13,7 @@ import { createPortal } from "react-dom";
 // devolve o primeiro valor concreto, e os valores sobem de volta resolvendo a
 // operação que ficou pendurada em cada frame.
 //
-// Três modos, porque o encontro comparou os três:
+// Três modos, porque são três lições diferentes sobre a mesma pilha:
 //   - clássico: a multiplicação fica pendente e só resolve na subida
 //   - cauda: o acumulador desce pronto, nada fica pendente na volta
 //   - caso base inalcançável: existe caso base, mas o estado anda para longe
@@ -21,38 +22,46 @@ import { createPortal } from "react-dom";
 // CPython é 1000 e não caberia na tela, mas a lição é a mesma: estourar não é
 // só "esquecer o caso base", é passar da profundidade que a linguagem aguenta.
 // Com limite 6, fatorial(10) estoura igualzinho.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Estado = "espera" | "ativo" | "base" | "volta" | "estoura";
+// Os valores são também nomes de classe do CSS (`.rec-frame.ativo` e companhia,
+// em `globals.css`), então eles NÃO acompanham a tradução dos identificadores:
+// renomeá-los pediria editar uma folha de estilo compartilhada com o
+// NAryTreeVisualizer.
+type FrameState = "espera" | "ativo" | "base" | "volta" | "estoura";
 
 type Frame = {
   id: number;
-  nivel: number;
+  level: number;
   n: number;
-  rotulo: string;
-  pendente?: string;
-  retorno?: string;
-  estado: Estado;
-  novo?: boolean;
+  label: string;
+  pending?: string;
+  ret?: string;
+  state: FrameState;
+  isNew?: boolean;
 };
 
-type Var = { nome: string; valor: string; best?: boolean };
+type Var = { name: string; value: string; best?: boolean };
 
-type Passo = {
-  linha: number;
+type Step = {
+  line: number;
   frames: Frame[];
-  chamadas: number;
-  maxProf: number;
-  nota: string;
+  calls: number;
+  maxDepth: number;
+  note: string;
   vars: Var[];
   ok?: boolean;
-  fim?: boolean;
-  erro?: boolean;
+  done?: boolean;
+  error?: boolean;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo do gerador do modo,
+// As linhas mapeiam 1:1 com o campo `line` de cada passo do gerador do modo,
 // então a ordem e a quantidade de linhas não podem mudar sem ajustar o gerador.
-const CLASSICO = [
+const CLASSIC = [
   "def fatorial(n):",
   "    if n <= 1:",
   "        return 1",
@@ -60,14 +69,14 @@ const CLASSICO = [
   "    return n * resultado",
 ];
 
-const CAUDA = [
+const TAIL = [
   "def fatorial(n, acc=1):",
   "    if n <= 1:",
   "        return acc",
   "    return fatorial(n - 1, acc * n)",
 ];
 
-const INALCANCAVEL = [
+const UNREACHABLE = [
   "def contagem(n):",
   "    if n == 0:",
   "        return",
@@ -75,8 +84,7 @@ const INALCANCAVEL = [
   "    return contagem(n + 1)",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
 // Formatação determinística (nada de Intl, para o HTML do servidor bater com o
 // do cliente na hidratação).
@@ -84,7 +92,7 @@ function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function fatorialDe(n: number): number {
+function factorialOf(n: number): number {
   let f = 1;
   for (let i = 2; i <= n; i++) f *= i;
   return f;
@@ -95,76 +103,76 @@ function fatorialDe(n: number): number {
 // "n × ?" enquanto espera, e é isso que impede a pilha de encolher antes da
 // hora.
 // --------------------------------------------------------------------------
-function gerarClassico(n0: number, limite: number): Passo[] {
-  const out: Passo[] = [];
+function generateClassic(n0: number, limit: number): Step[] {
+  const out: Step[] = [];
   const frames: Frame[] = [];
-  let chamadas = 0;
-  let maxProf = 0;
+  let calls = 0;
+  let maxDepth = 0;
   let id = 0;
 
-  const snap = (novoId?: number) => frames.map((f) => ({ ...f, novo: f.id === novoId }));
-  const vars = (topo: string, devolvido: string): Var[] => [
-    { nome: "n (frame do topo)", valor: topo },
-    { nome: "valor devolvido", valor: devolvido },
-    { nome: "frames na pilha", valor: `${frames.length}` },
-    { nome: "chamadas", valor: `${chamadas}`, best: true },
+  const snap = (newId?: number) => frames.map((f) => ({ ...f, isNew: f.id === newId }));
+  const vars = (top: string, returned: string): Var[] => [
+    { name: "n (frame do topo)", value: top },
+    { name: "valor devolvido", value: returned },
+    { name: "frames na pilha", value: `${frames.length}` },
+    { name: "chamadas", value: `${calls}`, best: true },
   ];
-  const passo = (
-    linha: number,
-    nota: string,
-    topo: string,
-    devolvido: string,
-    extra?: Partial<Passo>,
-    novoId?: number
+  const emit = (
+    line: number,
+    note: string,
+    top: string,
+    returned: string,
+    extra?: Partial<Step>,
+    newId?: number
   ) => {
-    out.push({ linha, frames: snap(novoId), chamadas, maxProf, nota, vars: vars(topo, devolvido), ...extra });
+    out.push({ line, frames: snap(newId), calls, maxDepth, note, vars: vars(top, returned), ...extra });
   };
 
   let k = n0;
-  let guarda = 0;
-  let estourou = false;
+  let guard = 0;
+  let overflowed = false;
 
-  while (guarda++ < 40) {
-    const meu = id++;
-    frames.push({ id: meu, nivel: frames.length + 1, n: k, rotulo: `fatorial(n=${k})`, estado: "ativo" });
-    chamadas++;
+  while (guard++ < 40) {
+    const mine = id++;
+    frames.push({ id: mine, level: frames.length + 1, n: k, label: `fatorial(n=${k})`, state: "ativo" });
+    calls++;
 
-    if (frames.length > limite) {
-      frames[frames.length - 1].estado = "estoura";
-      passo(
+    if (frames.length > limit) {
+      frames[frames.length - 1].state = "estoura";
+      emit(
         0,
-        `Tentei abrir o frame ${frames.length} e o limite da pilha é ${limite}: RecursionError, maximum recursion depth exceeded. Nenhuma resposta voltou, porque nenhuma chamada chegou ao caso base antes do teto.`,
+        `Tentei abrir o frame ${frames.length} e o limite da pilha é ${limit}: RecursionError, maximum recursion depth exceeded. Nenhuma resposta voltou, porque nenhuma chamada chegou ao caso base antes do teto.`,
         `${k}`,
         "-",
-        { fim: true, erro: true },
-        meu
+        { done: true, error: true },
+        mine
       );
-      estourou = true;
+      overflowed = true;
       break;
     }
-    maxProf = Math.max(maxProf, frames.length);
+    maxDepth = Math.max(maxDepth, frames.length);
 
-    passo(
+    emit(
       0,
       `Entro em fatorial(${k}). Um frame novo vai para o topo da pilha, com um n = ${k} que é só dele: o n dos frames de baixo continua intacto.`,
       `${k}`,
       "-",
       undefined,
-      meu
+      mine
     );
 
     if (k <= 1) {
-      passo(1, `n = ${k} bate no caso base. Esta eu respondo sozinha, sem chamar mais ninguém.`, `${k}`, "-");
-      frames[frames.length - 1].estado = "base";
-      frames[frames.length - 1].retorno = "1";
-      passo(2, `Devolvo 1. É a primeira resposta concreta da execução inteira, e é dela que todas as outras vão nascer.`, `${k}`, "1");
+      emit(1, `n = ${k} bate no caso base. Esta eu respondo sozinha, sem chamar mais ninguém.`, `${k}`, "-");
+      frames[frames.length - 1].state = "base";
+      frames[frames.length - 1].ret = "1";
+      emit(2, `Devolvo 1. É a primeira resposta concreta da execução inteira, e é dela que todas as outras vão nascer.`, `${k}`, "1");
       break;
     }
 
-    passo(1, `n = ${k} não é 0 nem 1, então não tenho a resposta na mão: preciso quebrar em um problema menor.`, `${k}`, "-");
-    frames[frames.length - 1].estado = "espera";
-    frames[frames.length - 1].pendente = `${k} × ?`;
-    passo(
+    emit(1, `n = ${k} não é 0 nem 1, então não tenho a resposta na mão: preciso quebrar em um problema menor.`, `${k}`, "-");
+    frames[frames.length - 1].state = "espera";
+    frames[frames.length - 1].pending = `${k} × ?`;
+    emit(
       3,
       `Chamo fatorial(${k - 1}). A multiplicação por ${k} fica pendurada neste frame: enquanto a resposta de baixo não chegar, este frame não pode sair da pilha.`,
       `${k}`,
@@ -173,42 +181,42 @@ function gerarClassico(n0: number, limite: number): Passo[] {
     k--;
   }
 
-  if (estourou) return out;
+  if (overflowed) return out;
 
   // Subida: cada frame recebe o valor de baixo, resolve a multiplicação que
   // estava pendente e sai da pilha.
-  let valor = 1;
+  let value = 1;
   frames.pop();
-  while (frames.length > 0 && guarda++ < 80) {
-    const topo = frames[frames.length - 1];
-    const novo = topo.n * valor;
-    topo.estado = "volta";
-    topo.pendente = undefined;
-    topo.retorno = num(novo);
-    passo(
+  while (frames.length > 0 && guard++ < 80) {
+    const top = frames[frames.length - 1];
+    const next = top.n * value;
+    top.state = "volta";
+    top.pending = undefined;
+    top.ret = num(next);
+    emit(
       4,
-      `fatorial(${topo.n}) recebe ${num(valor)} de baixo, resolve a conta que estava pendurada, ${topo.n} × ${num(valor)} = ${num(novo)}, e devolve. O frame sai da pilha e a memória dele é liberada.`,
-      `${topo.n}`,
-      num(novo)
+      `fatorial(${top.n}) recebe ${num(value)} de baixo, resolve a conta que estava pendurada, ${top.n} × ${num(value)} = ${num(next)}, e devolve. O frame sai da pilha e a memória dele é liberada.`,
+      `${top.n}`,
+      num(next)
     );
-    valor = novo;
+    value = next;
     frames.pop();
   }
 
   out.push({
-    linha: 4,
+    line: 4,
     frames: [],
-    chamadas,
-    maxProf,
-    nota: `A pilha voltou a ficar vazia: fatorial(${n0}) = ${num(valor)}. Deu ${chamadas} ${chamadas === 1 ? "chamada" : "chamadas"} no total e, no pico, ${maxProf} ${maxProf === 1 ? "frame vivo" : "frames vivos"} ao mesmo tempo. Esse pico é a complexidade de espaço da recursão: O(n).`,
+    calls,
+    maxDepth,
+    note: `A pilha voltou a ficar vazia: fatorial(${n0}) = ${num(value)}. Deu ${calls} ${calls === 1 ? "chamada" : "chamadas"} no total e, no pico, ${maxDepth} ${maxDepth === 1 ? "frame vivo" : "frames vivos"} ao mesmo tempo. Esse pico é a complexidade de espaço da recursão: O(n).`,
     vars: [
-      { nome: "n (frame do topo)", valor: "-" },
-      { nome: "valor devolvido", valor: num(valor) },
-      { nome: "frames na pilha", valor: "0" },
-      { nome: "chamadas", valor: `${chamadas}`, best: true },
+      { name: "n (frame do topo)", value: "-" },
+      { name: "valor devolvido", value: num(value) },
+      { name: "frames na pilha", value: "0" },
+      { name: "chamadas", value: `${calls}`, best: true },
     ],
     ok: true,
-    fim: true,
+    done: true,
   });
   return out;
 }
@@ -218,73 +226,73 @@ function gerarClassico(n0: number, limite: number): Passo[] {
 // é exatamente esse "nada pendente" que abre espaço para a otimização de
 // chamada final nas linguagens que a fazem.
 // --------------------------------------------------------------------------
-function gerarCauda(n0: number, limite: number): Passo[] {
-  const out: Passo[] = [];
+function generateTail(n0: number, limit: number): Step[] {
+  const out: Step[] = [];
   const frames: Frame[] = [];
-  let chamadas = 0;
-  let maxProf = 0;
+  let calls = 0;
+  let maxDepth = 0;
   let id = 0;
 
-  const snap = (novoId?: number) => frames.map((f) => ({ ...f, novo: f.id === novoId }));
-  const vars = (topo: string, acc: string, devolvido: string): Var[] => [
-    { nome: "n (frame do topo)", valor: topo },
-    { nome: "acc", valor: acc },
-    { nome: "valor devolvido", valor: devolvido },
-    { nome: "chamadas", valor: `${chamadas}`, best: true },
+  const snap = (newId?: number) => frames.map((f) => ({ ...f, isNew: f.id === newId }));
+  const vars = (top: string, acc: string, returned: string): Var[] => [
+    { name: "n (frame do topo)", value: top },
+    { name: "acc", value: acc },
+    { name: "valor devolvido", value: returned },
+    { name: "chamadas", value: `${calls}`, best: true },
   ];
-  const passo = (
-    linha: number,
-    nota: string,
-    topo: string,
+  const emit = (
+    line: number,
+    note: string,
+    top: string,
     acc: string,
-    devolvido: string,
-    extra?: Partial<Passo>,
-    novoId?: number
+    returned: string,
+    extra?: Partial<Step>,
+    newId?: number
   ) => {
-    out.push({ linha, frames: snap(novoId), chamadas, maxProf, nota, vars: vars(topo, acc, devolvido), ...extra });
+    out.push({ line, frames: snap(newId), calls, maxDepth, note, vars: vars(top, acc, returned), ...extra });
   };
 
   let k = n0;
   let acc = 1;
-  let guarda = 0;
-  let estourou = false;
+  let guard = 0;
+  let overflowed = false;
 
-  while (guarda++ < 40) {
-    const meu = id++;
-    frames.push({ id: meu, nivel: frames.length + 1, n: k, rotulo: `fatorial(n=${k}, acc=${num(acc)})`, estado: "ativo" });
-    chamadas++;
+  while (guard++ < 40) {
+    const mine = id++;
+    frames.push({ id: mine, level: frames.length + 1, n: k, label: `fatorial(n=${k}, acc=${num(acc)})`, state: "ativo" });
+    calls++;
 
-    if (frames.length > limite) {
-      frames[frames.length - 1].estado = "estoura";
-      passo(
+    if (frames.length > limit) {
+      frames[frames.length - 1].state = "estoura";
+      emit(
         0,
-        `Tentei abrir o frame ${frames.length} e o limite da pilha é ${limite}: RecursionError. Sem otimização de chamada final, a recursão de cauda empilha exatamente igual à clássica.`,
+        `Tentei abrir o frame ${frames.length} e o limite da pilha é ${limit}: RecursionError. Sem otimização de chamada final, a recursão de cauda empilha exatamente igual à clássica.`,
         `${k}`,
         num(acc),
         "-",
-        { fim: true, erro: true },
-        meu
+        { done: true, error: true },
+        mine
       );
-      estourou = true;
+      overflowed = true;
       break;
     }
-    maxProf = Math.max(maxProf, frames.length);
+    maxDepth = Math.max(maxDepth, frames.length);
 
-    passo(
+    emit(
       0,
       `Entro em fatorial(${k}, acc=${num(acc)}). Repare que o trabalho já vem feito de cima: o acumulador carrega tudo o que foi multiplicado até aqui.`,
       `${k}`,
       num(acc),
       "-",
       undefined,
-      meu
+      mine
     );
 
     if (k <= 1) {
-      passo(1, `n = ${k} bate no caso base.`, `${k}`, num(acc), "-");
-      frames[frames.length - 1].estado = "base";
-      frames[frames.length - 1].retorno = num(acc);
-      passo(
+      emit(1, `n = ${k} bate no caso base.`, `${k}`, num(acc), "-");
+      frames[frames.length - 1].state = "base";
+      frames[frames.length - 1].ret = num(acc);
+      emit(
         2,
         `Devolvo o acumulador: ${num(acc)}. A resposta final já estava pronta ANTES da volta começar, ninguém precisa calcular mais nada na subida.`,
         `${k}`,
@@ -294,54 +302,54 @@ function gerarCauda(n0: number, limite: number): Passo[] {
       break;
     }
 
-    passo(1, `n = ${k} ainda não é caso base.`, `${k}`, num(acc), "-");
-    const proximo = acc * k;
-    frames[frames.length - 1].estado = "espera";
-    frames[frames.length - 1].pendente = "nada pendente";
-    passo(
+    emit(1, `n = ${k} ainda não é caso base.`, `${k}`, num(acc), "-");
+    const next = acc * k;
+    frames[frames.length - 1].state = "espera";
+    frames[frames.length - 1].pending = "nada pendente";
+    emit(
       3,
-      `Chamo fatorial(${k - 1}, ${num(acc)} × ${k} = ${num(proximo)}). A chamada é a ÚLTIMA operação da função: depois dela não sobra nenhuma conta neste frame.`,
+      `Chamo fatorial(${k - 1}, ${num(acc)} × ${k} = ${num(next)}). A chamada é a ÚLTIMA operação da função: depois dela não sobra nenhuma conta neste frame.`,
       `${k}`,
       num(acc),
       "-"
     );
-    acc = proximo;
+    acc = next;
     k--;
   }
 
-  if (estourou) return out;
+  if (overflowed) return out;
 
-  const resultado = acc;
+  const result = acc;
   frames.pop();
-  while (frames.length > 0 && guarda++ < 80) {
-    const topo = frames[frames.length - 1];
-    topo.estado = "volta";
-    topo.pendente = undefined;
-    topo.retorno = num(resultado);
-    passo(
+  while (frames.length > 0 && guard++ < 80) {
+    const top = frames[frames.length - 1];
+    top.state = "volta";
+    top.pending = undefined;
+    top.ret = num(result);
+    emit(
       3,
-      `O frame de fatorial(${topo.n}, ...) recebe ${num(resultado)} e só repassa, porque não tinha nada pendente. Este frame ficou vivo à toa: é justamente ele que a otimização de chamada final sabe reaproveitar.`,
-      `${topo.n}`,
+      `O frame de fatorial(${top.n}, ...) recebe ${num(result)} e só repassa, porque não tinha nada pendente. Este frame ficou vivo à toa: é justamente ele que a otimização de chamada final sabe reaproveitar.`,
+      `${top.n}`,
       num(acc),
-      num(resultado)
+      num(result)
     );
     frames.pop();
   }
 
   out.push({
-    linha: 2,
+    line: 2,
     frames: [],
-    chamadas,
-    maxProf,
-    nota: `fatorial(${n0}) = ${num(resultado)} com ${chamadas} ${chamadas === 1 ? "chamada" : "chamadas"} e pico de ${maxProf} ${maxProf === 1 ? "frame" : "frames"}: os mesmos números do modo clássico. Em Python o custo é idêntico, o ganho da cauda só aparece em linguagem que faz a otimização.`,
+    calls,
+    maxDepth,
+    note: `fatorial(${n0}) = ${num(result)} com ${calls} ${calls === 1 ? "chamada" : "chamadas"} e pico de ${maxDepth} ${maxDepth === 1 ? "frame" : "frames"}: os mesmos números do modo clássico. Em Python o custo é idêntico, o ganho da cauda só aparece em linguagem que faz a otimização.`,
     vars: [
-      { nome: "n (frame do topo)", valor: "-" },
-      { nome: "acc", valor: num(resultado) },
-      { nome: "valor devolvido", valor: num(resultado) },
-      { nome: "chamadas", valor: `${chamadas}`, best: true },
+      { name: "n (frame do topo)", value: "-" },
+      { name: "acc", value: num(result) },
+      { name: "valor devolvido", value: num(result) },
+      { name: "chamadas", value: `${calls}`, best: true },
     ],
     ok: true,
-    fim: true,
+    done: true,
   });
   return out;
 }
@@ -350,57 +358,57 @@ function gerarCauda(n0: number, limite: number): Passo[] {
 // Modo caso base inalcançável: o caso base EXISTE, o que falha é a regra 2. O
 // estado anda, mas para o lado errado, e a pilha cresce até o teto.
 // --------------------------------------------------------------------------
-function gerarInalcancavel(n0: number, limite: number): Passo[] {
-  const out: Passo[] = [];
+function generateUnreachable(n0: number, limit: number): Step[] {
+  const out: Step[] = [];
   const frames: Frame[] = [];
-  let chamadas = 0;
-  let maxProf = 0;
+  let calls = 0;
+  let maxDepth = 0;
   let id = 0;
 
-  const snap = (novoId?: number) => frames.map((f) => ({ ...f, novo: f.id === novoId }));
-  const passo = (linha: number, nota: string, topo: string, extra?: Partial<Passo>, novoId?: number) => {
+  const snap = (newId?: number) => frames.map((f) => ({ ...f, isNew: f.id === newId }));
+  const emit = (line: number, note: string, top: string, extra?: Partial<Step>, newId?: number) => {
     out.push({
-      linha,
-      frames: snap(novoId),
-      chamadas,
-      maxProf,
-      nota,
+      line,
+      frames: snap(newId),
+      calls,
+      maxDepth,
+      note,
       vars: [
-        { nome: "n (frame do topo)", valor: topo },
-        { nome: "caso base", valor: "n == 0" },
-        { nome: "frames na pilha", valor: `${frames.length}` },
-        { nome: "chamadas", valor: `${chamadas}`, best: true },
+        { name: "n (frame do topo)", value: top },
+        { name: "caso base", value: "n == 0" },
+        { name: "frames na pilha", value: `${frames.length}` },
+        { name: "chamadas", value: `${calls}`, best: true },
       ],
       ...extra,
     });
   };
 
   let k = n0;
-  let guarda = 0;
-  while (guarda++ < 40) {
-    const meu = id++;
-    frames.push({ id: meu, nivel: frames.length + 1, n: k, rotulo: `contagem(n=${k})`, estado: "ativo" });
-    chamadas++;
+  let guard = 0;
+  while (guard++ < 40) {
+    const mine = id++;
+    frames.push({ id: mine, level: frames.length + 1, n: k, label: `contagem(n=${k})`, state: "ativo" });
+    calls++;
 
-    if (frames.length > limite) {
-      frames[frames.length - 1].estado = "estoura";
-      passo(
+    if (frames.length > limit) {
+      frames[frames.length - 1].state = "estoura";
+      emit(
         4,
-        `Frame ${frames.length} com o limite em ${limite}: RecursionError, maximum recursion depth exceeded. O caso base n == 0 existe e está escrito ali, mas eu comecei em ${n0} e ando para cima: cada chamada me deixa mais longe dele, não mais perto.`,
+        `Frame ${frames.length} com o limite em ${limit}: RecursionError, maximum recursion depth exceeded. O caso base n == 0 existe e está escrito ali, mas eu comecei em ${n0} e ando para cima: cada chamada me deixa mais longe dele, não mais perto.`,
         `${k}`,
-        { fim: true, erro: true },
-        meu
+        { done: true, error: true },
+        mine
       );
       return out;
     }
-    maxProf = Math.max(maxProf, frames.length);
+    maxDepth = Math.max(maxDepth, frames.length);
 
-    passo(0, `Entro em contagem(${k}). Mais um frame no topo, mais um escopo vivo na memória.`, `${k}`, undefined, meu);
-    passo(1, `Testo o caso base: ${k} == 0? Não. Então sigo.`, `${k}`);
-    passo(3, `Imprimo ${k} e vou em frente.`, `${k}`);
-    frames[frames.length - 1].estado = "espera";
-    frames[frames.length - 1].pendente = "nunca resolve";
-    passo(
+    emit(0, `Entro em contagem(${k}). Mais um frame no topo, mais um escopo vivo na memória.`, `${k}`, undefined, mine);
+    emit(1, `Testo o caso base: ${k} == 0? Não. Então sigo.`, `${k}`);
+    emit(3, `Imprimo ${k} e vou em frente.`, `${k}`);
+    frames[frames.length - 1].state = "espera";
+    frames[frames.length - 1].pending = "nunca resolve";
+    emit(
       4,
       `Chamo contagem(${k + 1}). O estado muda a cada chamada, que é a regra 2, mas muda para o lado errado: de ${k} para ${k + 1}, sempre se afastando do zero.`,
       `${k}`
@@ -410,134 +418,105 @@ function gerarInalcancavel(n0: number, limite: number): Passo[] {
   return out;
 }
 
-type Modo = {
+type Mode = {
   key: string;
-  rotulo: string;
-  arquivo: string;
-  codigo: string[];
-  nRotulo: string;
+  label: string;
+  file: string;
+  code: string[];
+  nLabel: string;
   nMin: number;
   nMax: number;
-  gerar: (n: number, limite: number) => Passo[];
+  generate: (n: number, limit: number) => Step[];
 };
 
-const MODOS: Modo[] = [
-  { key: "classico", rotulo: "fatorial clássico", arquivo: "fatorial.py", codigo: CLASSICO, nRotulo: "n", nMin: 0, nMax: 12, gerar: gerarClassico },
-  { key: "cauda", rotulo: "fatorial em cauda", arquivo: "fatorial_cauda.py", codigo: CAUDA, nRotulo: "n", nMin: 0, nMax: 12, gerar: gerarCauda },
-  { key: "inalcancavel", rotulo: "caso base inalcançável", arquivo: "contagem.py", codigo: INALCANCAVEL, nRotulo: "começa em", nMin: 1, nMax: 12, gerar: gerarInalcancavel },
+const MODES: Mode[] = [
+  { key: "classico", label: "fatorial clássico", file: "fatorial.py", code: CLASSIC, nLabel: "n", nMin: 0, nMax: 12, generate: generateClassic },
+  { key: "cauda", label: "fatorial em cauda", file: "fatorial_cauda.py", code: TAIL, nLabel: "n", nMin: 0, nMax: 12, generate: generateTail },
+  { key: "inalcancavel", label: "caso base inalcançável", file: "contagem.py", code: UNREACHABLE, nLabel: "começa em", nMin: 1, nMax: 12, generate: generateUnreachable },
 ];
 
-type Preset = { key: string; rotulo: string; modo: string; n: number; limite: number };
+type Preset = { key: string; label: string; mode: string; n: number; limit: number };
 
 const PRESETS: Preset[] = [
-  { key: "cinco", rotulo: "fatorial(5): o clássico", modo: "classico", n: 5, limite: 12 },
-  { key: "base", rotulo: "fatorial(1): caso base de cara", modo: "classico", n: 1, limite: 12 },
-  { key: "cauda", rotulo: "fatorial(5) em cauda", modo: "cauda", n: 5, limite: 12 },
-  { key: "fundo", rotulo: "fatorial(10) com limite 6", modo: "classico", n: 10, limite: 6 },
-  { key: "solto", rotulo: "caso base fora de alcance", modo: "inalcancavel", n: 1, limite: 6 },
+  { key: "cinco", label: "fatorial(5): o clássico", mode: "classico", n: 5, limit: 12 },
+  { key: "base", label: "fatorial(1): caso base de cara", mode: "classico", n: 1, limit: 12 },
+  { key: "cauda", label: "fatorial(5) em cauda", mode: "cauda", n: 5, limit: 12 },
+  { key: "fundo", label: "fatorial(10) com limite 6", mode: "classico", n: 10, limit: 6 },
+  { key: "solto", label: "caso base fora de alcance", mode: "inalcancavel", n: 1, limit: 6 },
 ];
 
 export function RecursionVisualizer() {
-  const [iModo, setIModo] = useState(0);
+  const [modeIndex, setModeIndex] = useState(0);
   const [n, setN] = useState(5);
-  const [limite, setLimite] = useState(12);
+  const [limit, setLimit] = useState(12);
   const [preset, setPreset] = useState("cinco");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const mode = MODES[modeIndex];
+  const steps = useMemo(() => mode.generate(n, limit), [mode, n, limit]);
 
-  const modo = MODOS[iModo];
-  const passos = useMemo(() => modo.gerar(n, limite), [modo, n, limite]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · a pilha de chamadas: empilha na descida, resolve na subida",
+    total: steps.length,
+    speeds: SPEEDS,
+    // O que muda a altura da peça: o modo (o código vai de 4 a 5 linhas e o
+    // painel de variáveis troca de conteúdo) e, sobretudo, quantos frames cabem
+    // na pilha — que é o produto de `n` com `limit`. O eixo que vira ALTURA
+    // aqui é a FILEIRA de frames, não o valor de n: com `limit` em 3 a peça
+    // mede 956px e com `limit` em 12 mede 1379px, com o mesmo n.
+    measureOn: [modeIndex, n, limit],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-
-  const trocarModo = (i: number) => {
-    reiniciar(); setPreset("");
-    setIModo(i);
-    setN((v) => Math.min(MODOS[i].nMax, Math.max(MODOS[i].nMin, v)));
+  const pickMode = (i: number) => {
+    viz.reset();
+    setPreset("");
+    setModeIndex(i);
+    setN((v) => Math.min(MODES[i].nMax, Math.max(MODES[i].nMin, v)));
   };
-  const aoMudarN = (v: string) => {
+  const onChangeN = (v: string) => {
     const x = parseInt(v, 10);
-    reiniciar(); setPreset("");
-    setN(isNaN(x) ? modo.nMin : Math.min(modo.nMax, Math.max(modo.nMin, x)));
+    viz.reset();
+    setPreset("");
+    setN(isNaN(x) ? mode.nMin : Math.min(mode.nMax, Math.max(mode.nMin, x)));
   };
-  const aoMudarLimite = (v: string) => {
+  const onChangeLimit = (v: string) => {
     const x = parseInt(v, 10);
-    reiniciar(); setPreset("");
-    setLimite(isNaN(x) ? 3 : Math.min(12, Math.max(3, x)));
+    viz.reset();
+    setPreset("");
+    setLimit(isNaN(x) ? 3 : Math.min(12, Math.max(3, x)));
   };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar(); setPreset(pr.key);
-    setIModo(MODOS.findIndex((m) => m.key === pr.modo));
-    setN(pr.n); setLimite(pr.limite);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setPreset(pr.key);
+    setModeIndex(MODES.findIndex((m) => m.key === pr.mode));
+    setN(pr.n);
+    setLimit(pr.limit);
   };
 
   const frames = [...p.frames].reverse(); // topo da pilha em cima
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.erro ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.error ? " invalid" : "");
 
   // A execução chega a devolver alguma coisa? Se ela estoura na pilha, mostrar
   // "fatorial(10) = 3.628.800" no painel seria mentira: aquele valor nunca
   // voltou. Nesse caso o card diz o que de fato aconteceu.
-  const estourou = passos[total - 1].erro === true;
-  const esperado = modo.key === "inalcancavel" || estourou ? null : fatorialDe(n);
+  const overflowed = steps[steps.length - 1].error === true;
+  const expected = mode.key === "inalcancavel" || overflowed ? null : factorialOf(n);
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a pilha de chamadas: empilha na descida, resolve na subida</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -546,68 +525,77 @@ export function RecursionVisualizer() {
           <div className="viz-field">
             <span>Função</span>
             <div className="sub-modo">
-              {MODOS.map((m, i) => (
+              {MODES.map((m, i) => (
                 <button
                   key={m.key}
-                  className={`sub-modo-btn${i === iModo ? " on" : ""}`}
-                  onClick={() => trocarModo(i)}
-                  aria-pressed={i === iModo}
+                  className={`sub-modo-btn${i === modeIndex ? " on" : ""}`}
+                  onClick={() => pickMode(i)}
+                  aria-pressed={i === modeIndex}
                 >
-                  {m.rotulo}
+                  {m.label}
                 </button>
               ))}
             </div>
           </div>
           <label className="viz-field">
-            <span>{modo.nRotulo}</span>
-            <input className="viz-input k" type="number" min={modo.nMin} max={modo.nMax} value={n} onChange={(e) => aoMudarN(e.target.value)} />
+            <span>{mode.nLabel}</span>
+            <input className="viz-input k" type="number" min={mode.nMin} max={mode.nMax} value={n} onChange={(e) => onChangeN(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>limite da pilha</span>
-            <input className="viz-input k" type="number" min={3} max={12} value={limite} onChange={(e) => aoMudarLimite(e.target.value)} />
+            <input className="viz-input k" type="number" min={3} max={12} value={limit} onChange={(e) => onChangeLimit(e.target.value)} />
           </label>
         </div>
 
         <div className="rec-stack-lbl">
           <span>Call stack{frames.length > 0 ? " · topo em cima" : ""}</span>
-          <span>{frames.length} de {limite} frames</span>
+          <span>{frames.length} de {limit} frames</span>
         </div>
         <div className="rec-stack">
           {frames.length === 0 ? (
             <div className="rec-stack-vazia">pilha vazia</div>
           ) : (
             frames.map((f, i) => (
-              <div key={f.id} className={`rec-frame ${f.estado}${f.novo ? " novo" : ""}`}>
-                <span className="rec-frame-nome">{f.rotulo}</span>
-                {f.pendente ? <span className="rec-frame-pend">{f.pendente}</span> : null}
-                {f.retorno ? <span className="rec-frame-ret">devolve {f.retorno}</span> : null}
-                <span className="rec-frame-tag">{i === 0 ? "topo" : `nível ${f.nivel}`}</span>
+              <div key={f.id} className={`rec-frame ${f.state}${f.isNew ? " novo" : ""}`}>
+                <span className="rec-frame-nome">{f.label}</span>
+                {f.pending ? <span className="rec-frame-pend">{f.pending}</span> : null}
+                {f.ret ? <span className="rec-frame-ret">devolve {f.ret}</span> : null}
+                <span className="rec-frame-tag">{i === 0 ? "topo" : `nível ${f.level}`}</span>
               </div>
             ))
           )}
-          {p.erro ? <div className="rec-limite">limite da pilha: {limite} frames</div> : null}
+          {p.error ? <div className="rec-limite">limite da pilha: {limit} frames</div> : null}
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo.arquivo}</div>
-            <div className="viz-code-body">
-              {modo.codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso;
+              `inert` tira ele do teclado e dos leitores de tela enquanto está
+              fora de vista. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode.file}</div>
+              <div className="viz-code-body">
+                {mode.code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {p.vars.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
@@ -616,47 +604,28 @@ export function RecursionVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>chamadas feitas</span>
-            <strong>{num(p.chamadas)}</strong>
+            <strong>{num(p.calls)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pico de frames</span>
-            <strong>{num(p.maxProf)}</strong>
+            <strong>{num(p.maxDepth)}</strong>
           </div>
           <div className="bigo-stat">
             <span>memória da pilha</span>
             <strong>O(n)</strong>
           </div>
           <div className="bigo-stat">
-            <span>{esperado === null ? "resposta" : `fatorial(${n})`}</span>
-            <strong>{esperado === null ? (estourou ? "estourou" : "nunca chega") : num(esperado)}</strong>
+            <span>{expected === null ? "resposta" : `fatorial(${n})`}</span>
+            <strong>{expected === null ? (overflowed ? "estourou" : "nunca chega") : num(expected)}</strong>
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/StackCallStackVisualizer.tsx
+++ b/content/visualizers/StackCallStackVisualizer.tsx
@@ -1,37 +1,39 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // StackCallStackVisualizer, a mesma conta resolvida por duas pilhas: a call
 // stack do interpretador (recursão) e uma pilha explícita escrita na mão.
 //
-// É o exercício que a comunidade fez no encontro: calcular 2³ de dois jeitos e
-// provar que os passos são os mesmos. A única coisa que o aluno precisa ver:
-// na recursão a pilha existe do mesmo jeito, ele só não a escreveu.
+// Calcular uma potência dos dois jeitos e provar que os passos são os mesmos.
+// A única coisa que o aluno precisa ver: na recursão a pilha existe do mesmo
+// jeito, ele só não a escreveu.
 //
 // Gerador PURO de passos, um por modo. Cada modo tem a sua constante de código,
-// e o campo `linha` de cada passo aponta para o array daquele modo.
+// e o campo `line` de cada passo aponta para o array daquele modo.
 // ---------------------------------------------------------------------------
 
-type Modo = "recursao" | "explicita";
+type Mode = "recursao" | "explicita";
 
-type Frame = { rot: string; est: string; destaque?: "entra" | "sai" };
+// `highlight` guarda o nome da classe de CSS que a ficha recebe (`.pl-item.entra`,
+// `.pl-item.sai`), então o VALOR não se traduz: ele é a API do `globals.css`.
+type Frame = { label: string; state: string; highlight?: "entra" | "sai" };
 
-type Passo = {
-  linha: number;
-  pilha: Frame[];
-  empilhados: number;
-  alturaMax: number;
-  topo: string;
-  retorno: string;
-  resultado: string;
+type Step = {
+  line: number;
+  stack: Frame[];
+  pushed: number;
+  maxHeight: number;
+  top: string;
+  returned: string;
+  result: string;
   ok?: boolean;
-  nota: string;
+  note: string;
 };
 
-const CODIGO: Record<Modo, string[]> = {
+const CODE: Record<Mode, string[]> = {
   recursao: [
     "def potencia(x, n):",
     "    if n == 1:",
@@ -50,231 +52,192 @@ const CODIGO: Record<Modo, string[]> = {
   ],
 };
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+function generateRecursion(x: number, n: number): Step[] {
+  const out: Step[] = [];
+  const stack: Frame[] = [];
+  let pushed = 0;
+  let maxHeight = 0;
 
-function gerarRecursao(x: number, n: number): Passo[] {
-  const out: Passo[] = [];
-  const pilha: Frame[] = [];
-  let empilhados = 0;
-  let alturaMax = 0;
-
-  const snap = (linha: number, nota: string, extra: Partial<Passo> = {}) => {
+  const snap = (line: number, note: string, extra: Partial<Step> = {}) => {
     out.push({
-      linha,
-      pilha: pilha.map((f) => ({ ...f })),
-      empilhados,
-      alturaMax,
-      topo: pilha.length ? pilha[pilha.length - 1].rot : "vazia",
-      retorno: "-",
-      resultado: "-",
-      nota,
+      line,
+      stack: stack.map((f) => ({ ...f })),
+      pushed,
+      maxHeight,
+      top: stack.length ? stack[stack.length - 1].label : "vazia",
+      returned: "-",
+      result: "-",
+      note,
       ...extra,
     });
   };
 
   for (let k = n; k >= 1; k--) {
-    pilha.forEach((f) => { f.destaque = undefined; });
-    pilha.push({ rot: `potencia(${x}, ${k})`, est: "acabou de entrar", destaque: "entra" });
-    empilhados++;
-    alturaMax = Math.max(alturaMax, pilha.length);
+    stack.forEach((f) => { f.highlight = undefined; });
+    stack.push({ label: `potencia(${x}, ${k})`, state: "acabou de entrar", highlight: "entra" });
+    pushed++;
+    maxHeight = Math.max(maxHeight, stack.length);
     snap(0, `Chamei potencia(${x}, ${k}): um frame novo entra no topo da pilha, com x = ${x} e n = ${k}.`);
 
     if (k > 1) {
-      pilha[pilha.length - 1].destaque = undefined;
-      pilha[pilha.length - 1].est = `parado, esperando potencia(${x}, ${k - 1})`;
+      stack[stack.length - 1].highlight = undefined;
+      stack[stack.length - 1].state = `parado, esperando potencia(${x}, ${k - 1})`;
       snap(1, `n = ${k} não é 1, então este frame ainda não sabe a resposta: ele precisa de potencia(${x}, ${k - 1}) antes de multiplicar. Fica parado na pilha, ocupando memória.`);
     }
   }
 
   // Caso base: o único frame que devolve valor sem chamar mais ninguém.
-  let valor = x;
-  pilha[pilha.length - 1].est = `caso base, devolve ${x}`;
-  pilha[pilha.length - 1].destaque = "sai";
+  let value = x;
+  stack[stack.length - 1].state = `caso base, devolve ${x}`;
+  stack[stack.length - 1].highlight = "sai";
   snap(2, `n = 1, o caso base! Devolvo x = ${x} e desempilho este frame. A partir daqui a pilha se desfaz de cima para baixo.`, {
-    retorno: `${valor}`,
+    returned: `${value}`,
   });
-  pilha.pop();
+  stack.pop();
 
   for (let k = 2; k <= n; k++) {
-    const anterior = valor;
-    valor = valor * x;
-    pilha[pilha.length - 1].est = `recebeu ${anterior}, devolve ${valor}`;
-    pilha[pilha.length - 1].destaque = "sai";
-    snap(3, `O frame de n = ${k} estava esperando: recebi ${anterior}, multiplico por x = ${x} e devolvo ${valor}. Desempilho ele também.`, {
-      retorno: `${valor}`,
+    const previous = value;
+    value = value * x;
+    stack[stack.length - 1].state = `recebeu ${previous}, devolve ${value}`;
+    stack[stack.length - 1].highlight = "sai";
+    snap(3, `O frame de n = ${k} estava esperando: recebi ${previous}, multiplico por x = ${x} e devolvo ${value}. Desempilho ele também.`, {
+      returned: `${value}`,
     });
-    pilha.pop();
+    stack.pop();
   }
 
-  snap(3, `Pilha vazia de novo: ${x}^${n} = ${valor}. Foram ${empilhados} ${empilhados === 1 ? "frame empilhado" : "frames empilhados"} e a profundidade máxima foi ${alturaMax}, ou seja, memória O(n).`, {
+  snap(3, `Pilha vazia de novo: ${x}^${n} = ${value}. Foram ${pushed} ${pushed === 1 ? "frame empilhado" : "frames empilhados"} e a profundidade máxima foi ${maxHeight}, ou seja, memória O(n).`, {
     ok: true,
-    retorno: `${valor}`,
-    resultado: `${valor}`,
+    returned: `${value}`,
+    result: `${value}`,
   });
   return out;
 }
 
-function gerarExplicita(x: number, n: number): Passo[] {
-  const out: Passo[] = [];
-  const pilha: Frame[] = [];
-  let empilhados = 0;
-  let alturaMax = 0;
-  let resultado = 1;
+function generateExplicit(x: number, n: number): Step[] {
+  const out: Step[] = [];
+  const stack: Frame[] = [];
+  let pushed = 0;
+  let maxHeight = 0;
+  let result = 1;
 
-  const snap = (linha: number, nota: string, extra: Partial<Passo> = {}) => {
+  const snap = (line: number, note: string, extra: Partial<Step> = {}) => {
     out.push({
-      linha,
-      pilha: pilha.map((f) => ({ ...f })),
-      empilhados,
-      alturaMax,
-      topo: pilha.length ? pilha[pilha.length - 1].rot : "vazia",
-      retorno: "-",
-      resultado: `${resultado}`,
-      nota,
+      line,
+      stack: stack.map((f) => ({ ...f })),
+      pushed,
+      maxHeight,
+      top: stack.length ? stack[stack.length - 1].label : "vazia",
+      returned: "-",
+      result: `${result}`,
+      note,
       ...extra,
     });
   };
 
-  snap(1, `Crio a pilha vazia na mão. A ideia é a mesma da recursão, só que agora a pilha é um objeto meu, e não a call stack do interpretador.`, { resultado: "-" });
+  snap(1, `Crio a pilha vazia na mão. A ideia é a mesma da recursão, só que agora a pilha é um objeto meu, e não a call stack do interpretador.`, { result: "-" });
 
   for (let k = 1; k <= n; k++) {
-    pilha.forEach((f) => { f.destaque = undefined; });
-    pilha.push({ rot: `${x}`, est: `cópia ${k} da base`, destaque: "entra" });
-    empilhados++;
-    alturaMax = Math.max(alturaMax, pilha.length);
-    snap(3, `Empilho mais uma cópia da base x = ${x}. A pilha tem ${pilha.length} ${pilha.length === 1 ? "item" : "itens"}, e ainda não multipliquei nada.`, { resultado: "-" });
+    stack.forEach((f) => { f.highlight = undefined; });
+    stack.push({ label: `${x}`, state: `cópia ${k} da base`, highlight: "entra" });
+    pushed++;
+    maxHeight = Math.max(maxHeight, stack.length);
+    snap(3, `Empilho mais uma cópia da base x = ${x}. A pilha tem ${stack.length} ${stack.length === 1 ? "item" : "itens"}, e ainda não multipliquei nada.`, { result: "-" });
   }
 
-  pilha.forEach((f) => { f.destaque = undefined; });
+  stack.forEach((f) => { f.highlight = undefined; });
   snap(4, `Todas as ${n} cópias empilhadas. Começo o resultado em 1 e agora vou desempilhando e multiplicando.`);
 
   for (let k = 1; k <= n; k++) {
-    const antes = resultado;
-    resultado = resultado * x;
-    pilha[pilha.length - 1].destaque = "sai";
-    pilha[pilha.length - 1].est = `saindo: ${antes} × ${x} = ${resultado}`;
-    snap(6, `Desempilho o topo: resultado = ${antes} × ${x} = ${resultado}. Sobra${pilha.length - 1 === 1 ? "" : "m"} ${pilha.length - 1} na pilha.`);
-    pilha.pop();
+    const before = result;
+    result = result * x;
+    stack[stack.length - 1].highlight = "sai";
+    stack[stack.length - 1].state = `saindo: ${before} × ${x} = ${result}`;
+    snap(6, `Desempilho o topo: resultado = ${before} × ${x} = ${result}. Sobra${stack.length - 1 === 1 ? "" : "m"} ${stack.length - 1} na pilha.`);
+    stack.pop();
   }
 
-  snap(7, `Pilha vazia: ${x}^${n} = ${resultado}. Mesmo resultado, mesma altura máxima (${alturaMax}) e os mesmos ${empilhados} empilhamentos da versão recursiva.`, { ok: true });
+  snap(7, `Pilha vazia: ${x}^${n} = ${result}. Mesmo resultado, mesma altura máxima (${maxHeight}) e os mesmos ${pushed} empilhamentos da versão recursiva.`, { ok: true });
   return out;
 }
 
-const MODOS: { key: Modo; rotulo: string }[] = [
-  { key: "recursao", rotulo: "Recursão (call stack)" },
-  { key: "explicita", rotulo: "Pilha explícita" },
+const MODES: { key: Mode; label: string }[] = [
+  { key: "recursao", label: "Recursão (call stack)" },
+  { key: "explicita", label: "Pilha explícita" },
 ];
 
-const X_PADRAO = 2;
-const N_PADRAO = 3;
+const X_DEFAULT = 2;
+const N_DEFAULT = 3;
 
-function limitar(v: string, min: number, max: number, padrao: number): number {
+function clamp(v: string, min: number, max: number, fallback: number): number {
   const k = parseInt(v, 10);
-  if (isNaN(k)) return padrao;
+  if (isNaN(k)) return fallback;
   return Math.min(max, Math.max(min, k));
 }
 
 export function StackCallStackVisualizer() {
-  const [modo, setModo] = useState<Modo>("recursao");
-  const [x, setX] = useState(X_PADRAO);
-  const [n, setN] = useState(N_PADRAO);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [mode, setMode] = useState<Mode>("recursao");
+  const [x, setX] = useState(X_DEFAULT);
+  const [n, setN] = useState(N_DEFAULT);
 
-  useEffect(() => setMounted(true), []);
-
-  const passos = useMemo(
-    () => (modo === "recursao" ? gerarRecursao(x, n) : gerarExplicita(x, n)),
-    [modo, x, n]
+  const steps = useMemo(
+    () => (mode === "recursao" ? generateRecursion(x, n) : generateExplicit(x, n)),
+    [mode, x, n]
   );
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const codigo = CODIGO[modo];
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const viz = useVisualizer({
+    title: "Visualizador · a mesma potência com duas pilhas",
+    total: steps.length,
+    // O que muda a altura da peça: o modo (o código vai de 4 a 8 linhas) e o
+    // expoente, que é a profundidade máxima da torre de frames.
+    measureOn: [mode, n],
+  });
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+  const p = steps[viz.step];
+  const code = CODE[mode];
 
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
+  const change = (fn: () => void) => { viz.reset(); fn(); };
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const tower = [...p.stack].reverse();
 
-  const trocar = (fn: () => void) => { parar(); setTocando(false); setPasso(0); fn(); };
-
-  const torre = [...p.pilha].reverse();
-
-  const variaveis =
-    modo === "recursao"
+  const variables =
+    mode === "recursao"
       ? [
-          { nome: "topo", valor: p.topo },
-          { nome: "frames", valor: `${p.pilha.length}` },
-          { nome: "return", valor: p.retorno },
-          { nome: `${x}^${n}`, valor: p.resultado, best: !!p.ok },
+          { name: "topo", value: p.top },
+          { name: "frames", value: `${p.stack.length}` },
+          { name: "return", value: p.returned },
+          { name: `${x}^${n}`, value: p.result, best: !!p.ok },
         ]
       : [
-          { nome: "topo", valor: p.topo },
-          { nome: "len(pilha)", valor: `${p.pilha.length}` },
-          { nome: "resultado", valor: p.resultado },
-          { nome: `${x}^${n}`, valor: p.ok ? p.resultado : "-", best: !!p.ok },
+          { name: "topo", value: p.top },
+          { name: "len(pilha)", value: `${p.stack.length}` },
+          { name: "resultado", value: p.result },
+          { name: `${x}^${n}`, value: p.ok ? p.result : "-", best: !!p.ok },
         ];
 
-  const estatisticas = [
-    { k: "n", rot: "expoente (n)", val: `${n}` },
-    { k: "alt", rot: "altura máxima da pilha", val: `${p.alturaMax}` },
-    { k: "emp", rot: "empilhamentos", val: `${p.empilhados}` },
-    { k: "esp", rot: "memória extra", val: "O(n)" },
+  const stats = [
+    { k: "n", label: "expoente (n)", value: `${n}` },
+    { k: "alt", label: "altura máxima da pilha", value: `${p.maxHeight}` },
+    { k: "emp", label: "empilhamentos", value: `${p.pushed}` },
+    { k: "esp", label: "memória extra", value: "O(n)" },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.ok ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a mesma potência com duas pilhas</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {MODOS.map((m) => (
+          {MODES.map((m) => (
             <button
               key={m.key}
-              className={`bigo-chip${modo === m.key ? " on" : ""}`}
-              onClick={() => trocar(() => setModo(m.key))}
-              aria-pressed={modo === m.key}
+              className={`bigo-chip${mode === m.key ? " on" : ""}`}
+              onClick={() => change(() => setMode(m.key))}
+              aria-pressed={mode === m.key}
             >
-              {m.rotulo}
+              {m.label}
             </button>
           ))}
         </div>
@@ -288,7 +251,7 @@ export function StackCallStackVisualizer() {
               min={1}
               max={9}
               value={x}
-              onChange={(e) => trocar(() => setX(limitar(e.target.value, 1, 9, X_PADRAO)))}
+              onChange={(e) => change(() => setX(clamp(e.target.value, 1, 9, X_DEFAULT)))}
             />
           </label>
           <label className="viz-field">
@@ -299,10 +262,13 @@ export function StackCallStackVisualizer() {
               min={1}
               max={8}
               value={n}
-              onChange={(e) => trocar(() => setN(limitar(e.target.value, 1, 8, N_PADRAO)))}
+              onChange={(e) => change(() => setN(clamp(e.target.value, 1, 8, N_DEFAULT)))}
             />
           </label>
-          <button className="viz-btn" onClick={() => trocar(() => { setX(X_PADRAO); setN(N_PADRAO); })}>
+          {/* O `↺` do rodapé é só `viz.reset()`: ele volta ao passo 0 e não
+              desfaz a base e o expoente que o aluno montou. O caminho de volta
+              ao estado inicial é este botão, e o rótulo dele diz isso. */}
+          <button className="viz-btn" onClick={() => change(() => { setX(X_DEFAULT); setN(N_DEFAULT); })}>
             ↺ Voltar ao 2³
           </button>
         </div>
@@ -310,14 +276,14 @@ export function StackCallStackVisualizer() {
         <div className="pl-arena larga">
           <div className="pl-col">
             <span className="pl-lbl">
-              {modo === "recursao" ? "O que a call stack está fazendo" : "O que a pilha está fazendo"}
+              {mode === "recursao" ? "O que a call stack está fazendo" : "O que a pilha está fazendo"}
             </span>
-            <p className={notaCls}>{p.nota}</p>
+            <p className={noteClass}>{p.note}</p>
             <div className="bigo-stats">
-              {estatisticas.map((s) => (
+              {stats.map((s) => (
                 <div className="bigo-stat" key={s.k}>
-                  <span>{s.rot}</span>
-                  <strong>{s.val}</strong>
+                  <span>{s.label}</span>
+                  <strong>{s.value}</strong>
                 </div>
               ))}
             </div>
@@ -325,17 +291,17 @@ export function StackCallStackVisualizer() {
 
           <div className="pl-col">
             <span className="pl-lbl">
-              {modo === "recursao" ? "Call stack (topo em cima)" : "Pilha (topo em cima)"}
+              {mode === "recursao" ? "Call stack (topo em cima)" : "Pilha (topo em cima)"}
             </span>
             <div className="pl-torre">
-              {torre.length ? (
-                torre.map((f, k) => (
+              {tower.length ? (
+                tower.map((f, k) => (
                   <div
-                    key={`${f.rot}-${torre.length - k}`}
-                    className={`pl-item bloco${k === 0 ? " topo" : ""}${f.destaque ? ` ${f.destaque}` : ""}`}
+                    key={`${f.label}-${tower.length - k}`}
+                    className={`pl-item bloco${k === 0 ? " topo" : ""}${f.highlight ? ` ${f.highlight}` : ""}`}
                   >
-                    <span className="pl-frame-nome">{f.rot}</span>
-                    <span className="pl-frame-est">{f.est}</span>
+                    <span className="pl-frame-nome">{f.label}</span>
+                    <span className="pl-frame-est">{f.state}</span>
                   </div>
                 ))
               ) : (
@@ -347,53 +313,32 @@ export function StackCallStackVisualizer() {
         </div>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo === "recursao" ? "recursivo.py" : "com_pilha.py"}</div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode === "recursao" ? "recursivo.py" : "com_pilha.py"}</div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {variables.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={() => { parar(); setTocando(false); setPasso(0); }}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/StackMonotonicaVisualizer.tsx
+++ b/content/visualizers/StackMonotonicaVisualizer.tsx
@@ -1,14 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // StackMonotonicaVisualizer, a pilha monotônica resolvendo "próximo maior
 // elemento".
 //
-// Mesmo padrão do TwoPointersVisualizer: gerador PURO de passos + a mesma casca
-// (fitas de células, código sincronizado, variáveis, controles, Expandir).
+// Gerador PURO de passos + a casca adaptativa do `useVisualizer` (fitas de
+// células, código sincronizado, variáveis, controles, Expandir).
 //
 // A ÚNICA coisa que o aluno precisa ver acontecendo: quando chega um valor
 // grande, ele resolve de uma vez TODOS os que estavam esperando embaixo dele,
@@ -22,24 +22,24 @@ import { createPortal } from "react-dom";
 // sempre "não existe", nunca um valor legítimo do array.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   i: number; // índice atual; -1 na preparação, n no encerramento
-  pilha: number[]; // índices, da base para o topo
-  resp: (number | null)[]; // null = ainda o -1 provisório
-  linha: number;
-  popou?: number; // índice que acabou de receber resposta
-  comparou?: number; // topo comparado e mantido
-  empurrou?: number;
-  comps: number;
+  stack: number[]; // índices, da base para o topo
+  answers: (number | null)[]; // null = ainda o -1 provisório
+  line: number;
+  poppedIdx?: number; // índice que acabou de receber resposta
+  comparedIdx?: number; // topo comparado e mantido
+  pushedIdx?: number;
+  comparisons: number;
   pushes: number;
   pops: number;
-  fim?: boolean;
-  nota: string;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO = [
+const CODE = [
   "def proximo_maior(nums):",
   "    resp = [-1] * len(nums)",
   "    pilha = []                 # índices em espera",
@@ -50,23 +50,20 @@ const CODIGO = [
   "    return resp",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const MAX_ITEMS = 12;
 
-const MAX_ITENS = 12;
-
-function limpar(v: string): number[] {
+function clean(v: string): number[] {
   return v
     .split(/[\s,]+/)
     .map((x) => parseInt(x, 10))
     .filter((x) => !isNaN(x) && x >= 0 && x <= 99)
-    .slice(0, MAX_ITENS);
+    .slice(0, MAX_ITEMS);
 }
 
 // Quantas comparações a força bruta faria no MESMO array: para cada i, varre
 // para a direita até achar alguém maior. É o número que o painel põe ao lado
 // do contador da pilha.
-function compsForcaBruta(nums: number[]): number {
+function bruteForceComparisons(nums: number[]): number {
   let c = 0;
   for (let i = 0; i < nums.length; i++) {
     for (let j = i + 1; j < nums.length; j++) {
@@ -77,235 +74,205 @@ function compsForcaBruta(nums: number[]): number {
   return c;
 }
 
-function gerarPassos(nums: number[]): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(nums: number[]): Step[] {
+  const out: Step[] = [];
   const n = nums.length;
-  const pilha: number[] = [];
-  const resp: (number | null)[] = new Array(n).fill(null);
-  let comps = 0;
+  const stack: number[] = [];
+  const answers: (number | null)[] = new Array(n).fill(null);
+  let comparisons = 0;
   let pushes = 0;
   let pops = 0;
 
-  const snap = (p: Omit<Passo, "comps" | "pushes" | "pops" | "pilha" | "resp">) => {
-    out.push({ ...p, pilha: [...pilha], resp: [...resp], comps, pushes, pops });
+  const snap = (p: Omit<Step, "comparisons" | "pushes" | "pops" | "stack" | "answers">) => {
+    out.push({ ...p, stack: [...stack], answers: [...answers], comparisons, pushes, pops });
   };
 
   if (!n) {
-    snap({ i: -1, linha: 1, fim: true, nota: "Array vazio: não existe resposta para dar, e a pilha nunca chega a receber nada." });
+    snap({ i: -1, line: 1, done: true, note: "Array vazio: não existe resposta para dar, e a pilha nunca chega a receber nada." });
     return out;
   }
 
   snap({
     i: -1,
-    linha: 1,
-    nota: `Começo com as ${n} respostas em -1. Esse é o palpite padrão: se ninguém maior aparecer à direita, o -1 fica.`,
+    line: 1,
+    note: `Começo com as ${n} respostas em -1. Esse é o palpite padrão: se ninguém maior aparecer à direita, o -1 fica.`,
   });
   snap({
     i: -1,
-    linha: 2,
-    nota: "A pilha começa vazia e vai guardar ÍNDICES de quem ainda não achou ninguém maior. Ela sempre fica em ordem decrescente de valor, do fundo para o topo.",
+    line: 2,
+    note: "A pilha começa vazia e vai guardar ÍNDICES de quem ainda não achou ninguém maior. Ela sempre fica em ordem decrescente de valor, do fundo para o topo.",
   });
 
-  let guarda = 0;
-  for (let i = 0; i < n && guarda++ < 400; i++) {
+  let guard = 0;
+  for (let i = 0; i < n && guard++ < 400; i++) {
     const v = nums[i];
     snap({
       i,
-      linha: 3,
-      nota: `Chego no índice ${i}, valor ${v}. Pergunta única deste passo: esse ${v} é o próximo maior de alguém que está esperando na pilha?`,
+      line: 3,
+      note: `Chego no índice ${i}, valor ${v}. Pergunta única deste passo: esse ${v} é o próximo maior de alguém que está esperando na pilha?`,
     });
 
-    while (pilha.length) {
-      const j = pilha[pilha.length - 1];
-      comps++;
+    while (stack.length) {
+      const j = stack[stack.length - 1];
+      comparisons++;
       if (nums[j] < v) {
-        pilha.pop();
+        stack.pop();
         pops++;
-        resp[j] = v;
+        answers[j] = v;
         snap({
           i,
-          linha: 5,
-          popou: j,
-          nota: `O topo é o índice ${j}, valor ${nums[j]}, e ${nums[j]} < ${v}: achei. O próximo maior de ${nums[j]} é ${v}, então gravo resp[${j}] = ${v} e desempilho, porque ele nunca mais vai precisar de resposta.`,
+          line: 5,
+          poppedIdx: j,
+          note: `O topo é o índice ${j}, valor ${nums[j]}, e ${nums[j]} < ${v}: achei. O próximo maior de ${nums[j]} é ${v}, então gravo resp[${j}] = ${v} e desempilho, porque ele nunca mais vai precisar de resposta.`,
         });
       } else {
         snap({
           i,
-          linha: 4,
-          comparou: j,
-          nota: `O topo é o índice ${j}, valor ${nums[j]}, e ${nums[j]} não é menor que ${v}: ele continua esperando. Como a pilha é decrescente, todo mundo abaixo dele é ainda maior, então nem preciso olhar. Paro o while.`,
+          line: 4,
+          comparedIdx: j,
+          note: `O topo é o índice ${j}, valor ${nums[j]}, e ${nums[j]} não é menor que ${v}: ele continua esperando. Como a pilha é decrescente, todo mundo abaixo dele é ainda maior, então nem preciso olhar. Paro o while.`,
         });
         break;
       }
     }
 
     pushes++;
-    pilha.push(i);
+    stack.push(i);
     snap({
       i,
-      linha: 6,
-      empurrou: i,
-      nota: `Empilho o índice ${i}: agora é o ${v} que fica esperando o próximo maior dele. A pilha tem ${pilha.length} ${pilha.length === 1 ? "índice" : "índices"} em espera.`,
+      line: 6,
+      pushedIdx: i,
+      note: `Empilho o índice ${i}: agora é o ${v} que fica esperando o próximo maior dele. A pilha tem ${stack.length} ${stack.length === 1 ? "índice" : "índices"} em espera.`,
     });
   }
 
-  const sobrando = pilha.map((j) => `${nums[j]} (índice ${j})`).join(", ");
-  const quantos = pilha.length;
-  for (const j of pilha) resp[j] = -1;
-  pilha.length = 0;
+  const leftover = stack.map((j) => `${nums[j]} (índice ${j})`).join(", ");
+  const howMany = stack.length;
+  for (const j of stack) answers[j] = -1;
+  stack.length = 0;
   snap({
     i: n,
-    linha: 7,
-    fim: true,
-    nota: `Acabou o array e ${quantos === 1 ? "sobrou 1 índice" : `sobraram ${quantos} índices`} na pilha: ${sobrando}. Ninguém maior apareceu à direita, então a resposta ${quantos === 1 ? "dele" : "deles"} fica em -1 mesmo. Foram ${pushes} push e ${pops} pop para ${n} elementos, ou seja ${pushes + pops} operações de pilha contra o teto de ${2 * n}.`,
+    line: 7,
+    done: true,
+    note: `Acabou o array e ${howMany === 1 ? "sobrou 1 índice" : `sobraram ${howMany} índices`} na pilha: ${leftover}. Ninguém maior apareceu à direita, então a resposta ${howMany === 1 ? "dele" : "deles"} fica em -1 mesmo. Foram ${pushes} push e ${pops} pop para ${n} elementos, ou seja ${pushes + pops} operações de pilha contra o teto de ${2 * n}.`,
   });
   return out;
 }
 
-const PADRAO = [73, 74, 75, 71, 69, 72, 76, 73];
+const DEFAULT_NUMS = [73, 74, 75, 71, 69, 72, 76, 73];
 
 // Casos escolhidos a dedo: o clássico das temperaturas (LeetCode 739), o do
 // GeeksforGeeks, o pior caso da força bruta, o caso em que ela empata e a
 // borda do "estritamente maior".
-type Preset = { key: string; rotulo: string; nums: number[] };
+type Preset = { key: string; label: string; nums: number[] };
 const PRESETS: Preset[] = [
-  { key: "temp", rotulo: "Temperaturas (LeetCode 739)", nums: PADRAO },
-  { key: "gfg", rotulo: "Do GeeksforGeeks: 6 8 0 1 3", nums: [6, 8, 0, 1, 3] },
-  { key: "desce", rotulo: "Pior caso da força bruta", nums: [8, 7, 6, 5, 4, 3, 2, 1] },
-  { key: "sobe", rotulo: "Crescente: 1 2 3 4 5 6 7 8", nums: [1, 2, 3, 4, 5, 6, 7, 8] },
-  { key: "iguais", rotulo: "Tudo igual: 4 4 4 4", nums: [4, 4, 4, 4] },
+  { key: "temp", label: "Temperaturas (LeetCode 739)", nums: DEFAULT_NUMS },
+  { key: "gfg", label: "Do GeeksforGeeks: 6 8 0 1 3", nums: [6, 8, 0, 1, 3] },
+  { key: "desce", label: "Pior caso da força bruta", nums: [8, 7, 6, 5, 4, 3, 2, 1] },
+  { key: "sobe", label: "Crescente: 1 2 3 4 5 6 7 8", nums: [1, 2, 3, 4, 5, 6, 7, 8] },
+  { key: "iguais", label: "Tudo igual: 4 4 4 4", nums: [4, 4, 4, 4] },
 ];
 
 export function StackMonotonicaVisualizer() {
-  const [nums, setNums] = useState<number[]>(PADRAO);
-  const [entrada, setEntrada] = useState(PADRAO.join(", "));
+  const [nums, setNums] = useState<number[]>(DEFAULT_NUMS);
+  const [input, setInput] = useState(DEFAULT_NUMS.join(", "));
   const [preset, setPreset] = useState("temp");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(nums), [nums]);
+  const brute = useMemo(() => bruteForceComparisons(nums), [nums]);
 
-  const passos = useMemo(() => gerarPassos(nums), [nums]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const bruta = useMemo(() => compsForcaBruta(nums), [nums]);
-
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const aoMudarEntrada = (v: string) => {
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setEntrada(v); setNums(limpar(v));
-  };
-  const aplicarPreset = (pr: Preset) => {
-    parar(); setTocando(false); setPasso(0); setPreset(pr.key);
-    setNums(pr.nums); setEntrada(pr.nums.join(", "));
-  };
-  const sortear = () => {
-    const n = 7 + Math.floor(Math.random() * 3);
-    const arr = Array.from({ length: n }, () => 1 + Math.floor(Math.random() * 40));
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setNums(arr); setEntrada(arr.join(", "));
-  };
-
-  const naPilha = new Set(p.pilha);
-  const topoIdx = p.pilha.length ? p.pilha[p.pilha.length - 1] : -1;
-
-  const entradaCells = nums.map((v, i) => {
-    let cls = "viz-cell";
-    if (i === p.i) cls += " in";
-    if (naPilha.has(i)) cls += " pl-espera";
-    if (p.popou === i || p.comparou === i) cls += " entra";
-    if (p.resp[i] !== null && p.resp[i] !== -1) cls += " pl-feito";
-    let marca = "";
-    if (i === p.i) marca = "i";
-    else if (i === topoIdx) marca = "topo";
-    else if (naPilha.has(i)) marca = "•";
-    return { i, v, cls, marca };
+  const viz = useVisualizer({
+    title: "Visualizador · pilha monotônica: o próximo maior elemento",
+    total: steps.length,
+    // O que muda a altura da peça: o tamanho do array, que decide quantas
+    // células as duas fitas têm e quão alta a torre de índices pode ficar.
+    measureOn: [nums.length],
   });
 
-  const respCells = nums.map((_, i) => {
-    const r = p.resp[i];
+  const p = steps[viz.step];
+
+  const onInputChange = (v: string) => {
+    viz.reset();
+    setPreset("");
+    setInput(v);
+    setNums(clean(v));
+  };
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setPreset(pr.key);
+    setNums(pr.nums);
+    setInput(pr.nums.join(", "));
+  };
+  const shuffle = () => {
+    const size = 7 + Math.floor(Math.random() * 3);
+    const arr = Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 40));
+    viz.reset();
+    setPreset("");
+    setNums(arr);
+    setInput(arr.join(", "));
+  };
+
+  const inStack = new Set(p.stack);
+  const topIdx = p.stack.length ? p.stack[p.stack.length - 1] : -1;
+
+  const inputCells = nums.map((v, i) => {
+    let cls = "viz-cell";
+    if (i === p.i) cls += " in";
+    if (inStack.has(i)) cls += " pl-espera";
+    if (p.poppedIdx === i || p.comparedIdx === i) cls += " entra";
+    if (p.answers[i] !== null && p.answers[i] !== -1) cls += " pl-feito";
+    let mark = "";
+    if (i === p.i) mark = "i";
+    else if (i === topIdx) mark = "topo";
+    else if (inStack.has(i)) mark = "•";
+    return { i, v, cls, mark };
+  });
+
+  const answerCells = nums.map((_, i) => {
+    const r = p.answers[i];
     let cls = "viz-cell";
     if (r === null) cls += " pl-vaga";
     else if (r === -1) cls += " pl-nada";
     else cls += " pl-resp";
-    if (p.popou === i) cls += " entra";
+    if (p.poppedIdx === i) cls += " entra";
     return { i, txt: r === null ? "-1" : `${r}`, cls };
   });
 
   // A torre desenha o topo em cima, então a pilha é percorrida ao contrário.
-  const torre = [...p.pilha].reverse();
-  const resolvidos = p.resp.filter((r) => r !== null).length;
+  const tower = [...p.stack].reverse();
+  const answered = p.answers.filter((r) => r !== null).length;
 
-  const variaveis = [
-    { nome: "i", valor: p.i >= 0 && p.i < nums.length ? `${p.i}` : "-" },
-    { nome: "v", valor: p.i >= 0 && p.i < nums.length ? `${nums[p.i]}` : "-" },
-    { nome: "nums[pilha[-1]]", valor: topoIdx >= 0 ? `${nums[topoIdx]}` : "vazia" },
-    { nome: "respondidos", valor: `${resolvidos} de ${nums.length}`, best: !!p.fim },
+  const variables = [
+    { name: "i", value: p.i >= 0 && p.i < nums.length ? `${p.i}` : "-" },
+    { name: "v", value: p.i >= 0 && p.i < nums.length ? `${nums[p.i]}` : "-" },
+    { name: "nums[pilha[-1]]", value: topIdx >= 0 ? `${nums[topIdx]}` : "vazia" },
+    { name: "respondidos", value: `${answered} de ${nums.length}`, best: !!p.done },
   ];
 
-  const estatisticas = [
-    { k: "n", rot: "tamanho (n)", val: `${nums.length}` },
-    { k: "cmp", rot: "comparações até aqui", val: `${p.comps}` },
-    { k: "bruta", rot: "força bruta faria", val: `${bruta}` },
-    { k: "push", rot: "empilhados (push)", val: `${p.pushes}` },
-    { k: "pop", rot: "desempilhados (pop)", val: `${p.pops}` },
+  const stats = [
+    { k: "n", label: "tamanho (n)", value: `${nums.length}` },
+    { k: "cmp", label: "comparações até aqui", value: `${p.comparisons}` },
+    { k: "bruta", label: "força bruta faria", value: `${brute}` },
+    { k: "push", label: "empilhados (push)", value: `${p.pushes}` },
+    { k: "pop", label: "desempilhados (pop)", value: `${p.pops}` },
   ];
 
-  const notaCls = "viz-note" + (p.fim ? " ok" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.done ? " ok" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · pilha monotônica: o próximo maior elemento</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -313,9 +280,9 @@ export function StackMonotonicaVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Array (inteiros de 0 a 99)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>Sortear</button>
+          <button className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="pl-arena">
@@ -323,11 +290,11 @@ export function StackMonotonicaVisualizer() {
             <span className="pl-lbl">nums, o array de entrada</span>
             {nums.length ? (
               <div className="viz-cells">
-                {entradaCells.map((c) => (
+                {inputCells.map((c) => (
                   <div className="viz-cell-wrap" key={c.i}>
                     <span className="viz-cell-idx">{c.i}</span>
                     <div className={c.cls}>{c.v}</div>
-                    <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+                    <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
                   </div>
                 ))}
               </div>
@@ -338,7 +305,7 @@ export function StackMonotonicaVisualizer() {
             <span className="pl-lbl mt">resp, a resposta sendo preenchida</span>
             {nums.length ? (
               <div className="viz-cells">
-                {respCells.map((c) => (
+                {answerCells.map((c) => (
                   <div className="viz-cell-wrap" key={c.i}>
                     <span className="viz-cell-idx">{c.i}</span>
                     <div className={c.cls}>{c.txt}</div>
@@ -353,15 +320,15 @@ export function StackMonotonicaVisualizer() {
               <span><i className="tr" />ainda no -1 provisório</span>
             </p>
 
-            <p className={notaCls}>{p.nota}</p>
+            <p className={noteClass}>{p.note}</p>
           </div>
 
           <div className="pl-col">
             <span className="pl-lbl">Pilha de índices (topo em cima)</span>
             <div className="pl-torre">
-              {torre.length ? (
-                torre.map((j, k) => (
-                  <div key={j} className={`pl-item${k === 0 ? " topo" : ""}${p.empurrou === j && k === 0 ? " entra" : ""}`}>
+              {tower.length ? (
+                tower.map((j, k) => (
+                  <div key={j} className={`pl-item${k === 0 ? " topo" : ""}${p.pushedIdx === j && k === 0 ? " entra" : ""}`}>
                     <span>{nums[j]}</span>
                     <span className="pl-meta">{k === 0 ? "topo · " : ""}índice {j}</span>
                   </div>
@@ -375,62 +342,41 @@ export function StackMonotonicaVisualizer() {
         </div>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">monotonica.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">monotonica.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {variables.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={() => { parar(); setTocando(false); setPasso(0); }}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/StackVisualizer.tsx
+++ b/content/visualizers/StackVisualizer.tsx
@@ -1,16 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // StackVisualizer, a pilha em ação resolvendo parênteses balanceados.
 //
-// Mesmo padrão do TwoPointersVisualizer: um gerador PURO de passos + a mesma
-// casca (fita de caracteres, código sincronizado, variáveis, controles,
-// Expandir). O que muda é o desenho central: aqui a estrela é a TORRE, a pilha
-// crescendo e encolhendo com o topo sempre na primeira linha, que é como todo
-// mundo desenha pilha no quadro.
+// Gerador PURO de passos + a casca adaptativa do `useVisualizer`. O que muda
+// em relação aos outros: o desenho central é a TORRE, a pilha crescendo e
+// encolhendo com o topo sempre na primeira linha, que é como todo mundo
+// desenha pilha no quadro.
 //
 // A única coisa que o aluno precisa ver acontecendo: cada abertura empurra um
 // item para o topo, cada fechamento só pode consumir QUEM ESTÁ NO TOPO, e o
@@ -22,24 +21,24 @@ import { createPortal } from "react-dom";
 
 type Item = { c: string; i: number };
 
-type Passo = {
+type Step = {
   i: number; // caractere atual, -1 no passo de preparação
-  pilha: Item[];
-  linha: number;
-  parA?: number; // abertura que acabou de casar
-  parB?: number; // fechamento que acabou de casar
-  erroEm?: number;
-  empilhados: number;
-  desempilhados: number;
-  alturaMax: number;
+  stack: Item[];
+  line: number;
+  pairA?: number; // abertura que acabou de casar
+  pairB?: number; // fechamento que acabou de casar
+  errorAt?: number;
+  pushed: number;
+  popped: number;
+  maxHeight: number;
   ok?: boolean;
-  fim?: boolean;
-  nota: string;
+  done?: boolean;
+  note: string;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO = [
+const CODE = [
   "def valida(s):",
   "    pilha = []",
   '    pares = {")": "(", "]": "[", "}": "{"}',
@@ -53,268 +52,230 @@ const CODIGO = [
   "    return not pilha",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-const FECHA: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
-const VALIDOS = "()[]{}";
+const CLOSERS: Record<string, string> = { ")": "(", "]": "[", "}": "{" };
+const VALID = "()[]{}";
 const MAX_CHARS = 24;
 
-function limpar(v: string): string {
+function clean(v: string): string {
   return Array.from(v)
-    .filter((c) => VALIDOS.includes(c))
+    .filter((c) => VALID.includes(c))
     .slice(0, MAX_CHARS)
     .join("");
 }
 
-function gerarPassos(expr: string): Passo[] {
-  const out: Passo[] = [];
-  const pilha: Item[] = [];
-  let emp = 0;
-  let des = 0;
-  let alturaMax = 0;
+function generateSteps(expr: string): Step[] {
+  const out: Step[] = [];
+  const stack: Item[] = [];
+  let pushed = 0;
+  let popped = 0;
+  let maxHeight = 0;
 
-  const registrar = (p: Omit<Passo, "empilhados" | "desempilhados" | "alturaMax">) => {
-    out.push({ ...p, empilhados: emp, desempilhados: des, alturaMax });
+  const record = (p: Omit<Step, "pushed" | "popped" | "maxHeight">) => {
+    out.push({ ...p, pushed, popped, maxHeight });
   };
 
-  registrar({
+  record({
     i: -1,
-    pilha: [],
-    linha: 1,
-    nota: expr.length
+    stack: [],
+    line: 1,
+    note: expr.length
       ? `Começo com a pilha vazia e ${expr.length} ${expr.length === 1 ? "caractere" : "caracteres"} para ler, da esquerda para a direita.`
       : "Expressão vazia: o laço não roda nenhuma vez e a pilha continua vazia.",
   });
 
-  let guarda = 0;
-  for (let i = 0; i < expr.length && guarda++ < 100; i++) {
+  let guard = 0;
+  for (let i = 0; i < expr.length && guard++ < 100; i++) {
     const c = expr[i];
-    const abertura = FECHA[c];
+    const opener = CLOSERS[c];
 
-    if (!abertura) {
-      pilha.push({ c, i });
-      emp++;
-      alturaMax = Math.max(alturaMax, pilha.length);
-      registrar({
+    if (!opener) {
+      stack.push({ c, i });
+      pushed++;
+      maxHeight = Math.max(maxHeight, stack.length);
+      record({
         i,
-        pilha: [...pilha],
-        linha: 9,
-        nota: `'${c}' é abertura: empilho e sigo em frente. A pilha fica com ${pilha.length} ${pilha.length === 1 ? "item" : "itens"} e o topo agora é '${c}'.`,
+        stack: [...stack],
+        line: 9,
+        note: `'${c}' é abertura: empilho e sigo em frente. A pilha fica com ${stack.length} ${stack.length === 1 ? "item" : "itens"} e o topo agora é '${c}'.`,
       });
       continue;
     }
 
-    if (!pilha.length) {
-      registrar({
+    if (!stack.length) {
+      record({
         i,
-        pilha: [],
-        linha: 6,
-        erroEm: i,
-        fim: true,
-        nota: `'${c}' é fechamento, mas a pilha está vazia: esse '${c}' fecha o quê? Todo fechamento precisa de uma abertura antes dele. Inválida.`,
+        stack: [],
+        line: 6,
+        errorAt: i,
+        done: true,
+        note: `'${c}' é fechamento, mas a pilha está vazia: esse '${c}' fecha o quê? Todo fechamento precisa de uma abertura antes dele. Inválida.`,
       });
       return out;
     }
 
-    const topo = pilha[pilha.length - 1];
-    if (topo.c !== abertura) {
-      registrar({
+    const top = stack[stack.length - 1];
+    if (top.c !== opener) {
+      record({
         i,
-        pilha: [...pilha],
-        linha: 6,
-        erroEm: i,
-        fim: true,
-        nota: `'${c}' pede '${abertura}' no topo, mas o topo é '${topo.c}' (posição ${topo.i}). Tipo trocado: paro aqui e devolvo inválida.`,
+        stack: [...stack],
+        line: 6,
+        errorAt: i,
+        done: true,
+        note: `'${c}' pede '${opener}' no topo, mas o topo é '${top.c}' (posição ${top.i}). Tipo trocado: paro aqui e devolvo inválida.`,
       });
       return out;
     }
 
-    pilha.pop();
-    des++;
-    registrar({
+    stack.pop();
+    popped++;
+    record({
       i,
-      pilha: [...pilha],
-      linha: 7,
-      parA: topo.i,
-      parB: i,
-      nota: `'${c}' pede '${abertura}', e o topo é exatamente o '${topo.c}' da posição ${topo.i}: par fechado, desempilho. Sobra${pilha.length === 1 ? "" : "m"} ${pilha.length} na pilha.`,
+      stack: [...stack],
+      line: 7,
+      pairA: top.i,
+      pairB: i,
+      note: `'${c}' pede '${opener}', e o topo é exatamente o '${top.c}' da posição ${top.i}: par fechado, desempilho. Sobra${stack.length === 1 ? "" : "m"} ${stack.length} na pilha.`,
     });
   }
 
-  if (pilha.length) {
-    const sobrando = pilha.map((it) => `'${it.c}' na posição ${it.i}`).join(", ");
-    registrar({
+  if (stack.length) {
+    const leftover = stack.map((it) => `'${it.c}' na posição ${it.i}`).join(", ");
+    record({
       i: expr.length,
-      pilha: [...pilha],
-      linha: 10,
-      fim: true,
-      nota: `Acabaram os caracteres, mas a pilha não esvaziou: ${sobrando} ${pilha.length === 1 ? "ficou" : "ficaram"} sem fechamento. Inválida.`,
+      stack: [...stack],
+      line: 10,
+      done: true,
+      note: `Acabaram os caracteres, mas a pilha não esvaziou: ${leftover} ${stack.length === 1 ? "ficou" : "ficaram"} sem fechamento. Inválida.`,
     });
     return out;
   }
 
-  registrar({
+  record({
     i: expr.length,
-    pilha: [],
-    linha: 10,
+    stack: [],
+    line: 10,
     ok: true,
-    fim: true,
-    nota: expr.length
-      ? `Fim da expressão com a pilha vazia: todo fechamento achou a abertura dele, na ordem certa. Válida, com ${emp} push e ${des} pop.`
+    done: true,
+    note: expr.length
+      ? `Fim da expressão com a pilha vazia: todo fechamento achou a abertura dele, na ordem certa. Válida, com ${pushed} push e ${popped} pop.`
       : "Pilha vazia no fim, porque nunca teve nada nela. Uma expressão vazia é válida por definição.",
   });
   return out;
 }
 
-const PADRAO = "{[()]}";
+const DEFAULT_EXPR = "{[()]}";
 
 // Casos escolhidos a dedo: o aninhado, o lado a lado, o cruzado (que é o que
 // separa pilha de contador), a sobra de abertura e o fechamento órfão.
-type Preset = { key: string; rotulo: string; expr: string };
+type Preset = { key: string; label: string; expr: string };
 const PRESETS: Preset[] = [
-  { key: "aninhado", rotulo: "Aninhado: {[()]}", expr: "{[()]}" },
-  { key: "lado", rotulo: "Lado a lado: ()[]{}", expr: "()[]{}" },
-  { key: "cruzado", rotulo: "Cruzado: ([)]", expr: "([)]" },
-  { key: "sobra", rotulo: "Sobra aberto: ([]", expr: "([]" },
-  { key: "orfao", rotulo: "Fecha sem abrir: )(", expr: ")(" },
+  { key: "aninhado", label: "Aninhado: {[()]}", expr: "{[()]}" },
+  { key: "lado", label: "Lado a lado: ()[]{}", expr: "()[]{}" },
+  { key: "cruzado", label: "Cruzado: ([)]", expr: "([)]" },
+  { key: "sobra", label: "Sobra aberto: ([]", expr: "([]" },
+  { key: "orfao", label: "Fecha sem abrir: )(", expr: ")(" },
 ];
 
-const SORTEIO_ABRE = ["(", "[", "{"];
+const RANDOM_OPENERS = ["(", "[", "{"];
 
 export function StackVisualizer() {
-  const [expr, setExpr] = useState(PADRAO);
+  const [expr, setExpr] = useState(DEFAULT_EXPR);
   const [preset, setPreset] = useState("aninhado");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(expr), [expr]);
 
-  const passos = useMemo(() => gerarPassos(expr), [expr]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · a pilha em ação: parênteses balanceados",
+    total: steps.length,
+    // O que muda a altura da peça: o tamanho da expressão, que decide quantas
+    // células a fita tem e quão alta a torre pode ficar.
+    measureOn: [expr.length],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-
-  const aoMudarExpr = (v: string) => {
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setExpr(limpar(v));
+  const onExprChange = (v: string) => {
+    viz.reset();
+    setPreset("");
+    setExpr(clean(v));
   };
-  const aplicarPreset = (pr: Preset) => {
-    parar(); setTocando(false); setPasso(0); setPreset(pr.key);
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
+    setPreset(pr.key);
     setExpr(pr.expr);
   };
-  const sortear = () => {
-    const abertas: string[] = [];
-    let out = "";
-    const alvo = 6 + Math.floor(Math.random() * 5);
-    while (out.length < alvo) {
-      const podeFechar = abertas.length > 0;
-      if (podeFechar && (Math.random() < 0.5 || out.length + abertas.length >= alvo)) {
-        const a = abertas.pop() as string;
-        out += a === "(" ? ")" : a === "[" ? "]" : "}";
+  const shuffle = () => {
+    const openers: string[] = [];
+    let text = "";
+    const target = 6 + Math.floor(Math.random() * 5);
+    while (text.length < target) {
+      const canClose = openers.length > 0;
+      if (canClose && (Math.random() < 0.5 || text.length + openers.length >= target)) {
+        const a = openers.pop() as string;
+        text += a === "(" ? ")" : a === "[" ? "]" : "}";
       } else {
-        const a = SORTEIO_ABRE[Math.floor(Math.random() * 3)];
-        abertas.push(a);
-        out += a;
+        const a = RANDOM_OPENERS[Math.floor(Math.random() * 3)];
+        openers.push(a);
+        text += a;
       }
     }
-    while (abertas.length) {
-      const a = abertas.pop() as string;
-      out += a === "(" ? ")" : a === "[" ? "]" : "}";
+    while (openers.length) {
+      const a = openers.pop() as string;
+      text += a === "(" ? ")" : a === "[" ? "]" : "}";
     }
-    parar(); setTocando(false); setPasso(0); setPreset("");
-    setExpr(limpar(out));
+    viz.reset();
+    setPreset("");
+    setExpr(clean(text));
   };
 
-  const naPilha = new Set(p.pilha.map((it) => it.i));
-  const topoIdx = p.pilha.length ? p.pilha[p.pilha.length - 1].i : -1;
+  const inStack = new Set(p.stack.map((it) => it.i));
+  const topIdx = p.stack.length ? p.stack[p.stack.length - 1].i : -1;
 
   const cells = Array.from(expr).map((c, i) => {
     let cls = "viz-cell";
     if (i === p.i) cls += " in";
-    else if (i < p.i && !naPilha.has(i)) cls += " drop";
-    if (p.parA === i || p.parB === i) cls += " entra";
-    if (p.erroEm === i) cls += " sai";
-    let marca = "";
-    if (i === topoIdx) marca = "topo";
-    else if (naPilha.has(i)) marca = "•";
-    return { i, c, cls, marca };
+    else if (i < p.i && !inStack.has(i)) cls += " drop";
+    if (p.pairA === i || p.pairB === i) cls += " entra";
+    if (p.errorAt === i) cls += " sai";
+    let mark = "";
+    if (i === topIdx) mark = "topo";
+    else if (inStack.has(i)) mark = "•";
+    return { i, c, cls, mark };
   });
 
   // A torre desenha o topo em cima, então a pilha é percorrida ao contrário.
-  const torre = [...p.pilha].reverse();
+  const tower = [...p.stack].reverse();
 
-  const variaveis = [
-    { nome: "c", valor: p.i >= 0 && p.i < expr.length ? `'${expr[p.i]}'` : "-" },
-    { nome: "pilha[-1]", valor: p.pilha.length ? `'${p.pilha[p.pilha.length - 1].c}'` : "vazia" },
-    { nome: "len(pilha)", valor: `${p.pilha.length}` },
-    { nome: "veredito", valor: p.ok ? "válida" : p.fim ? "inválida" : "…", best: !!p.ok },
+  const variables = [
+    { name: "c", value: p.i >= 0 && p.i < expr.length ? `'${expr[p.i]}'` : "-" },
+    { name: "pilha[-1]", value: p.stack.length ? `'${p.stack[p.stack.length - 1].c}'` : "vazia" },
+    { name: "len(pilha)", value: `${p.stack.length}` },
+    { name: "veredito", value: p.ok ? "válida" : p.done ? "inválida" : "…", best: !!p.ok },
   ];
 
-  const estatisticas = [
-    { k: "n", rot: "caracteres (n)", val: `${expr.length}` },
-    { k: "push", rot: "empilhados (push)", val: `${p.empilhados}` },
-    { k: "pop", rot: "desempilhados (pop)", val: `${p.desempilhados}` },
-    { k: "alt", rot: "altura máxima", val: `${p.alturaMax}` },
+  const stats = [
+    { k: "n", label: "caracteres (n)", value: `${expr.length}` },
+    { k: "push", label: "empilhados (push)", value: `${p.pushed}` },
+    { k: "pop", label: "desempilhados (pop)", value: `${p.popped}` },
+    { k: "alt", label: "altura máxima", value: `${p.maxHeight}` },
   ];
 
-  const notaCls = "viz-note" + (p.ok ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.ok ? " ok" : p.done ? " invalid" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a pilha em ação: parênteses balanceados</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={preset === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -322,9 +283,9 @@ export function StackVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Expressão (só ( ) [ ] {"{"} {"}"} )</span>
-            <input className="viz-input" value={expr} onChange={(e) => aoMudarExpr(e.target.value)} />
+            <input className="viz-input" value={expr} onChange={(e) => onExprChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>Sortear válida</button>
+          <button className="viz-btn" onClick={shuffle}>Sortear válida</button>
         </div>
 
         <div className="pl-arena">
@@ -336,24 +297,24 @@ export function StackVisualizer() {
                   <div className="viz-cell-wrap" key={c.i}>
                     <span className="viz-cell-idx">{c.i}</span>
                     <div className={c.cls}>{c.c}</div>
-                    <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+                    <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
                   </div>
                 ))}
               </div>
             ) : (
               <p className="pl-vazia">expressão vazia</p>
             )}
-            <p className={notaCls}>{p.nota}</p>
+            <p className={noteClass}>{p.note}</p>
           </div>
 
           <div className="pl-col">
             <span className="pl-lbl">Pilha (topo em cima)</span>
             <div className="pl-torre">
-              {torre.length ? (
-                torre.map((it, k) => (
+              {tower.length ? (
+                tower.map((it, k) => (
                   <div
                     key={`${it.i}-${it.c}`}
-                    className={`pl-item${k === 0 ? " topo" : ""}${k === 0 && p.linha === 9 ? " entra" : ""}`}
+                    className={`pl-item${k === 0 ? " topo" : ""}${k === 0 && p.line === 9 ? " entra" : ""}`}
                   >
                     <span>{it.c}</span>
                     <span className="pl-meta">{k === 0 ? "topo · " : ""}pos {it.i}</span>
@@ -368,62 +329,41 @@ export function StackVisualizer() {
         </div>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">solucao.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">solucao.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {variables.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/TailRecursionForma.tsx
+++ b/content/visualizers/TailRecursionForma.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TailRecursionForma, o classificador: "esta chamada está em posição de cauda?"
@@ -20,114 +21,123 @@ import { createPortal } from "react-dom";
 //
 // O painel de código usa .tr-code em vez de .viz-code de propósito: o .viz-code
 // some abaixo de 760px por design, e aqui o código É o conteúdo.
+//
+// Por isso mesmo, `collapsible: false`: o bloco de código não é dispensável,
+// ele é o objeto da classificação — no modo treino a própria nota manda "leia o
+// código acima". A casca entra com o painel de cabeçalho e controles parados, e
+// nada mais. Medido a 1512x900: o pior caso (busca em BST) pede 737px de um
+// orçamento de 816, então não há o que recolher; e a 1440x600 nem recolher o
+// código resolveria (533px de um orçamento de 516).
+//
+// A casca vem do `useVisualizer`. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Caso = {
+type Case = {
   key: string;
-  rotulo: string;
-  arquivo: string;
-  codigo: string[];
-  alvos: number[]; // linhas da última instrução executada em cada caminho
-  cauda: boolean;
-  recursiva: boolean;
-  pendente: string;
-  leitura: string;
-  conserto: string;
-  pilha: string;
+  label: string;
+  file: string;
+  code: string[];
+  targets: number[]; // linhas da última instrução executada em cada caminho
+  tail: boolean;
+  recursive: boolean;
+  pending: string;
+  reading: string;
+  fix: string;
+  stack: string;
 };
 
-const CASOS: Caso[] = [
+const CASES: Case[] = [
   {
     key: "comum",
-    rotulo: "soma comum",
-    arquivo: "soma.py",
-    codigo: [
+    label: "soma comum",
+    file: "soma.py",
+    code: [
       "def soma(nums):",
       "    if not nums:",
       "        return 0",
       "    return nums[0] + soma(nums[1:])",
     ],
-    alvos: [3],
-    cauda: false,
-    recursiva: true,
-    pendente: "nums[0] + ?",
-    leitura:
+    targets: [3],
+    tail: false,
+    recursive: true,
+    pending: "nums[0] + ?",
+    reading:
       "A última coisa que a função faz não é chamar soma, é somar. A chamada precisa voltar com um número para o + acontecer, e por isso este frame fica vivo esperando, com o nums[0] guardado dentro dele.",
-    conserto: "Empurre a soma para dentro do argumento: soma(nums[1:], acc + nums[0]).",
-    pilha: "O(n) sempre",
+    fix: "Empurre a soma para dentro do argumento: soma(nums[1:], acc + nums[0]).",
+    stack: "O(n) sempre",
   },
   {
     key: "cauda",
-    rotulo: "soma de cauda",
-    arquivo: "soma_cauda.py",
-    codigo: [
+    label: "soma de cauda",
+    file: "soma_cauda.py",
+    code: [
       "def soma(nums, acc=0):",
       "    if not nums:",
       "        return acc",
       "    return soma(nums[1:], acc + nums[0])",
     ],
-    alvos: [3],
-    cauda: true,
-    recursiva: true,
-    pendente: "nada",
-    leitura:
+    targets: [3],
+    tail: true,
+    recursive: true,
+    pending: "nada",
+    reading:
       "acc + nums[0] é avaliado antes da chamada, na hora de montar o argumento. Quando soma é chamada, este frame já não tem mais nada a fazer: o valor que ela devolver é, sem tocar em nada, o valor que ele devolve.",
-    conserto: "Já está pronta. Numa linguagem com TCO este frame é reescrito no lugar e a pilha fica em 1.",
-    pilha: "O(1) com TCO, O(n) sem",
+    fix: "Já está pronta. Numa linguagem com TCO este frame é reescrito no lugar e a pilha fica em 1.",
+    stack: "O(1) com TCO, O(n) sem",
   },
   {
     key: "elixir",
-    rotulo: "a mesma soma em Elixir",
-    arquivo: "soma.ex",
-    codigo: [
+    label: "a mesma soma em Elixir",
+    file: "soma.ex",
+    code: [
       "def soma([], acc), do: acc",
       "",
       "def soma([head | tail], acc) do",
       "  soma(tail, acc + head)",
       "end",
     ],
-    alvos: [3],
-    cauda: true,
-    recursiva: true,
-    pendente: "nada",
-    leitura:
+    targets: [3],
+    tail: true,
+    recursive: true,
+    pending: "nada",
+    reading:
       "É a função do encontro. O caso base virou uma cláusula separada por pattern matching, e [head | tail] decompõe a lista sem copiar nada: tail é um ponteiro para o resto, não uma cópia como o nums[1:] do Python.",
-    conserto: "A BEAM aplica a otimização sozinha, sem anotação nenhuma: lista de 1.000 elementos, 1 frame.",
-    pilha: "O(1), a BEAM otimiza",
+    fix: "A BEAM aplica a otimização sozinha, sem anotação nenhuma: lista de 1.000 elementos, 1 frame.",
+    stack: "O(1), a BEAM otimiza",
   },
   {
     key: "outra",
-    rotulo: "chama outra função",
-    arquivo: "validar.py",
-    codigo: ["def validar(texto):", "    return checar(list(texto), [])"],
-    alvos: [1],
-    cauda: true,
-    recursiva: false,
-    pendente: "nada",
-    leitura:
+    label: "chama outra função",
+    file: "validar.py",
+    code: ["def validar(texto):", "    return checar(list(texto), [])"],
+    targets: [1],
+    tail: true,
+    recursive: false,
+    pending: "nada",
+    reading:
       "Chamada de cauda não precisa ser recursiva. Aqui a última instrução chama outra função, e o frame de validar também não serve mais para nada depois disso. Foi exatamente a pergunta do Giovani no encontro, e a resposta é sim: a otimização vale igual.",
-    conserto: "Nada a consertar. Só repare no vocabulário: isto é tail call, e tail recursion é o caso em que a função chamada é ela mesma.",
-    pilha: "O(1) com TCO",
+    fix: "Nada a consertar. Só repare no vocabulário: isto é tail call, e tail recursion é o caso em que a função chamada é ela mesma.",
+    stack: "O(1) com TCO",
   },
   {
     key: "fib",
-    rotulo: "fibonacci ingênuo",
-    arquivo: "fib.py",
-    codigo: ["def fib(n):", "    if n < 2:", "        return n", "    return fib(n - 1) + fib(n - 2)"],
-    alvos: [3],
-    cauda: false,
-    recursiva: true,
-    pendente: "fib(n - 1) + ?",
-    leitura:
+    label: "fibonacci ingênuo",
+    file: "fib.py",
+    code: ["def fib(n):", "    if n < 2:", "        return n", "    return fib(n - 1) + fib(n - 2)"],
+    targets: [3],
+    tail: false,
+    recursive: true,
+    pending: "fib(n - 1) + ?",
+    reading:
       "Duas chamadas e um +. Nenhuma das duas está em posição de cauda: fib(n - 1) tem que voltar para o + acontecer, e o + tem que acontecer para existir um return. Não existe otimização de linguagem que salve esta forma.",
-    conserto: "Vire o problema de cabeça para baixo: fib(n, a=0, b=1) carrega os dois últimos valores e a chamada passa a ser a última instrução.",
-    pilha: "O(n) de pilha, O(2ⁿ) de tempo",
+    fix: "Vire o problema de cabeça para baixo: fib(n, a=0, b=1) carrega os dois últimos valores e a chamada passa a ser a última instrução.",
+    stack: "O(n) de pilha, O(2ⁿ) de tempo",
   },
   {
     key: "bst",
-    rotulo: "busca em BST",
-    arquivo: "bst.py",
-    codigo: [
+    label: "busca em BST",
+    file: "bst.py",
+    code: [
       "def buscar(no, alvo):",
       "    if no is None or no.val == alvo:",
       "        return no",
@@ -135,167 +145,128 @@ const CASOS: Caso[] = [
       "        return buscar(no.esq, alvo)",
       "    return buscar(no.dir, alvo)",
     ],
-    alvos: [4, 5],
-    cauda: true,
-    recursiva: true,
-    pendente: "nada",
-    leitura:
+    targets: [4, 5],
+    tail: true,
+    recursive: true,
+    pending: "nada",
+    reading:
       "Os ifs antes não atrapalham: o que conta é a última instrução executada em cada caminho. Aqui os dois returns recursivos são só a chamada, sem nenhuma conta pendurada em cima dela.",
-    conserto: "Já é de cauda, e é por isso que a busca em BST vira um while de três linhas sem nenhum esforço.",
-    pilha: "O(1) com TCO, O(altura) sem",
+    fix: "Já é de cauda, e é por isso que a busca em BST vira um while de três linhas sem nenhum esforço.",
+    stack: "O(1) com TCO, O(altura) sem",
   },
   {
     key: "map",
-    rotulo: "dobrar os valores",
-    arquivo: "dobrar.py",
-    codigo: [
+    label: "dobrar os valores",
+    file: "dobrar.py",
+    code: [
       "def dobrar(nums):",
       "    if not nums:",
       "        return []",
       "    return [nums[0] * 2] + dobrar(nums[1:])",
     ],
-    alvos: [3],
-    cauda: false,
-    recursiva: true,
-    pendente: "[nums[0] * 2] + ?",
-    leitura:
+    targets: [3],
+    tail: false,
+    recursive: true,
+    pending: "[nums[0] * 2] + ?",
+    reading:
       "Mesmo formato da soma comum, só que juntando listas em vez de números. E é o caso que o Tiago mediu no encontro: aqui a versão de cauda saiu mais lenta, porque ela monta a lista ao contrário e precisa de um reverse no fim.",
-    conserto: "Dá para transformar (acc=[] e reverse no fim), só que o conserto custa uma passada extra. Nem toda recursão quer virar de cauda.",
-    pilha: "O(n) sempre",
+    fix: "Dá para transformar (acc=[] e reverse no fim), só que o conserto custa uma passada extra. Nem toda recursão quer virar de cauda.",
+    stack: "O(n) sempre",
   },
 ];
 
-const VELOCIDADES = [0, 3200, 2400, 1800, 1300, 900];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// Ritmo próprio, bem mais lento que o padrão: cada passo aqui é um caso inteiro
+// para ler, não uma troca de posição num array.
+const SPEEDS = [0, 3200, 2400, 1800, 1300, 900];
 
 export function TailRecursionForma() {
-  const [i, setI] = useState(0);
   // Modo treino: esconde o veredito e a leitura, deixando só o código na tela.
   // É o exercício que o artigo pede (decidir antes de olhar o selo).
-  const [treino, setTreino] = useState(false);
-  const [revelado, setRevelado] = useState(false);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [training, setTraining] = useState(false);
+  // Qual caso está revelado, e não um booleano solto: trocar de caso tem que
+  // esconder o veredito de novo, e agora o caso também muda pelas setas e pelo
+  // ▶ Rodar, que são da casca e não passam por nenhum handler daqui.
+  const [revealedFor, setRevealedFor] = useState<number | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const viz = useVisualizer({
+    title: "Visualizador · esta chamada está em posição de cauda?",
+    total: CASES.length,
+    speeds: SPEEDS,
+    // Sem bloco dispensável: o código É o conteúdo que se classifica aqui.
+    collapsible: false,
+  });
 
-  const total = CASOS.length;
-  const c = CASOS[Math.min(i, total - 1)];
+  const c = CASES[viz.step];
+  const revealed = revealedFor === viz.step;
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setI((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && i >= total - 1) setTocando(false);
-  }, [tocando, i, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const escolher = (k: number) => {
-    parar();
-    setTocando(false);
-    setI(k);
-    setRevelado(false);
+  const pick = (k: number) => {
+    viz.setStep(k);
+    setRevealedFor(null);
   };
 
   // Fora do modo treino tudo aparece de uma vez, como antes.
-  const mostra = !treino || revelado;
+  const shows = !training || revealed;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · esta chamada está em posição de cauda?</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            caso {i + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {CASOS.map((caso, k) => (
+          {CASES.map((item, k) => (
             <button
-              key={caso.key}
-              className={`bigo-chip${k === i ? " on" : ""}`}
-              aria-pressed={k === i}
-              onClick={() => escolher(k)}
+              key={item.key}
+              className={`bigo-chip${k === viz.step ? " on" : ""}`}
+              aria-pressed={k === viz.step}
+              onClick={() => pick(k)}
             >
               <span
                 className="sw"
-                style={{ background: k === i && mostra ? (caso.cauda ? "#34d399" : "#f87171") : "#3a4a60" }}
+                style={{ background: k === viz.step && shows ? (item.tail ? "#34d399" : "#f87171") : "#3a4a60" }}
               />
-              {caso.rotulo}
+              {item.label}
             </button>
           ))}
         </div>
 
         <div className="bigo-chips">
           <button
-            className={`bigo-chip${treino ? " on" : ""}`}
-            aria-pressed={treino}
+            className={`bigo-chip${training ? " on" : ""}`}
+            aria-pressed={training}
             onClick={() => {
-              setTreino((t) => !t);
-              setRevelado(false);
+              setTraining((t) => !t);
+              setRevealedFor(null);
             }}
           >
-            <span className="sw" style={{ background: treino ? "#fbbf24" : "#3a4a60" }} />
+            <span className="sw" style={{ background: training ? "#fbbf24" : "#3a4a60" }} />
             Modo treino: esconder o veredito
           </button>
         </div>
 
         <div className="tr-verd">
-          {mostra ? (
+          {shows ? (
             <>
-              <span className={`tr-selo ${c.cauda ? "sim" : "nao"}`}>
-                {c.cauda ? "✓ está em posição de cauda" : "✗ não está em posição de cauda"}
+              <span className={`tr-selo ${c.tail ? "sim" : "nao"}`}>
+                {c.tail ? "✓ está em posição de cauda" : "✗ não está em posição de cauda"}
               </span>
-              <span className="tr-selo">{c.recursiva ? "chama a si mesma" : "chama outra função"}</span>
+              <span className="tr-selo">{c.recursive ? "chama a si mesma" : "chama outra função"}</span>
             </>
           ) : (
             <>
               <span className="tr-selo">? decida antes de revelar</span>
-              <button className="viz-btn" onClick={() => setRevelado(true)}>
+              <button className="viz-btn" onClick={() => setRevealedFor(viz.step)}>
                 Revelar veredito
               </button>
             </>
           )}
-          <span className="tr-lang">{c.arquivo}</span>
+          <span className="tr-lang">{c.file}</span>
         </div>
 
         <div className="tr-code">
           <div className="tr-code-head">a linha destacada é a última instrução executada</div>
           <div className="tr-code-body">
-            {c.codigo.map((txt, k) => (
-              <div key={k} className={`viz-line${c.alvos.includes(k) ? " tr-alvo" : ""}`}>
+            {c.code.map((txt, k) => (
+              <div key={k} className={`viz-line${c.targets.includes(k) ? " tr-alvo" : ""}`}>
                 <span className="ln">{k + 1}</span>
                 {txt || " "}
               </div>
@@ -303,22 +274,22 @@ export function TailRecursionForma() {
           </div>
         </div>
 
-        {mostra ? (
+        {shows ? (
           <>
-            <p className={`viz-note${c.cauda ? " ok" : " invalid"}`}>{c.leitura}</p>
+            <p className={`viz-note${c.tail ? " ok" : " invalid"}`}>{c.reading}</p>
 
             <div className="tr-fatos">
               <div className="tr-fato">
                 <span className="tr-fato-rot">o que fica pendente</span>
-                <p className="tr-fato-txt tr-mono">{c.pendente}</p>
+                <p className="tr-fato-txt tr-mono">{c.pending}</p>
               </div>
               <div className="tr-fato">
                 <span className="tr-fato-rot">espaço na pilha</span>
-                <p className="tr-fato-txt tr-mono">{c.pilha}</p>
+                <p className="tr-fato-txt tr-mono">{c.stack}</p>
               </div>
               <div className="tr-fato">
-                <span className="tr-fato-rot">{c.cauda ? "o que isso te dá" : "como vira de cauda"}</span>
-                <p className="tr-fato-txt">{c.conserto}</p>
+                <span className="tr-fato-rot">{c.tail ? "o que isso te dá" : "como vira de cauda"}</span>
+                <p className="tr-fato-txt">{c.fix}</p>
               </div>
             </div>
           </>
@@ -328,62 +299,11 @@ export function TailRecursionForma() {
             Se sobra, não é posição de cauda.
           </p>
         )}
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Voltar ao primeiro caso" onClick={() => escolher(0)}>
-            ↺
-          </button>
-          <button className="viz-btn" disabled={i === 0} onClick={() => escolher(Math.max(0, i - 1))}>
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setI(i >= total - 1 ? 0 : i);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar os 7 casos"}
-          </button>
-          <button className="viz-btn" disabled={i === total - 1} onClick={() => escolher(Math.min(i + 1, total - 1))}>
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${Math.round(((i + 1) / total) * 100)}%` }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/TailRecursionTrampolim.tsx
+++ b/content/visualizers/TailRecursionTrampolim.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TailRecursionTrampolim, a recursão de cauda rodando numa linguagem que não
@@ -19,25 +20,29 @@ import { createPortal } from "react-dom";
 // A lista padrão [1, 2, 3, 4] e o rastro do acumulador (1, 3, 6, 10) são os
 // mesmos do encontro, para o aluno reconhecer a conta de um visualizador para
 // o outro.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Estado = "espera" | "ativo" | "base" | "pronto";
-type Frame = { chamada: string; pend: string; estado: Estado };
-type Passo = {
+type State = "espera" | "ativo" | "base" | "pronto";
+type Frame = { call: string; pending: string; state: State };
+type Step = {
   frames: Frame[];
-  linha: number;
+  line: number;
   acc: number;
-  saltos: number;
-  consumidos: number;
+  hops: number;
+  consumed: number;
   thunk: string | null;
-  nota: string;
-  fim: boolean;
+  note: string;
+  done: boolean;
   ok: boolean;
 };
 
-// As linhas mapeiam 1:1 com o campo `linha` de cada passo, então a ordem e a
+// As linhas mapeiam 1:1 com o campo `line` de cada passo, então a ordem e a
 // quantidade de linhas não podem mudar sem ajustar o gerador junto.
-const CODIGO = [
+const CODE = [
   "def soma_passo(nums, acc=0):",
   "    if not nums:",
   "        return acc",
@@ -50,132 +55,131 @@ const CODIGO = [
   "    return r",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
 // Formatação determinística de milhar (nada de Intl no caminho de render, senão
 // o HTML do build diverge do cliente na hidratação).
-function milhar(v: number): string {
+function thousands(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function lista(v: number[]): string {
+function listOf(v: number[]): string {
   return `[${v.join(", ")}]`;
 }
 
-function gerarPassos(nums: number[]): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(nums: number[]): Step[] {
+  const out: Step[] = [];
   const n = nums.length;
-  const chao = (pend: string, estado: Estado = "ativo"): Frame => ({
-    chamada: "trampolim(soma_passo, nums)",
-    pend,
-    estado,
+  const floor = (pending: string, state: State = "ativo"): Frame => ({
+    call: "trampolim(soma_passo, nums)",
+    pending,
+    state,
   });
 
   out.push({
     frames: [
-      chao("r = f(*args)"),
-      { chamada: `soma_passo(${lista(nums)}, 0)`, pend: "primeira chamada", estado: "espera" },
+      floor("r = f(*args)"),
+      { call: `soma_passo(${listOf(nums)}, 0)`, pending: "primeira chamada", state: "espera" },
     ],
-    linha: 6,
+    line: 6,
     acc: 0,
-    saltos: 0,
-    consumidos: 0,
+    hops: 0,
+    consumed: 0,
     thunk: null,
-    nota:
+    note:
       n === 0
         ? "Chamo soma_passo uma única vez, de dentro do trampolim. Com a lista vazia ela já cai no caso base."
         : "Chamo soma_passo uma única vez, de dentro do trampolim. Ela não vai recursionar: vai devolver um thunk, que é a próxima chamada embrulhada numa função sem argumentos.",
-    fim: false,
+    done: false,
     ok: false,
   });
 
   let acc = 0;
-  let guarda = 0;
-  for (let i = 0; i < n && guarda++ < 100; i++) {
-    const novo = acc + nums[i];
-    const resto = nums.slice(i + 1);
+  let guard = 0;
+  for (let i = 0; i < n && guard++ < 100; i++) {
+    const next = acc + nums[i];
+    const rest = nums.slice(i + 1);
     out.push({
-      frames: [chao(`r = thunk`)],
-      linha: 3,
-      acc: novo,
-      saltos: i,
-      consumidos: i + 1,
-      thunk: `soma_passo(${lista(resto)}, ${novo})`,
-      nota: `A conta acontece agora, na ida: acc ${acc} + ${nums[i]} = ${novo}. Em vez de se chamar, soma_passo embrulha a próxima chamada num thunk e retorna. O frame dela sai da pilha na hora: sobra só o trampolim.`,
-      fim: false,
+      frames: [floor(`r = thunk`)],
+      line: 3,
+      acc: next,
+      hops: i,
+      consumed: i + 1,
+      thunk: `soma_passo(${listOf(rest)}, ${next})`,
+      note: `A conta acontece agora, na ida: acc ${acc} + ${nums[i]} = ${next}. Em vez de se chamar, soma_passo embrulha a próxima chamada num thunk e retorna. O frame dela sai da pilha na hora: sobra só o trampolim.`,
+      done: false,
       ok: false,
     });
     out.push({
       frames: [
-        chao("r = r()"),
+        floor("r = r()"),
         {
-          chamada: `soma_passo(${lista(resto)}, ${novo})`,
-          pend: "pendente: nada",
-          estado: i + 1 === n ? "pronto" : "espera",
+          call: `soma_passo(${listOf(rest)}, ${next})`,
+          pending: "pendente: nada",
+          state: i + 1 === n ? "pronto" : "espera",
         },
       ],
-      linha: 8,
-      acc: novo,
-      saltos: i + 1,
-      consumidos: i + 1,
+      line: 8,
+      acc: next,
+      hops: i + 1,
+      consumed: i + 1,
       thunk: null,
-      nota: `O while vê que r ainda é uma função e chama r(). soma_passo volta para a pilha no mesmo lugar de onde a anterior saiu. Salto ${i + 1}: a pilha vai a 2 frames e desce de novo.`,
-      fim: false,
+      note: `O while vê que r ainda é uma função e chama r(). soma_passo volta para a pilha no mesmo lugar de onde a anterior saiu. Salto ${i + 1}: a pilha vai a 2 frames e desce de novo.`,
+      done: false,
       ok: false,
     });
-    acc = novo;
+    acc = next;
   }
 
   out.push({
     frames: [
-      chao("r = ..."),
-      { chamada: `soma_passo([], ${acc})`, pend: `caso base: retorna ${acc}`, estado: "base" },
+      floor("r = ..."),
+      { call: `soma_passo([], ${acc})`, pending: `caso base: retorna ${acc}`, state: "base" },
     ],
-    linha: 2,
+    line: 2,
     acc,
-    saltos: n,
-    consumidos: n,
+    hops: n,
+    consumed: n,
     thunk: null,
-    nota:
+    note:
       n === 0
         ? "A lista já chegou vazia: o primeiro retorno já é o acumulador 0, e o while nem chega a girar."
         : `Lista vazia: devolvo o acumulador ${acc}. Desta vez o retorno é um número, não uma função.`,
-    fim: false,
+    done: false,
     ok: false,
   });
 
   out.push({
-    frames: [chao(`devolve ${acc}`, "pronto")],
-    linha: 9,
+    frames: [floor(`devolve ${acc}`, "pronto")],
+    line: 9,
     acc,
-    saltos: n,
-    consumidos: n,
+    hops: n,
+    consumed: n,
     thunk: null,
-    nota: `callable(${acc}) é falso, o while para e o trampolim devolve ${acc} depois de ${n} ${n === 1 ? "salto" : "saltos"}. A pilha nunca passou de 2 frames, e não passaria nem com 4 milhões de números.`,
-    fim: true,
+    note: `callable(${acc}) é falso, o while para e o trampolim devolve ${acc} depois de ${n} ${n === 1 ? "salto" : "saltos"}. A pilha nunca passou de 2 frames, e não passaria nem com 4 milhões de números.`,
+    done: true,
     ok: true,
   });
 
   return out;
 }
 
-const PADRAO = [1, 2, 3, 4];
+const DEFAULT_LIST = [1, 2, 3, 4];
 
-type Preset = { key: string; rotulo: string; nums: number[] };
+type Preset = { key: string; label: string; nums: number[] };
 const PRESETS: Preset[] = [
-  { key: "encontro", rotulo: "Do encontro: [1, 2, 3, 4]", nums: PADRAO },
-  { key: "sete", rotulo: "Sete números", nums: [5, 3, 8, 1, 9, 2, 7] },
-  { key: "um", rotulo: "Um elemento só", nums: [7] },
-  { key: "vazia", rotulo: "Lista vazia", nums: [] },
+  { key: "encontro", label: "Do encontro: [1, 2, 3, 4]", nums: DEFAULT_LIST },
+  { key: "sete", label: "Sete números", nums: [5, 3, 8, 1, 9, 2, 7] },
+  { key: "um", label: "Um elemento só", nums: [7] },
+  { key: "vazia", label: "Lista vazia", nums: [] },
 ];
 
 // Tamanhos hipotéticos da régua, do "cabe na pilha" ao "nem sonhando".
-const HIPOTESES = [10, 100, 500, 999, 5000, 100000];
-const LIMITE_PYTHON = 1000;
+const HYPOTHESES = [10, 100, 500, 999, 5000, 100000];
+const PYTHON_LIMIT = 1000;
 
-function lerLista(texto: string): number[] {
-  return texto
+function parseList(text: string): number[] {
+  return text
     .split(",")
     .map((x) => parseInt(x.trim(), 10))
     .filter((x) => !isNaN(x))
@@ -183,132 +187,85 @@ function lerLista(texto: string): number[] {
 }
 
 export function TailRecursionTrampolim() {
-  const [entrada, setEntrada] = useState(PADRAO.join(", "));
-  const [nums, setNums] = useState<number[]>(PADRAO);
+  const [input, setInput] = useState(DEFAULT_LIST.join(", "));
+  const [nums, setNums] = useState<number[]>(DEFAULT_LIST);
   const [preset, setPreset] = useState("encontro");
-  const [iHip, setIHip] = useState(3); // 999, coladinho no limite
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [iHyp, setIHyp] = useState(3); // 999, coladinho no limite
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(nums), [nums]);
+  const n = nums.length;
 
-  const passos = useMemo(() => gerarPassos(nums), [nums]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · trampolim: recursão de cauda sem ajuda da linguagem",
+    total: steps.length,
+    speeds: SPEEDS,
+    // Só o tamanho da lista muda a altura: a pilha tem teto de 2 frames, e a
+    // régua de hipótese só troca dígitos (medido: 0px entre n = 10 e n = 100.000).
+    measureOn: [n],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aoMudarEntrada = (v: string) => {
-    reiniciar();
+  const onInputChange = (v: string) => {
+    viz.reset();
     setPreset("");
-    setEntrada(v);
-    setNums(lerLista(v));
+    setInput(v);
+    setNums(parseList(v));
   };
-  const aplicar = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
-    setEntrada(pr.nums.join(", "));
+    setInput(pr.nums.join(", "));
     setNums(pr.nums);
   };
   // Math.random só em handler de clique: no render quebraria a hidratação.
-  const sortear = () => {
-    const tam = 3 + Math.floor(Math.random() * 4);
-    const arr = Array.from({ length: tam }, () => 1 + Math.floor(Math.random() * 12));
-    reiniciar();
+  const randomize = () => {
+    const size = 3 + Math.floor(Math.random() * 4);
+    const arr = Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 12));
+    viz.reset();
     setPreset("");
-    setEntrada(arr.join(", "));
+    setInput(arr.join(", "));
     setNums(arr);
   };
 
-  const n = nums.length;
-  const nHip = HIPOTESES[iHip];
-  const estoura = nHip + 1 > LIMITE_PYTHON;
+  const nHyp = HYPOTHESES[iHyp];
+  const overflows = nHyp + 1 > PYTHON_LIMIT;
 
   const cells = nums.map((v, i) => {
     let cls = "viz-cell";
-    if (i < p.consumidos) cls += " drop";
-    if (i === p.consumidos) cls += " in";
+    if (i < p.consumed) cls += " drop";
+    if (i === p.consumed) cls += " in";
     return { i, v, cls };
   });
 
-  const variaveis = [
-    { nome: "acc", valor: `${p.acc}`, best: true },
-    { nome: "saltos", valor: `${p.saltos}` },
-    { nome: "frames", valor: `${p.frames.length}` },
-    { nome: "r", valor: p.thunk ? "thunk" : p.fim ? `${p.acc}` : "chamando", best: p.fim },
+  const vars = [
+    { name: "acc", value: `${p.acc}`, best: true },
+    { name: "saltos", value: `${p.hops}` },
+    { name: "frames", value: `${p.frames.length}` },
+    { name: "r", value: p.thunk ? "thunk" : p.done ? `${p.acc}` : "chamando", best: p.done },
   ];
 
-  const estatisticas = [
-    { k: "pico", rot: "pilha máxima · trampolim", val: "2", cls: "tr-bom" },
-    { k: "dir", rot: "pilha · recursão direta", val: `${n + 1}`, cls: "" },
-    { k: "saltos", rot: "saltos até aqui", val: `${p.saltos}`, cls: "" },
-    { k: "espaco", rot: "espaço extra", val: "O(1)", cls: "tr-bom" },
+  const stats = [
+    { k: "pico", label: "pilha máxima · trampolim", value: "2", cls: "tr-bom" },
+    { k: "dir", label: "pilha · recursão direta", value: `${n + 1}`, cls: "" },
+    { k: "saltos", label: "saltos até aqui", value: `${p.hops}`, cls: "" },
+    { k: "espaco", label: "espaço extra", value: "O(1)", cls: "tr-bom" },
   ];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · trampolim: recursão de cauda sem ajuda da linguagem</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               aria-pressed={preset === pr.key}
-              onClick={() => aplicar(pr)}
+              onClick={() => applyPreset(pr)}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -316,9 +273,9 @@ export function TailRecursionTrampolim() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Lista de números</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={randomize}>
             Sortear
           </button>
         </div>
@@ -329,8 +286,8 @@ export function TailRecursionTrampolim() {
               <div className="viz-cell-wrap" key={c.i}>
                 <span className="viz-cell-idx">{c.i}</span>
                 <div className={c.cls}>{c.v}</div>
-                <span className={`viz-mark${c.i === p.consumidos ? " show" : ""}`}>
-                  {c.i === p.consumidos ? "head" : "·"}
+                <span className={`viz-mark${c.i === p.consumed ? " show" : ""}`}>
+                  {c.i === p.consumed ? "head" : "·"}
                 </span>
               </div>
             ))}
@@ -345,9 +302,9 @@ export function TailRecursionTrampolim() {
             </div>
             <div className="tr-pilha">
               {p.frames.map((f, i) => (
-                <div className={`tr-frame ${f.estado}`} key={`${f.chamada}-${i}`}>
-                  <div className="tr-frame-chamada">{f.chamada}</div>
-                  <div className="tr-frame-pend">{f.pend}</div>
+                <div className={`tr-frame ${f.state}`} key={`${f.call}-${i}`}>
+                  <div className="tr-frame-chamada">{f.call}</div>
+                  <div className="tr-frame-pend">{f.pending}</div>
                 </div>
               ))}
             </div>
@@ -357,13 +314,13 @@ export function TailRecursionTrampolim() {
           <div className="tr-painel">
             <div className="tr-painel-tit">
               <span>O thunk na mão do laço</span>
-              <em>salto {p.saltos}</em>
+              <em>salto {p.hops}</em>
             </div>
             <div className="tr-pilha">
               <div className={`tr-frame ${p.thunk ? "ativo" : "livre"}`}>
-                <div className="tr-frame-chamada">{p.thunk ?? (p.fim ? `r = ${p.acc}` : "r ainda não é um thunk")}</div>
+                <div className="tr-frame-chamada">{p.thunk ?? (p.done ? `r = ${p.acc}` : "r ainda não é um thunk")}</div>
                 <div className="tr-frame-pend">
-                  {p.thunk ? "uma função esperando ser chamada" : p.fim ? "não é função, o while parou" : "o laço está no meio de uma chamada"}
+                  {p.thunk ? "uma função esperando ser chamada" : p.done ? "não é função, o while parou" : "o laço está no meio de uma chamada"}
                 </div>
               </div>
             </div>
@@ -371,50 +328,58 @@ export function TailRecursionTrampolim() {
           </div>
         </div>
 
-        <p className={`viz-note${p.ok ? " ok" : ""}`}>{p.nota}</p>
+        <p className={`viz-note${p.ok ? " ok" : ""}`}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">trampolim.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt || " "}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuava com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso de
+              altura; `inert` tira ele do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">trampolim.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt || " "}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong className={s.cls}>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong className={s.cls}>{s.value}</strong>
             </div>
           ))}
         </div>
 
         <div className="viz-controls">
           <div className="viz-field grow">
-            <span>E se a lista tivesse n = {milhar(nHip)}?</span>
+            <span>E se a lista tivesse n = {thousands(nHyp)}?</span>
             <input
               type="range"
               min={0}
-              max={HIPOTESES.length - 1}
+              max={HYPOTHESES.length - 1}
               step={1}
-              value={iHip}
-              onChange={(e) => setIHip(parseInt(e.target.value, 10))}
+              value={iHyp}
+              onChange={(e) => setIHyp(parseInt(e.target.value, 10))}
               style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
             />
           </div>
@@ -423,11 +388,11 @@ export function TailRecursionTrampolim() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>recursão direta · frames</span>
-            <strong className={estoura ? "tr-ruim" : ""}>{milhar(nHip + 1)}</strong>
+            <strong className={overflows ? "tr-ruim" : ""}>{thousands(nHyp + 1)}</strong>
           </div>
           <div className="bigo-stat">
             <span>recursão direta · em Python</span>
-            <strong className={estoura ? "tr-ruim" : "tr-bom"}>{estoura ? "RecursionError" : "passa"}</strong>
+            <strong className={overflows ? "tr-ruim" : "tr-bom"}>{overflows ? "RecursionError" : "passa"}</strong>
           </div>
           <div className="bigo-stat">
             <span>trampolim · frames</span>
@@ -435,87 +400,20 @@ export function TailRecursionTrampolim() {
           </div>
           <div className="bigo-stat">
             <span>trampolim · saltos</span>
-            <strong>{milhar(nHip)}</strong>
+            <strong>{thousands(nHyp)}</strong>
           </div>
         </div>
 
         <p className="viz-note">
-          O limite padrão do Python é {milhar(LIMITE_PYTHON)} chamadas empilhadas. Com n = {milhar(nHip)}, a recursão de
-          cauda escrita direto {estoura ? "estoura antes de terminar" : "ainda passa, mas está andando na beira"}; o
-          trampolim faz {milhar(nHip)} {nHip === 1 ? "salto" : "saltos"} com os mesmos 2 frames.
+          O limite padrão do Python é {thousands(PYTHON_LIMIT)} chamadas empilhadas. Com n = {thousands(nHyp)}, a
+          recursão de cauda escrita direto {overflows ? "estoura antes de terminar" : "ainda passa, mas está andando na beira"}; o
+          trampolim faz {thousands(nHyp)} {nHyp === 1 ? "salto" : "saltos"} com os mesmos 2 frames.
         </p>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${Math.round(((idx + 1) / total) * 100)}%` }} />
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/TailRecursionVisualizer.tsx
+++ b/content/visualizers/TailRecursionVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TailRecursionVisualizer, a MESMA soma nas duas formas, lado a lado.
@@ -24,18 +25,22 @@ import { createPortal } from "react-dom";
 // mesmo contador de passos: quem termina primeiro fica parado (com o resultado
 // na tela) enquanto o outro continua. É essa imagem, a pilha da esquerda ainda
 // desempilhando enquanto a direita já respondeu, que ensina o tópico.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Estado = "espera" | "ativo" | "base" | "pronto";
-type Frame = { chamada: string; pend: string; estado: Estado };
-// `somas` é o contador de operações: ele existe para mostrar que o número de
+type State = "espera" | "ativo" | "base" | "pronto";
+type Frame = { call: string; pending: string; state: State };
+// `sums` é o contador de operações: ele existe para mostrar que o número de
 // somas é o MESMO nos dois lados (uma por elemento). O que muda de forma é
 // quando elas acontecem, e é o espaço, não o tempo, que a de cauda economiza.
-type Lado = { frames: Frame[]; linha: number; nota: string; somas: number; fim: boolean; ok: boolean };
+type Side = { frames: Frame[]; line: number; note: string; sums: number; done: boolean; ok: boolean };
 
-// As linhas mapeiam 1:1 com os campos `linha` dos dois geradores, então a ordem
+// As linhas mapeiam 1:1 com os campos `line` dos dois geradores, então a ordem
 // e a quantidade de linhas não podem mudar sem ajustar os geradores junto.
-const CODIGO = [
+const CODE = [
   "def soma(nums):                       # comum",
   "    if not nums:",
   "        return 0",
@@ -47,101 +52,101 @@ const CODIGO = [
   "    return soma_cauda(nums[1:], acc + nums[0])",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-function lista(v: number[]): string {
+function listOf(v: number[]): string {
   return `[${v.join(", ")}]`;
 }
 
-function prefixo(v: number[], ate: number): number {
+function prefix(v: number[], upTo: number): number {
   let s = 0;
-  for (let i = 0; i < ate; i++) s += v[i];
+  for (let i = 0; i < upTo; i++) s += v[i];
   return s;
 }
 
-function sufixo(v: number[], de: number): number {
+function suffix(v: number[], from: number): number {
   let s = 0;
-  for (let i = de; i < v.length; i++) s += v[i];
+  for (let i = from; i < v.length; i++) s += v[i];
   return s;
 }
 
 // Formatação determinística de milhar (nada de Intl no caminho de render, senão
 // o HTML do build diverge do cliente na hidratação).
-function milhar(v: number): string {
+function thousands(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function frames(v: number): string {
+// Rótulo de tela, em português: "1 frame" / "3 frames".
+function framesLabel(v: number): string {
   return `${v} ${v === 1 ? "frame" : "frames"}`;
 }
 
 // --- recursão comum: empilha n + 1 frames e só depois faz as n somas ---------
-function gerarComum(nums: number[]): Lado[] {
-  const out: Lado[] = [];
+function generatePlain(nums: number[]): Side[] {
+  const out: Side[] = [];
   const n = nums.length;
 
   for (let i = 0; i < n; i++) {
-    const pilha: Frame[] = [];
+    const stack: Frame[] = [];
     for (let j = 0; j <= i; j++) {
-      pilha.push({
-        chamada: `soma(${lista(nums.slice(j))})`,
-        pend: `pendente: ${nums[j]} + ?`,
-        estado: j === i ? "ativo" : "espera",
+      stack.push({
+        call: `soma(${listOf(nums.slice(j))})`,
+        pending: `pendente: ${nums[j]} + ?`,
+        state: j === i ? "ativo" : "espera",
       });
     }
     out.push({
-      frames: pilha,
-      linha: 3,
-      somas: 0,
-      fim: false,
+      frames: stack,
+      line: 3,
+      sums: 0,
+      done: false,
       ok: false,
-      nota: `A lista não está vazia, então guardo "${nums[i]} +" pendente aqui e desço para soma(${lista(nums.slice(i + 1))}). ${frames(i + 1)} na pilha, ${i + 1 === 1 ? "parado" : "parados"}, esperando uma resposta que ainda não existe.`,
+      note: `A lista não está vazia, então guardo "${nums[i]} +" pendente aqui e desço para soma(${listOf(nums.slice(i + 1))}). ${framesLabel(i + 1)} na pilha, ${i + 1 === 1 ? "parado" : "parados"}, esperando uma resposta que ainda não existe.`,
     });
   }
 
   const base: Frame[] = [];
   for (let j = 0; j < n; j++) {
     base.push({
-      chamada: `soma(${lista(nums.slice(j))})`,
-      pend: `pendente: ${nums[j]} + ?`,
-      estado: "espera",
+      call: `soma(${listOf(nums.slice(j))})`,
+      pending: `pendente: ${nums[j]} + ?`,
+      state: "espera",
     });
   }
-  base.push({ chamada: "soma([])", pend: "caso base: retorna 0", estado: "base" });
+  base.push({ call: "soma([])", pending: "caso base: retorna 0", state: "base" });
   out.push({
     frames: base,
-    linha: 2,
-    somas: 0,
-    fim: n === 0,
+    line: 2,
+    sums: 0,
+    done: n === 0,
     ok: n === 0,
-    nota:
+    note:
       n === 0
         ? "A lista já chegou vazia: caí direto no caso base, retorno 0 e nem cheguei a empilhar nada."
-        : `Cheguei na lista vazia com ${frames(n + 1)} empilhados. Retorno 0, e só agora a volta começa: nenhuma das ${n} somas foi feita ainda.`,
+        : `Cheguei na lista vazia com ${framesLabel(n + 1)} empilhados. Retorno 0, e só agora a volta começa: nenhuma das ${n} somas foi feita ainda.`,
   });
 
   for (let k = n - 1; k >= 0; k--) {
-    const anterior = sufixo(nums, k + 1);
-    const valor = anterior + nums[k];
-    const pilha: Frame[] = [];
+    const previous = suffix(nums, k + 1);
+    const value = previous + nums[k];
+    const stack: Frame[] = [];
     for (let j = 0; j <= k; j++) {
-      pilha.push({
-        chamada: `soma(${lista(nums.slice(j))})`,
-        pend: j === k ? `${nums[k]} + ${anterior} = ${valor}` : `pendente: ${nums[j]} + ?`,
-        estado: j === k ? "pronto" : "espera",
+      stack.push({
+        call: `soma(${listOf(nums.slice(j))})`,
+        pending: j === k ? `${nums[k]} + ${previous} = ${value}` : `pendente: ${nums[j]} + ?`,
+        state: j === k ? "pronto" : "espera",
       });
     }
     out.push({
-      frames: pilha,
-      linha: 3,
-      somas: n - k,
-      fim: k === 0,
+      frames: stack,
+      line: 3,
+      sums: n - k,
+      done: k === 0,
       ok: k === 0,
-      nota: `Desempilho e agora sim faço a conta que estava presa aqui: ${nums[k]} + ${anterior} = ${valor}. ${
+      note: `Desempilho e agora sim faço a conta que estava presa aqui: ${nums[k]} + ${previous} = ${value}. ${
         k === 0
-          ? `Pilha vazia, resposta final: ${valor}.`
-          : `Devolvo ${valor} para o frame de baixo. Ainda ${frames(k)} para desempilhar.`
+          ? `Pilha vazia, resposta final: ${value}.`
+          : `Devolvo ${value} para o frame de baixo. Ainda ${framesLabel(k)} para desempilhar.`
       }`,
     });
   }
@@ -149,66 +154,66 @@ function gerarComum(nums: number[]): Lado[] {
 }
 
 // --- recursão de cauda: com TCO o frame é reescrito, sem TCO empilha igual ---
-function gerarCauda(nums: number[], tco: boolean): Lado[] {
-  const out: Lado[] = [];
+function generateTail(nums: number[], tco: boolean): Side[] {
+  const out: Side[] = [];
   const n = nums.length;
-  const total = prefixo(nums, n);
+  const total = prefix(nums, n);
 
-  const frameEm = (i: number, estado: Estado): Frame => ({
-    chamada: `soma_cauda(${lista(nums.slice(i))}, ${prefixo(nums, i)})`,
-    pend: "pendente: nada",
-    estado,
+  const frameAt = (i: number, state: State): Frame => ({
+    call: `soma_cauda(${listOf(nums.slice(i))}, ${prefix(nums, i)})`,
+    pending: "pendente: nada",
+    state,
   });
 
   for (let i = 0; i < n; i++) {
-    const acc = prefixo(nums, i);
-    const novo = acc + nums[i];
-    const pilha: Frame[] = tco
-      ? [frameEm(i, "ativo")]
-      : Array.from({ length: i + 1 }, (_, j) => frameEm(j, j === i ? "ativo" : "espera"));
+    const acc = prefix(nums, i);
+    const next = acc + nums[i];
+    const stack: Frame[] = tco
+      ? [frameAt(i, "ativo")]
+      : Array.from({ length: i + 1 }, (_, j) => frameAt(j, j === i ? "ativo" : "espera"));
     out.push({
-      frames: pilha,
-      linha: 8,
-      somas: i + 1,
-      fim: false,
+      frames: stack,
+      line: 8,
+      sums: i + 1,
+      done: false,
       ok: false,
-      nota: tco
-        ? `acc vale ${acc}. Faço a conta agora, ${acc} + ${nums[i]} = ${novo}, e passo o resultado adiante. Como não sobrou nada para fazer aqui, o compilador reescreve ESTE frame com os parâmetros novos: a pilha continua com 1.`
-        : `acc vale ${acc}. Faço a conta agora, ${acc} + ${nums[i]} = ${novo}, e passo adiante. Só que sem TCO a chamada empilha do mesmo jeito: já são ${frames(i + 1)}.`,
+      note: tco
+        ? `acc vale ${acc}. Faço a conta agora, ${acc} + ${nums[i]} = ${next}, e passo o resultado adiante. Como não sobrou nada para fazer aqui, o compilador reescreve ESTE frame com os parâmetros novos: a pilha continua com 1.`
+        : `acc vale ${acc}. Faço a conta agora, ${acc} + ${nums[i]} = ${next}, e passo adiante. Só que sem TCO a chamada empilha do mesmo jeito: já são ${framesLabel(i + 1)}.`,
     });
   }
 
   const base: Frame[] = tco
-    ? [{ chamada: `soma_cauda([], ${total})`, pend: `caso base: retorna acc = ${total}`, estado: "base" }]
+    ? [{ call: `soma_cauda([], ${total})`, pending: `caso base: retorna acc = ${total}`, state: "base" }]
     : [
-        ...Array.from({ length: n }, (_, j) => frameEm(j, "espera")),
-        { chamada: `soma_cauda([], ${total})`, pend: `caso base: retorna acc = ${total}`, estado: "base" },
+        ...Array.from({ length: n }, (_, j) => frameAt(j, "espera")),
+        { call: `soma_cauda([], ${total})`, pending: `caso base: retorna acc = ${total}`, state: "base" },
       ];
   out.push({
     frames: base,
-    linha: 7,
-    somas: n,
-    fim: tco || n === 0,
+    line: 7,
+    sums: n,
+    done: tco || n === 0,
     ok: tco || n === 0,
-    nota: tco
+    note: tco
       ? `Lista vazia: devolvo o acumulador, ${total}. Não existe volta para fazer, a resposta já estava pronta na mão, e a pilha nunca passou de 1 frame.`
       : n === 0
         ? "A lista já chegou vazia: devolvo o acumulador 0 na primeira chamada."
-        : `Lista vazia: o acumulador já vale ${total}, a resposta está pronta. Mas ainda ${frames(n)} embaixo para desempilhar, um por um.`,
+        : `Lista vazia: o acumulador já vale ${total}, a resposta está pronta. Mas ainda ${framesLabel(n)} embaixo para desempilhar, um por um.`,
   });
 
   if (!tco) {
     for (let k = n - 1; k >= 0; k--) {
-      const pilha = Array.from({ length: k + 1 }, (_, j) => frameEm(j, j === k ? "pronto" : "espera"));
-      pilha[k] = { ...pilha[k], pend: `só repassa ${total}`, estado: "pronto" };
+      const stack = Array.from({ length: k + 1 }, (_, j) => frameAt(j, j === k ? "pronto" : "espera"));
+      stack[k] = { ...stack[k], pending: `só repassa ${total}`, state: "pronto" };
       out.push({
-        frames: pilha,
-        linha: 8,
-        somas: n,
-        fim: k === 0,
+        frames: stack,
+        line: 8,
+        sums: n,
+        done: k === 0,
         ok: k === 0,
-        nota: `Desempilho sem fazer conta nenhuma: só repasso o ${total} para baixo. ${
-          k === 0 ? "Fim." : `Restam ${frames(k)}.`
+        note: `Desempilho sem fazer conta nenhuma: só repasso o ${total} para baixo. ${
+          k === 0 ? "Fim." : `Restam ${framesLabel(k)}.`
         } A recursão de cauda arrumou a conta, mas sem otimização da linguagem a memória continua O(n).`,
       });
     }
@@ -216,25 +221,25 @@ function gerarCauda(nums: number[], tco: boolean): Lado[] {
   return out;
 }
 
-const PADRAO = [1, 2, 3, 4];
+const DEFAULT_LIST = [1, 2, 3, 4];
 
-type Preset = { key: string; rotulo: string; nums: number[] };
+type Preset = { key: string; label: string; nums: number[] };
 const PRESETS: Preset[] = [
-  { key: "encontro", rotulo: "Do encontro: [1, 2, 3, 4]", nums: PADRAO },
-  { key: "sete", rotulo: "Sete números", nums: [5, 3, 8, 1, 9, 2, 7] },
-  { key: "um", rotulo: "Um elemento só", nums: [7] },
-  { key: "vazia", rotulo: "Lista vazia", nums: [] },
+  { key: "encontro", label: "Do encontro: [1, 2, 3, 4]", nums: DEFAULT_LIST },
+  { key: "sete", label: "Sete números", nums: [5, 3, 8, 1, 9, 2, 7] },
+  { key: "um", label: "Um elemento só", nums: [7] },
+  { key: "vazia", label: "Lista vazia", nums: [] },
 ];
 
-function lerLista(texto: string): number[] {
-  return texto
+function parseList(text: string): number[] {
+  return text
     .split(",")
     .map((x) => parseInt(x.trim(), 10))
     .filter((x) => !isNaN(x))
     .slice(0, 9);
 }
 
-function Pilha({ frames: fs, rotulo }: { frames: Frame[]; rotulo: string }) {
+function Stack({ frames: fs, label }: { frames: Frame[]; label: string }) {
   return (
     <>
       <div className="tr-pilha">
@@ -244,155 +249,110 @@ function Pilha({ frames: fs, rotulo }: { frames: Frame[]; rotulo: string }) {
           </div>
         ) : (
           fs.map((f, i) => (
-            <div className={`tr-frame ${f.estado}`} key={`${f.chamada}-${i}`}>
-              <div className="tr-frame-chamada">{f.chamada}</div>
-              <div className="tr-frame-pend">{f.pend}</div>
+            <div className={`tr-frame ${f.state}`} key={`${f.call}-${i}`}>
+              <div className="tr-frame-chamada">{f.call}</div>
+              <div className="tr-frame-pend">{f.pending}</div>
             </div>
           ))
         )}
       </div>
-      <div className="tr-chao">{rotulo}</div>
+      <div className="tr-chao">{label}</div>
     </>
   );
 }
 
 export function TailRecursionVisualizer() {
-  const [entrada, setEntrada] = useState(PADRAO.join(", "));
-  const [nums, setNums] = useState<number[]>(PADRAO);
+  const [input, setInput] = useState(DEFAULT_LIST.join(", "));
+  const [nums, setNums] = useState<number[]>(DEFAULT_LIST);
   const [preset, setPreset] = useState("encontro");
   const [tco, setTco] = useState(true);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  const stepsA = useMemo(() => generatePlain(nums), [nums]);
+  const stepsB = useMemo(() => generateTail(nums, tco), [nums, tco]);
 
-  const passosA = useMemo(() => gerarComum(nums), [nums]);
-  const passosB = useMemo(() => gerarCauda(nums, tco), [nums, tco]);
+  const total = Math.max(stepsA.length, stepsB.length);
+  const n = nums.length;
 
-  const total = Math.max(passosA.length, passosB.length);
-  const idx = Math.min(passo, total - 1);
-  const iA = Math.min(idx, passosA.length - 1);
-  const iB = Math.min(idx, passosB.length - 1);
-  const a = passosA[iA];
-  const b = passosB[iB];
+  const viz = useVisualizer({
+    title: "Visualizador · a mesma soma nas duas formas: a pilha que cresce e a que não cresce",
+    total,
+    speeds: SPEEDS,
+    // O que muda a altura: o tamanho da lista e o TCO (sem ele o lado direito
+    // empilha igual ao esquerdo). E `total`, que com a lista vazia cai para 1 e
+    // apaga contador, rodapé e atalhos de uma vez — cerca de 90px de peça.
+    measureOn: [n, tco, total],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const iA = Math.min(viz.step, stepsA.length - 1);
+  const iB = Math.min(viz.step, stepsB.length - 1);
+  const a = stepsA[iA];
+  const b = stepsB[iB];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = useCallback(() => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  }, [parar]);
-
-  const aoMudarEntrada = (v: string) => {
-    reiniciar();
+  const onInputChange = (v: string) => {
+    viz.reset();
     setPreset("");
-    setEntrada(v);
-    setNums(lerLista(v));
+    setInput(v);
+    setNums(parseList(v));
   };
-  const aplicar = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPreset(pr.key);
-    setEntrada(pr.nums.join(", "));
+    setInput(pr.nums.join(", "));
     setNums(pr.nums);
   };
   // Math.random só em handler de clique: no render quebraria a hidratação.
-  const sortear = () => {
-    const n = 3 + Math.floor(Math.random() * 4);
-    const arr = Array.from({ length: n }, () => 1 + Math.floor(Math.random() * 12));
-    reiniciar();
+  const randomize = () => {
+    const size = 3 + Math.floor(Math.random() * 4);
+    const arr = Array.from({ length: size }, () => 1 + Math.floor(Math.random() * 12));
+    viz.reset();
     setPreset("");
-    setEntrada(arr.join(", "));
+    setInput(arr.join(", "));
     setNums(arr);
   };
 
-  const n = nums.length;
-  const totalSoma = prefixo(nums, n);
-  const picoA = n + 1;
-  const picoB = tco ? 1 : n + 1;
+  const sum = prefix(nums, n);
+  const peakPlain = n + 1;
+  const peakTail = tco ? 1 : n + 1;
 
   // Rastro do acumulador: 0, 1, 3, 6, 10 na lista do encontro. O passo atual do
   // lado direito manda, e na volta (sem TCO) ele fica travado no último.
-  const trilha = Array.from({ length: n + 1 }, (_, i) => prefixo(nums, i));
-  const trilhaIdx = Math.min(iB, n);
+  const trail = Array.from({ length: n + 1 }, (_, i) => prefix(nums, i));
+  const trailIdx = Math.min(iB, n);
 
-  const variaveis = [
-    { nome: "acc (cauda)", valor: `${trilha[trilhaIdx]}`, best: true },
-    { nome: "frames · comum", valor: `${a.frames.length}` },
-    { nome: "frames · cauda", valor: `${b.frames.length}` },
-    { nome: "somas · comum", valor: `${a.somas} de ${n}` },
-    { nome: "somas · cauda", valor: `${b.somas} de ${n}` },
-    { nome: "soma(nums)", valor: a.ok ? `${totalSoma}` : "...", best: a.ok },
+  const vars = [
+    { name: "acc (cauda)", value: `${trail[trailIdx]}`, best: true },
+    { name: "frames · comum", value: `${a.frames.length}` },
+    { name: "frames · cauda", value: `${b.frames.length}` },
+    { name: "somas · comum", value: `${a.sums} de ${n}` },
+    { name: "somas · cauda", value: `${b.sums} de ${n}` },
+    { name: "soma(nums)", value: a.ok ? `${sum}` : "...", best: a.ok },
   ];
 
-  const estatisticas = [
-    { k: "pa", rot: "pico de frames · comum", val: `${picoA}` },
-    { k: "pb", rot: "pico de frames · de cauda", val: `${picoB}` },
-    { k: "ea", rot: "espaço extra · comum", val: "O(n)" },
-    { k: "eb", rot: "espaço extra · de cauda", val: tco ? "O(1)" : "O(n)" },
+  const stats = [
+    { k: "pa", label: "pico de frames · comum", value: `${peakPlain}` },
+    { k: "pb", label: "pico de frames · de cauda", value: `${peakTail}` },
+    { k: "ea", label: "espaço extra · comum", value: "O(n)" },
+    { k: "eb", label: "espaço extra · de cauda", value: tco ? "O(1)" : "O(n)" },
   ];
 
-  const resumo = tco
-    ? `A recursão comum chegou a ${frames(picoA)}; a de cauda ficou em 1 do começo ao fim. Com uma lista de 1.000 números seriam ${milhar(1001)} frames de um lado e 1 do outro, e o Python nem chegaria lá: ele para com RecursionError, porque o limite padrão é 1.000 chamadas.`
-    : `Sem otimização da linguagem os dois lados empilham ${frames(picoA)}. A recursão de cauda continua valendo a pena para pensar, e é ela que vira laço na hora de reescrever, mas em Python, Java ou C# ela sozinha não economiza um byte de pilha.`;
+  const summary = tco
+    ? `A recursão comum chegou a ${framesLabel(peakPlain)}; a de cauda ficou em 1 do começo ao fim. Com uma lista de 1.000 números seriam ${thousands(1001)} frames de um lado e 1 do outro, e o Python nem chegaria lá: ele para com RecursionError, porque o limite padrão é 1.000 chamadas.`
+    : `Sem otimização da linguagem os dois lados empilham ${framesLabel(peakPlain)}. A recursão de cauda continua valendo a pena para pensar, e é ela que vira laço na hora de reescrever, mas em Python, Java ou C# ela sozinha não economiza um byte de pilha.`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a mesma soma nas duas formas: a pilha que cresce e a que não cresce</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               aria-pressed={preset === pr.key}
-              onClick={() => aplicar(pr)}
+              onClick={() => applyPreset(pr)}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
@@ -400,9 +360,9 @@ export function TailRecursionVisualizer() {
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Lista de números</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={sortear}>
+          <button className="viz-btn" onClick={randomize}>
             Sortear
           </button>
         </div>
@@ -412,7 +372,7 @@ export function TailRecursionVisualizer() {
             className={`bigo-chip${tco ? " on" : ""}`}
             aria-pressed={tco}
             onClick={() => {
-              reiniciar();
+              viz.reset();
               setTco(true);
             }}
           >
@@ -423,7 +383,7 @@ export function TailRecursionVisualizer() {
             className={`bigo-chip${!tco ? " on" : ""}`}
             aria-pressed={!tco}
             onClick={() => {
-              reiniciar();
+              viz.reset();
               setTco(false);
             }}
           >
@@ -436,140 +396,81 @@ export function TailRecursionVisualizer() {
           <div className="tr-painel">
             <div className="tr-painel-tit">
               <span>1. Recursão comum</span>
-              <em>{frames(a.frames.length)}</em>
+              <em>{framesLabel(a.frames.length)}</em>
             </div>
-            <Pilha frames={a.frames} rotulo="base da pilha" />
-            <p className={`viz-note${a.ok ? " ok" : ""}`}>{a.nota}</p>
+            <Stack frames={a.frames} label="base da pilha" />
+            <p className={`viz-note${a.ok ? " ok" : ""}`}>{a.note}</p>
           </div>
 
           <div className="tr-painel cauda">
             <div className="tr-painel-tit">
               <span>2. Recursão de cauda</span>
-              <em>{frames(b.frames.length)}</em>
+              <em>{framesLabel(b.frames.length)}</em>
             </div>
-            <Pilha frames={b.frames} rotulo="base da pilha" />
+            <Stack frames={b.frames} label="base da pilha" />
             <div className="tr-trilha" aria-label="rastro do acumulador">
-              {trilha.map((v, i) => (
+              {trail.map((v, i) => (
                 <span key={i}>
                   {i > 0 ? <span className="tr-seta">→</span> : null}
-                  <span className={`tr-acc${i === trilhaIdx ? " on" : ""}`}>acc {v}</span>
+                  <span className={`tr-acc${i === trailIdx ? " on" : ""}`}>acc {v}</span>
                 </span>
               ))}
             </div>
-            <p className={`viz-note${b.ok ? " ok" : ""}`}>{b.nota}</p>
+            <p className={`viz-note${b.ok ? " ok" : ""}`}>{b.note}</p>
           </div>
         </div>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">soma.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => {
-                let cls = "viz-line";
-                if (i === a.linha) cls += " on";
-                if (i === b.linha) cls += " tr-on-b";
-                return (
-                  <div key={i} className={cls}>
-                    <span className="ln">{i + 1}</span>
-                    {txt}
-                  </div>
-                );
-              })}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuava com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso de
+              altura; `inert` tira ele do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">soma.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => {
+                  let cls = "viz-line";
+                  if (i === a.line) cls += " on";
+                  if (i === b.line) cls += " tr-on-b";
+                  return (
+                    <div key={i} className={cls}>
+                      <span className="ln">{i + 1}</span>
+                      {txt}
+                    </div>
+                  );
+                })}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
         </div>
 
         <div className="bigo-stats">
-          {estatisticas.map((s) => (
+          {stats.map((s) => (
             <div className="bigo-stat" key={s.k}>
-              <span>{s.rot}</span>
-              <strong>{s.val}</strong>
+              <span>{s.label}</span>
+              <strong>{s.value}</strong>
             </div>
           ))}
         </div>
 
-        <p className="viz-note">{resumo}</p>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.max(0, idx - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso(Math.min(idx + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input
-              type="range"
-              min={1}
-              max={5}
-              step={1}
-              value={velocidade}
-              onChange={(e) => setVelocidade(parseInt(e.target.value, 10))}
-            />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${Math.round(((idx + 1) / total) * 100)}%` }} />
-        </div>
+        <p className="viz-note">{summary}</p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/tests/viz-filas.spec.ts
+++ b/tests/viz-filas.spec.ts
@@ -1,0 +1,364 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa dos três visualizadores de filas.
+//
+// A página tem três peças, nesta ordem:
+//   0 · QueueVisualizer       — a fila no array: ingênua x buffer circular
+//   1 · QueueDuasPilhas       — a fila com duas pilhas (LeetCode 232)
+//   2 · QueueDequeMonotonico  — o deque decrescente (LeetCode 239)
+//
+// O defeito que estes testes protegem não era altura: no painel expandido a
+// FIGURA inteira rolava, e o cabeçalho ia junto. Medido em 1512x900, antes:
+// o cabeçalho subia 837px (fila), 410px (duas pilhas) e 256px (deque), e o
+// `▶ Rodar` era desenhado com a base em 1678px, 1251px e 1097px numa janela de
+// 900 — o aluno perdia de vista justamente o botão que faz a peça andar.
+//
+// Todo teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada, e comportamento certo debaixo do rótulo errado ensina errado do mesmo
+// jeito.
+
+const URL = "/topico/filas/";
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+/** Congela a animação e espera as fontes: medir antes disso mede o fallback. */
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Abre o painel expandido da peça `i` SEM recarregar: o estado montado fica. */
+async function expandirAqui(page: Page, i: number) {
+  await page.locator("article figure.viz").nth(i).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+/** Abre a página e o painel expandido da peça `i`. */
+async function expandir(page: Page, i: number) {
+  await page.goto(URL);
+  await preparar(page);
+  return expandirAqui(page, i);
+}
+
+/** Orçamento de altura do fluxo do artigo: janela menos cabeçalho e respiro. */
+function orcamento(page: Page) {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+        60) -
+      24
+  );
+}
+
+/**
+ * Altura que parou de mudar. O `data-anim` do hook congela a transição da
+ * MEDIÇÃO dele, e não a do clique do aluno: ler no meio dos 0,32s devolve o
+ * layout a caminho e conclui "cabe" para uma peça que não cabe.
+ */
+async function alturaEstavel(alvo: Locator) {
+  let anterior = -1;
+  for (let k = 0; k < 40; k++) {
+    const h = await alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    if (h === anterior) return h;
+    anterior = h;
+    await alvo.page().waitForTimeout(60);
+  }
+  return anterior;
+}
+
+/**
+ * Rola o miolo até o fim e diz quanto o cabeçalho e o rodapé se mexeram, e se
+ * quem rolou foi mesmo o miolo. As três coisas juntas são o teste: com a
+ * rolagem devolvida à figura, `sobra` e `rolou` ficam em zero, o cabeçalho não
+ * se mexe, e um teste que só olhasse `headMoveu` aprovaria a quebra.
+ */
+async function rolarAteOFim(painel: Locator) {
+  return painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const foot = f.querySelector<HTMLElement>(".viz-foot")!;
+    const headAntes = Math.round(head.getBoundingClientRect().top);
+    const footAntes = Math.round(foot.getBoundingClientRect().top);
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    f.scrollTop = f.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return {
+      sobra,
+      rolou: Math.round(body.scrollTop),
+      figuraRolou: Math.round(f.scrollTop),
+      headMoveu: Math.round(head.getBoundingClientRect().top) - headAntes,
+      footMoveu: Math.round(foot.getBoundingClientRect().top) - footAntes,
+    };
+  });
+}
+
+/** Anda a peça até o último passo, clicando no botão que o aluno clicaria. */
+async function irAteOFim(peca: Locator) {
+  const proximo = peca.getByRole("button", { name: "Próximo ›" });
+  for (let k = 0; k < 90; k++) {
+    if (await proximo.isDisabled()) break;
+    await proximo.click();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Camada 1: cabeçalho e controles parados, só o miolo rola.
+// ---------------------------------------------------------------------------
+
+test("no expandido da fila, o ▶ Rodar fica parado enquanto o miolo rola", async ({ page }) => {
+  // Medido em 1512x900, antes da casca: o `.viz` inteiro rolava 837px, o
+  // cabeçalho subia os mesmos 837px e o `▶ Rodar` era desenhado com a base em
+  // 1678px numa janela de 900 — 778px abaixo do pé visível.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 0);
+
+  const r = await rolarAteOFim(painel);
+  // Sem sobra o teste não testaria nada: ele precisa de miolo para rolar.
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  // E quem rola tem que ser o miolo, não a figura.
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // Os controles continuam LEGÍVEIS, com o rótulo deles, depois de rolar.
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(painel.getByRole("button", { name: "Próximo ›" })).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · a fila no array: ingênua x buffer circular")
+  ).toBeInViewport();
+  // A dica de atalho só vale no expandido, e é o que torna o teclado descobrível.
+  await expect(painel.locator(".viz-atalhos")).toBeInViewport();
+});
+
+test("no expandido das duas pilhas, o Próximo › anda o passo depois da rolagem", async ({
+  page,
+}) => {
+  // 1440x600: medido, o miolo sobra 191px. Antes da casca a figura inteira
+  // rolava 710px e o `▶ Rodar` era desenhado com a base em 1251px numa janela
+  // de 600.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 1);
+
+  await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 21");
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // O contador vive no cabeçalho e o botão no rodapé: se qualquer um dos dois
+  // tivesse ido junto com a rolagem, este passo a passo seria impossível de
+  // acompanhar. Clico no botão que ficou à vista e leio o contador que ficou.
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeInViewport();
+  await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 21");
+  await expect(painel.locator(".viz-note")).toContainText(
+    "Enfileirar A é só empilhar na entrada, sem olhar para mais nada."
+  );
+  // Rótulo e valor lidos JUNTOS, no mesmo cartão: o guarda de idioma compara o
+  // conjunto de textos e não vê posição, então trocar dois campos de lugar
+  // passaria por ele. Aqui não passa.
+  await expect(painel.locator(".viz-var").filter({ hasText: "entrada" }).first()).toContainText("A");
+});
+
+test("no expandido do deque, o cabeçalho não sobe com o array cheio e k = 1", async ({ page }) => {
+  // O pior caso da ENTRADA desta peça: 14 números com k = 1 fecham 14 janelas,
+  // e cada uma vira uma ficha na fita de saída. Medido antes da casca: 1.247px
+  // de peça no artigo e a figura rolando 599px no expandido de 1440x600.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  await peca.locator("input.viz-input").first().fill("1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14");
+  await peca.locator("input.viz-input.k").fill("1");
+  // A entrada mudou mesmo, e a peça diz qual é: sem esta asserção o teste
+  // mediria o estado padrão e ficaria verde à toa.
+  await expect(peca.locator(".fila-resumo")).toContainText("n = 14, k = 1: são 14 janelas");
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 70");
+
+  const painel = await expandirAqui(page, 2);
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(painel.locator(".viz-step")).toBeInViewport();
+});
+
+// ---------------------------------------------------------------------------
+// Camada 3: o bloco de código recolhe, e o rótulo diz o que some.
+// ---------------------------------------------------------------------------
+
+test("em 1512x900 as três peças vêm com o código recolhido, sob o rótulo certo", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+
+  // Medido com o código à mostra: 1.532px, 1.222px e 1.095px, contra 816 de
+  // orçamento. As três estouram, então as três recolhem.
+  const arquivos = ["fila_ingenua.py", "fila_com_duas_pilhas.py", "maximos_da_janela.py"];
+  for (let i = 0; i < 3; i++) {
+    const peca = page.locator("article figure.viz").nth(i);
+    const codigo = peca.locator(".viz-code");
+
+    // O rótulo diz o que o botão FAZ, e o bloco está mesmo sem altura. Rótulo
+    // sem medida, ou medida sem rótulo, deixaria passar o caso em que o botão
+    // promete uma coisa e a peça faz outra.
+    await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+    await expect(peca).toHaveAttribute("data-codigo", "off");
+    expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+    // A premissa medida, dentro do teste: com o código à mostra a peça NÃO cabe
+    // no orçamento. Sem isto o teste ficaria verde no dia em que o recolhimento
+    // fosse decidido por engano.
+    await peca.getByRole("button", { name: "Mostrar código" }).click();
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+    expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+    // E o código que apareceu é o DESTA peça.
+    await expect(peca.locator(".viz-code-head")).toHaveText(arquivos[i]);
+  }
+});
+
+test("em janela alta o código do deque já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra o deque pede 1.095px. Em 1300px de janela o
+  // orçamento é 1.216px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1300 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  await expect(peca.locator(".viz-code-head")).toHaveText("maximos_da_janela.py");
+  await expect(peca.locator(".viz-line").first()).toContainText("from collections import deque");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+
+  // E a peça de cima, que pede 1.532px, continua recolhida na MESMA janela: a
+  // decisão é por medição, não por um breakpoint que valeria para as três.
+  await expect(page.locator("article figure.viz").nth(0)).toHaveAttribute("data-codigo", "off");
+});
+
+test("a escolha de mostrar o código sobrevive à troca de modo da fila", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // Trocar de modo troca o código inteiro e acrescenta uma quinta ficha de
+  // estatística: `mode` está no `measureOn`, então a medição roda de novo.
+  await peca.getByRole("button", { name: "buffer circular" }).click();
+  await expect(peca.locator(".viz-code-head")).toHaveText("fila_circular.py");
+  await expect(peca.locator(".bigo-stat").filter({ hasText: "início == fim?" })).toBeVisible();
+
+  // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
+  // Esta é a asserção que carrega o sentido do teste, e por isso vem ANTES da
+  // premissa: com a escolha do aluno desfeita, é ela que tem de reprovar.
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  // Premissa medida: neste estado, com o código à mostra, a peça estoura o
+  // orçamento — ou seja, uma medição sem a escolha do aluno recolheria.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+// ---------------------------------------------------------------------------
+// Teclado, e o inverso dele: campo em edição manda.
+// ---------------------------------------------------------------------------
+
+test("no expandido, seta e espaço andam o deque e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 2);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 40");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 40");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 40");
+
+  // Espaço roda e pausa, e o rótulo do botão diz em qual dos dois estados está.
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Com o cursor num campo, espaço é espaço e seta é cursor. Sequestrar isso
+  // deixaria o array impossível de editar, que é pior que não ter atalho.
+  const campo = painel.locator("input.viz-input").first();
+  await campo.fill("4, 5, 6");
+  await expect(passo).toHaveText("passo 1 de 15");
+
+  await campo.press("Space");
+  await expect(campo).toHaveValue("4, 5, 6 ");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // `fill` deixa o cursor no fim sem depender de `End`, que no macOS não leva o
+  // cursor ao fim de um input. Comparo o cursor com ele mesmo.
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(passo).toHaveText("passo 1 de 15");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// A aula da peça continua de pé depois do rename de identificadores: o número
+// e o rótulo que o explica, lidos juntos.
+// ---------------------------------------------------------------------------
+
+test("o contador de movimentações separa a fila ingênua do buffer circular", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const movs = peca.locator(".bigo-stat").filter({ hasText: "movimentações de elementos" });
+  const custo = peca.locator(".bigo-stat").filter({ hasText: "custo do desenfileirar" });
+
+  // Rótulo e valor no MESMO cartão: é o par que ensina, e é o par que um rename
+  // com dois campos trocados de lugar quebraria sem o guarda de idioma acusar.
+  await expect(movs).toContainText("0");
+  await irAteOFim(peca);
+  await expect(peca.locator(".viz-step")).toHaveText("passo 27 de 27");
+  await expect(movs).toContainText("7");
+  await expect(custo).toContainText("O(n)");
+  await expect(peca.locator(".viz-note")).toContainText("Repare no resíduo");
+
+  // O mesmo roteiro no buffer circular: zero movimentação, e o custo muda de
+  // rótulo junto. Se o contador ficasse em 7 aqui, o "aha" do tópico sumia.
+  await peca.getByRole("button", { name: "buffer circular" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 27");
+  await irAteOFim(peca);
+  await expect(movs).toContainText("0");
+  await expect(custo).toContainText("O(1)");
+  await expect(peca.locator(".viz-var").filter({ hasText: "devolvido" })).toContainText("B");
+});

--- a/tests/viz-intervals.spec.ts
+++ b/tests/viz-intervals.spec.ts
@@ -63,15 +63,27 @@ async function abrirCodigo(alvo: Locator) {
 
 /**
  * Rola o miolo até uma fração da sobra e só volta quando o navegador aplicou a
- * rolagem e pintou o quadro seguinte. O retorno é o `scrollTop` REAL: se a
- * rolagem não acontecer, "o cabeçalho não se mexeu" vira verdade à toa.
+ * rolagem e pintou o quadro seguinte.
+ *
+ * Devolve o alvo E o `scrollTop` real, os dois lidos no MESMO instante. Quem
+ * compara o real contra uma sobra medida antes do laço mede outra coisa: a
+ * sobra pode mudar entre as duas leituras (uma linha que requebra quando a
+ * fonte assenta muda o `scrollHeight`), e aí a asserção reprova por uma
+ * diferença que não é de rolagem nenhuma. Foi o que derrubou este teste no CI,
+ * com 1,5 e 2,5px, enquanto localmente a sobra ficava estável.
+ *
+ * O real continua sendo o que importa: se a rolagem não acontecer, "o cabeçalho
+ * não se mexeu" vira verdade à toa.
  */
-async function rolarMiolo(miolo: Locator, fracao: number): Promise<number> {
+async function rolarMiolo(miolo: Locator, fracao: number): Promise<{ alvo: number; real: number }> {
   return miolo.evaluate(
     (el, f) =>
-      new Promise<number>((resolve) => {
-        el.scrollTop = (el.scrollHeight - el.clientHeight) * f;
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve(el.scrollTop)));
+      new Promise<{ alvo: number; real: number }>((resolve) => {
+        const alvo = (el.scrollHeight - el.clientHeight) * f;
+        el.scrollTop = alvo;
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => resolve({ alvo, real: el.scrollTop }))
+        );
       }),
     fracao
   );
@@ -119,8 +131,13 @@ test("sweep expandido: cabeçalho e rodapé não se mexem quando o miolo rola at
   // "Está parado agora" não é "continua parado": amostra ao longo da rolagem.
   const desvios: number[] = [];
   for (const destino of [0.25, 0.5, 0.75, 1]) {
-    const real = await rolarMiolo(miolo, destino);
-    expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
+    const { alvo, real } = await rolarMiolo(miolo, destino);
+    // Alvo e real do mesmo instante: a tolerância de 1px é para o arredondamento
+    // sub-pixel do `scrollTop`, não para a sobra ter mudado no meio do caminho.
+    expect(Math.abs(real - alvo)).toBeLessThanOrEqual(1);
+    // E a rolagem aconteceu de verdade: sem isto, "o cabeçalho não se mexeu"
+    // seria verdade à toa num miolo parado no topo.
+    expect(real).toBeGreaterThan(sobra * destino * 0.5);
     desvios.push(
       Math.abs((await cabeca.boundingBox())!.y - antes.cabeca),
       Math.abs((await rodape.boundingBox())!.y - antes.rodape),

--- a/tests/viz-pilhas.spec.ts
+++ b/tests/viz-pilhas.spec.ts
@@ -1,0 +1,639 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa dos visualizadores de pilhas.
+//
+// A página tem três peças com overlay, nesta ordem:
+//   0 · StackVisualizer            — parênteses balanceados, as três camadas
+//   1 · StackCallStackVisualizer   — a mesma potência com duas pilhas, idem
+//   2 · StackMonotonicaVisualizer  — o próximo maior elemento, idem
+//
+// O `StackImplementacoes` não entra: é a tabela de custos, estática de
+// propósito (sem "use client"), sai como `<figure class="pl-tab">` no build, sem
+// overlay e sem controles — não há painel para arrumar.
+//
+// Todo teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada, e comportamento certo debaixo do rótulo errado ensina errado do mesmo
+// jeito. Nas três peças o rótulo mais frágil é o da torre — `topo · pos 2`,
+// `topo · índice 3` —, porque ele é texto de tela COLADO numa interpolação, que
+// é justamente o buraco aberto do `guarda-idioma.py` (contrato §0): um rename
+// cego o estragaria sem nenhum aviso. Por isso ele é lido junto com o valor.
+
+const URL = "/topico/pilhas/";
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+/** Congela a animação e espera as fontes: medir antes disso mede o fallback. */
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Orçamento de altura do fluxo do artigo: janela menos cabeçalho e respiro. */
+function orcamento(page: Page) {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+        60) -
+      24
+  );
+}
+
+/** Abre o painel expandido da peça `i` e devolve o `<figure>` do painel. */
+async function expandir(page: Page, i: number, antes?: (peca: Locator) => Promise<void>) {
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(i);
+  if (antes) await antes(peca);
+  await peca.getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+/**
+ * Altura que parou de mudar. O `data-anim` do hook congela a transição da
+ * MEDIÇÃO dele, e não a do clique do aluno: ler no meio dos 0,32s devolve o
+ * layout a caminho e conclui "cabe" para uma peça que não cabe.
+ */
+async function alturaEstavel(alvo: Locator) {
+  let anterior = -1;
+  for (let k = 0; k < 40; k++) {
+    const h = await alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    if (h === anterior) return h;
+    anterior = h;
+    await alvo.page().waitForTimeout(60);
+  }
+  return anterior;
+}
+
+/**
+ * Rola o MIOLO até o fim e diz quanto o cabeçalho e o rodapé se mexeram.
+ *
+ * Devolve também a sobra da FIGURA: sem isso o teste aprova justamente a quebra
+ * que a camada 1 conserta. Se a rolagem voltar para a figura inteira, o
+ * `.viz-body` não tem o que rolar, `scrollTop` fica em zero, o cabeçalho não se
+ * mexe em relação à figura — e um teste que só olhasse `headMoveu` passaria.
+ */
+async function rolarAteOFim(painel: Locator) {
+  return painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const foot = f.querySelector<HTMLElement>(".viz-foot")!;
+    const headAntes = Math.round(head.getBoundingClientRect().top);
+    const footAntes = Math.round(foot.getBoundingClientRect().top);
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return {
+      sobra,
+      rolou: Math.round(body.scrollTop),
+      sobraFigura: f.scrollHeight - f.clientHeight,
+      headMoveu: Math.round(head.getBoundingClientRect().top) - headAntes,
+      footMoveu: Math.round(foot.getBoundingClientRect().top) - footAntes,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 0 · StackVisualizer — parênteses balanceados
+// ---------------------------------------------------------------------------
+
+test("no expandido dos parênteses, o ▶ Rodar fica parado enquanto o miolo rola", async ({
+  page,
+}) => {
+  // 1440x600, com a pilha no fundo: medido, o miolo sobra 289px. Antes da casca
+  // a FIGURA inteira rolava (807px de sobra no pior caso), o cabeçalho subia
+  // 806px e o ▶ Rodar era desenhado com a base em 1348px numa janela de 600 —
+  // o aluno perdia de vista justamente o botão que faz o algoritmo andar.
+  //
+  // A altura desta peça vem da TORRE, e a torre só existe depois que o
+  // algoritmo empilha: no passo 1 ela está vazia e o miolo não sobra 1px. Medir
+  // (ou testar) o passo inicial de um gerador de passos é medir o estado mais
+  // BAIXO — por isso o teste anda até o fundo da pilha antes de rolar.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 0, async (peca) => {
+    await peca.locator("input.viz-input").first().fill("((((((((()))))))))");
+  });
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  for (let k = 0; k < 9; k++) await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 10 de 20");
+  await expect(painel.locator(".pl-torre .pl-item")).toHaveCount(9);
+
+  const r = await rolarAteOFim(painel);
+  // Sem sobra o teste não testaria nada, e sem provar que é o MIOLO que rola
+  // ele aprovaria a quebra que devolve a rolagem para a figura.
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.sobraFigura).toBeLessThanOrEqual(8);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // E os dois continuam LEGÍVEIS, com o rótulo deles, depois de rolar até o fim.
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · a pilha em ação: parênteses balanceados")
+  ).toBeInViewport();
+});
+
+test("em 1512x900 o código dos parênteses vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const codigo = peca.locator(".viz-code");
+
+  // O rótulo diz o que o botão FAZ, e o bloco está mesmo sem altura (2px de
+  // borda). Rótulo sem medida, ou medida sem rótulo, deixaria passar o caso em
+  // que o botão promete uma coisa e a peça faz outra.
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // A premissa medida, dentro do teste: com o código à mostra a peça pede 898px
+  // contra 816px de orçamento. Sem isto o teste ficaria verde no dia em que a
+  // peça encolhesse e o recolhimento deixasse de ter motivo.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em janela alta o código dos parênteses já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra a peça pede 898px. Em 1100px de janela o
+  // orçamento é 1016px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1100 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  // E o código é o DESTE visualizador, não um bloco qualquer.
+  await expect(peca.locator(".viz-code-head")).toHaveText("solucao.py");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+});
+
+test("a escolha de mostrar o código dos parênteses sobrevive à troca de preset", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // `expr.length` é o `measureOn` desta peça. O preset "Cruzado" leva de 6 para
+  // 4 caracteres, então ele pede medição nova de verdade — e a troca aparece NA
+  // TELA, senão o teste "sobrevive" a uma medição que nunca foi pedida.
+  await expect(peca.locator(".viz-cells .viz-cell-wrap")).toHaveCount(6);
+  await peca.getByRole("button", { name: "Cruzado: ([)]" }).click();
+  await expect(peca.locator(".viz-cells .viz-cell-wrap")).toHaveCount(4);
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 4");
+
+  // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
+  // A amostragem vem ANTES da premissa de propósito: com a escolha do aluno
+  // desligada a peça recolhe e encolhe, e aí a premissa vira falsa antes de a
+  // asserção que carrega o sentido rodar — o teste reprovaria pela linha errada.
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  // Premissa medida: neste estado, com o código à mostra, a peça estoura o
+  // orçamento — ou seja, uma medição sem a escolha do aluno recolheria.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("a torre dos parênteses lê caractere e posição no mesmo item", async ({ page }) => {
+  // `topo · pos 2` é texto de tela colado numa interpolação
+  // (`{k === 0 ? "topo · " : ""}pos {it.i}`), que o guarda de idioma não vê. E o
+  // conjunto de textos sozinho também não bastaria: o guarda compara o CONJUNTO,
+  // não onde cada um aparece. Aqui caractere, marca e posição são lidos juntos.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  const proximo = peca.getByRole("button", { name: "Próximo ›" });
+
+  // Passo 4 do preset padrão `{[()]}`: as três aberturas empilhadas.
+  await proximo.click();
+  await proximo.click();
+  await proximo.click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 4 de 8");
+
+  const itens = peca.locator(".pl-torre .pl-item");
+  await expect(itens).toHaveCount(3);
+  // Do topo para a base: '(' na 2, '[' na 1, '{' na 0 — a ordem É a aula.
+  await expect(itens.nth(0)).toHaveText("(topo · pos 2");
+  await expect(itens.nth(1)).toHaveText("[pos 1");
+  await expect(itens.nth(2)).toHaveText("{pos 0");
+  await expect(itens.nth(0)).toHaveClass(/topo/);
+
+  // E o painel de variáveis conta a mesma história, com o nome ao lado do valor.
+  const variavel = (nome: string) =>
+    peca.locator(".viz-var").filter({ hasText: nome }).locator(".viz-var-val");
+  await expect(variavel("len(pilha)")).toHaveText("3");
+  await expect(variavel("pilha[-1]")).toHaveText("'('");
+});
+
+test("no expandido dos parênteses, seta e espaço andam a animação e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 0);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 8");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 8");
+  // O rótulo e o número contam a mesma coisa: o passo 2 empilha o '{'.
+  await expect(painel.locator(".viz-note").first()).toContainText("'{' é abertura");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 8");
+
+  // Espaço roda e pausa, e o rótulo do botão diz em qual dos dois estados está.
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Com o cursor num campo, espaço é espaço e seta é cursor. Sequestrar isso
+  // deixaria a expressão impossível de editar, que é pior que não ter atalho.
+  // Afirmo DEPOIS DE CADA TECLA: duas setas opostas se cancelam e um teste que
+  // só olhasse o fim aprovaria a quebra.
+  const campo = painel.locator("input.viz-input").first();
+  await campo.fill("([])");
+  await expect(passo).toHaveText("passo 1 de 6");
+
+  // O campo filtra tudo que não é ( ) [ ] { }, então o espaço não fica no valor:
+  // o que prova que a tecla não foi sequestrada é a animação NÃO ter andado.
+  await campo.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+  await expect(passo).toHaveText("passo 1 de 6");
+  await expect(campo).toHaveValue("([])");
+
+  // `fill` deixa o cursor no fim sem depender de `End`, que no macOS não leva o
+  // cursor ao fim de um input. Comparo o cursor com ele mesmo.
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(passo).toHaveText("passo 1 de 6");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 1 · StackCallStackVisualizer — a mesma potência com duas pilhas
+// ---------------------------------------------------------------------------
+
+test("no expandido da call stack, o cabeçalho fica parado enquanto o miolo rola", async ({
+  page,
+}) => {
+  // 1440x600 com o expoente no máximo e a recursão no fundo: medido, o miolo
+  // sobra 296px. Antes da casca a figura inteira rolava (497px), o cabeçalho
+  // subia 496px e o ▶ Rodar era desenhado com a base em 1038px numa janela de
+  // 600. Como nos parênteses, a torre de frames só existe depois que a recursão
+  // desce: no passo 1 há um frame só e o miolo não sobra nada.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 1, async (peca) => {
+    await peca.locator("input.viz-input.k").nth(1).fill("8");
+  });
+  await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 24");
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  for (let k = 0; k < 14; k++) await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 15 de 24");
+  await expect(painel.locator(".pl-torre .pl-item")).toHaveCount(8);
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.sobraFigura).toBeLessThanOrEqual(8);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · a mesma potência com duas pilhas")
+  ).toBeInViewport();
+
+  // O contador vive no cabeçalho e o botão no rodapé: se qualquer um dos dois
+  // tivesse ido junto com a rolagem, este passo a passo seria impossível de
+  // acompanhar. Clico no botão que ficou à vista e leio o contador que ficou.
+  await expect(proximo).toBeInViewport();
+  await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 16 de 24");
+});
+
+test("em 1440x700 o código da call stack vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 700 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+  const codigo = peca.locator(".viz-code");
+
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // Premissa medida: com o código à mostra a peça pede 759px contra 616px de
+  // orçamento nesta janela.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(100);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em 1512x900 o código da call stack já vem aberto, e é o do modo escolhido", async ({
+  page,
+}) => {
+  // Medido: com o código à mostra a recursão pede 759px contra 816 de orçamento,
+  // então não há motivo para esconder nada. A pilha explícita, no MESMO tamanho
+  // de janela, recolhe: o código dela tem 8 linhas em vez de 4, e a peça aberta
+  // passa do orçamento. Cada modo é medido por si.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca.locator(".viz-code-head")).toHaveText("recursivo.py");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+
+  await peca.getByRole("button", { name: "Pilha explícita" }).click();
+  await expect(peca.locator(".viz-code-head")).toHaveText("com_pilha.py");
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  // E o título da coluna acompanha o modo: rótulo que não muda junto mente.
+  await expect(peca.locator(".pl-lbl").nth(1)).toHaveText("Pilha (topo em cima)");
+});
+
+test("a escolha de mostrar o código da call stack sobrevive à troca de expoente", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1440, height: 700 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // `n` é o `measureOn` desta peça, e a troca aparece na tela: a linha do tempo
+  // vai de 9 para 15 passos e a ficha do expoente acompanha.
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 9");
+  await peca.locator("input.viz-input.k").nth(1).fill("5");
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 15");
+  await expect(
+    peca.locator(".bigo-stat").filter({ hasText: "expoente (n)" }).locator("strong")
+  ).toHaveText("5");
+
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("na call stack o ↺ do rodapé volta só o passo, e o Voltar ao 2³ volta a conta", async ({
+  page,
+}) => {
+  // O `↺` do `VizFooter` é `viz.reset()`: volta ao passo 0 e NÃO desfaz o que o
+  // aluno montou. O rótulo dele promete uma coisa só, e é a que ele faz — quem
+  // devolve base e expoente é o botão que diz isso no rótulo.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+  const expoente = peca.locator("input.viz-input.k").nth(1);
+
+  await expoente.fill("5");
+  await peca.getByRole("button", { name: "Próximo ›" }).click();
+  await peca.getByRole("button", { name: "Próximo ›" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 3 de 15");
+
+  await peca.getByRole("button", { name: "↺", exact: true }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 15");
+  await expect(expoente).toHaveValue("5");
+
+  await peca.getByRole("button", { name: "↺ Voltar ao 2³" }).click();
+  await expect(expoente).toHaveValue("3");
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 9");
+});
+
+test("no expandido da call stack, seta e espaço andam a animação e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 1);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 9");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 9");
+  // O passo 2 é o frame que fica parado esperando o de baixo devolver.
+  await expect(painel.locator(".viz-note").first()).toContainText("n = 3 não é 1");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 9");
+
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Com o cursor no campo do expoente, seta e espaço são do campo. Afirmo
+  // depois de cada tecla, porque duas setas opostas se cancelariam no fim.
+  const expoente = painel.locator("input.viz-input.k").nth(1);
+  await expoente.click();
+  await expoente.press("Space");
+  await expect(passo).toHaveText("passo 1 de 9");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+  await expoente.press("ArrowRight");
+  await expect(passo).toHaveText("passo 1 de 9");
+  await expoente.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 9");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+// ---------------------------------------------------------------------------
+// 2 · StackMonotonicaVisualizer — o próximo maior elemento
+// ---------------------------------------------------------------------------
+
+test("no expandido da monotônica, o ▶ Rodar fica parado enquanto o miolo rola", async ({
+  page,
+}) => {
+  // 1440x600: medido, o miolo sobra 144px. Antes da casca a figura inteira
+  // rolava (475px), o cabeçalho subia 474px e o ▶ Rodar era desenhado com a base
+  // em 1016px numa janela de 600 — 416px abaixo do pé visível.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 2);
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.sobraFigura).toBeLessThanOrEqual(8);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · pilha monotônica: o próximo maior elemento")
+  ).toBeInViewport();
+});
+
+test("em 1512x900 o código da monotônica vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+  const codigo = peca.locator(".viz-code");
+
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // Premissa medida: com o código à mostra a peça pede 1038px contra 816px.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em janela alta o código da monotônica já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra a peça pede 1038px. Em 1300px de janela o
+  // orçamento é 1216px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1300 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  await expect(peca.locator(".viz-code-head")).toHaveText("monotonica.py");
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+});
+
+test("a escolha de mostrar o código da monotônica sobrevive à troca de preset", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // `nums.length` é o `measureOn` desta peça: o preset do GeeksforGeeks leva de
+  // 8 para 5 valores, então pede medição nova. As duas fitas (entrada e resposta)
+  // caem de 16 para 10 células, e é isso que prova a troca NA TELA.
+  await expect(peca.locator(".viz-cells .viz-cell-wrap")).toHaveCount(16);
+  await peca.getByRole("button", { name: "Do GeeksforGeeks: 6 8 0 1 3" }).click();
+  await expect(peca.locator(".viz-cells .viz-cell-wrap")).toHaveCount(10);
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 19");
+
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("os cartões da monotônica leem rótulo e valor juntos, no mesmo cartão", async ({ page }) => {
+  // O guarda de idioma compara o CONJUNTO de textos de tela, não onde cada um
+  // aparece: trocar dois campos de lugar num rename mantém o conjunto idêntico e
+  // passa verde com a tela mentindo. Quem pega isso é ler rótulo e valor juntos
+  // — e aqui os dois contadores lado a lado SÃO a aula desta peça: a pilha faz
+  // menos comparações que a força bruta faria no mesmo array.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+  const cartao = (rotulo: string) =>
+    peca.locator(".bigo-stat").filter({ hasText: rotulo }).locator("strong");
+
+  // Preset decrescente: a pilha nunca desempilha, e a força bruta varre tudo.
+  await peca.getByRole("button", { name: "Pior caso da força bruta" }).click();
+  await expect(cartao("tamanho (n)")).toHaveText("8");
+  await expect(cartao("força bruta faria")).toHaveText("28");
+
+  // Ando até o fim e leio os três contadores da pilha juntos: 8 push, 0 pop,
+  // 7 comparações — bem menos que as 28 da força bruta, que é o ponto.
+  const proximo = peca.getByRole("button", { name: "Próximo ›" });
+  for (let k = 0; k < 40; k++) {
+    if (await proximo.isDisabled()) break;
+    await proximo.click();
+  }
+  await expect(peca.locator(".viz-step")).toHaveText("passo 26 de 26");
+  await expect(cartao("empilhados (push)")).toHaveText("8");
+  await expect(cartao("desempilhados (pop)")).toHaveText("0");
+  await expect(cartao("comparações até aqui")).toHaveText("7");
+  await expect(cartao("força bruta faria")).toHaveText("28");
+
+  // E a torre lê valor e índice no mesmo item — o rótulo colado na interpolação.
+  await peca.getByRole("button", { name: "Temperaturas (LeetCode 739)" }).click();
+  await proximo.click();
+  await proximo.click();
+  await proximo.click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 4 de 29");
+  const itens = peca.locator(".pl-torre .pl-item");
+  await expect(itens).toHaveCount(1);
+  await expect(itens.nth(0)).toHaveText("73topo · índice 0");
+});
+
+test("no expandido da monotônica, seta e espaço andam a animação e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 2);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 29");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 29");
+  await expect(painel.locator(".viz-note").first()).toContainText("A pilha começa vazia");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 29");
+
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  const campo = painel.locator("input.viz-input").first();
+  await campo.fill("5, 4, 3");
+  await expect(passo).toHaveText("passo 1 de 11");
+
+  await campo.press("Space");
+  await expect(campo).toHaveValue("5, 4, 3 ");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+  await expect(passo).toHaveText("passo 1 de 11");
+
+  const antes = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  await campo.press("ArrowLeft");
+  const depois = await campo.evaluate((el: HTMLInputElement) => el.selectionStart ?? -1);
+  expect(depois).toBe(antes - 1);
+  await expect(passo).toHaveText("passo 1 de 11");
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});

--- a/tests/viz-recursao-funcional.spec.ts
+++ b/tests/viz-recursao-funcional.spec.ts
@@ -1,0 +1,474 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa dos três visualizadores de recursão de cauda.
+//
+// A página tem três peças, nesta ordem:
+//   0 · TailRecursionForma       — o classificador dos 7 casos. `collapsible:
+//                                  false`: o bloco de código É o conteúdo que
+//                                  se classifica, não um respiro dispensável
+//   1 · TailRecursionVisualizer  — a mesma soma nas duas formas, lado a lado
+//   2 · TailRecursionTrampolim   — o trampolim, com a régua de hipótese
+//
+// O defeito que estes testes protegem não era só altura: no painel expandido a
+// FIGURA inteira rolava e levava o cabeçalho junto. Medido em 1512x900, antes:
+// a figura rolava 278px (comparador) e 468px (trampolim), o cabeçalho subia o
+// mesmo tanto, e o `▶ Rodar` era desenhado com a base em 1.119px e 1.309px
+// numa janela de 900 — 219 e 409px abaixo do pé visível.
+//
+// Todo teste aqui mede COMPORTAMENTO e lê RÓTULO. Contar elemento não prova
+// nada, e comportamento certo debaixo do rótulo errado ensina errado igual.
+
+const URL = "/topico/recursao-funcional/";
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+/** Congela a animação e espera as fontes: medir antes disso mede o fallback. */
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Abre o painel expandido da peça `i` SEM recarregar: o estado montado fica. */
+async function expandirAqui(page: Page, i: number) {
+  await page.locator("article figure.viz").nth(i).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+/** Abre a página e o painel expandido da peça `i`. */
+async function expandir(page: Page, i: number) {
+  await page.goto(URL);
+  await preparar(page);
+  return expandirAqui(page, i);
+}
+
+/** Orçamento de altura do fluxo do artigo: janela menos cabeçalho e respiro. */
+function orcamento(page: Page) {
+  return page.evaluate(
+    () =>
+      window.innerHeight -
+      (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+        60) -
+      24
+  );
+}
+
+/**
+ * Altura que parou de mudar. O `data-anim` do hook congela a transição da
+ * MEDIÇÃO dele, e não a do clique do aluno: ler no meio dos 0,32s devolve o
+ * layout a caminho e conclui "cabe" para uma peça que não cabe.
+ */
+async function alturaEstavel(alvo: Locator) {
+  let anterior = -1;
+  for (let k = 0; k < 40; k++) {
+    const h = await alvo.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    if (h === anterior) return h;
+    anterior = h;
+    await alvo.page().waitForTimeout(60);
+  }
+  return anterior;
+}
+
+/**
+ * Rola o miolo até o fim e diz quanto o cabeçalho e o rodapé se mexeram, e se
+ * quem rolou foi mesmo o miolo. As três coisas juntas são o teste: com a
+ * rolagem devolvida à figura — que é exatamente o bug que a camada 1 conserta —
+ * `sobra` e `rolou` ficam em zero, o cabeçalho não se mexe, e um teste que só
+ * olhasse `headMoveu` aprovaria a quebra.
+ */
+async function rolarAteOFim(painel: Locator) {
+  return painel.evaluate(async (f) => {
+    const body = f.querySelector<HTMLElement>(".viz-body")!;
+    const head = f.querySelector<HTMLElement>(".viz-head")!;
+    const foot = f.querySelector<HTMLElement>(".viz-foot")!;
+    const headAntes = Math.round(head.getBoundingClientRect().top);
+    const footAntes = Math.round(foot.getBoundingClientRect().top);
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    f.scrollTop = f.scrollHeight;
+    await new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    return {
+      sobra,
+      rolou: Math.round(body.scrollTop),
+      figuraRolou: Math.round(f.scrollTop),
+      headMoveu: Math.round(head.getBoundingClientRect().top) - headAntes,
+      footMoveu: Math.round(foot.getBoundingClientRect().top) - footAntes,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 0 · TailRecursionForma — o classificador
+// ---------------------------------------------------------------------------
+
+test("no expandido do classificador, o veredito fica parado enquanto o miolo rola", async ({
+  page,
+}) => {
+  // 1440x600 com o caso mais alto (busca em BST, 6 linhas de código): medido,
+  // o miolo sobra 85px. Antes da casca a figura inteira rolava 94px, o
+  // cabeçalho subia o mesmo e o "▶ Rodar os 7 casos" era desenhado com a base
+  // em 635px numa janela de 600.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  await peca.getByRole("button", { name: "busca em BST" }).click();
+  // A entrada mudou mesmo: sem esta asserção o teste mediria o caso padrão.
+  await expect(peca.locator(".viz-step")).toHaveText("passo 6 de 7");
+  await expect(peca.locator(".tr-lang")).toHaveText("bst.py");
+
+  const painel = await expandirAqui(page, 0);
+  const r = await rolarAteOFim(painel);
+  // Sem sobra o teste não testaria nada: ele precisa de miolo para rolar.
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  // E quem rola tem que ser o miolo, não a figura.
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // Os controles seguem à vista, e sob o rótulo deles.
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(painel.locator(".viz-step")).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · esta chamada está em posição de cauda?")
+  ).toBeInViewport();
+});
+
+test("o classificador não promete esconder o código, porque o código é o conteúdo", async ({
+  page,
+}) => {
+  // A janela mais apertada das três réguas: é aqui que uma peça `collapsible`
+  // teria recolhido o bloco. Medido: mesmo recolhido o classificador pediria
+  // 533px de um orçamento de 516, então recolher esconderia o conteúdo E não
+  // resolveria nada.
+  await page.setViewportSize({ width: 1440, height: 600 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+
+  // Nenhum botão promete esconder um bloco: rótulo que mente ensina errado.
+  await expect(peca.getByRole("button", { name: /código/ })).toHaveCount(0);
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // E o código está mesmo na tela, com o rótulo que o explica.
+  await expect(peca.locator(".tr-code-head")).toHaveText(
+    "a linha destacada é a última instrução executada"
+  );
+  expect(await alturaEstavel(peca.locator(".tr-code"))).toBeGreaterThan(100);
+
+  // O modo treino é a prova de que o bloco não é dispensável: a própria nota
+  // manda ler o código. Com ele recolhido, a instrução apontaria para o nada.
+  await peca.getByRole("button", { name: "Modo treino: esconder o veredito" }).click();
+  await expect(peca.locator(".viz-note")).toContainText("Leia o código acima e responda");
+  await expect(peca.locator(".tr-selo")).toHaveText("? decida antes de revelar");
+  expect(await alturaEstavel(peca.locator(".tr-code"))).toBeGreaterThan(100);
+  await expect(peca.locator(".viz-line").first()).toContainText("def soma(nums):");
+});
+
+test("no expandido, seta e espaço andam os 7 casos e o veredito volta a se esconder", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0);
+  await peca.getByRole("button", { name: "Modo treino: esconder o veredito" }).click();
+  const painel = await expandirAqui(page, 0);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 7");
+  await expect(painel.locator(".tr-selo")).toHaveText("? decida antes de revelar");
+
+  // Revelo o caso 1: o veredito aparece com o rótulo certo.
+  await painel.getByRole("button", { name: "Revelar veredito" }).click();
+  await expect(painel.locator(".tr-selo").first()).toHaveText("✗ não está em posição de cauda");
+
+  // A seta anda o caso — e o veredito do caso NOVO tem que voltar a se
+  // esconder, senão o exercício entrega a resposta antes da pergunta.
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 7");
+  await expect(painel.locator(".tr-lang")).toHaveText("soma_cauda.py");
+  await expect(painel.locator(".tr-selo")).toHaveText("? decida antes de revelar");
+
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 7");
+
+  // Espaço roda e pausa, e o rótulo do botão diz em qual dos dois está.
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Campo em edição manda: com o slider de velocidade em foco, a seta é dele.
+  await painel.locator('.viz-speed input[type="range"]').focus();
+  const antes = await passo.innerText();
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(antes);
+});
+
+// ---------------------------------------------------------------------------
+// 1 · TailRecursionVisualizer — a mesma soma nas duas formas
+// ---------------------------------------------------------------------------
+
+test("no expandido do comparador, o Próximo › anda o passo depois da rolagem", async ({ page }) => {
+  await page.setViewportSize({ width: 1440, height: 600 });
+  const painel = await expandir(page, 1);
+
+  await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 9");
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  // O contador vive no cabeçalho e o botão no rodapé: se qualquer um dos dois
+  // tivesse ido junto com a rolagem, este passo a passo seria impossível de
+  // acompanhar. Clico no botão que ficou à vista e leio o contador que ficou.
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeInViewport();
+  await proximo.click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 9");
+  // O contador e a pilha contam a mesma coisa, e o painel de variáveis também.
+  await expect(painel.locator(".tr-painel").first().locator(".viz-note")).toContainText(
+    "2 frames na pilha, parados, esperando uma resposta que ainda não existe."
+  );
+  await expect(
+    painel.locator(".viz-var").filter({ hasText: "frames · comum" })
+  ).toContainText("2");
+});
+
+test("em 1512x900 o código do comparador vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(0 + 1);
+  const codigo = peca.locator(".viz-code");
+
+  // O rótulo diz o que o botão FAZ, e o bloco está mesmo sem altura (2px de
+  // borda). Rótulo sem medida, ou medida sem rótulo, deixaria passar o caso em
+  // que o botão promete uma coisa e a peça faz outra.
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  // A premissa medida, dentro do teste: com o código à mostra a peça NÃO cabe
+  // no orçamento da janela (1.139px contra 816). Sem isto o teste ficaria verde
+  // no dia em que o recolhimento fosse decidido por engano.
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.locator(".viz-code-head")).toHaveText("soma.py");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("em janela alta o código do comparador já vem aberto", async ({ page }) => {
+  // Medido: com o código à mostra a peça pede 1.139px. Em 1400px de janela o
+  // orçamento é 1.316px, então a medição não tem motivo para esconder nada.
+  await page.setViewportSize({ width: 1512, height: 1400 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  expect(await alturaEstavel(peca.locator(".viz-code"))).toBeGreaterThan(150);
+  // E o código é o deste visualizador, não um bloco qualquer: as duas somas.
+  await expect(peca.locator(".viz-code-head")).toHaveText("soma.py");
+  await expect(peca.locator(".viz-line").first()).toContainText(
+    "def soma(nums):                       # comum"
+  );
+  expect(await alturaEstavel(peca)).toBeLessThanOrEqual(await orcamento(page));
+});
+
+test("a escolha de mostrar o código do comparador sobrevive a desligar o TCO", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // Desligar o TCO está no `measureOn` e muda a peça de verdade: o lado direito
+  // passa a empilhar igual ao esquerdo. A medição roda de novo aqui.
+  await peca.getByRole("button", { name: "Python, Java, C# (sem TCO)" }).click();
+  await expect(peca.locator(".bigo-stat").filter({ hasText: "espaço extra · de cauda" })).toContainText(
+    "O(n)"
+  );
+  await expect(peca.locator(".bigo-stat").filter({ hasText: "pico de frames · de cauda" })).toContainText(
+    "5"
+  );
+
+  // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
+  // Esta é a asserção que carrega o sentido do teste, e por isso vem ANTES da
+  // premissa: com a escolha do aluno desfeita, é ela que tem de reprovar.
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  // Premissa medida: neste estado, com o código à mostra, a peça estoura o
+  // orçamento — ou seja, uma medição sem a escolha do aluno recolheria.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("no expandido, seta e espaço andam o comparador e não roubam a tecla de quem digita", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 1);
+  const passo = painel.locator(".viz-step");
+
+  await expect(passo).toHaveText("passo 1 de 9");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 2 de 9");
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText("passo 1 de 9");
+
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+  // Campo em edição manda: com o cursor na lista, seta é cursor e espaço é
+  // espaço. Sequestrar isso deixaria a lista impossível de editar.
+  //
+  // Uma seta SÓ, e nunca o par ida-e-volta: `ArrowRight` seguido de
+  // `ArrowLeft` devolve a peça ao passo de origem, e aí a asserção fica verde
+  // exatamente igual com a tecla roubada. Medido, com a quebra aplicada.
+  const campo = painel.locator("input.viz-input");
+  await campo.click();
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 1 de 9");
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText("passo 1 de 9");
+
+  // Espaço é espaço: entra no campo em vez de rodar a animação.
+  await campo.fill("5, 6");
+  await campo.press("End");
+  await campo.press("Space");
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+  await expect(campo).toHaveValue("5, 6 ");
+
+  // E o campo continua editável: digitar muda a lista e a peça acompanha.
+  await expect(passo).toHaveText("passo 1 de 5");
+  await expect(painel.locator(".bigo-stat").filter({ hasText: "pico de frames · comum" })).toContainText(
+    "3"
+  );
+});
+
+test("com a lista vazia o comparador perde a linha do tempo, e o que fica tem rótulo", async ({
+  page,
+}) => {
+  // `total` derivado da entrada atravessa 1: o gerador devolve um passo só. O
+  // contrato manda o rodapé de reprodução sumir inteiro — e é por isso que
+  // `total` está no `measureOn`, senão a travessia não pediria medição nova.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(1);
+
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 9");
+  await peca.getByRole("button", { name: "Lista vazia" }).click();
+
+  await expect(peca.locator(".viz-step")).toHaveCount(0);
+  await expect(peca.locator(".viz-foot")).toHaveCount(0);
+  await expect(peca.getByRole("button", { name: "▶ Rodar" })).toHaveCount(0);
+
+  // O que fica continua dizendo o que é — e é o número que o artigo promete
+  // para este preset: 1 frame de pico dos dois lados.
+  await expect(peca.locator(".bigo-stat").filter({ hasText: "pico de frames · comum" })).toContainText(
+    "1"
+  );
+  await expect(peca.locator(".bigo-stat").filter({ hasText: "pico de frames · de cauda" })).toContainText(
+    "1"
+  );
+  // E o preset segue no miolo, que é como se volta de lá.
+  await expect(peca.getByRole("button", { name: "Sete números" })).toBeVisible();
+});
+
+// ---------------------------------------------------------------------------
+// 2 · TailRecursionTrampolim — o trampolim
+// ---------------------------------------------------------------------------
+
+test("no expandido do trampolim, o ▶ Rodar fica parado enquanto o miolo rola", async ({ page }) => {
+  // 1512x900: medido, o miolo sobra 100px. Antes da casca a figura inteira
+  // rolava 468px, o cabeçalho subia 468px e o `▶ Rodar` era desenhado com a
+  // base em 1.309px numa janela de 900 — 409px abaixo do pé visível.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  const painel = await expandir(page, 2);
+
+  const r = await rolarAteOFim(painel);
+  expect(r.sobra).toBeGreaterThan(20);
+  expect(r.rolou).toBeGreaterThan(20);
+  expect(r.figuraRolou).toBe(0);
+  expect(r.headMoveu).toBe(0);
+  expect(r.footMoveu).toBe(0);
+
+  await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport();
+  await expect(painel.locator(".viz-step")).toBeInViewport();
+  await expect(
+    painel.getByText("Visualizador · trampolim: recursão de cauda sem ajuda da linguagem")
+  ).toBeInViewport();
+
+  // E ele anda de verdade depois de a rolagem ter acontecido.
+  await painel.getByRole("button", { name: "Próximo ›" }).click();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 11");
+  await expect(painel.locator(".viz-note").first()).toContainText(
+    "A conta acontece agora, na ida: acc 0 + 1 = 1."
+  );
+});
+
+test("em 1512x900 o código do trampolim vem recolhido, sob o rótulo certo", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+  const codigo = peca.locator(".viz-code");
+
+  await expect(peca.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "off");
+  expect(await alturaEstavel(codigo)).toBeLessThanOrEqual(4);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+  await expect(peca.locator(".viz-code-head")).toHaveText("trampolim.py");
+  await expect(peca.locator(".viz-line").first()).toContainText("def soma_passo(nums, acc=0):");
+  expect(await alturaEstavel(codigo)).toBeGreaterThan(150);
+  // Premissa medida: com o código à mostra a peça pede 1.278px de um orçamento
+  // de 816. Recolher não é capricho.
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});
+
+test("a escolha de mostrar o código do trampolim sobrevive à troca da lista", async ({ page }) => {
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto(URL);
+  await preparar(page);
+  const peca = page.locator("article figure.viz").nth(2);
+
+  await peca.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(peca).toHaveAttribute("data-codigo", "on");
+
+  // "Sete números" muda o tamanho da lista, que é o que está no `measureOn`:
+  // a linha do tempo vai de 11 para 17 passos e a medição roda de novo.
+  await peca.getByRole("button", { name: "Sete números" }).click();
+  await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 17");
+  await expect(peca.locator(".viz-cell")).toHaveCount(7);
+
+  for (let k = 0; k < 6; k++) {
+    await expect(peca).toHaveAttribute("data-codigo", "on");
+    await expect(peca.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+    await page.waitForTimeout(120);
+  }
+
+  expect(await alturaEstavel(peca)).toBeGreaterThan(await orcamento(page));
+});

--- a/tests/viz-recursao.spec.ts
+++ b/tests/viz-recursao.spec.ts
@@ -29,6 +29,9 @@ const ALTA = { width: 1512, height: 1600 };
 // medição REALMENTE discordaria de quem abre o código na mão.
 const APERTADA = { width: 1512, height: 700 };
 
+/** Os rótulos das marchas, na ordem do `input[type=range]` (o índice 0 não é usado). */
+const ROTULOS_MARCHA = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
 const VISUALIZADORES = [
   {
     i: 0,
@@ -42,6 +45,11 @@ const VISUALIZADORES = [
     provaRotulo: "caso base",
     provaValor: "n == 0",
     arquivoDepois: "contagem.py",
+    // A marcha em que a peça ABRE e a seguinte. Não é a mesma nas duas: a
+    // pilha usa a marcha padrão do hook e a árvore abre uma acima, porque ela
+    // desenha dezenas de nós. Deixar o valor esperado aqui, por peça, é o que
+    // faz este teste falhar se alguém tirar a marcha própria de uma delas.
+    marchaInicial: "1x",
     // Recolhida, a pilha volta para dentro do orçamento do artigo: 731px
     // contra 816 em 1512x900 (eram 885 com o código à mostra).
     cabeNoOrcamento: true,
@@ -57,6 +65,9 @@ const VISUALIZADORES = [
     provaRotulo: "acertos no cache",
     provaValor: "0",
     arquivoDepois: "fib_memo.py",
+    // Abre no "1.5x" (`initialSpeed: 4`), não no padrão do hook: a árvore tem
+    // dezenas de nós e no 1x a reprodução inteira fica longa demais.
+    marchaInicial: "1.5x",
     // A árvore NÃO cabe no artigo nem recolhida: 1137px contra 816. O que
     // sobra não é bloco dispensável — é o desenho (440px), a tabela de
     // comparação (196px), as fichas (78px) e o respiro do miolo, que a camada 2
@@ -320,12 +331,19 @@ for (const v of VISUALIZADORES) {
       const marcha = painel.locator(".viz-speed .val");
 
       const total = (await passo.textContent())!.match(/de (\d+)/)![1];
-      await expect(marcha).toHaveText("1x");
+      // A marcha de ABERTURA é da peça, não do hook: a árvore abre uma acima.
+      await expect(marcha).toHaveText(v.marchaInicial);
 
+      // O clique no `input[type=range]` reposiciona a marcha pelo ponto
+      // clicado, então o valor de partida da seta é o de DEPOIS do clique —
+      // não o de abertura. Ler aqui é o que torna a asserção sobre a seta
+      // independente da marcha inicial de cada peça.
       await slider.click();
+      const antes = Number(await slider.inputValue());
       await page.keyboard.press("ArrowRight");
 
-      await expect(marcha).toHaveText("1.5x");
+      await expect(slider).toHaveValue(String(antes + 1));
+      await expect(marcha).toHaveText(ROTULOS_MARCHA[antes + 1]);
       await expect(passo).toHaveText(`passo 1 de ${total}`);
     });
   });

--- a/tests/viz-recursao.spec.ts
+++ b/tests/viz-recursao.spec.ts
@@ -1,0 +1,416 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa nos dois visualizadores de Recursão.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura. A régua aqui é sempre um número medido no
+// navegador (altura, posição, deslocamento) ou o texto que o aluno lê.
+//
+// Antes da casca, as duas peças rolavam INTEIRAS dentro do painel expandido, e
+// o que saía da tela era o cabeçalho: medido em 1512x900, ele subia 491px na
+// pilha e 615px na árvore; em 1440x600, 791 e 915px. O `.viz-foot` nem existia,
+// porque os controles moravam dentro do miolo rolável.
+//
+// O terceiro componente do tópico, `RecursionTipos`, fica fora de propósito:
+// é `figure.rec-tipos`, tabela estática sem overlay. Sem botão Expandir não há
+// painel para arrumar.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/recursao/";
+
+// Janela de notebook de 16", que é o caso que motivou a casca. Nela as duas
+// peças passam do orçamento com o código à mostra (885 e 1291px contra 816).
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para as duas caberem com o código aberto (orçamento 1516px).
+const ALTA = { width: 1512, height: 1600 };
+// Apertada de propósito: garante que o miolo do painel tem o que rolar e que a
+// medição REALMENTE discordaria de quem abre o código na mão.
+const APERTADA = { width: 1512, height: 700 };
+
+const VISUALIZADORES = [
+  {
+    i: 0,
+    nome: "pilha de chamadas",
+    arquivo: "fatorial.py",
+    // Um preset que mexe nos TRÊS valores de `measureOn` (modo, n e limite),
+    // não só no alvo da animação.
+    preset: "caso base fora de alcance",
+    // A prova, na tela, de que a entrada da medição mudou mesmo: o painel de
+    // variáveis do modo inalcançável tem uma linha que nenhum outro modo tem.
+    provaRotulo: "caso base",
+    provaValor: "n == 0",
+    arquivoDepois: "contagem.py",
+    // Recolhida, a pilha volta para dentro do orçamento do artigo: 731px
+    // contra 816 em 1512x900 (eram 885 com o código à mostra).
+    cabeNoOrcamento: true,
+    tetoRecolhida: 816,
+  },
+  {
+    i: 1,
+    nome: "árvore do Fibonacci",
+    arquivo: "fib.py",
+    // Ligar o cache troca o código de 4 para 9 linhas e acrescenta uma tarja na
+    // legenda: é a entrada de medição desta peça que mais muda a altura.
+    preset: "fib(6) com cache: 11 chamadas",
+    provaRotulo: "acertos no cache",
+    provaValor: "0",
+    arquivoDepois: "fib_memo.py",
+    // A árvore NÃO cabe no artigo nem recolhida: 1137px contra 816. O que
+    // sobra não é bloco dispensável — é o desenho (440px), a tabela de
+    // comparação (196px), as fichas (78px) e o respiro do miolo, que a camada 2
+    // apertaria se ela alcançasse o fluxo do artigo (contrato §9).
+    cabeNoOrcamento: false,
+    tetoRecolhida: 1200,
+  },
+];
+
+/** A peça no fluxo do artigo. */
+function noArtigo(page: Page, i: number): Locator {
+  return page.locator("article figure.viz").nth(i);
+}
+
+/** A peça depois de expandida: ela é portada para fora do artigo. */
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto(URL);
+  // As fontes chegam com `display: swap`: medir antes é medir o fallback, e a
+  // casca só decide depois delas.
+  await page.evaluate(() => document.fonts.ready);
+  await expect(page.locator("article figure.viz-fit").first()).toBeVisible();
+  // `data-anim` volta para "on" quando a casca terminou de medir e decidir. É o
+  // sinal que ela já publica; esperar por ele custa menos que um sono fixo e
+  // não vira flake com a máquina cheia.
+  await expect(page.locator("article figure.viz-fit").first()).toHaveAttribute("data-anim", "on");
+}
+
+async function expandir(page: Page, i: number): Promise<Locator> {
+  await noArtigo(page, i).getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = noPainel(page);
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+async function altura(loc: Locator): Promise<number> {
+  return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+/** O orçamento do artigo: a janela menos o cabeçalho fixo e um respiro. */
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const h = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+    return window.innerHeight - h - 24;
+  });
+}
+
+/**
+ * Amostra o estado do bloco recolhível N vezes ao longo de `ms` e devolve as
+ * amostras que falharam.
+ *
+ * Quando a promessa é PERMANÊNCIA ("a escolha do aluno sobrevive"), uma espera
+ * fixa seguida de uma leitura olha um instante só. Amostrar responde a pergunta
+ * certa: nenhum instante da janela pode ter falhado.
+ */
+async function amostrarAberto(page: Page, fig: Locator, ms = 900, n = 9): Promise<string[]> {
+  const falhas: string[] = [];
+  for (let k = 0; k < n; k++) {
+    const alturaSlot = await altura(fig.locator(".viz-code-slot"));
+    const rotulo = (await fig.locator("button.viz-toggle-codigo").textContent()) ?? "";
+    if (alturaSlot <= 60 || rotulo !== "Ocultar código") {
+      falhas.push(`aos ${Math.round((k * ms) / n)}ms: slot=${alturaSlot}px, rótulo=${JSON.stringify(rotulo)}`);
+    }
+    await page.waitForTimeout(ms / n);
+  }
+  return falhas;
+}
+
+for (const v of VISUALIZADORES) {
+  test.describe(`recursao · ${v.nome}`, () => {
+    // §8.1: no expandido o cabeçalho e o rodapé ficam parados, e o botão que faz
+    // o algoritmo andar nunca sai da tela.
+    //
+    // As duas primeiras asserções não são cerimônia: um teste que rola o
+    // `.viz-body` sem provar que é ELE quem rola aprova justamente a quebra que
+    // devolve a rolagem para a figura inteira — ali o `scrollTop` do miolo fica
+    // em zero, o cabeçalho não se mexe, e o teste passa feliz.
+    test("expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({ page }) => {
+      await abrir(page, APERTADA);
+      const painel = await expandir(page, v.i);
+
+      const mostrar = painel.locator("button.viz-toggle-codigo");
+      if ((await mostrar.textContent()) === "Mostrar código") await mostrar.click();
+      await expect(mostrar).toHaveText("Ocultar código");
+
+      const miolo = painel.locator(".viz-body");
+      const cabeca = painel.locator(".viz-head");
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+      // 1. o miolo é o que estoura...
+      await expect
+        .poll(() => miolo.evaluate((el) => el.scrollHeight - el.clientHeight))
+        .toBeGreaterThan(8);
+
+      const topoAntes = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+      // O rótulo importa tanto quanto a posição: um botão no lugar certo
+      // dizendo a coisa errada ensina errado do mesmo jeito.
+      await expect(rodar).toHaveText("▶ Rodar");
+      await expect(rodar).toBeInViewport();
+
+      // 2. ...e é ele que rola, não a figura inteira.
+      await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+      await expect.poll(() => miolo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(8);
+      expect(await painel.evaluate((f) => Math.round(f.scrollTop))).toBe(0);
+
+      // 3. e o cabeçalho não saiu do lugar. (Antes da casca ele subia 691px
+      // nesta mesma janela de 700 de altura.)
+      const topoDepois = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+      expect(Math.abs(topoDepois - topoAntes)).toBeLessThanOrEqual(1);
+      await expect(rodar).toBeInViewport();
+      await expect(rodar).toHaveText("▶ Rodar");
+
+      // E o rodapé está colado no pé da figura, não empurrado para fora dela.
+      const folga = await painel.evaluate((f) => {
+        const foot = f.querySelector(".viz-foot") as HTMLElement;
+        return Math.round(f.getBoundingClientRect().bottom - foot.getBoundingClientRect().bottom);
+      });
+      expect(folga).toBeLessThanOrEqual(2);
+    });
+
+    // §8.2: em tela baixa a peça não cabe com o código à mostra, então ele
+    // recolhe — e o botão passa a dizer o que faria aparecer.
+    test("tela baixa: o botão diz 'Mostrar código' e o bloco está recolhido", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Mostrar código");
+      await expect(botao).toHaveAttribute("aria-expanded", "false");
+      // Recolhido de verdade: o slot perde a ALTURA, não só a largura. Zerar a
+      // trilha da coluna deixava a linha do grid com a altura do código.
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeLessThanOrEqual(4);
+
+      const recolhida = await altura(fig);
+      const orc = await orcamento(page);
+
+      // A premissa medida DENTRO do teste: com o código à mostra a peça não
+      // cabe. Sem ela, no dia em que a peça encolher isto vira decoração verde.
+      await botao.click();
+      await expect(botao).toHaveText("Ocultar código");
+      await expect.poll(() => altura(fig)).toBeGreaterThan(orc);
+      const aberta = await altura(fig);
+      expect(aberta - recolhida).toBeGreaterThan(120);
+
+      if (v.cabeNoOrcamento) {
+        // E recolhida a peça inteira passa a caber, que é o ponto de tudo isto.
+        expect(recolhida).toBeLessThanOrEqual(orc);
+      } else {
+        // A árvore não cabe nem recolhida (1137px contra 816). O teto aqui é
+        // regressão: recolher tem que continuar valendo a pena.
+        expect(recolhida).toBeLessThan(v.tetoRecolhida);
+      }
+    });
+
+    // §8.3: onde cabe, o código já vem à mostra — a medição decide, não um
+    // breakpoint de largura.
+    test("tela alta: o código já vem aberto e o botão diz 'Ocultar código'", async ({ page }) => {
+      await abrir(page, ALTA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Ocultar código");
+      await expect(botao).toHaveAttribute("aria-expanded", "true");
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+      // O bloco é mesmo o código DESTE visualizador, não um bloco qualquer.
+      await expect(fig.locator(".viz-code-head")).toHaveText(v.arquivo);
+    });
+
+    // §8.4: a escolha explícita do aluno vence a medição e não é desfeita por
+    // uma troca de estado que pediria medição nova.
+    test("a escolha do aluno sobrevive a uma troca de estado que pede medição nova", async ({ page }) => {
+      await abrir(page, APERTADA);
+      const fig = noArtigo(page, v.i);
+      const botao = fig.locator("button.viz-toggle-codigo");
+
+      await expect(botao).toHaveText("Mostrar código");
+      await botao.click();
+      await expect(botao).toHaveText("Ocultar código");
+      await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+
+      await fig.getByRole("button", { name: v.preset, exact: true }).click();
+
+      // A entrada da medição mudou MESMO — e a leitura é do rótulo junto com o
+      // valor, no mesmo cartão: comportamento certo com rótulo errado ensina
+      // errado do mesmo jeito.
+      const ficha = fig.locator(".bigo-stat, .viz-var").filter({ hasText: v.provaRotulo });
+      await expect(ficha).toHaveCount(1);
+      await expect(ficha.locator("strong, .viz-var-val")).toHaveText(v.provaValor);
+      // E o código que apareceria é o do estado NOVO, não o do anterior.
+      await expect(fig.locator(".viz-code-head")).toHaveText(v.arquivoDepois);
+
+      // A janela amostrada cobre a medição E a transição de 0,32s que viria
+      // depois dela. Exigir que NENHUMA amostra tenha falhado é o que separa
+      // "está aberto" de "continua aberto".
+      expect(await amostrarAberto(page, fig)).toEqual([]);
+    });
+
+    // §8.5: as teclas dirigem a animação dentro do painel.
+    test("expandido: as setas andam o passo e o espaço roda", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const painel = await expandir(page, v.i);
+      const passo = painel.locator(".viz-step");
+
+      const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+      await expect(passo).toHaveText(`passo 1 de ${total}`);
+
+      // Uma asserção DEPOIS DE CADA TECLA: `→` seguido de `←` se cancelam, e um
+      // teste que só olha o fim aprova a quebra que ignora as duas.
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 2 de ${total}`);
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 3 de ${total}`);
+      await page.keyboard.press("ArrowLeft");
+      await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("❚❚ Pausar");
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("▶ Rodar");
+    });
+
+    // A regra mais importante dos atalhos é o inverso deles: com o cursor num
+    // campo, seta é do campo e espaço é do campo. Sequestrar isso deixa a
+    // entrada impossível de editar, o que é pior que não ter atalho.
+    //
+    // As duas peças daqui têm campo NUMÉRICO, onde `→` move o cursor sem mudar
+    // o valor. Então a régua não é o valor mudar: é o passo NÃO andar e a
+    // animação NÃO começar — que é exatamente o que o contrato promete.
+    test("o campo numérico em edição manda na seta e no espaço", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const painel = await expandir(page, v.i);
+      const campo = painel.locator("input.viz-input.k").first();
+      const passo = painel.locator(".viz-step");
+      const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+      const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+      await campo.click();
+      const valor = await campo.inputValue();
+
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText(`passo 1 de ${total}`);
+      await page.keyboard.press("Space");
+      await expect(rodar).toHaveText("▶ Rodar");
+      await expect(passo).toHaveText(`passo 1 de ${total}`);
+      // O campo continua editável e intacto: a seta foi para o cursor.
+      await expect(campo).toHaveValue(valor);
+    });
+
+    // No slider a seta é do slider — e o rótulo da marcha é como o aluno
+    // confere que ela andou.
+    test("no slider de velocidade a seta é do slider, não do passo", async ({ page }) => {
+      await abrir(page, BAIXA);
+      const painel = await expandir(page, v.i);
+      const slider = painel.locator('input[type="range"]').first();
+      const passo = painel.locator(".viz-step");
+      const marcha = painel.locator(".viz-speed .val");
+
+      const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+      await expect(marcha).toHaveText("1x");
+
+      await slider.click();
+      await page.keyboard.press("ArrowRight");
+
+      await expect(marcha).toHaveText("1.5x");
+      await expect(passo).toHaveText(`passo 1 de ${total}`);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// O que a medição deste tópico contrariou, agora como regressão.
+//
+// A árvore de recursão cresce por fórmula: fib(8) sem cache tem 67 nós e com
+// cache tem 15. A intuição diz que o pior caso de ALTURA é o de 67 nós — e o
+// número disse o contrário. Os nós viram LARGURA (`.rec-arv` mantém o tamanho
+// natural e `.rec-arv-wrap` rola na horizontal); o eixo que vira altura é a
+// PROFUNDIDADE, que é n − 1 e é a MESMA com e sem cache.
+//
+// É esse fato que sustenta `measureOn: [n, withMemo]` — sem ele alguém trocaria
+// por uma contagem de nós e mediria a coisa errada. Antes da casca, a peça com
+// cache era 81px MAIS ALTA (1496 contra 1415), e a diferença inteira era o
+// código de 9 linhas contra 4.
+// ---------------------------------------------------------------------------
+test("recursao · árvore: o cache muda a LARGURA do desenho, não a altura", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const fig = noArtigo(page, 1);
+  const svg = fig.locator("svg.rec-arv");
+  const wrap = fig.locator(".rec-arv-wrap");
+
+  await fig.locator("input.viz-input.k").fill("8");
+  await fig.getByRole("button", { name: "desligada", exact: true }).click();
+  await expect(svg).toHaveAttribute("aria-label", /fib\(8\) sem memoização/);
+
+  const semCache = await svg.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { alt: Math.round(r.height), larg: Math.round(r.width) };
+  });
+  // Sem cache o desenho é mais largo que o container, e quem rola é o wrapper —
+  // não a página. É isso que tira o número de nós do eixo da altura.
+  expect(await wrap.evaluate((el) => el.scrollWidth - el.clientWidth)).toBeGreaterThan(100);
+
+  await fig.getByRole("button", { name: "ligada", exact: true }).click();
+  await expect(svg).toHaveAttribute("aria-label", /fib\(8\) com memoização/);
+  // O rótulo da ficha confirma que é o MESMO estado que a legenda anuncia.
+  await expect(fig.locator(".bigo-stat").filter({ hasText: "acertos no cache" })).toHaveCount(1);
+
+  const comCache = await svg.evaluate((el) => {
+    const r = el.getBoundingClientRect();
+    return { alt: Math.round(r.height), larg: Math.round(r.width) };
+  });
+
+  expect(comCache.alt).toBe(semCache.alt);
+  expect(semCache.larg).toBeGreaterThan(comCache.larg * 2);
+});
+
+// ---------------------------------------------------------------------------
+// O guarda de idioma, agora como teste: identificador em inglês, tela em
+// português (contrato §0). Um `find & replace` de `chamadas` → `calls` traduz o
+// identificador e estraga a aula junto, e o `tsc` não reclama de nada.
+//
+// Os dois arquivos deste tópico têm rótulo colado numa interpolação
+// (`>devolve {f.ret}<`, `{num(...)}×`, a legenda inteira do rodapé da árvore),
+// que é o buraco SILENCIOSO do `scripts/guarda-idioma.py`. Por isso o texto
+// destes casos está aqui, onde o navegador é quem responde.
+// ---------------------------------------------------------------------------
+test("recursao · o Python da tela e os rótulos seguem em português", async ({ page }) => {
+  await abrir(page, ALTA);
+
+  const pilha = noArtigo(page, 0);
+  await expect(pilha.locator(".viz-code-body")).toContainText("def fatorial(n):");
+  await expect(pilha.locator(".viz-code-body")).toContainText("resultado = fatorial(n - 1)");
+  await expect(pilha.locator(".viz-vars")).toContainText("n (frame do topo)");
+  await expect(pilha.locator(".rec-stack-lbl")).toContainText("Call stack · topo em cima");
+  // Rótulo colado numa interpolação: o guarda não vê nenhum destes dois.
+  // O segundo frame só existe depois que a primeira chamada desce, então o
+  // passo 0 não serviria: lá a pilha tem um frame só, e ele é o "topo".
+  for (let k = 0; k < 3; k++) await pilha.getByRole("button", { name: "Próximo ›" }).click();
+  await expect(pilha.locator(".rec-frame-tag")).toHaveCount(2);
+  await expect(pilha.locator(".rec-frame-tag").last()).toHaveText("nível 1");
+  await pilha.getByRole("button", { name: "fatorial(1): caso base de cara", exact: true }).click();
+  await pilha.getByRole("button", { name: "Próximo ›" }).click();
+  await pilha.getByRole("button", { name: "Próximo ›" }).click();
+  await expect(pilha.locator(".rec-frame-ret")).toHaveText("devolve 1");
+
+  const arvore = noArtigo(page, 1);
+  await expect(arvore.locator(".viz-code-body")).toContainText("return fib(n - 1) + fib(n - 2)");
+  await expect(arvore.locator(".rec-legenda")).toContainText("valor já calculado antes");
+  await expect(arvore.locator(".rec-comp caption")).toHaveText("Chamadas para calcular fib(n), contagem exata");
+  // O "×" também é texto colado numa interpolação.
+  await expect(arvore.locator(".rec-comp tbody tr").first().locator("td").last()).toHaveText("2×");
+  await expect(arvore.locator(".viz-caption")).toContainText("Em fib(20) a diferença é 21.891 contra 39.");
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores dos grupos **Pilhas e
Filas** e **Recursão**: quatro tópicos, **11 visualizadores adaptados**, com um
agente por tópico em paralelo e consolidação num PR só.

## O que entrou, e o que ficou de fora

| tópico | adaptados | fora do escopo | por quê |
|---|---|---|---|
| `pilhas` | `StackVisualizer`, `StackCallStackVisualizer`, `StackMonotonicaVisualizer` | `StackImplementacoes` | estático, sem `"use client"`; sai como `<figure class="pl-tab">`, sem overlay |
| `filas` | `QueueVisualizer`, `QueueDuasPilhas`, `QueueDequeMonotonico` | — | — |
| `recursao` | `RecursionVisualizer`, `RecursionArvoreVisualizer` | `RecursionTipos` | tabela estática de consulta, sem overlay |
| `recursao-funcional` | `TailRecursionVisualizer`, `TailRecursionTrampolim`, `TailRecursionForma` | — | — |

**11 de 13 entraram.** Os dois de fora não têm painel expandido. Ambos
conferidos lendo o arquivo, não só a coluna do inventário.

**Um desvio deliberado:** `TailRecursionForma` saiu com `collapsible: false`, não
com as três camadas. O bloco de código dele **não é dispensável — é o objeto da
classificação** («esta chamada está em posição de cauda?» se responde lendo o
código), a nota de tela manda ler o código, e a medição o recolheria a 1440x700.
E não resolveria: recolhido, ele ainda pediria 533px de um orçamento de 516 a
1440x600. Virou regra no contrato (§2).

## Medições

Janela **1512x900**, fontes carregadas, animação congelada. Orçamento no artigo =
900 − 60 − 24 = **816px**. "Cabeça" = quanto o `.viz-head` sobe ao rolar o painel.

| peça | artigo antes | depois | cabeça | base do controle |
|---|---|---|---|---|
| pilha · parênteses | 917 | **631** | −119 → **0** | 961 → 843 |
| pilha · call stack (explícita 9⁸) | 1105 | **896** | −291 → **0** | 1133 → 843 |
| pilha · monotônica | 1049 | **840** | −174 → **0** | 1016 → 763 |
| fila · no array | 1522 | **1068** | −837 → **0** | 1678 → 843 |
| fila · duas pilhas | 1212 | **860** | −410 → **0** | 1251 → 796 |
| fila · deque monotônico | 1085 | **723** | −256 → **0** | 1097 → 728 |
| recursão · pilha de chamadas | 885 | **731** | −491 → **0** | — |
| recursão · árvore do Fibonacci | 1291 | **1137** | −615 → **0** | — |
| cauda · classificador | 686 | 696 | 0 → 0 | 738 → 717 |
| cauda · comparador | 1139 | **983** | −278 → **0** | 1119 → 822 |
| cauda · trampolim | 1278 | **1032** | −468 → **0** | 1309 → 843 |

**Em todas, o cabeçalho para de sair da tela ao rolar o expandido.** Era esse o
defeito maior, e não altura do miolo: em todos os estados medidos a sobra do
miolo era **0px** e quem rolava era a figura inteira, levando cabeçalho e
controles junto. Em 1440x600 a fila chegava a subir 1.528px.

### O que não fechou, com número

- **fila no array 1068** e **duas pilhas 860** contra 816, com o código já
  recolhido — limite do §9;
- **árvore do Fibonacci 1137** contra 816, quebrada por bloco: desenho 440,
  tabela 196, fichas 78, chips 70, campos 54. Nada dispensável;
- **comparador 983** e **trampolim 1032** contra 816, idem;
- **monotônica 840** contra 816 (819 no passo 0);
- o **classificador (+10px)** e a **call stack no 2³ (+10px)** ficaram mais altos
  no artigo: é o `.viz-foot` saindo do `.viz-body` e levando o respiro dele, já
  documentado no §9. Terceira e quarta medições da mesma constante.

## Testes

**58 testes novos** em quatro arquivos disjuntos, **51 quebras provadas**, todas
compilando, com build visível e resumo imprimindo `failed` **e** `passed`.

**Suíte completa na branch integrada: 259 passed, 0 failed** (`--workers=2`, com a
máquina livre) — leitura limpa na primeira tentativa, sem flake.

## O que a consolidação pegou, e nenhum tópico sozinho pegaria

**Um defeito real: a árvore de recursão perdeu a marcha inicial.** Ela abria no
`1.5x` (`useState(4)`) porque desenha dezenas de nós; a adaptação passou `speeds`
ao hook mas não a marcha, e o hook assume `1x`. Nenhum teste pegou — o rótulo da
velocidade não é medido por altura nem por rolagem, e a peça continua
funcionando. Quem pegou foi o **diff do texto renderizado do build inteiro**
(36.010 linhas, todas as páginas) contra a `main`, onde a página de recursão
passou a imprimir `1x` no lugar de `1.5x`. Corrigido com `initialSpeed: 4`, com
teste que reprova sem ele (2 passed → 1 failed 1 passed → 2 passed).

Varredura da classe: das 11 peças desta rodada só a árvore tinha marcha própria,
e das já adaptadas nos PRs anteriores só `ArraysCrescimento` e
`TwoPointersPalindromo` — as duas com `initialSpeed: 4` correto. Classe fechada.

**O resto do diff de texto é só o esperado:** as afordâncias novas da casca
("Ocultar código" nas nove peças com bloco recolhível, a dica de teclado nas onze
com linha do tempo), e três mudanças reportadas no classificador de cauda —
`caso N de 7` → `passo N de 7`, `▶ Rodar os 7 casos` → `▶ Rodar` e o `title` do
`↺` —, que são vocabulário do hook e não dá para evitar sem tocar na mecânica
compartilhada. Conferido: nenhum artigo e nenhum teste cita essas frases.

**Uma verificação de confiança nos números anteriores.** Um agente descobriu que
`newPage({ viewportSize })` é ignorado em silêncio no Playwright (a opção chama-se
`viewport`), o que produz medições plausíveis e erradas. Re-medi quatro números
publicados no PR #29 com o device do runner e a janela afirmada: **os quatro
batem no pixel** (758, 875, 744, 783). Nenhum teste mergeado usa a forma errada.

**Outras varreduras:** `stepBy` com aritmética (a classe do #28) — nenhuma
ocorrência; rodapé escrito à mão que o hook dispensa — nenhum; CSS novo — nenhum.

## Contrato (`content/visualizers/README.md`)

Quatro promoções, três delas achadas por mais de um agente:

1. **§2 — existir um bloco não quer dizer que ele seja dispensável.** O teste é
   procurar uma frase de tela que fale do bloco na segunda pessoa («Leia o código
   acima»). O `inventario.sh` responde `code = sim` e responde certo: a pergunta
   dele é *existe um bloco?*, não *o bloco é dispensável?*.
2. **§3 — o estado mais alto pode ser o do meio.** Numa peça que cresce e desfaz,
   o pico não está no passo 0 nem no último: ler o passo 0 com a entrada cheia
   errou por 218, 301 e 87px para baixo nas três peças de `pilhas`. Junto vem o
   segundo critério para `measureOn`: *se a decisão mudasse, a peça passaria a
   caber?*
3. **§3/§7 — "o desenho é grande" não é "o desenho está esticado".** Correção de
   uma regra que este contrato promoveu: o teto de altura só devolve **vazio**, e
   só há vazio quando o renderizado passa do natural do `viewBox`. Dois desenhos
   desta rodada pareciam o mesmo caso e não eram — o anel da fila é desenhado a
   320px contra viewBox de 340, e a árvore a 426 contra 426, onde um teto levaria
   a fonte dos nós de 10,5px para **6,5px**. Dois agentes chegaram nisso
   separadamente.
4. **§9 — `measureOn` não enxerga o passo**, e há peça cujo bloco mais alto cresce
   com ele: a fileira de frames da call stack vai de 168 a 662px na mesma
   execução.

E a tabela do §3 ganha um quarto caso do "encher a entrada até o máximo" errar:
`fib(8)` **com** cache (15 nós) é 81px **mais alta** que sem cache (67 nós),
porque o eixo da altura é a profundidade e os nós viram largura.

## Idioma

Identificadores traduzidos nos 11 componentes. O `guarda-idioma.py` **não é prova**
em nenhum deles (crase aninhada e rótulo colado em interpolação, os dois buracos
documentados no §0), então a prova foi comparar o texto renderizado dos estados no
navegador: **1.526 estados** somados (278 + 521 + 442 + 185), com diff vazio no
miolo, mais o diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
