### PR TITLE
feat(seo): cada página de entrada com o seu título, descrição e card

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -1208,6 +1208,12 @@ export const TOTAL_TOPICS = ALL_TOPICS.length;
 // (um tópico pode embutir vários, como Big O e Sliding Window).
 export const TOTAL_VISUALIZERS = ALL_TOPICS.filter((t) => t.viz).length;
 export const TOTAL_PROBLEMS = ALL_TOPICS.reduce((n, t) => n + (t.problems?.length ?? 0), 0);
+// Só os do LeetCode. Os textos de SEO citam "problemas do LeetCode" nominalmente,
+// e prometer o total (que inclui GeeksforGeeks) seria contar duas fontes como uma.
+export const TOTAL_LEETCODE_PROBLEMS = ALL_TOPICS.reduce(
+  (n, t) => n + (t.problems?.filter((p) => p.source === "LeetCode").length ?? 0),
+  0
+);
 
 export function getTopic(slug: string): Topic | undefined {
   return ALL_TOPICS.find((t) => t.slug === slug);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -232,7 +232,10 @@ html { scroll-behavior: smooth; }
 /* ------ roadmap ------ */
 .roadmap-wrap { padding: 48px 56px 72px; max-width: 1080px; }
 .roadmap-eyebrow { font-size: 12px; font-weight: 600; letter-spacing: 0.08em; text-transform: uppercase; color: var(--ccc-muted); }
-.roadmap-wrap h1 { margin: 10px 0 8px; font-size: 40px; font-weight: 600; letter-spacing: -0.03em; }
+/* O `clamp` entrou quando o H1 virou "Roadmap de Algoritmos e Estruturas de
+   Dados": em 40px fixos ele quebrava em quatro linhas a 390px e empurrava o
+   primeiro grupo para fora da tela. Título curto não sente diferença. */
+.roadmap-wrap h1 { margin: 10px 0 8px; font-size: clamp(28px, 7vw, 40px); font-weight: 600; letter-spacing: -0.03em; }
 .roadmap-intro { margin: 0 0 36px; max-width: 62ch; font-size: 16px; line-height: 1.6; color: #a3b6cf; }
 .rgroup { margin-bottom: 34px; }
 .rgroup-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; }

--- a/src/app/introducao/opengraph-image.tsx
+++ b/src/app/introducao/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { ogImage, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
+
+export const alt =
+  "Por onde começar em Algoritmos e Estruturas de Dados: o que estudar primeiro e em que ordem";
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const dynamic = "force-static";
+
+export default function IntroducaoOpengraphImage() {
+  return ogImage({
+    highlight: "Por onde começar",
+    title: "em Algoritmos e Estruturas de Dados",
+    subtitle: "O que estudar primeiro, em que ordem, e como usar o roadmap.",
+    titleSize: 56,
+  });
+}

--- a/src/app/introducao/page.tsx
+++ b/src/app/introducao/page.tsx
@@ -1,20 +1,27 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { LINKS } from "@/lib/links";
+import { pageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Introdução",
-  description:
-    "Como o Roadmap DSA funciona: aprenda algoritmos vendo cada um rodar passo a passo, com o código em Python, artigo, vídeo e uma lista de problemas para praticar.",
-};
+export function generateMetadata(): Metadata {
+  return pageMetadata({
+    title: "Por onde começar em Algoritmos e Estruturas de Dados",
+    description:
+      "Guia para quem está começando em algoritmos e estruturas de dados: o que estudar primeiro, em que ordem e como se preparar para entrevistas técnicas.",
+    ogTitle: "Por onde começar em Algoritmos e Estruturas de Dados",
+    ogDescription:
+      "O que estudar primeiro, em que ordem, e como usar o roadmap para se preparar para entrevistas.",
+    path: "/introducao/",
+  });
+}
 
 export const dynamic = "force-static";
 
 export default function IntroducaoPage() {
   return (
     <div className="intro-wrap">
-      <span className="hero-badge">Comece por aqui</span>
-      <h1>Introdução</h1>
+      <span className="hero-badge">Introdução</span>
+      <h1>Por onde começar</h1>
       <p className="lead">
         Boas-vindas ao <strong style={{ color: "#fff" }}>Roadmap DSA</strong>, o maior guia visual e
         gratuito de Estruturas de Dados e Algoritmos em português, feito pela comunidade Craft &amp;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,14 @@ import { ProgressProvider } from "@/components/ProgressProvider";
 import { Shell } from "@/components/Shell";
 import { SITE_URL } from "@/lib/links";
 
+// Só o que é global de verdade mora aqui. Título, descrição e Open Graph são de
+// cada rota (ver `src/lib/seo.ts`): quando `openGraph.title`/`description` eram
+// fixados aqui, o valor do layout vencia o da página e TODA rota compartilhava o
+// card da home no LinkedIn e no Facebook.
+//
+// O `template` continua sendo o fallback das rotas que não definem OG próprio
+// (os /topico/*): o Next preenche `og:title`/`og:description` a partir do
+// `title`/`description` resolvidos da página quando o layout não os impõe.
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
@@ -12,12 +20,13 @@ export const metadata: Metadata = {
   },
   description:
     "O maior guia visual e gratuito de Algoritmos e Estruturas de Dados em português. Cada tópico com o algoritmo rodando passo a passo, artigo, vídeo e problemas do LeetCode e GeeksforGeeks. Feito pela comunidade Craft & Code Club.",
-  keywords: ["DSA", "algoritmos", "estruturas de dados", "LeetCode", "roadmap", "português", "Craft & Code Club"],
   openGraph: {
-    title: "Roadmap DSA · Craft & Code Club",
-    description: "Visualização e aprofundamento em cada estrutura. Guia visual, gratuito e open source de DSA em português.",
     type: "website",
     locale: "pt_BR",
+    siteName: "Roadmap DSA",
+  },
+  twitter: {
+    card: "summary_large_image",
   },
 };
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,95 +1,17 @@
-import { ImageResponse } from "next/og";
+import { TOTAL_TOPICS } from "@content/roadmap";
+import { ogImage, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
 
-export const alt = "Roadmap DSA, guia visual e gratuito de Algoritmos e Estruturas de Dados";
-export const size = { width: 1200, height: 630 };
-export const contentType = "image/png";
+export const alt = `Roadmap DSA: o maior guia visual de Algoritmos e Estruturas de Dados em português, com ${TOTAL_TOPICS} tópicos, grátis`;
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
 export const dynamic = "force-static";
 
-// Gerada no build (SSG). Vira a imagem de preview (Open Graph + Twitter).
+// Card da home. Também é o fallback de toda rota sem card próprio (os /topico/*),
+// por isso a chamada aqui fala do site inteiro e não de uma página só.
 export default function OpengraphImage() {
-  return new ImageResponse(
-    (
-      <div
-        style={{
-          height: "100%",
-          width: "100%",
-          display: "flex",
-          flexDirection: "column",
-          justifyContent: "space-between",
-          background: "#0b111c",
-          color: "#e7edf6",
-          padding: "72px",
-          fontFamily: "sans-serif",
-        }}
-      >
-        <div
-          style={{
-            position: "absolute",
-            inset: 0,
-            background:
-              "radial-gradient(680px 420px at 10% -5%, rgba(59,130,246,0.24), transparent 60%), radial-gradient(680px 440px at 88% 8%, rgba(124,58,237,0.20), transparent 62%)",
-          }}
-        />
-
-        {/* topo: marca */}
-        <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
-          <div
-            style={{
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-              width: "78px",
-              height: "78px",
-              borderRadius: "18px",
-              background: "linear-gradient(150deg, #7c3aed, #3b82f6)",
-              fontSize: "27px",
-              fontWeight: 800,
-              letterSpacing: "-0.02em",
-              color: "#fff",
-            }}
-          >
-            DSA
-          </div>
-          <div style={{ display: "flex", flexDirection: "column" }}>
-            <div style={{ fontSize: "32px", fontWeight: 700 }}>Roadmap DSA</div>
-            <div style={{ fontSize: "20px", color: "#8ba0bb" }}>pela comunidade Craft &amp; Code Club</div>
-          </div>
-        </div>
-
-        {/* meio: chamada */}
-        <div style={{ display: "flex", flexDirection: "column", maxWidth: "1000px" }}>
-          <div style={{ display: "flex", flexWrap: "wrap", lineHeight: 1.08 }}>
-            <span style={{ fontSize: "62px", fontWeight: 800, letterSpacing: "-0.03em", color: "#3b82f6", marginRight: "18px" }}>
-              Visualização
-            </span>
-            <span style={{ fontSize: "62px", fontWeight: 800, letterSpacing: "-0.03em" }}>e aprofundamento</span>
-          </div>
-          <div style={{ fontSize: "62px", fontWeight: 800, letterSpacing: "-0.03em", lineHeight: 1.08 }}>em cada estrutura</div>
-          <div style={{ fontSize: "26px", color: "#a9bcd4", marginTop: "26px" }}>
-            O maior guia visual de Algoritmos e Estruturas de Dados, em português.
-          </div>
-        </div>
-
-        {/* base: selos */}
-        <div style={{ display: "flex", gap: "14px" }}>
-          {["100% grátis", "open source", "feito pela comunidade"].map((t) => (
-            <div
-              key={t}
-              style={{
-                display: "flex",
-                padding: "9px 18px",
-                border: "1px solid rgba(255,255,255,0.16)",
-                borderRadius: "99px",
-                fontSize: "21px",
-                color: "#9fb4cf",
-              }}
-            >
-              {t}
-            </div>
-          ))}
-        </div>
-      </div>
-    ),
-    { ...size }
-  );
+  return ogImage({
+    highlight: "Visualização",
+    title: "e aprofundamento em cada estrutura",
+    subtitle: "O maior guia visual de Algoritmos e Estruturas de Dados, em português.",
+  });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,28 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import {
   FEATURED,
   getTopic,
+  TOTAL_LEETCODE_PROBLEMS,
   TOTAL_PROBLEMS,
   TOTAL_TOPICS,
   TOTAL_VISUALIZERS,
 } from "@content/roadmap";
 import { LINKS } from "@/lib/links";
+import { pageMetadata } from "@/lib/seo";
 import { levelClass } from "@/lib/ui";
+
+// Os números saem do roadmap.ts (fonte única) em vez de escritos à mão: tópico
+// novo já entra no título e no card sem ninguém lembrar de atualizar o SEO.
+export function generateMetadata(): Metadata {
+  return pageMetadata({
+    title: `Algoritmos e Estruturas de Dados: Guia Visual com ${TOTAL_TOPICS} Tópicos`,
+    description: `O guia mais completo de algoritmos e estruturas de dados em português: ${TOTAL_TOPICS} tópicos com visualização passo a passo, código Python e problemas do LeetCode para entrevistas. Grátis.`,
+    ogTitle: "O maior guia visual de Algoritmos e Estruturas de Dados",
+    ogDescription: `${TOTAL_TOPICS} tópicos com o algoritmo rodando passo a passo, código em Python, vídeo e ${TOTAL_LEETCODE_PROBLEMS} problemas do LeetCode. Grátis, para sempre.`,
+    path: "/",
+  });
+}
 
 const FEATURES = [
   { icone: "▶", titulo: "O algoritmo rodando", texto: "Passo a passo, no seu ritmo, com o seu próprio array de entrada e o código Python acompanhando linha a linha." },
@@ -30,7 +45,7 @@ export default function Home() {
         <span className="hero-badge">Feito pela comunidade Craft &amp; Code Club · 100% grátis · open source</span>
         <h1><span className="accent">Visualização</span> e aprofundamento em cada estrutura</h1>
         <p>
-          O maior guia visual de algoritmos em português. Cada tópico traz o texto, o algoritmo
+          O maior guia visual de algoritmos e estruturas de dados em português. Cada tópico traz o texto, o algoritmo
           animado passo a passo com o código sincronizado, vídeo e uma lista de problemas do
           LeetCode e do GeeksforGeeks.
         </p>

--- a/src/app/roadmap/opengraph-image.tsx
+++ b/src/app/roadmap/opengraph-image.tsx
@@ -1,0 +1,15 @@
+import { TOTAL_TOPICS } from "@content/roadmap";
+import { ogImage, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
+
+export const alt = `Roadmap de Algoritmos e Estruturas de Dados: ${TOTAL_TOPICS} tópicos na ordem certa de estudo, do Big O aos grafos`;
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const dynamic = "force-static";
+
+export default function RoadmapOpengraphImage() {
+  return ogImage({
+    highlight: "Roadmap",
+    title: "de Algoritmos e Estruturas de Dados",
+    subtitle: `${TOTAL_TOPICS} tópicos na ordem certa de estudo, do Big O aos grafos.`,
+  });
+}

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,16 +1,23 @@
 import type { Metadata } from "next";
+import { TOTAL_TOPICS } from "@content/roadmap";
 import { RoadmapGroups } from "@/components/RoadmapGroups";
+import { pageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Do zero à entrevista",
-  description: "O roadmap completo de Algoritmos e Estruturas de Dados da comunidade Craft & Code Club, do básico ao avançado.",
-};
+export function generateMetadata(): Metadata {
+  return pageMetadata({
+    title: "Roadmap de Algoritmos e Estruturas de Dados: trilha completa",
+    description: `Trilha completa de algoritmos e estruturas de dados em português, do Big O aos grafos: ${TOTAL_TOPICS} tópicos na ordem certa, com visualização, vídeo e problemas do LeetCode.`,
+    ogTitle: "Roadmap de Algoritmos e Estruturas de Dados",
+    ogDescription: `${TOTAL_TOPICS} tópicos na ordem certa de estudo, do Big O aos grafos. Trilha completa, visual e gratuita.`,
+    path: "/roadmap/",
+  });
+}
 
 export default function RoadmapPage() {
   return (
     <div className="roadmap-wrap">
-      <span className="roadmap-eyebrow">Roadmap</span>
-      <h1>Do zero à entrevista</h1>
+      <span className="roadmap-eyebrow">Do zero à entrevista</span>
+      <h1>Roadmap de Algoritmos e Estruturas de Dados</h1>
       <p className="roadmap-intro">
         Siga na ordem ou pule direto para o que você precisa. Seu progresso fica salvo neste
         navegador, sem login, sem conta.

--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -1,0 +1,110 @@
+import { ImageResponse } from "next/og";
+
+// Template único dos cards de Open Graph (1200x630, gerados no build).
+//
+// Cada rota tem o seu `opengraph-image.tsx` e chama `ogImage()` com o próprio
+// título: o layout, as cores e os selos ficam aqui, para que um card novo seja
+// três linhas de texto e não uma cópia do arquivo inteiro. O card da raiz também
+// é o fallback de toda rota que não define o seu (os /topico/*).
+export const OG_SIZE = { width: 1200, height: 630 };
+export const OG_CONTENT_TYPE = "image/png";
+
+export type OgImageProps = {
+  // Primeiras palavras do título, em azul. Opcional.
+  highlight?: string;
+  title: string;
+  subtitle: string;
+  // O título mais longo precisa de corpo menor para caber em três linhas.
+  titleSize?: number;
+};
+
+export function ogImage({ highlight, title, subtitle, titleSize = 62 }: OgImageProps) {
+  const tituloEstilo = {
+    fontSize: `${titleSize}px`,
+    fontWeight: 800,
+    letterSpacing: "-0.03em",
+  } as const;
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          background: "#0b111c",
+          color: "#e7edf6",
+          padding: "72px",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            position: "absolute",
+            inset: 0,
+            background:
+              "radial-gradient(680px 420px at 10% -5%, rgba(59,130,246,0.24), transparent 60%), radial-gradient(680px 440px at 88% 8%, rgba(124,58,237,0.20), transparent 62%)",
+          }}
+        />
+
+        {/* topo: marca */}
+        <div style={{ display: "flex", alignItems: "center", gap: "20px" }}>
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: "78px",
+              height: "78px",
+              borderRadius: "18px",
+              background: "linear-gradient(150deg, #7c3aed, #3b82f6)",
+              fontSize: "27px",
+              fontWeight: 800,
+              letterSpacing: "-0.02em",
+              color: "#fff",
+            }}
+          >
+            DSA
+          </div>
+          <div style={{ display: "flex", flexDirection: "column" }}>
+            <div style={{ fontSize: "32px", fontWeight: 700 }}>Roadmap DSA</div>
+            <div style={{ fontSize: "20px", color: "#8ba0bb" }}>pela comunidade Craft &amp; Code Club</div>
+          </div>
+        </div>
+
+        {/* meio: chamada */}
+        <div style={{ display: "flex", flexDirection: "column", maxWidth: "1000px" }}>
+          <div style={{ display: "flex", flexWrap: "wrap", lineHeight: 1.08 }}>
+            {highlight && (
+              <span style={{ ...tituloEstilo, color: "#3b82f6", marginRight: "18px" }}>{highlight}</span>
+            )}
+            <span style={tituloEstilo}>{title}</span>
+          </div>
+          <div style={{ fontSize: "26px", color: "#a9bcd4", marginTop: "26px" }}>{subtitle}</div>
+        </div>
+
+        {/* base: selos */}
+        <div style={{ display: "flex", gap: "14px" }}>
+          {["100% grátis", "open source", "feito pela comunidade"].map((t) => (
+            <div
+              key={t}
+              style={{
+                display: "flex",
+                padding: "9px 18px",
+                border: "1px solid rgba(255,255,255,0.16)",
+                borderRadius: "99px",
+                fontSize: "21px",
+                color: "#9fb4cf",
+              }}
+            >
+              {t}
+            </div>
+          ))}
+        </div>
+      </div>
+    ),
+    { ...OG_SIZE }
+  );
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,42 @@
+import type { Metadata } from "next";
+
+// Metadados por rota, em um lugar só.
+//
+// Por que existe: o layout raiz só guarda o que é global de verdade (locale,
+// type, siteName, twitter.card, metadataBase). Título, descrição e Open Graph
+// são de cada página — quando ficavam no layout, todas as rotas compartilhavam
+// o mesmo card e o LinkedIn mostrava a home ao compartilhar qualquer tópico.
+//
+// `title` sai como `absolute`: o template do layout ("%s · Roadmap DSA") é bom
+// para tópico, mas empurraria os títulos longos destas páginas para muito além
+// dos ~60 caracteres que o Google mostra.
+//
+// `path` precisa da barra final (o site é `trailingSlash: true`), e vira tanto
+// o canonical quanto o `og:url` — os dois têm que apontar para a mesma URL.
+export type PageSeo = {
+  title: string;
+  description: string;
+  ogTitle: string;
+  ogDescription: string;
+  path: `/${string}` | "/";
+};
+
+export function pageMetadata({ title, description, ogTitle, ogDescription, path }: PageSeo): Metadata {
+  return {
+    title: { absolute: title },
+    description,
+    alternates: { canonical: path },
+    openGraph: {
+      // `openGraph` da página SUBSTITUI o do layout, não faz merge campo a campo:
+      // sem repetir type/locale/siteName aqui, as três rotas saíam sem eles.
+      // (A `og:image` é a exceção — vem do arquivo `opengraph-image.tsx` do
+      // segmento, ou do da raiz quando o segmento não tem o seu.)
+      type: "website",
+      locale: "pt_BR",
+      siteName: "Roadmap DSA",
+      title: ogTitle,
+      description: ogDescription,
+      url: path,
+    },
+  };
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -11,14 +11,19 @@ import type { Metadata } from "next";
 // para tópico, mas empurraria os títulos longos destas páginas para muito além
 // dos ~60 caracteres que o Google mostra.
 //
-// `path` precisa da barra final (o site é `trailingSlash: true`), e vira tanto
-// o canonical quanto o `og:url` — os dois têm que apontar para a mesma URL.
+// `path` vira tanto o canonical quanto o `og:url` — os dois têm que apontar para
+// a mesma URL, e o site é `trailingSlash: true`.
+//
+// O tipo cobra a barra final em vez de só pedir por comentário: `/${string}`
+// aceitava "/roadmap" de boa, e um path quase certo aqui vira canonical apontando
+// para uma URL que não existe. Erro de SEO não quebra teste nem build — ou o
+// compilador pega, ou ninguém pega.
 export type PageSeo = {
   title: string;
   description: string;
   ogTitle: string;
   ogDescription: string;
-  path: `/${string}` | "/";
+  path: "/" | `/${string}/`;
 };
 
 export function pageMetadata({ title, description, ogTitle, ogDescription, path }: PageSeo): Metadata {

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -13,7 +13,9 @@ test("nav do topo abre o roadmap e um tópico", async ({ page }) => {
   await page.goto("/");
   await page.getByRole("link", { name: "Roadmap", exact: true }).click();
   await expect(page).toHaveURL(/\/roadmap/);
-  await expect(page.getByRole("heading", { name: "Do zero à entrevista" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Roadmap de Algoritmos e Estruturas de Dados" })
+  ).toBeVisible();
   await page.getByRole("link", { name: /Two Pointers/ }).first().click();
   await expect(page).toHaveURL(/topico\/two-pointers/);
 });
@@ -591,7 +593,7 @@ test("selo NOVO segue a tag isNew, não a existência de visualizador", async ({
 
 test("página de introdução explica o guia e leva ao primeiro tópico", async ({ page }) => {
   await page.goto("/introducao/");
-  await expect(page.getByRole("heading", { level: 1, name: "Introdução" })).toBeVisible();
+  await expect(page.getByRole("heading", { level: 1, name: "Por onde começar" })).toBeVisible();
   await page.getByRole("link", { name: "Começar por Big O" }).click();
   await expect(page).toHaveURL(/topico\/big-o/);
 });

--- a/tests/seo.spec.ts
+++ b/tests/seo.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect, type Page } from "@playwright/test";
+import { SITE_URL } from "../src/lib/links";
+
+// SEO das páginas de entrada (home, roadmap, introdução).
+//
+// O que este arquivo protege: durante muito tempo o `openGraph` morava só no
+// layout raiz, e o valor do layout VENCE o da página. Resultado: compartilhar
+// qualquer URL do site mostrava o card da home. Voltar a fixar `openGraph.title`
+// ou `openGraph.description` no layout reintroduz o bug em silêncio — nenhuma
+// página quebra, os cards é que passam a mentir. Daí os testes de unicidade.
+//
+// O contrário também é armadilha: `openGraph` da página SUBSTITUI o do layout
+// inteiro, não faz merge campo a campo. Quem define OG próprio precisa repetir
+// type/locale/siteName, senão eles somem só naquela rota (ver `src/lib/seo.ts`).
+
+const ROTAS = [
+  { path: "/", nome: "home" },
+  { path: "/roadmap/", nome: "roadmap" },
+  { path: "/introducao/", nome: "introdução" },
+];
+
+async function meta(page: Page, seletor: string): Promise<string | null> {
+  return page.locator(`head ${seletor}`).getAttribute("content");
+}
+
+async function seo(page: Page, path: string) {
+  await page.goto(path);
+  return {
+    title: await page.title(),
+    description: await meta(page, 'meta[name="description"]'),
+    ogTitle: await meta(page, 'meta[property="og:title"]'),
+    ogDescription: await meta(page, 'meta[property="og:description"]'),
+    ogImage: await meta(page, 'meta[property="og:image"]'),
+    canonical: await page.locator('head link[rel="canonical"]').getAttribute("href"),
+  };
+}
+
+test("as três páginas de entrada têm título, descrição e card próprios", async ({ page }) => {
+  const vistos = new Map<string, string[]>();
+  for (const rota of ROTAS) {
+    const s = await seo(page, rota.path);
+    for (const [campo, valor] of Object.entries(s)) {
+      expect(valor, `${rota.nome}: ${campo} vazio`).toBeTruthy();
+      const anteriores = vistos.get(campo) ?? [];
+      expect(anteriores, `${rota.nome}: ${campo} repete o de outra rota`).not.toContain(valor);
+      vistos.set(campo, [...anteriores, valor as string]);
+    }
+  }
+});
+
+test("a home fala de algoritmos E estruturas de dados, no título e na abertura", async ({ page }) => {
+  const s = await seo(page, "/");
+  expect(s.title).toContain("Algoritmos e Estruturas de Dados");
+  expect(s.description).toContain("algoritmos e estruturas de dados");
+  // O H1 é decisão editorial e não repete o termo de busca: quem carrega o
+  // termo no corpo é o parágrafo logo abaixo.
+  await expect(page.getByRole("heading", { level: 1 })).toContainText("aprofundamento em cada estrutura");
+  await expect(page.locator(".hero > p")).toContainText("algoritmos e estruturas de dados");
+});
+
+test("o canonical de cada rota é absoluto e aponta para ela mesma", async ({ page }) => {
+  for (const rota of ROTAS) {
+    const s = await seo(page, rota.path);
+    expect(s.canonical, rota.nome).toBe(`${SITE_URL}${rota.path}`);
+    // og:url e canonical não podem divergir: são a mesma promessa para dois leitores.
+    expect(await meta(page, 'meta[property="og:url"]'), rota.nome).toBe(s.canonical);
+  }
+});
+
+test("cada página tem exatamente um h1", async ({ page }) => {
+  for (const rota of [...ROTAS, { path: "/topico/big-o/", nome: "big-o" }]) {
+    await page.goto(rota.path);
+    await expect(page.getByRole("heading", { level: 1 }), rota.nome).toHaveCount(1);
+  }
+});
+
+// Regressão: as rotas fora do escopo do SEO por página não definem OG próprio.
+// Elas dependem do Next derivar og:title/og:description do title/description
+// resolvidos. Se alguém voltar a impor OG no layout, isto continua passando —
+// por isso o teste checa que o valor é o DA PÁGINA, não um genérico do site.
+test("tópico sem OG próprio herda o título e a descrição dele mesmo", async ({ page }) => {
+  await page.goto("/topico/big-o/");
+  expect(await meta(page, 'meta[property="og:title"]')).toContain("Big O");
+  const desc = await meta(page, 'meta[name="description"]');
+  expect(await meta(page, 'meta[property="og:description"]')).toBe(desc);
+});
+
+test("o que é global segue global em toda rota", async ({ page }) => {
+  for (const rota of [...ROTAS, { path: "/topico/big-o/", nome: "big-o" }, { path: "/apoie/", nome: "apoie" }]) {
+    await page.goto(rota.path);
+    expect(await meta(page, 'meta[property="og:locale"]'), rota.nome).toBe("pt_BR");
+    expect(await meta(page, 'meta[property="og:type"]'), rota.nome).toBe("website");
+    expect(await meta(page, 'meta[property="og:site_name"]'), rota.nome).toBe("Roadmap DSA");
+    expect(await meta(page, 'meta[name="twitter:card"]'), rota.nome).toBe("summary_large_image");
+    // `keywords` é ignorada por buscador desde 2009 e era a mesma em todas as páginas.
+    await expect(page.locator('head meta[name="keywords"]'), rota.nome).toHaveCount(0);
+  }
+});


### PR DESCRIPTION
## O que muda

Home, `/roadmap` e `/introducao` passam a ter `title`, `description`, Open Graph e imagem de card próprios. Antes as três (e todas as outras rotas) compartilhavam o mesmo `og:title`/`og:description`, fixados no layout raiz: compartilhar qualquer URL do site mostrava o card da home.

## Tipo

- [x] `feat` novo conteúdo/tópico/visualizador
- [ ] `fix` correção
- [ ] `docs` documentação
- [ ] `refactor` / `style` / `perf`
- [ ] `ci` / `build` / `chore`

## Antes e depois

| | `/` | `/roadmap` | `/introducao` |
|---|---|---|---|
| `title` antes | Roadmap DSA · Craft & Code Club | Do zero à entrevista · Roadmap DSA | Introdução · Roadmap DSA |
| `title` depois | Algoritmos e Estruturas de Dados: Guia Visual com 47 Tópicos | Roadmap de Algoritmos e Estruturas de Dados: trilha completa | Por onde começar em Algoritmos e Estruturas de Dados |
| `og:title` antes | Roadmap DSA · Craft & Code Club (igual nas três) | idem | idem |
| `og:title` depois | O maior guia visual de Algoritmos e Estruturas de Dados | Roadmap de Algoritmos e Estruturas de Dados | Por onde começar em Algoritmos e Estruturas de Dados |
| `og:image` antes | `/opengraph-image`, uma só para o site inteiro | idem | idem |
| `og:image` depois | própria, com o título da página | própria | própria |
| `<h1>` antes | Visualização e aprofundamento em cada estrutura | Do zero à entrevista | Introdução |
| `<h1>` depois | **inalterado** | Roadmap de Algoritmos e Estruturas de Dados | Por onde começar |
| canonical | ausente | ausente | ausente |
| canonical depois | presente, absoluto, junto de `og:url` | idem | idem |

Tamanhos renderizados: títulos 60 / 60 / 52 caracteres; descrições 177 / 162 / 149.

## Como ficou organizado

- **`src/app/layout.tsx`** guarda só o que é global de verdade: `metadataBase`, `og:type`, `og:locale`, `og:site_name`, `twitter:card`, ícones. Saíram `openGraph.title`, `openGraph.description` e a meta `keywords`.
- **`src/lib/seo.ts`** é o ponto único de metadados por rota: título absoluto (o `template` do layout empurraria estes títulos longos para muito além dos ~60 caracteres que o Google mostra), descrição, OG e canonical, com `og:url` sempre igual ao canonical.
- **`src/lib/og.tsx`** extrai o template visual do card. Cada rota tem o seu `opengraph-image.tsx` de três linhas, com `alt` próprio, reaproveitando fontes, cores e selos do card que já existia.

**Armadilha que custou uma rodada:** o `openGraph` da página **substitui** o do layout inteiro, não faz merge campo a campo. Na primeira versão as três rotas saíram sem `og:type`, `og:locale` e `og:site_name`. O helper repete os três, e tem teste cobrindo.

## Rotas fora do escopo não perderam card

`/topico/*` e `/apoie` continuam sem OG próprio de propósito (serão tratadas em outra tarefa). Sem o OG imposto pelo layout, o Next preenche `og:title`/`og:description` a partir do `title`/`description` resolvidos da página. Elas **ganharam**: `/topico/big-o` agora mostra "Notação Big O · Roadmap DSA" e a descrição dele, em vez do card genérico da home.

## Decisões que valem revisão

1. **192 em vez de 185 problemas do LeetCode.** O `roadmap.ts` tem 227 problemas, 192 do LeetCode e 35 do GeeksforGeeks. O número (e o 47 de tópicos) sai do `roadmap.ts` via o novo `TOTAL_LEETCODE_PROBLEMS`, e não escrito à mão, para o SEO não envelhecer sozinho quando entrar tópico novo.
2. **A `description` da home tem 177 caracteres**, um pouco acima do teto de 175 que costuma ser a referência. Mantive o texto pedido em vez de parafrasear.
3. **Dois rótulos ajustados junto dos H1 novos**, para não ficar redundante: no roadmap o eyebrow virou "Do zero à entrevista" (era "Roadmap", logo acima de um H1 que começa com "Roadmap"); na introdução o badge virou "Introdução" (era "Comece por aqui", logo acima de "Por onde começar").
4. **`clamp()` no `.roadmap-wrap h1`.** Em 40px fixos o H1 novo quebrava em quatro linhas a 390px e empurrava o primeiro grupo para fora da tela. Conferido com screenshot: agora são duas linhas.
5. **O H1 da home não muda.** Quem carrega o termo de busca completo é o parágrafo logo abaixo dele, que passou de "guia visual de algoritmos" para "guia visual de algoritmos e estruturas de dados".

## Checklist

- [x] `npm run build` passa (59 rotas, sem warning novo de metadata)
- [x] `npm test` passa (265 testes, `PORT=3111 --workers=3`)
- [x] Segui o padrão de [Conventional Commits](https://conventionalcommits.org/)
- [x] Sem o caractere travessão (`—`) na copy do site
- [x] Li o [guia de contribuição](../CONTRIBUTING.md)

Sobre os workers: com o número padrão, a máquina carregada produz falhas espúrias nos testes de viz. É o flake de servidor já documentado no `playwright.config.ts`; os mesmos testes passam isolados e com concorrência menor.

Novo `tests/seo.spec.ts` cobre: unicidade de título, descrição e OG entre as três rotas; canonical igual a `og:url`; um único `<h1>` por página; `/topico/big-o` com OG preenchido (regressão do fallback); `keywords` ausente; e o que é global presente em toda rota.

## Depois do merge e do deploy

Revalidar o cache de Open Graph, senão os cards novos demoram a aparecer:

- [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) (cache agressivo, precisa ser forçado)
- [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLsDN8doSymkf4AYKfknPK
