### PR TITLE
feat(viz): casca adaptativa no grupo Árvores

### DIFF
--- a/content/visualizers/BSTVisualizer.tsx
+++ b/content/visualizers/BSTVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BSTVisualizer, a invariante construindo e pagando a árvore.
@@ -18,23 +19,30 @@ import { createPortal } from "react-dom";
 // Gerador puro em cima de uma árvore imutável reconstruída a cada passo? Não:
 // a árvore é construída uma vez (determinística, mesma entrada, mesmo shape) e
 // os passos só apontam para nós dela. Navegar para trás fica de graça.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type No = { v: number; esq: number; dir: number };
+type TreeNode = { v: number; left: number; right: number };
 
-type Passo = {
-  no: number;          // nó em foco
-  caminho: number[];   // da raiz até o foco
-  visiveis: number;    // quantos nós já foram inseridos
-  linha: number;
-  nota: string;
+type Step = {
+  node: number;        // nó em foco
+  path: number[];      // da raiz até o foco
+  visible: number;     // quantos nós já foram inseridos
+  line: number;
+  note: string;
   ok?: boolean;
-  falha?: boolean;
+  failed?: boolean;
 };
 
-type Modo = "inserir" | "buscar";
+type Mode = "inserir" | "buscar";
 
-const CODIGO_INSERIR = [
+// Python de tela: conteúdo didático em português, mesmo morando numa string.
+// `no.esq`, `no.dir` e `no.valor` são o código que o aluno lê — não são os
+// identificadores deste arquivo e não acompanham o rename da §0 do contrato.
+const INSERT_CODE = [
   "def insere(no, valor):",
   "    if no is None:",
   "        return No(valor)      # nasce sempre como folha",
@@ -45,7 +53,7 @@ const CODIGO_INSERIR = [
   "    return no",
 ];
 
-const CODIGO_BUSCAR = [
+const SEARCH_CODE = [
   "def busca(no, alvo):",
   "    while no is not None:",
   "        if alvo == no.valor:",
@@ -57,261 +65,233 @@ const CODIGO_BUSCAR = [
   "    return None                # não existe",
 ];
 
-type Preset = { key: string; rotulo: string; ordem: number[]; dica: string };
+type Preset = { key: string; label: string; order: number[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
     key: "meio",
-    rotulo: "Inserindo pelo meio: 4 2 6 1 3 5 7",
-    ordem: [4, 2, 6, 1, 3, 5, 7],
-    dica: "Cada valor cai num lado diferente e a árvore fica perfeita: altura 3 para 7 nós.",
+    label: "Inserindo pelo meio: 4 2 6 1 3 5 7",
+    order: [4, 2, 6, 1, 3, 5, 7],
+    hint: "Cada valor cai num lado diferente e a árvore fica perfeita: altura 3 para 7 nós.",
   },
   {
     key: "ordenado",
-    rotulo: "Inserindo ordenado: 1 2 3 4 5 6 7",
-    ordem: [1, 2, 3, 4, 5, 6, 7],
-    dica: "Os MESMOS sete valores. Como cada um é maior que todos os anteriores, ninguém vai para a esquerda: a árvore vira uma lista de altura 7.",
+    label: "Inserindo ordenado: 1 2 3 4 5 6 7",
+    order: [1, 2, 3, 4, 5, 6, 7],
+    hint: "Os MESMOS sete valores. Como cada um é maior que todos os anteriores, ninguém vai para a esquerda: a árvore vira uma lista de altura 7.",
   },
   {
     key: "tipico",
-    rotulo: "Um caso típico: 50 30 70 20 40 60 80",
-    ordem: [50, 30, 70, 20, 40, 60, 80],
-    dica: "O formato que todo material desenha, e o que você deve esperar de dados razoavelmente embaralhados.",
+    label: "Um caso típico: 50 30 70 20 40 60 80",
+    order: [50, 30, 70, 20, 40, 60, 80],
+    hint: "O formato que todo material desenha, e o que você deve esperar de dados razoavelmente embaralhados.",
   },
   {
     key: "quase",
-    rotulo: "Quase ordenado: 3 1 2 4 5 6 7",
-    ordem: [3, 1, 2, 4, 5, 6, 7],
-    dica: "Basta a cauda vir ordenada para a árvore pender para um lado. Degeneração não é tudo ou nada.",
+    label: "Quase ordenado: 3 1 2 4 5 6 7",
+    order: [3, 1, 2, 4, 5, 6, 7],
+    hint: "Basta a cauda vir ordenada para a árvore pender para um lado. Degeneração não é tudo ou nada.",
   },
 ];
 
 // Constrói a BST inserindo na ordem dada. Determinístico: mesma ordem, mesma
 // árvore, o que é justamente a propriedade que o modo "ordenado" explora.
-function construir(ordem: number[]): { nos: No[]; raiz: number } {
-  const nos: No[] = [];
-  let raiz = -1;
-  for (const v of ordem) {
-    const novo = nos.length;
-    nos.push({ v, esq: -1, dir: -1 });
-    if (raiz < 0) { raiz = novo; continue; }
-    let cur = raiz;
-    let guarda = 0;
-    while (guarda++ < 200) {
-      if (v < nos[cur].v) {
-        if (nos[cur].esq < 0) { nos[cur].esq = novo; break; }
-        cur = nos[cur].esq;
+function buildTree(order: number[]): { nodes: TreeNode[]; root: number } {
+  const nodes: TreeNode[] = [];
+  let root = -1;
+  for (const v of order) {
+    const fresh = nodes.length;
+    nodes.push({ v, left: -1, right: -1 });
+    if (root < 0) { root = fresh; continue; }
+    let cur = root;
+    let guard = 0;
+    while (guard++ < 200) {
+      if (v < nodes[cur].v) {
+        if (nodes[cur].left < 0) { nodes[cur].left = fresh; break; }
+        cur = nodes[cur].left;
       } else {
-        if (nos[cur].dir < 0) { nos[cur].dir = novo; break; }
-        cur = nos[cur].dir;
+        if (nodes[cur].right < 0) { nodes[cur].right = fresh; break; }
+        cur = nodes[cur].right;
       }
     }
   }
-  return { nos, raiz };
+  return { nodes, root };
 }
 
-function passosInserir(ordem: number[], nos: No[], raiz: number): Passo[] {
-  const out: Passo[] = [];
-  const idDe = new Map<number, number>();
-  nos.forEach((n, i) => { if (!idDe.has(n.v)) idDe.set(n.v, i); });
+function insertSteps(order: number[], nodes: TreeNode[], root: number): Step[] {
+  const out: Step[] = [];
+  const idOf = new Map<number, number>();
+  nodes.forEach((n, i) => { if (!idOf.has(n.v)) idOf.set(n.v, i); });
 
-  for (let k = 0; k < ordem.length; k++) {
-    const v = ordem[k];
-    const alvo = idDe.get(v) as number;
+  for (let k = 0; k < order.length; k++) {
+    const v = order[k];
+    const goal = idOf.get(v) as number;
     if (k === 0) {
       out.push({
-        no: alvo, caminho: [alvo], visiveis: 1, linha: 2,
-        nota: `A árvore estava vazia, então ${v} vira a raiz. Todo valor que entrar depois será comparado com ele primeiro.`,
+        node: goal, path: [goal], visible: 1, line: 2,
+        note: `A árvore estava vazia, então ${v} vira a raiz. Todo valor que entrar depois será comparado com ele primeiro.`,
       });
       continue;
     }
-    const caminho: number[] = [];
-    let cur = raiz;
-    let guarda = 0;
-    while (cur >= 0 && cur !== alvo && guarda++ < 200) {
-      caminho.push(cur);
-      const paraEsq = v < nos[cur].v;
+    const path: number[] = [];
+    let cur = root;
+    let guard = 0;
+    while (cur >= 0 && cur !== goal && guard++ < 200) {
+      path.push(cur);
+      const goLeft = v < nodes[cur].v;
       out.push({
-        no: cur, caminho: [...caminho], visiveis: k, linha: paraEsq ? 4 : 6,
-        nota: `Onde ${v} mora? Comparo com ${nos[cur].v}: ${v} ${paraEsq ? "<" : ">"} ${nos[cur].v}, então desço para a ${paraEsq ? "esquerda" : "direita"}. A invariante não deixa dúvida: só existe um caminho possível.`,
+        node: cur, path: [...path], visible: k, line: goLeft ? 4 : 6,
+        note: `Onde ${v} mora? Comparo com ${nodes[cur].v}: ${v} ${goLeft ? "<" : ">"} ${nodes[cur].v}, então desço para a ${goLeft ? "esquerda" : "direita"}. A invariante não deixa dúvida: só existe um caminho possível.`,
       });
-      cur = paraEsq ? nos[cur].esq : nos[cur].dir;
+      cur = goLeft ? nodes[cur].left : nodes[cur].right;
     }
-    caminho.push(alvo);
+    path.push(goal);
     out.push({
-      no: alvo, caminho: [...caminho], visiveis: k + 1, linha: 2,
-      nota: `Cheguei num ponto vazio, então ${v} nasce aqui, como FOLHA. Inserção em BST nunca mexe no meio da árvore: ela só pendura na ponta do caminho de busca, e por isso custa o mesmo que buscar.`,
+      node: goal, path: [...path], visible: k + 1, line: 2,
+      note: `Cheguei num ponto vazio, então ${v} nasce aqui, como FOLHA. Inserção em BST nunca mexe no meio da árvore: ela só pendura na ponta do caminho de busca, e por isso custa o mesmo que buscar.`,
     });
   }
 
-  const alt = altura(nos, raiz);
+  const h = heightOf(nodes, root);
   out.push({
-    no: -1, caminho: [], visiveis: nos.length, linha: 7, ok: true,
-    nota: `Árvore montada: ${nos.length} nós, altura ${alt}. A altura mínima possível para ${nos.length} nós é ${Math.ceil(Math.log2(nos.length + 1))}. ${alt === Math.ceil(Math.log2(nos.length + 1)) ? "Esta ficou no mínimo: é o melhor caso." : `Esta ficou ${alt - Math.ceil(Math.log2(nos.length + 1))} ${alt - Math.ceil(Math.log2(nos.length + 1)) === 1 ? "nível" : "níveis"} acima do mínimo, e cada nível extra é uma comparação a mais em TODA busca daqui para frente.`}`,
+    node: -1, path: [], visible: nodes.length, line: 7, ok: true,
+    note: `Árvore montada: ${nodes.length} nós, altura ${h}. A altura mínima possível para ${nodes.length} nós é ${Math.ceil(Math.log2(nodes.length + 1))}. ${h === Math.ceil(Math.log2(nodes.length + 1)) ? "Esta ficou no mínimo: é o melhor caso." : `Esta ficou ${h - Math.ceil(Math.log2(nodes.length + 1))} ${h - Math.ceil(Math.log2(nodes.length + 1)) === 1 ? "nível" : "níveis"} acima do mínimo, e cada nível extra é uma comparação a mais em TODA busca daqui para frente.`}`,
   });
   return out;
 }
 
-function passosBuscar(alvo: number, nos: No[], raiz: number): Passo[] {
-  const out: Passo[] = [];
-  const caminho: number[] = [];
-  let cur = raiz;
-  let guarda = 0;
-  while (cur >= 0 && guarda++ < 200) {
-    caminho.push(cur);
-    if (nos[cur].v === alvo) {
+function searchSteps(target: number, nodes: TreeNode[], root: number): Step[] {
+  const out: Step[] = [];
+  const path: number[] = [];
+  let cur = root;
+  let guard = 0;
+  while (cur >= 0 && guard++ < 200) {
+    path.push(cur);
+    if (nodes[cur].v === target) {
       out.push({
-        no: cur, caminho: [...caminho], visiveis: nos.length, linha: 3, ok: true,
-        nota: `Achei ${alvo} em ${caminho.length} ${caminho.length === 1 ? "comparação" : "comparações"}. Uma varredura linear teria olhado até ${nos.length} elementos: é essa a troca que a BST oferece.`,
+        node: cur, path: [...path], visible: nodes.length, line: 3, ok: true,
+        note: `Achei ${target} em ${path.length} ${path.length === 1 ? "comparação" : "comparações"}. Uma varredura linear teria olhado até ${nodes.length} elementos: é essa a troca que a BST oferece.`,
       });
       return out;
     }
-    const paraEsq = alvo < nos[cur].v;
+    const goLeft = target < nodes[cur].v;
     out.push({
-      no: cur, caminho: [...caminho], visiveis: nos.length, linha: paraEsq ? 5 : 7,
-      nota: `${alvo} ${paraEsq ? "<" : ">"} ${nos[cur].v}, então vou para a ${paraEsq ? "esquerda" : "direita"} e DESCARTO a outra subárvore inteira sem olhar. É a mesma jogada da busca binária, e é daqui que sai o log.`,
+      node: cur, path: [...path], visible: nodes.length, line: goLeft ? 5 : 7,
+      note: `${target} ${goLeft ? "<" : ">"} ${nodes[cur].v}, então vou para a ${goLeft ? "esquerda" : "direita"} e DESCARTO a outra subárvore inteira sem olhar. É a mesma jogada da busca binária, e é daqui que sai o log.`,
     });
-    cur = paraEsq ? nos[cur].esq : nos[cur].dir;
+    cur = goLeft ? nodes[cur].left : nodes[cur].right;
   }
   out.push({
-    no: -1, caminho: [...caminho], visiveis: nos.length, linha: 8, falha: true,
-    nota: `Cheguei num ponto vazio: ${alvo} não está na árvore. Foram ${caminho.length} ${caminho.length === 1 ? "comparação" : "comparações"}, e repare que o caminho percorrido é exatamente onde ${alvo} SERIA inserido. Buscar e inserir são o mesmo passeio.`,
+    node: -1, path: [...path], visible: nodes.length, line: 8, failed: true,
+    note: `Cheguei num ponto vazio: ${target} não está na árvore. Foram ${path.length} ${path.length === 1 ? "comparação" : "comparações"}, e repare que o caminho percorrido é exatamente onde ${target} SERIA inserido. Buscar e inserir são o mesmo passeio.`,
   });
   return out;
 }
 
-function altura(nos: No[], id: number): number {
+function heightOf(nodes: TreeNode[], id: number): number {
   if (id < 0) return 0;
-  return 1 + Math.max(altura(nos, nos[id].esq), altura(nos, nos[id].dir));
+  return 1 + Math.max(heightOf(nodes, nodes[id].left), heightOf(nodes, nodes[id].right));
 }
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-const NO_R = 17;
-const PASSO_X = 54;
-const PASSO_Y = 58;
-const MARGEM = 22;
-const TOPO = 20;
+const NODE_R = 17;
+const STEP_X = 54;
+const STEP_Y = 58;
+const MARGIN = 22;
+const TOP = 20;
 
-function posicionar(nos: No[], raiz: number) {
-  const pos = nos.map(() => ({ x: 0, prof: 0 }));
+function layout(nodes: TreeNode[], root: number) {
+  const pos = nodes.map(() => ({ x: 0, depth: 0 }));
   let slot = 0;
-  const visita = (id: number, prof: number) => {
+  const visit = (id: number, depth: number) => {
     if (id < 0) return;
-    visita(nos[id].esq, prof + 1);
-    pos[id] = { x: slot++, prof };
-    visita(nos[id].dir, prof + 1);
+    visit(nodes[id].left, depth + 1);
+    pos[id] = { x: slot++, depth };
+    visit(nodes[id].right, depth + 1);
   };
-  visita(raiz, 0);
+  visit(root, 0);
   return pos;
 }
 
 export function BSTVisualizer() {
   const [presetKey, setPresetKey] = useState("meio");
-  const [modo, setModo] = useState<Modo>("inserir");
-  const [alvo, setAlvo] = useState(7);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [mode, setMode] = useState<Mode>("inserir");
+  const [target, setTarget] = useState(7);
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const { nos, raiz } = useMemo(() => construir(preset.ordem), [preset]);
-  const pos = useMemo(() => posicionar(nos, raiz), [nos, raiz]);
-  const passos = useMemo(
-    () => (modo === "inserir" ? passosInserir(preset.ordem, nos, raiz) : passosBuscar(alvo, nos, raiz)),
-    [modo, preset, nos, raiz, alvo]
+  const { nodes, root } = useMemo(() => buildTree(preset.order), [preset]);
+  const pos = useMemo(() => layout(nodes, root), [nodes, root]);
+  const steps = useMemo(
+    () => (mode === "inserir" ? insertSteps(preset.order, nodes, root) : searchSteps(target, nodes, root)),
+    [mode, preset, nodes, root, target]
   );
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · a invariante da BST, construindo e cobrando",
+    total: steps.length,
+    // A peça abre no 1.5x, não no padrão do hook: a construção tem 18 a 29
+    // passos e no 1x a reprodução inteira fica longa demais.
+    initialSpeed: 4,
+    // O preset é o que MAIS muda a altura, e não pelo número de nós: ele muda a
+    // PROFUNDIDADE da árvore, que é o eixo que vira altura (190px de SVG com
+    // "pelo meio", 422px com "ordenado", os mesmos 7 nós). O modo acrescenta o
+    // campo "Procurar" e uma linha de código. E `steps.length` entra porque ele
+    // atravessa 1: buscar a raiz devolve UM passo, e aí o rodapé inteiro some.
+    measureOn: [presetKey, mode, steps.length],
+  });
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const trocarPreset = (k: string) => { reiniciar(); setPresetKey(k); };
-  const trocarModo = (m: Modo) => { reiniciar(); setModo(m); };
+  const p = steps[viz.step];
 
-  const alt = altura(nos, raiz);
-  const altMin = Math.ceil(Math.log2(nos.length + 1));
+  const changePreset = (k: string) => { viz.reset(); setPresetKey(k); };
+  const changeMode = (m: Mode) => { viz.reset(); setMode(m); };
+
+  const treeHeight = heightOf(nodes, root);
+  const minHeight = Math.ceil(Math.log2(nodes.length + 1));
   const maxSlot = pos.reduce((m, q) => Math.max(m, q.x), 0);
-  const maxProf = pos.reduce((m, q) => Math.max(m, q.prof), 0);
-  const W = MARGEM * 2 + maxSlot * PASSO_X + NO_R * 2;
-  const H = TOPO * 2 + maxProf * PASSO_Y + NO_R * 2;
-  const cx = (id: number) => MARGEM + NO_R + pos[id].x * PASSO_X;
-  const cy = (id: number) => TOPO + NO_R + pos[id].prof * PASSO_Y;
+  const maxDepth = pos.reduce((m, q) => Math.max(m, q.depth), 0);
+  const W = MARGIN * 2 + maxSlot * STEP_X + NODE_R * 2;
+  const H = TOP * 2 + maxDepth * STEP_Y + NODE_R * 2;
+  const cx = (id: number) => MARGIN + NODE_R + pos[id].x * STEP_X;
+  const cy = (id: number) => TOP + NODE_R + pos[id].depth * STEP_Y;
 
-  const noCaminho = useMemo(() => new Set(p.caminho), [p.caminho]);
-  const comparacoes = p.caminho.length;
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const valoresOrdenados = useMemo(() => [...preset.ordem].sort((a, b) => a - b), [preset]);
+  const onPath = useMemo(() => new Set(p.path), [p.path]);
+  const comparisons = p.path.length;
+  const sortedValues = useMemo(() => [...preset.order].sort((a, b) => a - b), [preset]);
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a invariante da BST, construindo e cobrando</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => trocarPreset(pr.key)} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => changePreset(pr.key)} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="viz-inputs">
           <div className="viz-field">
             <span>O que mostrar</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${modo === "inserir" ? " on" : ""}`} onClick={() => trocarModo("inserir")} aria-pressed={modo === "inserir"}>
+              <button className={`sub-modo-btn${mode === "inserir" ? " on" : ""}`} onClick={() => changeMode("inserir")} aria-pressed={mode === "inserir"}>
                 construir
               </button>
-              <button className={`sub-modo-btn${modo === "buscar" ? " on" : ""}`} onClick={() => trocarModo("buscar")} aria-pressed={modo === "buscar"}>
+              <button className={`sub-modo-btn${mode === "buscar" ? " on" : ""}`} onClick={() => changeMode("buscar")} aria-pressed={mode === "buscar"}>
                 buscar
               </button>
             </div>
           </div>
-          {modo === "buscar" && (
+          {mode === "buscar" && (
             <label className="viz-field">
               <span>Procurar</span>
               <input
                 className="viz-input k"
                 type="number"
-                value={alvo}
-                onChange={(e) => { reiniciar(); setAlvo(parseInt(e.target.value, 10) || 0); }}
+                value={target}
+                onChange={(e) => { viz.reset(); setTarget(parseInt(e.target.value, 10) || 0); }}
               />
             </label>
           )}
@@ -324,70 +304,75 @@ export function BSTVisualizer() {
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`Árvore de busca binária com ${nos.length} nós e altura ${alt}. ${p.nota}`}
+            aria-label={`Árvore de busca binária com ${nodes.length} nós e altura ${treeHeight}. ${p.note}`}
           >
-            {nos.map((no, id) =>
-              [no.esq, no.dir]
-                .filter((f) => f >= 0 && f < p.visiveis)
+            {nodes.map((node, id) =>
+              [node.left, node.right]
+                .filter((f) => f >= 0 && f < p.visible)
                 .map((f) => (
                   <line
                     key={`${id}-${f}`}
-                    className={`tt-aresta${noCaminho.has(f) && noCaminho.has(id) ? " on" : ""}`}
-                    x1={cx(id)} y1={cy(id) + NO_R} x2={cx(f)} y2={cy(f) - NO_R}
+                    className={`tt-aresta${onPath.has(f) && onPath.has(id) ? " on" : ""}`}
+                    x1={cx(id)} y1={cy(id) + NODE_R} x2={cx(f)} y2={cy(f) - NODE_R}
                   />
                 ))
             )}
-            {nos.map((no, id) => {
-              if (id >= p.visiveis) return null;
+            {nodes.map((node, id) => {
+              if (id >= p.visible) return null;
               const cls = ["tt-no", "bst-no"];
-              if (id === p.no) cls.push("on");
-              else if (noCaminho.has(id)) cls.push("caminho");
+              if (id === p.node) cls.push("on");
+              else if (onPath.has(id)) cls.push("caminho");
               return (
                 <g key={id} className={cls.join(" ")}>
-                  <circle cx={cx(id)} cy={cy(id)} r={NO_R} />
-                  <text x={cx(id)} y={cy(id) + 4} textAnchor="middle">{no.v}</text>
+                  <circle cx={cx(id)} cy={cy(id)} r={NODE_R} />
+                  <text x={cx(id)} y={cy(id) + 4} textAnchor="middle">{node.v}</text>
                 </g>
               );
             })}
           </svg>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : p.falha ? " invalid" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : p.failed ? " invalid" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo === "inserir" ? "insere.py" : "busca.py"}</div>
-            <div className="viz-code-body">
-              {(modo === "inserir" ? CODIGO_INSERIR : CODIGO_BUSCAR).map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` é o que recolhe a ALTURA: zerar a trilha da
+              coluna tira só a largura e a linha do grid fica com a altura do
+              bloco (contrato §7). */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode === "inserir" ? "insere.py" : "busca.py"}</div>
+              <div className="viz-code-body">
+                {(mode === "inserir" ? INSERT_CODE : SEARCH_CODE).map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">nó atual</span>
-              <span className="viz-var-val">{p.no >= 0 ? nos[p.no].v : "vazio"}</span>
+              <span className="viz-var-val">{p.node >= 0 ? nodes[p.node].v : "vazio"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">comparações</span>
-              <span className="viz-var-val best">{comparacoes}</span>
+              <span className="viz-var-val best">{comparisons}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">varredura linear</span>
-              <span className="viz-var-val">{nos.length}</span>
+              <span className="viz-var-val">{nodes.length}</span>
             </div>
           </div>
         </div>
 
         <div className="bigo-stats">
-          <div className="bigo-stat"><span>nós</span><strong>{nos.length}</strong></div>
-          <div className="bigo-stat"><span>altura</span><strong>{alt}</strong></div>
-          <div className="bigo-stat"><span>altura mínima</span><strong>{altMin}</strong></div>
-          <div className="bigo-stat"><span>pior busca</span><strong>{alt} comparações</strong></div>
+          <div className="bigo-stat"><span>nós</span><strong>{nodes.length}</strong></div>
+          <div className="bigo-stat"><span>altura</span><strong>{treeHeight}</strong></div>
+          <div className="bigo-stat"><span>altura mínima</span><strong>{minHeight}</strong></div>
+          <div className="bigo-stat"><span>pior busca</span><strong>{treeHeight} comparações</strong></div>
         </div>
 
         <div className="bt-array-bloco">
@@ -395,7 +380,7 @@ export function BSTVisualizer() {
             Percurso em ordem <em>esquerda, eu, direita</em>
           </div>
           <div className="bt-array">
-            {valoresOrdenados.map((v) => (
+            {sortedValues.map((v) => (
               <span key={v} className="bt-cel" style={{ paddingTop: 0 }}>{v}</span>
             ))}
           </div>
@@ -406,37 +391,14 @@ export function BSTVisualizer() {
           </p>
         </div>
 
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
-
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Compare os dois primeiros presets: mesmos sete valores, mesma invariante, mesmo código.
           Só a ORDEM de inserção muda, e com ela a altura vai de 3 para 7. A BST não protege
           você de dado ordenado, e é por isso que existem árvores balanceadas.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/BinaryTreeFormatos.tsx
+++ b/content/visualizers/BinaryTreeFormatos.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinaryTreeFormatos, o classificador de árvore binária.
@@ -19,145 +19,159 @@ import { createPortal } from "react-dom";
 //
 // Invariante mantida na interação: um nó só existe se o pai existir. Ligar um
 // nó liga a cadeia de ancestrais; desligar um nó desliga a subárvore inteira.
+//
+// Sobre a casca: este é um CLASSIFICADOR, não uma animação. Não há linha do
+// tempo (`total: 1`) nem bloco dispensável para recolher (`collapsible: false`)
+// — o desenho e os cinco vereditos são o conteúdo. Da casca ele usa o que lhe
+// cabe: o painel expandido com o cabeçalho parado enquanto o miolo rola. Os
+// presets continuam sendo chips do miolo, e não do rodapé, porque no rodapé só
+// mora reprodução.
 // ---------------------------------------------------------------------------
 
-const NIVEIS = 4;                 // 4 níveis => 15 posições
-const TAM = (1 << NIVEIS) - 1;    // 15
+const LEVELS = 4;                  // 4 níveis => 15 posições
+const SIZE = (1 << LEVELS) - 1;    // 15
 
-type Preset = { key: string; rotulo: string; slots: number[]; dica: string };
+type Preset = { key: string; label: string; slots: number[]; hint: string };
 
 // Cada preset é a lista de índices ligados no array de 15 posições.
 const PRESETS: Preset[] = [
   {
     key: "perfeita",
-    rotulo: "Perfeita",
+    label: "Perfeita",
     slots: [0, 1, 2, 3, 4, 5, 6],
-    dica: "Todo nó interno com dois filhos e todas as folhas no mesmo nível. É o melhor caso de altura: 7 nós em altura 3.",
+    hint: "Todo nó interno com dois filhos e todas as folhas no mesmo nível. É o melhor caso de altura: 7 nós em altura 3.",
   },
   {
     key: "completa",
-    rotulo: "Completa, não perfeita",
+    label: "Completa, não perfeita",
     slots: [0, 1, 2, 3, 4, 5],
-    dica: "Níveis cheios, menos o último, que é preenchido da esquerda para a direita sem buraco. É a forma da heap.",
+    hint: "Níveis cheios, menos o último, que é preenchido da esquerda para a direita sem buraco. É a forma da heap.",
   },
   {
     key: "cheia",
-    rotulo: "Cheia, não completa",
+    label: "Cheia, não completa",
     slots: [0, 1, 2, 5, 6],
-    dica: "Todo nó tem 0 ou 2 filhos, mas o último nível tem buraco à esquerda. Cheia não implica completa.",
+    hint: "Todo nó tem 0 ou 2 filhos, mas o último nível tem buraco à esquerda. Cheia não implica completa.",
   },
   {
     key: "balanceada",
-    rotulo: "Balanceada, não cheia",
+    label: "Balanceada, não cheia",
     slots: [0, 1, 2, 3, 6],
-    dica: "Nenhum nó tem subárvores com mais de um nível de diferença, mesmo com nó de um filho só.",
+    hint: "Nenhum nó tem subárvores com mais de um nível de diferença, mesmo com nó de um filho só.",
   },
   {
     key: "degenerada",
-    rotulo: "Degenerada",
+    label: "Degenerada",
     slots: [0, 1, 3, 7],
-    dica: "Todo nó tem no máximo um filho: virou uma lista encadeada com passos extras, e a altura vira n.",
+    hint: "Todo nó tem no máximo um filho: virou uma lista encadeada com passos extras, e a altura vira n.",
   },
 ];
 
-const pai = (i: number) => (i - 1) >> 1;
-const esq = (i: number) => 2 * i + 1;
-const dir = (i: number) => 2 * i + 2;
-const nivelDe = (i: number) => Math.floor(Math.log2(i + 1));
+const parentOf = (i: number) => (i - 1) >> 1;
+const leftOf = (i: number) => 2 * i + 1;
+const rightOf = (i: number) => 2 * i + 2;
+const levelOf = (i: number) => Math.floor(Math.log2(i + 1));
 
-type Veredito = { ok: boolean; motivo: string };
+type Verdict = { ok: boolean; reason: string };
 
-function alturaDe(on: boolean[], i: number): number {
-  if (i >= TAM || !on[i]) return 0;
-  return 1 + Math.max(alturaDe(on, esq(i)), alturaDe(on, dir(i)));
+function heightOf(on: boolean[], i: number): number {
+  if (i >= SIZE || !on[i]) return 0;
+  return 1 + Math.max(heightOf(on, leftOf(i)), heightOf(on, rightOf(i)));
 }
 
 // As cinco definições, cada uma devolvendo o motivo do "não". O motivo é o que
 // transforma o veredito em aprendizado: dizer "não é completa" não ensina nada,
 // dizer "o índice 5 está vazio e o 6 está ocupado" ensina.
-function classificar(on: boolean[]) {
-  const ativos: number[] = [];
-  for (let i = 0; i < TAM; i++) if (on[i]) ativos.push(i);
-  const n = ativos.length;
+function classify(on: boolean[]) {
+  const active: number[] = [];
+  for (let i = 0; i < SIZE; i++) if (on[i]) active.push(i);
+  const n = active.length;
 
   if (n === 0) {
-    const vazio: Veredito = { ok: false, motivo: "A árvore está vazia. Clique num nó para começar." };
-    return { cheia: vazio, perfeita: vazio, completa: vazio, balanceada: vazio, degenerada: vazio, n, altura: 0, folhas: 0 };
+    const empty: Verdict = { ok: false, reason: "A árvore está vazia. Clique num nó para começar." };
+    return { full: empty, perfect: empty, complete: empty, balanced: empty, degenerate: empty, n, height: 0, leaves: 0 };
   }
 
-  const filhosDe = (i: number) => [esq(i), dir(i)].filter((c) => c < TAM && on[c]);
-  const folhas = ativos.filter((i) => filhosDe(i).length === 0);
-  const altura = alturaDe(on, 0);
+  const childrenOf = (i: number) => [leftOf(i), rightOf(i)].filter((c) => c < SIZE && on[c]);
+  const leaves = active.filter((i) => childrenOf(i).length === 0);
+  const height = heightOf(on, 0);
 
   // Cheia: todo nó tem 0 ou 2 filhos.
-  const comUmFilho = ativos.find((i) => filhosDe(i).length === 1);
-  const cheia: Veredito = comUmFilho === undefined
-    ? { ok: true, motivo: "Todo nó tem 0 ou 2 filhos." }
-    : { ok: false, motivo: `O nó do índice ${comUmFilho} tem um filho só. Numa árvore cheia não existe nó com exatamente um filho.` };
+  const withOneChild = active.find((i) => childrenOf(i).length === 1);
+  const full: Verdict = withOneChild === undefined
+    ? { ok: true, reason: "Todo nó tem 0 ou 2 filhos." }
+    : { ok: false, reason: `O nó do índice ${withOneChild} tem um filho só. Numa árvore cheia não existe nó com exatamente um filho.` };
 
   // Completa: os índices ocupados são exatamente 0..n-1 no array.
-  const buraco = ativos.find((i) => i >= n);
-  const completa: Veredito = buraco === undefined
-    ? { ok: true, motivo: `Os ${n} nós ocupam exatamente os índices 0 a ${n - 1}: nenhum buraco.` }
-    : { ok: false, motivo: `O índice ${buraco} está ocupado, mas a árvore tem ${n} nós: sobrou buraco antes dele. Numa completa os nós preenchem o array sem pular posição.` };
+  const hole = active.find((i) => i >= n);
+  const complete: Verdict = hole === undefined
+    ? { ok: true, reason: `Os ${n} nós ocupam exatamente os índices 0 a ${n - 1}: nenhum buraco.` }
+    : { ok: false, reason: `O índice ${hole} está ocupado, mas a árvore tem ${n} nós: sobrou buraco antes dele. Numa completa os nós preenchem o array sem pular posição.` };
 
   // Perfeita: n = 2^altura - 1 e todas as folhas no último nível.
-  const folhaAlta = folhas.find((i) => nivelDe(i) !== altura - 1);
-  const perfeita: Veredito = cheia.ok && folhaAlta === undefined
-    ? { ok: true, motivo: `Todos os níveis estão cheios: ${n} nós = 2^${altura} - 1.` }
-    : { ok: false, motivo: folhaAlta !== undefined
-        ? `A folha do índice ${folhaAlta} está no nível ${nivelDe(folhaAlta)}, mas a árvore tem altura ${altura}. Na perfeita, toda folha fica no último nível.`
-        : `Falta ser cheia primeiro: ${cheia.motivo}` };
+  const highLeaf = leaves.find((i) => levelOf(i) !== height - 1);
+  const perfect: Verdict = full.ok && highLeaf === undefined
+    ? { ok: true, reason: `Todos os níveis estão cheios: ${n} nós = 2^${height} - 1.` }
+    : { ok: false, reason: highLeaf !== undefined
+        ? `A folha do índice ${highLeaf} está no nível ${levelOf(highLeaf)}, mas a árvore tem altura ${height}. Na perfeita, toda folha fica no último nível.`
+        : `Falta ser cheia primeiro: ${full.reason}` };
 
   // Balanceada: em TODO nó, |altura(esq) - altura(dir)| <= 1.
-  const desbalanceado = ativos.find((i) => Math.abs(alturaDe(on, esq(i)) - alturaDe(on, dir(i))) > 1);
-  const balanceada: Veredito = desbalanceado === undefined
-    ? { ok: true, motivo: "Em todo nó, as duas subárvores diferem em no máximo um nível de altura." }
-    : { ok: false, motivo: `No nó do índice ${desbalanceado}, a subárvore esquerda tem altura ${alturaDe(on, esq(desbalanceado))} e a direita ${alturaDe(on, dir(desbalanceado))}. A diferença passou de 1.` };
+  const unbalanced = active.find((i) => Math.abs(heightOf(on, leftOf(i)) - heightOf(on, rightOf(i))) > 1);
+  const balanced: Verdict = unbalanced === undefined
+    ? { ok: true, reason: "Em todo nó, as duas subárvores diferem em no máximo um nível de altura." }
+    : { ok: false, reason: `No nó do índice ${unbalanced}, a subárvore esquerda tem altura ${heightOf(on, leftOf(unbalanced))} e a direita ${heightOf(on, rightOf(unbalanced))}. A diferença passou de 1.` };
 
   // Degenerada: nenhum nó tem dois filhos.
-  const comDois = ativos.find((i) => filhosDe(i).length === 2);
-  const degenerada: Veredito = comDois === undefined
-    ? { ok: true, motivo: `Nenhum nó tem dois filhos: a árvore virou uma lista de ${n} elementos, com altura ${altura} em vez de ${Math.ceil(Math.log2(n + 1))}.` }
-    : { ok: false, motivo: `O nó do índice ${comDois} tem dois filhos, então a árvore ramifica.` };
+  const withTwoChildren = active.find((i) => childrenOf(i).length === 2);
+  const degenerate: Verdict = withTwoChildren === undefined
+    ? { ok: true, reason: `Nenhum nó tem dois filhos: a árvore virou uma lista de ${n} elementos, com altura ${height} em vez de ${Math.ceil(Math.log2(n + 1))}.` }
+    : { ok: false, reason: `O nó do índice ${withTwoChildren} tem dois filhos, então a árvore ramifica.` };
 
-  return { cheia, perfeita, completa, balanceada, degenerada, n, altura, folhas: folhas.length };
+  return { full, perfect, complete, balanced, degenerate, n, height, leaves: leaves.length };
 }
 
 // Geometria: nível k tem 2^k posições, distribuídas para caber na mesma largura.
-const LARG = 620;
-const PASSO_Y = 66;
+const WIDTH = 620;
+const STEP_Y = 66;
 const R = 15;
-const TOPO = 20;
+const TOP = 20;
+// Altura natural do desenho, no atributo E no viewBox. Renderizado igual ao
+// natural quer dizer que não existe esticão, e portanto não existe vazio que um
+// teto de altura pudesse devolver — só conteúdo que ele encolheria (§3).
+const HEIGHT = TOP * 2 + (LEVELS - 1) * STEP_Y + R * 2;
 
-function cxDe(i: number): number {
-  const nivel = nivelDe(i);
-  const idxNoNivel = i - ((1 << nivel) - 1);
-  const total = 1 << nivel;
-  return ((idxNoNivel + 0.5) / total) * LARG;
+function cxOf(i: number): number {
+  const level = levelOf(i);
+  const idxInLevel = i - ((1 << level) - 1);
+  const perLevel = 1 << level;
+  return ((idxInLevel + 0.5) / perLevel) * WIDTH;
 }
-const cyDe = (i: number) => TOPO + R + nivelDe(i) * PASSO_Y;
+const cyOf = (i: number) => TOP + R + levelOf(i) * STEP_Y;
 
 export function BinaryTreeFormatos() {
   const [on, setOn] = useState<boolean[]>(() => {
-    const a = new Array(TAM).fill(false);
+    const a = new Array(SIZE).fill(false);
     for (const i of PRESETS[0].slots) a[i] = true;
     return a;
   });
   const [preset, setPreset] = useState("perfeita");
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
 
-  useEffect(() => setMounted(true), []);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · monte a árvore e veja as cinco definições responderem",
+    // Classificador: o veredito é imediato, não há passo a passo. Com `total: 1`
+    // somem o contador de passo, os atalhos e a barra de progresso.
+    total: 1,
+    // Não há bloco dispensável: o desenho e os cinco vereditos SÃO o conteúdo.
+    // Sem isso o cabeçalho prometeria esconder um bloco que não existe.
+    collapsible: false,
+    // `measureOn` fica de fora de propósito: com `collapsible: false` não há
+    // decisão a tomar, e o hook nem espera as fontes. Passar a lista seria
+    // anunciar uma medição que não acontece.
+  });
 
-  const aplicar = (p: Preset) => {
-    const a = new Array(TAM).fill(false);
+  const apply = (p: Preset) => {
+    const a = new Array(SIZE).fill(false);
     for (const i of p.slots) a[i] = true;
     setOn(a);
     setPreset(p.key);
@@ -165,113 +179,106 @@ export function BinaryTreeFormatos() {
 
   // Ligar um nó liga a cadeia de ancestrais; desligar apaga a subárvore.
   // É o que mantém "todo nó tem pai" verdadeiro sem precisar avisar o usuário.
-  const alternar = (i: number) => {
+  const toggleNode = (i: number) => {
     setPreset("");
-    setOn((atual) => {
-      const novo = [...atual];
-      if (novo[i]) {
-        const apaga = (k: number) => {
-          if (k >= TAM || !novo[k]) return;
-          novo[k] = false;
-          apaga(esq(k));
-          apaga(dir(k));
+    setOn((current) => {
+      const next = [...current];
+      if (next[i]) {
+        const erase = (k: number) => {
+          if (k >= SIZE || !next[k]) return;
+          next[k] = false;
+          erase(leftOf(k));
+          erase(rightOf(k));
         };
-        apaga(i);
-        if (i === 0) novo[0] = false;
+        erase(i);
+        if (i === 0) next[0] = false;
       } else {
         let k = i;
-        while (k >= 0) { novo[k] = true; if (k === 0) break; k = pai(k); }
+        while (k >= 0) { next[k] = true; if (k === 0) break; k = parentOf(k); }
       }
-      return novo;
+      return next;
     });
   };
 
-  const c = useMemo(() => classificar(on), [on]);
+  const c = useMemo(() => classify(on), [on]);
   const arrayView = useMemo(() => {
     const out: (number | null)[] = [];
-    for (let i = 0; i < TAM; i++) out.push(on[i] ? i : null);
+    for (let i = 0; i < SIZE; i++) out.push(on[i] ? i : null);
     while (out.length && out[out.length - 1] === null) out.pop();
     return out;
   }, [on]);
 
-  const dicaPreset = PRESETS.find((p) => p.key === preset)?.dica;
-  const alturaMin = c.n > 0 ? Math.ceil(Math.log2(c.n + 1)) : 0;
+  const presetHint = PRESETS.find((p) => p.key === preset)?.hint;
+  const minHeight = c.n > 0 ? Math.ceil(Math.log2(c.n + 1)) : 0;
 
-  const vereditos: { rotulo: string; v: Veredito }[] = [
-    { rotulo: "Cheia", v: c.cheia },
-    { rotulo: "Perfeita", v: c.perfeita },
-    { rotulo: "Completa", v: c.completa },
-    { rotulo: "Balanceada", v: c.balanceada },
-    { rotulo: "Degenerada", v: c.degenerada },
+  const verdicts: { label: string; v: Verdict }[] = [
+    { label: "Cheia", v: c.full },
+    { label: "Perfeita", v: c.perfect },
+    { label: "Completa", v: c.complete },
+    { label: "Balanceada", v: c.balanced },
+    { label: "Degenerada", v: c.degenerate },
   ];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · monte a árvore e veja as cinco definições responderem</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">{c.n} {c.n === 1 ? "nó" : "nós"} · altura {c.altura}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo não há "passo N de M"; o número que resume o estado
+          entra no lugar dele, com o rótulo junto. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">{c.n} {c.n === 1 ? "nó" : "nós"} · altura {c.height}</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((p) => (
             <button
               key={p.key}
               className={`bigo-chip${preset === p.key ? " on" : ""}`}
-              onClick={() => aplicar(p)}
+              onClick={() => apply(p)}
               aria-pressed={preset === p.key}
             >
-              {p.rotulo}
+              {p.label}
             </button>
           ))}
         </div>
 
         <p className="tt-legenda-arvore">
-          {dicaPreset ?? "Clique em qualquer posição para ligar ou desligar o nó. Ligar um nó traz os ancestrais junto; desligar leva a subárvore embora."}
+          {presetHint ?? "Clique em qualquer posição para ligar ou desligar o nó. Ligar um nó traz os ancestrais junto; desligar leva a subárvore embora."}
         </p>
 
         <div className="tt-arv-wrap">
           <svg
             className="tt-arv bt-arv"
-            width={LARG}
-            height={TOPO * 2 + (NIVEIS - 1) * PASSO_Y + R * 2}
-            viewBox={`0 0 ${LARG} ${TOPO * 2 + (NIVEIS - 1) * PASSO_Y + R * 2}`}
+            width={WIDTH}
+            height={HEIGHT}
+            viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
             role="img"
-            aria-label={`Árvore binária com ${c.n} nós e altura ${c.altura}. Cheia: ${c.cheia.ok ? "sim" : "não"}. Perfeita: ${c.perfeita.ok ? "sim" : "não"}. Completa: ${c.completa.ok ? "sim" : "não"}. Balanceada: ${c.balanceada.ok ? "sim" : "não"}.`}
+            aria-label={`Árvore binária com ${c.n} nós e altura ${c.height}. Cheia: ${c.full.ok ? "sim" : "não"}. Perfeita: ${c.perfect.ok ? "sim" : "não"}. Completa: ${c.complete.ok ? "sim" : "não"}. Balanceada: ${c.balanced.ok ? "sim" : "não"}.`}
           >
-            {Array.from({ length: TAM }, (_, i) => i)
-              .filter((i) => i > 0 && on[i] && on[pai(i)])
+            {Array.from({ length: SIZE }, (_, i) => i)
+              .filter((i) => i > 0 && on[i] && on[parentOf(i)])
               .map((i) => (
-                <line key={`a${i}`} className="tt-aresta on" x1={cxDe(pai(i))} y1={cyDe(pai(i)) + R} x2={cxDe(i)} y2={cyDe(i) - R} />
+                <line key={`a${i}`} className="tt-aresta on" x1={cxOf(parentOf(i))} y1={cyOf(parentOf(i)) + R} x2={cxOf(i)} y2={cyOf(i) - R} />
               ))}
-            {Array.from({ length: TAM }, (_, i) => i).map((i) => {
-              const podeLigar = i === 0 || on[pai(i)];
+            {Array.from({ length: SIZE }, (_, i) => i).map((i) => {
+              const canEnable = i === 0 || on[parentOf(i)];
               return (
                 <g
                   key={i}
-                  className={`bt-slot${on[i] ? " on" : podeLigar ? " livre" : " bloq"}`}
-                  onClick={() => { if (on[i] || podeLigar) alternar(i); }}
+                  className={`bt-slot${on[i] ? " on" : canEnable ? " livre" : " bloq"}`}
+                  onClick={() => { if (on[i] || canEnable) toggleNode(i); }}
                   role="button"
-                  tabIndex={on[i] || podeLigar ? 0 : -1}
-                  aria-label={`Posição ${i}, nível ${nivelDe(i)}, ${on[i] ? "ocupada" : "vazia"}`}
+                  tabIndex={on[i] || canEnable ? 0 : -1}
+                  aria-label={`Posição ${i}, nível ${levelOf(i)}, ${on[i] ? "ocupada" : "vazia"}`}
                   aria-pressed={on[i]}
                   onKeyDown={(e) => {
-                    if ((e.key === "Enter" || e.key === " ") && (on[i] || podeLigar)) {
+                    if ((e.key === "Enter" || e.key === " ") && (on[i] || canEnable)) {
                       e.preventDefault();
-                      alternar(i);
+                      toggleNode(i);
                     }
                   }}
                 >
-                  <circle cx={cxDe(i)} cy={cyDe(i)} r={R} />
-                  <text x={cxDe(i)} y={cyDe(i) + 4} textAnchor="middle">{i}</text>
+                  <circle cx={cxOf(i)} cy={cyOf(i)} r={R} />
+                  <text x={cxOf(i)} y={cyOf(i) + 4} textAnchor="middle">{i}</text>
                 </g>
               );
             })}
@@ -279,13 +286,13 @@ export function BinaryTreeFormatos() {
         </div>
 
         <div className="bt-vereditos">
-          {vereditos.map(({ rotulo, v }) => (
-            <div key={rotulo} className={`bt-veredito${v.ok ? " sim" : ""}`}>
+          {verdicts.map(({ label, v }) => (
+            <div key={label} className={`bt-veredito${v.ok ? " sim" : ""}`}>
               <div className="bt-veredito-topo">
-                <span className="bt-veredito-nome">{rotulo}</span>
+                <span className="bt-veredito-nome">{label}</span>
                 <span className="bt-veredito-selo">{v.ok ? "sim" : "não"}</span>
               </div>
-              <p>{v.motivo}</p>
+              <p>{v.reason}</p>
             </div>
           ))}
         </div>
@@ -307,7 +314,7 @@ export function BinaryTreeFormatos() {
             )}
           </div>
           <p className="bt-array-nota">
-            {c.completa.ok && c.n > 0
+            {c.complete.ok && c.n > 0
               ? `Sem buraco: os ${c.n} nós ocupam os índices 0 a ${c.n - 1}. É por isso que a heap, que é sempre completa, vive num array sem ponteiro nenhum.`
               : `Repare nos buracos (·): num array, cada buraco é memória reservada e não usada. Guardar uma árvore que não é completa num array desperdiça espaço, e é por isso que a representação com ponteiros existe.`}
           </p>
@@ -315,10 +322,10 @@ export function BinaryTreeFormatos() {
 
         <div className="bigo-stats">
           <div className="bigo-stat"><span>nós</span><strong>{c.n}</strong></div>
-          <div className="bigo-stat"><span>altura</span><strong>{c.altura}</strong></div>
-          <div className="bigo-stat"><span>altura mínima possível</span><strong>{alturaMin}</strong></div>
-          <div className="bigo-stat"><span>folhas</span><strong>{c.folhas}</strong></div>
-          <div className="bigo-stat"><span>máximo em {c.altura} {c.altura === 1 ? "nível" : "níveis"}</span><strong>{c.altura ? (1 << c.altura) - 1 : 0}</strong></div>
+          <div className="bigo-stat"><span>altura</span><strong>{c.height}</strong></div>
+          <div className="bigo-stat"><span>altura mínima possível</span><strong>{minHeight}</strong></div>
+          <div className="bigo-stat"><span>folhas</span><strong>{c.leaves}</strong></div>
+          <div className="bigo-stat"><span>máximo em {c.height} {c.height === 1 ? "nível" : "níveis"}</span><strong>{c.height ? (1 << c.height) - 1 : 0}</strong></div>
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -326,16 +333,11 @@ export function BinaryTreeFormatos() {
           o que uma árvore balanceada evita, e o que separa O(log n) de O(n) na busca.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o rodapé não desenha nada — é o
+          comportamento documentado do hook, e está aqui para que acrescentar um
+          controle no futuro não passe por reescrever a casca à mão. */}
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/NAryTreeVisualizer.tsx
+++ b/content/visualizers/NAryTreeVisualizer.tsx
@@ -51,7 +51,7 @@ type Tree = { key: string; label: string; nodes: TreeNode[]; caption: string };
 // A pré-ordem dela sai 1 a 9 na sequência, que foi como apareceu no quadro.
 const TREES: Tree[] = [
   {
-    key: "artigo",
+    key: "article",
     label: "A árvore do artigo",
     caption: "Pré: 1 2 3 4 5 6 7 8 9 · Pós: 3 4 5 2 7 8 9 6 1 · Nível: 1 2 6 3 4 5 7 8 9",
     nodes: [
@@ -267,7 +267,7 @@ const DEGREES = [2, 4, 8, 16, 64, 256];
 const N_EXAMPLE = 1_000_000;
 
 export function NAryTreeVisualizer() {
-  const [treeKey, setTreeKey] = useState("artigo");
+  const [treeKey, setTreeKey] = useState("article");
   const [order, setOrder] = useState<Order>("pre");
   const [inOrderNote, setInOrderNote] = useState(false);
 

--- a/content/visualizers/NAryTreeVisualizer.tsx
+++ b/content/visualizers/NAryTreeVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // NAryTreeVisualizer, o mesmo percurso quando os filhos viram lista.
@@ -20,76 +21,86 @@ import { createPortal } from "react-dom";
 //
 // Gerador puro: monta a lista de passos com uma pilha explícita (DFS) ou uma
 // fila (BFS), sem estado externo, para navegar nos dois sentidos de graça.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
+//
+// Nota de medição, para quem mexer nisto: o eixo que vira ALTURA do desenho é a
+// PROFUNDIDADE da árvore, não o número de nós nem o grau. Aumentar o grau
+// alarga e não sobe — a árvore DOM tem grau 3 e profundidade 4, e é 136px mais
+// alta que a do artigo, que tem grau 3 e profundidade 2. Largura rola sozinha,
+// porque `.tt-arv-wrap` é `overflow-x: auto`.
 // ---------------------------------------------------------------------------
 
-type No = { rot: string; filhos: number[] };
-type Ordem = "pre" | "pos" | "nivel";
+type TreeNode = { label: string; children: number[] };
+type Order = "pre" | "post" | "level";
 
-type Passo = {
-  no: number;
+type Step = {
+  node: number;
   aux: number[];
-  saida: number[];
-  linha: number;
-  nota: string;
+  out: number[];
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-type Arvore = { key: string; rotulo: string; nos: No[]; legenda: string };
+type Tree = { key: string; label: string; nodes: TreeNode[]; caption: string };
 
 // A árvore do encontro: a raiz com dois filhos, e cada um deles com três.
 // A pré-ordem dela sai 1 a 9 na sequência, que foi como apareceu no quadro.
-const ARVORES: Arvore[] = [
+const TREES: Tree[] = [
   {
-    key: "encontro",
-    rotulo: "A árvore do artigo",
-    legenda: "Pré: 1 2 3 4 5 6 7 8 9 · Pós: 3 4 5 2 7 8 9 6 1 · Nível: 1 2 6 3 4 5 7 8 9",
-    nos: [
-      { rot: "1", filhos: [1, 5] },
-      { rot: "2", filhos: [2, 3, 4] },
-      { rot: "3", filhos: [] },
-      { rot: "4", filhos: [] },
-      { rot: "5", filhos: [] },
-      { rot: "6", filhos: [6, 7, 8] },
-      { rot: "7", filhos: [] },
-      { rot: "8", filhos: [] },
-      { rot: "9", filhos: [] },
+    key: "artigo",
+    label: "A árvore do artigo",
+    caption: "Pré: 1 2 3 4 5 6 7 8 9 · Pós: 3 4 5 2 7 8 9 6 1 · Nível: 1 2 6 3 4 5 7 8 9",
+    nodes: [
+      { label: "1", children: [1, 5] },
+      { label: "2", children: [2, 3, 4] },
+      { label: "3", children: [] },
+      { label: "4", children: [] },
+      { label: "5", children: [] },
+      { label: "6", children: [6, 7, 8] },
+      { label: "7", children: [] },
+      { label: "8", children: [] },
+      { label: "9", children: [] },
     ],
   },
   {
-    key: "arquivos",
-    rotulo: "Uma árvore de diretórios",
-    legenda: "O exemplo mais honesto de árvore n-ária: uma pasta tem quantos filhos quiser.",
-    nos: [
-      { rot: "/projeto", filhos: [1, 5, 8] },
-      { rot: "src", filhos: [2, 3, 4] },
-      { rot: "app.py", filhos: [] },
-      { rot: "util.py", filhos: [] },
-      { rot: "db.py", filhos: [] },
-      { rot: "testes", filhos: [6, 7] },
-      { rot: "test_app.py", filhos: [] },
-      { rot: "test_db.py", filhos: [] },
-      { rot: "README.md", filhos: [] },
+    key: "files",
+    label: "Uma árvore de diretórios",
+    caption: "O exemplo mais honesto de árvore n-ária: uma pasta tem quantos filhos quiser.",
+    nodes: [
+      { label: "/projeto", children: [1, 5, 8] },
+      { label: "src", children: [2, 3, 4] },
+      { label: "app.py", children: [] },
+      { label: "util.py", children: [] },
+      { label: "db.py", children: [] },
+      { label: "testes", children: [6, 7] },
+      { label: "test_app.py", children: [] },
+      { label: "test_db.py", children: [] },
+      { label: "README.md", children: [] },
     ],
   },
   {
     key: "dom",
-    rotulo: "Uma árvore DOM",
-    legenda: "HTML é uma árvore n-ária, e é por isso que querySelector é um percurso.",
-    nos: [
-      { rot: "html", filhos: [1, 2] },
-      { rot: "head", filhos: [] },
-      { rot: "body", filhos: [3, 4] },
-      { rot: "header", filhos: [] },
-      { rot: "main", filhos: [5, 6, 7] },
-      { rot: "h1", filhos: [] },
-      { rot: "p", filhos: [] },
-      { rot: "ul", filhos: [8] },
-      { rot: "li", filhos: [] },
+    label: "Uma árvore DOM",
+    caption: "HTML é uma árvore n-ária, e é por isso que querySelector é um percurso.",
+    nodes: [
+      { label: "html", children: [1, 2] },
+      { label: "head", children: [] },
+      { label: "body", children: [3, 4] },
+      { label: "header", children: [] },
+      { label: "main", children: [5, 6, 7] },
+      { label: "h1", children: [] },
+      { label: "p", children: [] },
+      { label: "ul", children: [8] },
+      { label: "li", children: [] },
     ],
   },
 ];
 
-const CODIGO: Record<Ordem, string[]> = {
+const CODE: Record<Order, string[]> = {
   pre: [
     "def percorre(no):",
     "    if no is None:",
@@ -98,7 +109,7 @@ const CODIGO: Record<Ordem, string[]> = {
     "    for filho in no.filhos:  # era esq e dir",
     "        percorre(filho)",
   ],
-  pos: [
+  post: [
     "def percorre(no):",
     "    if no is None:",
     "        return",
@@ -106,7 +117,7 @@ const CODIGO: Record<Ordem, string[]> = {
     "        percorre(filho)",
     "    processa(no)              # PÓS",
   ],
-  nivel: [
+  level: [
     "def por_nivel(raiz):",
     "    fila = deque([raiz])",
     "    while fila:",
@@ -117,135 +128,134 @@ const CODIGO: Record<Ordem, string[]> = {
   ],
 };
 
-const ROTULO_ORDEM: Record<Ordem, string> = {
+const ORDER_LABEL: Record<Order, string> = {
   pre: "Pré-ordem",
-  pos: "Pós-ordem",
-  nivel: "Por nível (BFS)",
+  post: "Pós-ordem",
+  level: "Por nível (BFS)",
 };
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
-const PASSO_X = 96;
-const PASSO_Y = 68;
-const NO_L = 84;
-const NO_A = 28;
-const MARGEM = 14;
-const TOPO = 16;
+const STEP_X = 96;
+const STEP_Y = 68;
+const NODE_W = 84;
+const NODE_H = 28;
+const MARGIN = 14;
+const TOP = 16;
 
-type Pos = { x: number; prof: number };
+type Pos = { x: number; depth: number };
 
 // Layout n-ário: cada folha ocupa um slot, cada nó interno senta no meio dos
 // filhos. Serve para qualquer grau, ao contrário do layout por posição em
 // ordem que a árvore binária usa (em ordem não existe aqui).
-function posicionar(nos: No[]): Pos[] {
-  const pos: Pos[] = nos.map(() => ({ x: 0, prof: 0 }));
+function place(nodes: TreeNode[]): Pos[] {
+  const pos: Pos[] = nodes.map(() => ({ x: 0, depth: 0 }));
   let slot = 0;
-  const visita = (id: number, prof: number) => {
-    pos[id].prof = prof;
-    const f = nos[id].filhos;
+  const visit = (id: number, depth: number) => {
+    pos[id].depth = depth;
+    const f = nodes[id].children;
     if (f.length === 0) { pos[id].x = slot++; return; }
-    for (const c of f) visita(c, prof + 1);
+    for (const c of f) visit(c, depth + 1);
     pos[id].x = (pos[f[0]].x + pos[f[f.length - 1]].x) / 2;
   };
-  visita(0, 0);
+  visit(0, 0);
   return pos;
 }
 
-function gerarPassos(nos: No[], ordem: Ordem): Passo[] {
-  const out: Passo[] = [];
-  const saida: number[] = [];
-  const rot = (i: number) => nos[i].rot;
+function generateSteps(nodes: TreeNode[], order: Order): Step[] {
+  const steps: Step[] = [];
+  const out: number[] = [];
+  const label = (i: number) => nodes[i].label;
 
-  if (ordem === "nivel") {
-    const fila = [0];
-    out.push({
-      no: 0, aux: [...fila], saida: [], linha: 1,
-      nota: `A fila começa com a raiz. O BFS não muda nada em árvore n-ária: onde a binária enfileirava dois filhos, aqui um for enfileira quantos existirem.`,
+  if (order === "level") {
+    const queue = [0];
+    steps.push({
+      node: 0, aux: [...queue], out: [], line: 1,
+      note: `A fila começa com a raiz. O BFS não muda nada em árvore n-ária: onde a binária enfileirava dois filhos, aqui um for enfileira quantos existirem.`,
     });
-    let guarda = 0;
-    while (fila.length && guarda++ < 300) {
-      const id = fila.shift() as number;
-      saida.push(id);
-      out.push({
-        no: id, aux: [...fila], saida: [...saida], linha: 4,
-        nota: `Processo ${rot(id)}, que estava na frente da fila. ${nos[id].filhos.length === 0 ? "É folha, não acrescenta ninguém." : `Agora enfileiro os ${nos[id].filhos.length} filhos dele, no fim da fila.`}`,
+    let guard = 0;
+    while (queue.length && guard++ < 300) {
+      const id = queue.shift() as number;
+      out.push(id);
+      steps.push({
+        node: id, aux: [...queue], out: [...out], line: 4,
+        note: `Processo ${label(id)}, que estava na frente da fila. ${nodes[id].children.length === 0 ? "É folha, não acrescenta ninguém." : `Agora enfileiro os ${nodes[id].children.length} filhos dele, no fim da fila.`}`,
       });
-      for (const f of nos[id].filhos) {
-        fila.push(f);
-        out.push({
-          no: f, aux: [...fila], saida: [...saida], linha: 6,
-          nota: `${rot(f)} entra no fim da fila. Ele só será processado depois de todo mundo que já estava lá, e é isso que mantém a leitura nível a nível.`,
+      for (const f of nodes[id].children) {
+        queue.push(f);
+        steps.push({
+          node: f, aux: [...queue], out: [...out], line: 6,
+          note: `${label(f)} entra no fim da fila. Ele só será processado depois de todo mundo que já estava lá, e é isso que mantém a leitura nível a nível.`,
         });
       }
     }
-    out.push({
-      no: -1, aux: [], saida: [...saida], linha: 2, ok: true,
-      nota: `Por nível: ${saida.map(rot).join(", ")}. Cada nó entrou e saiu da fila uma vez, então o tempo é O(n) mesmo com grau qualquer.`,
+    steps.push({
+      node: -1, aux: [], out: [...out], line: 2, ok: true,
+      note: `Por nível: ${out.map(label).join(", ")}. Cada nó entrou e saiu da fila uma vez, então o tempo é O(n) mesmo com grau qualquer.`,
     });
-    return out;
+    return steps;
   }
 
-  const linhaProcessa = ordem === "pre" ? 3 : 5;
-  const linhaFor = ordem === "pre" ? 5 : 4;
-  const pilha: { id: number; i: number; processado: boolean }[] = [{ id: 0, i: 0, processado: false }];
-  const idsNaPilha = () => pilha.map((q) => q.id);
+  const processLine = order === "pre" ? 3 : 5;
+  const loopLine = order === "pre" ? 5 : 4;
+  const stack: { id: number; i: number; processed: boolean }[] = [{ id: 0, i: 0, processed: false }];
+  const stackIds = () => stack.map((q) => q.id);
 
-  out.push({
-    no: 0, aux: idsNaPilha(), saida: [], linha: 0,
-    nota: `Entro na raiz. A pilha é a mesma da árvore binária: ela guarda o caminho da raiz até onde estou, nada mais.`,
+  steps.push({
+    node: 0, aux: stackIds(), out: [], line: 0,
+    note: `Entro na raiz. A pilha é a mesma da árvore binária: ela guarda o caminho da raiz até onde estou, nada mais.`,
   });
 
-  let guarda = 0;
-  while (pilha.length && guarda++ < 600) {
-    const topo = pilha[pilha.length - 1];
-    const filhos = nos[topo.id].filhos;
+  let guard = 0;
+  while (stack.length && guard++ < 600) {
+    const top = stack[stack.length - 1];
+    const children = nodes[top.id].children;
 
     // pré processa antes do laço; pós processa quando o laço terminou
-    const naHora = ordem === "pre" ? topo.i === 0 : topo.i >= filhos.length;
-    if (!topo.processado && naHora) {
-      saida.push(topo.id);
-      topo.processado = true;
-      out.push({
-        no: topo.id, aux: idsNaPilha(), saida: [...saida], linha: linhaProcessa,
-        nota: ordem === "pre"
-          ? `Processo ${rot(topo.id)} na chegada, antes de olhar qualquer filho. Com grau qualquer, "antes de todos os filhos" continua fazendo sentido.`
-          : `Os ${filhos.length === 0 ? "zero" : filhos.length} ${filhos.length === 1 ? "filho" : "filhos"} de ${rot(topo.id)} já saíram, então agora processo ele. Pós-ordem é a que mais sobrevive à generalização: "depois de todos os filhos" é sempre bem definido.`,
+    const dueNow = order === "pre" ? top.i === 0 : top.i >= children.length;
+    if (!top.processed && dueNow) {
+      out.push(top.id);
+      top.processed = true;
+      steps.push({
+        node: top.id, aux: stackIds(), out: [...out], line: processLine,
+        note: order === "pre"
+          ? `Processo ${label(top.id)} na chegada, antes de olhar qualquer filho. Com grau qualquer, "antes de todos os filhos" continua fazendo sentido.`
+          : `Os ${children.length === 0 ? "zero" : children.length} ${children.length === 1 ? "filho" : "filhos"} de ${label(top.id)} já saíram, então agora processo ele. Pós-ordem é a que mais sobrevive à generalização: "depois de todos os filhos" é sempre bem definido.`,
       });
       continue;
     }
 
-    if (topo.i < filhos.length) {
-      const filho = filhos[topo.i];
-      const posicao = topo.i + 1;
-      topo.i++;
-      pilha.push({ id: filho, i: 0, processado: false });
-      out.push({
-        no: filho, aux: idsNaPilha(), saida: [...saida], linha: linhaFor,
-        nota: `Desço para o ${posicao}º de ${filhos.length} ${filhos.length === 1 ? "filho" : "filhos"} de ${rot(topo.id)}: entro em ${rot(filho)}. A pilha tem ${pilha.length} ${pilha.length === 1 ? "quadro" : "quadros"}, e continua limitada pela ALTURA, não pelo grau.`,
+    if (top.i < children.length) {
+      const child = children[top.i];
+      const position = top.i + 1;
+      top.i++;
+      stack.push({ id: child, i: 0, processed: false });
+      steps.push({
+        node: child, aux: stackIds(), out: [...out], line: loopLine,
+        note: `Desço para o ${position}º de ${children.length} ${children.length === 1 ? "filho" : "filhos"} de ${label(top.id)}: entro em ${label(child)}. A pilha tem ${stack.length} ${stack.length === 1 ? "quadro" : "quadros"}, e continua limitada pela ALTURA, não pelo grau.`,
       });
       continue;
     }
 
-    pilha.pop();
-    out.push({
-      no: topo.id, aux: idsNaPilha(), saida: [...saida], linha: 5,
-      nota: pilha.length
-        ? `Acabou o for de ${rot(topo.id)}: desempilho e volto para o pai, que retoma o laço dele de onde parou.`
+    stack.pop();
+    steps.push({
+      node: top.id, aux: stackIds(), out: [...out], line: 5,
+      note: stack.length
+        ? `Acabou o for de ${label(top.id)}: desempilho e volto para o pai, que retoma o laço dele de onde parou.`
         : `Desempilho a raiz. Percurso terminado.`,
     });
   }
 
-  out.push({
-    no: -1, aux: [], saida: [...saida], linha: linhaProcessa, ok: true,
-    nota: `${ROTULO_ORDEM[ordem]}: ${saida.map(rot).join(", ")}. São ${saida.length} nós, cada um visitado uma vez: O(n) de tempo e O(altura) de pilha.`,
+  steps.push({
+    node: -1, aux: [], out: [...out], line: processLine, ok: true,
+    note: `${ORDER_LABEL[order]}: ${out.map(label).join(", ")}. São ${out.length} nós, cada um visitado uma vez: O(n) de tempo e O(altura) de pilha.`,
   });
-  return out;
+  return steps;
 }
 
 // Altura mínima de uma árvore de grau k com n nós: log base k de n.
 // É a conta que justifica B-tree, e a razão de índice de banco ter grau alto.
-function alturaPara(n: number, k: number): number {
+function heightFor(n: number, k: number): number {
   if (k < 2) return n;
   return Math.ceil(Math.log(n * (k - 1) + 1) / Math.log(k));
 }
@@ -253,105 +263,78 @@ function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-const GRAUS = [2, 4, 8, 16, 64, 256];
-const N_EXEMPLO = 1_000_000;
+const DEGREES = [2, 4, 8, 16, 64, 256];
+const N_EXAMPLE = 1_000_000;
 
 export function NAryTreeVisualizer() {
-  const [arvoreKey, setArvoreKey] = useState("encontro");
-  const [ordem, setOrdem] = useState<Ordem>("pre");
-  const [semOrdem, setSemOrdem] = useState(false);
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [treeKey, setTreeKey] = useState("artigo");
+  const [order, setOrder] = useState<Order>("pre");
+  const [inOrderNote, setInOrderNote] = useState(false);
 
-  useEffect(() => setMounted(true), []);
+  const tree = useMemo(() => TREES.find((a) => a.key === treeKey) ?? TREES[0], [treeKey]);
+  const pos = useMemo(() => place(tree.nodes), [tree]);
+  const steps = useMemo(() => generateSteps(tree.nodes, order), [tree, order]);
 
-  const arvore = useMemo(() => ARVORES.find((a) => a.key === arvoreKey) ?? ARVORES[0], [arvoreKey]);
-  const pos = useMemo(() => posicionar(arvore.nos), [arvore]);
-  const passos = useMemo(() => gerarPassos(arvore.nos, ordem), [arvore, ordem]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · o mesmo template quando os filhos viram uma lista",
+    total: steps.length,
+    speeds: SPEEDS,
+    // A marcha inicial desta peça é a 4 ("1.5x"), não a 3 do hook: o percurso
+    // mais curto tem 19 passos e o mais longo 28, e no 1x a reprodução inteira
+    // fica longa demais para quem só quer ver a forma do percurso. Era o valor
+    // que o componente já tinha.
+    initialSpeed: 4,
+    // O que muda a altura da peça, medido em 1512x900: a ÁRVORE, porque o
+    // desenho cresce com a PROFUNDIDADE dela (1228px na do artigo contra 1396
+    // na do DOM, que tem dois níveis a mais); a ORDEM, que troca um código de 6
+    // linhas por um de 7 e muda o comprimento das notas; e o chip "Em ordem?",
+    // que acrescenta um parágrafo de 70px sem mexer em nenhum dos outros dois.
+    measureOn: [treeKey, order, inOrderNote],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
+  const p = steps[viz.step];
 
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const trocarOrdem = (o: Ordem) => { reiniciar(); setSemOrdem(false); setOrdem(o); };
+  const pickOrder = (o: Order) => { viz.reset(); setInOrderNote(false); setOrder(o); };
+  const pickTree = (key: string) => { viz.reset(); setTreeKey(key); };
 
   const maxSlot = pos.reduce((m, q) => Math.max(m, q.x), 0);
-  const maxProf = pos.reduce((m, q) => Math.max(m, q.prof), 0);
-  const W = MARGEM * 2 + maxSlot * PASSO_X + NO_L;
-  const H = TOPO * 2 + maxProf * PASSO_Y + NO_A;
-  const cx = (id: number) => MARGEM + NO_L / 2 + pos[id].x * PASSO_X;
-  const cyTopo = (id: number) => TOPO + pos[id].prof * PASSO_Y;
+  const maxDepth = pos.reduce((m, q) => Math.max(m, q.depth), 0);
+  const W = MARGIN * 2 + maxSlot * STEP_X + NODE_W;
+  const H = TOP * 2 + maxDepth * STEP_Y + NODE_H;
+  const cx = (id: number) => MARGIN + NODE_W / 2 + pos[id].x * STEP_X;
+  const cyTop = (id: number) => TOP + pos[id].depth * STEP_Y;
 
-  const jaSaiu = useMemo(() => new Set(p.saida), [p.saida]);
-  const naAux = useMemo(() => new Set(p.aux), [p.aux]);
-  const ehBfs = ordem === "nivel";
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const grauMax = arvore.nos.reduce((m, n) => Math.max(m, n.filhos.length), 0);
+  const done = useMemo(() => new Set(p.out), [p.out]);
+  const inAux = useMemo(() => new Set(p.aux), [p.aux]);
+  const isBfs = order === "level";
+  const maxDegree = tree.nodes.reduce((m, n) => Math.max(m, n.children.length), 0);
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o mesmo template quando os filhos viram uma lista</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {(["pre", "pos", "nivel"] as Ordem[]).map((o) => (
+          {(["pre", "post", "level"] as Order[]).map((o) => (
             <button
               key={o}
-              className={`bigo-chip${ordem === o && !semOrdem ? " on" : ""}`}
-              onClick={() => trocarOrdem(o)}
-              aria-pressed={ordem === o && !semOrdem}
+              className={`bigo-chip${order === o && !inOrderNote ? " on" : ""}`}
+              onClick={() => pickOrder(o)}
+              aria-pressed={order === o && !inOrderNote}
             >
-              {ROTULO_ORDEM[o]}
+              {ORDER_LABEL[o]}
             </button>
           ))}
           <button
-            className={`bigo-chip na${semOrdem ? " on" : ""}`}
-            onClick={() => setSemOrdem((v) => !v)}
-            aria-pressed={semOrdem}
+            className={`bigo-chip na${inOrderNote ? " on" : ""}`}
+            onClick={() => setInOrderNote((v) => !v)}
+            aria-pressed={inOrderNote}
           >
             Em ordem?
           </button>
         </div>
 
-        {semOrdem && (
+        {inOrderNote && (
           <p className="viz-note invalid" style={{ marginTop: 10 }}>
             Em ordem não existe em árvore n-ária. A definição é "esquerda, eu, direita", e ela depende
             de haver exatamente dois lados. Com três filhos, onde entra o nó: depois do primeiro?
@@ -362,50 +345,55 @@ export function NAryTreeVisualizer() {
         )}
 
         <div className="bigo-chips" style={{ marginTop: 2 }}>
-          {ARVORES.map((a) => (
+          {TREES.map((a) => (
             <button
               key={a.key}
-              className={`bigo-chip${arvoreKey === a.key ? " on" : ""}`}
-              onClick={() => { reiniciar(); setArvoreKey(a.key); }}
-              aria-pressed={arvoreKey === a.key}
+              className={`bigo-chip${treeKey === a.key ? " on" : ""}`}
+              onClick={() => pickTree(a.key)}
+              aria-pressed={treeKey === a.key}
             >
-              {a.rotulo}
+              {a.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{arvore.legenda}</p>
+        <p className="tt-legenda-arvore">{tree.caption}</p>
 
         <div className="tt-arv-wrap">
+          {/* `width`/`height` de atributo, sem `width: 100%` no CSS: o desenho
+              sai no tamanho NATURAL do viewBox (medido: 496x332 renderizado
+              contra 496x332 de viewBox). Não há esticão, então não há vazio a
+              devolver com um teto de altura — ele encolheria o desenho de
+              verdade, texto junto. O que passa da largura rola no wrapper. */}
           <svg
             className="tt-arv"
             width={W}
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`${ROTULO_ORDEM[ordem]} sobre ${arvore.rotulo}. Passo ${idx + 1} de ${total}. ${p.nota}`}
+            aria-label={`${ORDER_LABEL[order]} sobre ${tree.label}. Passo ${viz.step + 1} de ${viz.total}. ${p.note}`}
           >
-            {arvore.nos.map((no, id) =>
-              no.filhos.map((f) => (
+            {tree.nodes.map((no, id) =>
+              no.children.map((f) => (
                 <line
                   key={`${id}-${f}`}
-                  className={`tt-aresta${jaSaiu.has(f) || naAux.has(f) ? " on" : ""}`}
+                  className={`tt-aresta${done.has(f) || inAux.has(f) ? " on" : ""}`}
                   x1={cx(id)}
-                  y1={cyTopo(id) + NO_A}
+                  y1={cyTop(id) + NODE_H}
                   x2={cx(f)}
-                  y2={cyTopo(f)}
+                  y2={cyTop(f)}
                 />
               ))
             )}
-            {arvore.nos.map((no, id) => {
+            {tree.nodes.map((no, id) => {
               const cls = ["na-no"];
-              if (id === p.no) cls.push("on");
-              else if (jaSaiu.has(id)) cls.push("saiu");
-              else if (naAux.has(id)) cls.push("aux");
+              if (id === p.node) cls.push("on");
+              else if (done.has(id)) cls.push("saiu");
+              else if (inAux.has(id)) cls.push("aux");
               return (
                 <g key={id} className={cls.join(" ")}>
-                  <rect x={cx(id) - NO_L / 2} y={cyTopo(id)} width={NO_L} height={NO_A} rx={7} />
-                  <text x={cx(id)} y={cyTopo(id) + 18} textAnchor="middle">{no.rot}</text>
+                  <rect x={cx(id) - NODE_W / 2} y={cyTop(id)} width={NODE_W} height={NODE_H} rx={7} />
+                  <text x={cx(id)} y={cyTop(id) + 18} textAnchor="middle">{no.label}</text>
                 </g>
               );
             })}
@@ -415,66 +403,75 @@ export function NAryTreeVisualizer() {
         <div className="tt-paineis">
           <div className="tt-painel">
             <div className="tt-painel-tit">
-              {ehBfs ? "Fila" : "Pilha"} <em>{ehBfs ? "FIFO" : "LIFO, altura da árvore"}</em>
+              {isBfs ? "Fila" : "Pilha"} <em>{isBfs ? "FIFO" : "LIFO, altura da árvore"}</em>
             </div>
             <div className="tt-aux">
               {p.aux.length === 0 ? <span className="tt-vazio">vazia</span> : p.aux.map((id, i) => (
-                <span key={`${id}-${i}`} className={`tt-aux-item${(ehBfs ? i === 0 : i === p.aux.length - 1) ? " topo" : ""}`}>
-                  {arvore.nos[id].rot}
+                <span key={`${id}-${i}`} className={`tt-aux-item${(isBfs ? i === 0 : i === p.aux.length - 1) ? " topo" : ""}`}>
+                  {tree.nodes[id].label}
                 </span>
               ))}
             </div>
           </div>
           <div className="tt-painel">
-            <div className="tt-painel-tit">Saída <em>{ROTULO_ORDEM[ordem]}</em></div>
+            <div className="tt-painel-tit">Saída <em>{ORDER_LABEL[order]}</em></div>
             <div className="tt-saida">
-              {p.saida.length === 0 ? <span className="tt-vazio">nada ainda</span> : p.saida.map((id, i) => (
-                <span key={`${id}-${i}`} className={`tt-saida-item${i === p.saida.length - 1 ? " novo" : ""}`}>
-                  {arvore.nos[id].rot}
+              {p.out.length === 0 ? <span className="tt-vazio">nada ainda</span> : p.out.map((id, i) => (
+                <span key={`${id}-${i}`} className={`tt-saida-item${i === p.out.length - 1 ? " novo" : ""}`}>
+                  {tree.nodes[id].label}
                 </span>
               ))}
             </div>
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{ehBfs ? "por_nivel.py" : "percorre.py"}</div>
-            <div className="viz-code-body">
-              {CODIGO[ordem].map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` recolhe a ALTURA (grid 1fr→0fr); zerar a trilha
+              da coluna só tiraria a largura. O bloco continua no DOM para a
+              medição enxergar o pior caso, com `inert` tirando ele do teclado e
+              dos leitores de tela enquanto está fora de vista. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{isBfs ? "por_nivel.py" : "percorre.py"}</div>
+              <div className="viz-code-body">
+                {CODE[order].map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">nó atual</span>
-              <span className="viz-var-val">{p.no >= 0 ? arvore.nos[p.no].rot : "-"}</span>
+              <span className="viz-var-val">{p.node >= 0 ? tree.nodes[p.node].label : "-"}</span>
             </div>
             <div className="viz-var">
-              <span className="viz-var-name">{ehBfs ? "fila" : "pilha"}</span>
+              <span className="viz-var-name">{isBfs ? "fila" : "pilha"}</span>
               <span className="viz-var-val">{p.aux.length}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">processados</span>
-              <span className="viz-var-val best">{p.saida.length} de {arvore.nos.length}</span>
+              <span className="viz-var-val best">{p.out.length} de {tree.nodes.length}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">grau máximo</span>
-              <span className="viz-var-val">{grauMax}</span>
+              <span className="viz-var-val">{maxDegree}</span>
             </div>
           </div>
         </div>
 
+        {/* `.rec-comp` é do bloco temático da Recursão, e é compartilhada com o
+            `RecursionArvoreVisualizer`: a mesma tabela de comparação serve as
+            duas aulas. Renomear a classe aqui quebraria a peça de lá. */}
         <div className="rec-comp-wrap">
           <table className="rec-comp">
-            <caption>Altura mínima para guardar {num(N_EXEMPLO)} nós, por grau</caption>
+            <caption>Altura mínima para guardar {num(N_EXAMPLE)} nós, por grau</caption>
             <thead>
               <tr>
                 <th>Grau (filhos por nó)</th>
@@ -483,31 +480,16 @@ export function NAryTreeVisualizer() {
               </tr>
             </thead>
             <tbody>
-              {GRAUS.map((k) => (
-                <tr key={k} className={k === grauMax ? "on" : undefined}>
-                  <td>{k}{k === grauMax ? " (o desta árvore)" : ""}</td>
-                  <td>{alturaPara(N_EXEMPLO, k)}</td>
-                  <td>~{num(alturaPara(N_EXEMPLO, k) * Math.ceil(Math.log2(k)))}</td>
+              {DEGREES.map((k) => (
+                <tr key={k} className={k === maxDegree ? "on" : undefined}>
+                  <td>{k}{k === maxDegree ? " (o desta árvore)" : ""}</td>
+                  <td>{heightFor(N_EXAMPLE, k)}</td>
+                  <td>~{num(heightFor(N_EXAMPLE, k) * Math.ceil(Math.log2(k)))}</td>
                 </tr>
               ))}
             </tbody>
           </table>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           De grau 2 para grau 256, um milhão de nós sai de 20 níveis para 4. Repare na terceira
@@ -516,16 +498,12 @@ export function NAryTreeVisualizer() {
           banco de dados guarda índice em B-tree, e não em árvore binária.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -209,6 +209,9 @@ foi tentado numa mesma rodada, e nas três por um motivo diferente**:
 | busca da skip list | **0px de diferença** com 14 elementos | a altura vem dos NÍVEIS, que têm teto (`MAX_LEVELS = 4`), e o padrão já batia nele; mais elementos só alargam o SVG, e o wrapper rola na horizontal |
 | reversão da lista | 4 nós = **979px**, 5 nós = 954px | o viewBox tem piso de largura, então menos nós = razão altura/largura maior = mais altura no esticão até a largura do corpo |
 | árvore do Fibonacci | `fib(8)` **com** cache (15 nós) é **81px mais alta** que sem cache (67 nós) | o eixo da altura é a PROFUNDIDADE, `n − 1`, igual nos dois; os nós viram largura. Desligar o cache — o movimento óbvio — dá o caso mais baixo |
+| árvore n-ária | três árvores com **9 nós e grau máximo 3** dão desenhos de 196, 196 e **332px** | o grau vira largura e a profundidade vira altura, então **a mais alta é a mais estreita**. O controle que parece o pior caso (o grau) é justamente o que não mexe na altura |
+| BST | os quatro presets têm **sete nós**, e o SVG vai de 190px a **422px** | não existe campo para encher: o eixo é a ORDEM DE INSERÇÃO. Inserir 1,2,3,4,5… em sequência degenera a árvore em lista, com a mesma contagem de nós |
+| formatos de árvore binária | o preset mais alto é o de **menos nós** (4 nós, 1025px); o de 15 posições é **53px mais baixo** | a profundidade do desenho é fixa nesta peça, então nem a contagem nem a profundidade são o eixo — quem manda é **o tamanho da prosa dos vereditos** |
 
 O que fazer em vez disso, na ordem:
 
@@ -223,6 +226,10 @@ O que fazer em vez disso, na ordem:
    dá metade da altura — 21 linhas em vez de 40.
 4. **Se o pior caso construído der um número MENOR que o padrão, o padrão é o
    pior caso.** Troque o número, não a narrativa.
+5. **Se não houver campo para encher, o pior caso está nos PRESETS** — e aí
+   compare presets do mesmo tamanho, senão você mede a contagem em vez do eixo.
+   Numa BST os quatro presets têm sete nós e a altura do desenho varia 2,2x
+   entre eles.
 
 ### E o estado mais alto não é o último passo: pode ser o do meio
 
@@ -237,6 +244,14 @@ até 85px.
 escreva o teste de rolagem **naquele** passo: a asserção "existe sobra para
 rolar" reprova sozinha no passo 1, onde o miolo ainda não tem o que rolar —
 custou dois testes verdes que não testavam nada.
+
+**Mas confirme que existe pico antes de caçá-lo.** Nem toda peça que empilha
+cresce em altura: se as fichas vivem num eixo horizontal com `flex-wrap`, elas
+só viram altura **depois que a linha quebra**, e o teto é a largura do contêiner,
+não uma constante. Medido no percurso de árvores: 6 fichas cabem numa linha, e a
+amplitude ao longo dos 26 passos é de **20px** — que vêm da nota ter uma ou duas
+linhas, não da pilha. Um relatório que anunciasse "o pico está no meio" ali
+estaria certo por acidente e errado no motivo.
 
 Isso volta na decisão de `measureOn`, com uma segunda pergunta além da do
 `hash-table` ("os dois extremos caem do mesmo lado do orçamento?"): **se a
@@ -624,6 +639,18 @@ camada 2 não alcança o artigo (limite acima). Medido:
 |---|---|---|
 | `HashTableBuscaVisualizer` (`collapsible: false`, com linha do tempo) | 847px | **875px** (+28) |
 | `PrefixSumTradeoff` (`collapsible: false`, `total: 1`, rodapé à mão) | 731px | **741px** (+10) |
+| `SkipListNiveis` (`collapsible: false`, `total: 1`, controles próprios) | 915px | **925px** (+10) |
+| **`BinaryTreeFormatos`** (`collapsible: false`, `total: 1`, **sem rodapé nenhum**) | 915–1025px | **911–1021px (−4)** |
+
+**E a última linha inverte o sinal, o que corrige o enunciado desta seção.** O
+custo não é de adotar a casca: é de **ter um `.viz-foot`**. As três primeiras
+peças pagam porque, mesmo sem linha do tempo, elas têm controles próprios no
+rodapé. A quarta não tem rodapé nenhum — `total: 1` **e** sem `children` fazem o
+`VizFooter` sumir inteiro —, e aí a casca **devolve** 4px, idênticos nos sete
+estados medidos.
+
+Quem citar o `+28` ou o `+10` sem medir a própria peça vai escrever o contrário
+do que ela faz. A pergunta é *esta peça tem rodapé?*, não *esta peça tem bloco?*.
 
 Nos dois a adaptação valeu, porque o que ela conserta é outra coisa — e só
 aparece **abaixo** da régua de 1512x900. Na busca da hash table, o `▶ Rodar` era

--- a/content/visualizers/TreeTraversalVisualizer.tsx
+++ b/content/visualizers/TreeTraversalVisualizer.tsx
@@ -20,71 +20,74 @@ import { createPortal } from "react-dom";
 // um passo por evento e navegar para frente e para trás de graça.
 // ---------------------------------------------------------------------------
 
-type No = { v: number; esq: number; dir: number };
+type TreeNode = { value: number; left: number; right: number };
 
-type Ordem = "pre" | "in" | "pos" | "nivel";
+type Order = "pre" | "in" | "post" | "level";
 
-type Passo = {
-  no: number;
+type Step = {
+  node: number;
   aux: number[];        // pilha (DFS) ou fila (BFS), de baixo/frente para cima/trás
-  saida: number[];
-  linha: number;
-  acao: "entra" | "processa" | "sobe" | "enfileira" | "fim";
-  nota: string;
+  output: number[];
+  line: number;
+  action: "enter" | "process" | "up" | "enqueue" | "end";
+  note: string;
   ok?: boolean;
 };
 
-type Arvore = { key: string; rotulo: string; nos: No[]; raiz: number; legenda: string };
+type Tree = { key: string; label: string; nodes: TreeNode[]; root: number; legend: string };
 
 // A árvore do encontro: raiz 1, à esquerda o 2 (com 4 e 5), à direita o 3 (com 6).
 // É a mesma que foi desenhada no quadro, e é dela que saem as quatro sequências
 // que o artigo cita.
-const ARVORES: Arvore[] = [
+const TREES: Tree[] = [
   {
-    key: "encontro",
-    rotulo: "A árvore do artigo",
-    raiz: 0,
-    legenda: "Pré: 1 2 4 5 3 6 · Em: 4 2 5 1 6 3 · Pós: 4 5 2 6 3 1 · Nível: 1 2 3 4 5 6",
-    nos: [
-      { v: 1, esq: 1, dir: 2 },
-      { v: 2, esq: 3, dir: 4 },
-      { v: 3, esq: 5, dir: -1 },
-      { v: 4, esq: -1, dir: -1 },
-      { v: 5, esq: -1, dir: -1 },
-      { v: 6, esq: -1, dir: -1 },
+    key: "article",
+    label: "A árvore do artigo",
+    root: 0,
+    legend: "Pré: 1 2 4 5 3 6 · Em: 4 2 5 1 6 3 · Pós: 4 5 2 6 3 1 · Nível: 1 2 3 4 5 6",
+    nodes: [
+      { value: 1, left: 1, right: 2 },
+      { value: 2, left: 3, right: 4 },
+      { value: 3, left: 5, right: -1 },
+      { value: 4, left: -1, right: -1 },
+      { value: 5, left: -1, right: -1 },
+      { value: 6, left: -1, right: -1 },
     ],
   },
   {
     key: "bst",
-    rotulo: "Uma BST: em ordem sai ordenado",
-    raiz: 0,
-    legenda: "A mesma máquina, outra arrumação dos valores. Rode em ordem.",
-    nos: [
-      { v: 4, esq: 1, dir: 2 },
-      { v: 2, esq: 3, dir: 4 },
-      { v: 5, esq: -1, dir: 5 },
-      { v: 1, esq: -1, dir: -1 },
-      { v: 3, esq: -1, dir: -1 },
-      { v: 6, esq: -1, dir: -1 },
+    label: "Uma BST: em ordem sai ordenado",
+    root: 0,
+    legend: "A mesma máquina, outra arrumação dos valores. Rode em ordem.",
+    nodes: [
+      { value: 4, left: 1, right: 2 },
+      { value: 2, left: 3, right: 4 },
+      { value: 5, left: -1, right: 5 },
+      { value: 1, left: -1, right: -1 },
+      { value: 3, left: -1, right: -1 },
+      { value: 6, left: -1, right: -1 },
     ],
   },
   {
-    key: "degenerada",
-    rotulo: "Degenerada: a pilha vai ao fundo",
-    raiz: 0,
-    legenda: "Todo nó só tem filho à esquerda: a altura vira n e o O(h) do DFS vira O(n).",
-    nos: [
-      { v: 1, esq: 1, dir: -1 },
-      { v: 2, esq: 2, dir: -1 },
-      { v: 3, esq: 3, dir: -1 },
-      { v: 4, esq: 4, dir: -1 },
-      { v: 5, esq: 5, dir: -1 },
-      { v: 6, esq: -1, dir: -1 },
+    key: "degenerate",
+    label: "Degenerada: a pilha vai ao fundo",
+    root: 0,
+    legend: "Todo nó só tem filho à esquerda: a altura vira n e o O(h) do DFS vira O(n).",
+    nodes: [
+      { value: 1, left: 1, right: -1 },
+      { value: 2, left: 2, right: -1 },
+      { value: 3, left: 3, right: -1 },
+      { value: 4, left: 4, right: -1 },
+      { value: 5, left: 5, right: -1 },
+      { value: 6, left: -1, right: -1 },
     ],
   },
 ];
 
-const CODIGO: Record<Ordem, string[]> = {
+// O Python da tela é conteúdo didático em português, e continua em português:
+// `percorre`, `no.esq`, `no.dir` e `fila` são o que o aluno lê e o que as notas
+// do passo a passo explicam.
+const CODE: Record<Order, string[]> = {
   pre: [
     "def percorre(no):",
     "    if no is None:",
@@ -101,7 +104,7 @@ const CODIGO: Record<Ordem, string[]> = {
     "    processa(no)          # EM ORDEM",
     "    percorre(no.dir)",
   ],
-  pos: [
+  post: [
     "def percorre(no):",
     "    if no is None:",
     "        return",
@@ -109,7 +112,7 @@ const CODIGO: Record<Ordem, string[]> = {
     "    percorre(no.dir)",
     "    processa(no)          # PÓS",
   ],
-  nivel: [
+  level: [
     "def por_nivel(raiz):",
     "    fila = deque([raiz])",
     "    while fila:",
@@ -120,26 +123,26 @@ const CODIGO: Record<Ordem, string[]> = {
   ],
 };
 
-const ROTULO_ORDEM: Record<Ordem, string> = {
+const ORDER_LABEL: Record<Order, string> = {
   pre: "Pré-ordem",
   in: "Em ordem",
-  pos: "Pós-ordem",
-  nivel: "Por nível (BFS)",
+  post: "Pós-ordem",
+  level: "Por nível (BFS)",
 };
 
-const ORDENS: Ordem[] = ["pre", "in", "pos", "nivel"];
+const ORDERS: Order[] = ["pre", "in", "post", "level"];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1400, 950, 650, 420, 250];
+const SPEED_LABELS = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
 
 // Geometria
-const NO_R = 17;
-const PASSO_X = 56;
-const PASSO_Y = 62;
-const MARGEM = 24;
-const TOPO = 22;
+const NODE_R = 17;
+const STEP_X = 56;
+const STEP_Y = 62;
+const MARGIN = 24;
+const TOP = 22;
 
-type Pos = { x: number; prof: number };
+type Pos = { x: number; depth: number };
 
 // Layout por posição EM ORDEM: o x de cada nó é o índice dele no percurso em
 // ordem, e o y é a profundidade. É o layout canônico de árvore binária e não
@@ -147,56 +150,56 @@ type Pos = { x: number; prof: number };
 //
 // O efeito colateral é didático de propósito: ler a árvore da esquerda para a
 // direita na tela É o percurso em ordem. Numa BST, isso significa ler ordenado.
-function posicionar(nos: No[], raiz: number): Pos[] {
-  const pos: Pos[] = nos.map(() => ({ x: 0, prof: 0 }));
+function placeNodes(nodes: TreeNode[], root: number): Pos[] {
+  const pos: Pos[] = nodes.map(() => ({ x: 0, depth: 0 }));
   let slot = 0;
-  const visita = (id: number, prof: number) => {
+  const visit = (id: number, depth: number) => {
     if (id < 0) return;
-    visita(nos[id].esq, prof + 1);
-    pos[id] = { x: slot++, prof };
-    visita(nos[id].dir, prof + 1);
+    visit(nodes[id].left, depth + 1);
+    pos[id] = { x: slot++, depth };
+    visit(nodes[id].right, depth + 1);
   };
-  visita(raiz, 0);
+  visit(root, 0);
   return pos;
 }
 
-function gerarPassos(nos: No[], raiz: number, ordem: Ordem): Passo[] {
-  const out: Passo[] = [];
-  const saida: number[] = [];
-  const nome = (id: number) => `${nos[id].v}`;
+function generateSteps(nodes: TreeNode[], root: number, order: Order): Step[] {
+  const out: Step[] = [];
+  const output: number[] = [];
+  const name = (id: number) => `${nodes[id].value}`;
 
-  if (ordem === "nivel") {
-    const fila: number[] = [raiz];
+  if (order === "level") {
+    const queue: number[] = [root];
     out.push({
-      no: raiz, aux: [...fila], saida: [], linha: 1, acao: "enfileira",
-      nota: `Começo com a raiz sozinha na fila. A fila é a única diferença estrutural entre o BFS e o DFS: ela devolve quem chegou primeiro, então o percurso espalha em vez de afundar.`,
+      node: root, aux: [...queue], output: [], line: 1, action: "enqueue",
+      note: `Começo com a raiz sozinha na fila. A fila é a única diferença estrutural entre o BFS e o DFS: ela devolve quem chegou primeiro, então o percurso espalha em vez de afundar.`,
     });
-    let guarda = 0;
-    while (fila.length && guarda++ < 200) {
-      const id = fila.shift() as number;
-      saida.push(id);
-      const filhos = [nos[id].esq, nos[id].dir].filter((f) => f >= 0);
+    let guard = 0;
+    while (queue.length && guard++ < 200) {
+      const id = queue.shift() as number;
+      output.push(id);
+      const children = [nodes[id].left, nodes[id].right].filter((f) => f >= 0);
       out.push({
-        no: id, aux: [...fila], saida: [...saida], linha: 4, acao: "processa",
-        nota: `Tiro o ${nome(id)} da frente da fila e processo agora. Um nó só entra na fila depois do pai, então ninguém do próximo nível é processado antes de o nível atual terminar.`,
+        node: id, aux: [...queue], output: [...output], line: 4, action: "process",
+        note: `Tiro o ${name(id)} da frente da fila e processo agora. Um nó só entra na fila depois do pai, então ninguém do próximo nível é processado antes de o nível atual terminar.`,
       });
-      for (const f of filhos) {
-        fila.push(f);
+      for (const child of children) {
+        queue.push(child);
         out.push({
-          no: f, aux: [...fila], saida: [...saida], linha: nos[id].esq === f ? 5 : 6, acao: "enfileira",
-          nota: `O ${nome(f)} é filho do ${nome(id)}, então entra no FIM da fila. Ele vai esperar todo mundo que já estava lá, e é isso que mantém a leitura por níveis.`,
+          node: child, aux: [...queue], output: [...output], line: nodes[id].left === child ? 5 : 6, action: "enqueue",
+          note: `O ${name(child)} é filho do ${name(id)}, então entra no FIM da fila. Ele vai esperar todo mundo que já estava lá, e é isso que mantém a leitura por níveis.`,
         });
       }
-      if (!filhos.length) {
+      if (!children.length) {
         out[out.length - 1] = {
           ...out[out.length - 1],
-          nota: `${out[out.length - 1].nota} O ${nome(id)} é folha: não acrescenta ninguém à fila.`,
+          note: `${out[out.length - 1].note} O ${name(id)} é folha: não acrescenta ninguém à fila.`,
         };
       }
     }
     out.push({
-      no: -1, aux: [], saida: [...saida], linha: 2, acao: "fim", ok: true,
-      nota: `Fila vazia, percurso terminado: ${saida.map(nome).join(", ")}. Foram ${saida.length} nós, cada um processado uma vez, então o tempo é O(n). O espaço é o tamanho da fila no pior momento, que é o nível mais largo da árvore.`,
+      node: -1, aux: [], output: [...output], line: 2, action: "end", ok: true,
+      note: `Fila vazia, percurso terminado: ${output.map(name).join(", ")}. Foram ${output.length} nós, cada um processado uma vez, então o tempo é O(n). O espaço é o tamanho da fila no pior momento, que é o nível mais largo da árvore.`,
     });
     return out;
   }
@@ -204,121 +207,122 @@ function gerarPassos(nos: No[], raiz: number, ordem: Ordem): Passo[] {
   // DFS: pilha explícita de quadros, em vez de recursão de verdade, para poder
   // emitir um passo por evento e navegar para trás.
   //
-  // `fase` conta quantos filhos já foram despachados (0, 1 ou 2) e `processado`
+  // `phase` conta quantos filhos já foram despachados (0, 1 ou 2) e `processed`
   // marca se o nó já saiu. É esse par que faz o MESMO laço servir para as três
-  // ordens: muda só o valor de `alvo`, ou seja, em qual fase o nó é processado.
-  //   pré  -> alvo 0 (antes de despachar a esquerda)
-  //   em   -> alvo 1 (entre esquerda e direita)
-  //   pós  -> alvo 2 (depois dos dois filhos)
-  const alvo = ordem === "pre" ? 0 : ordem === "in" ? 1 : 2;
-  const linhaProcessa = ordem === "pre" ? 3 : ordem === "in" ? 4 : 5;
-  const linhaEsq = ordem === "pre" ? 4 : 3;
-  const linhaDir = ordem === "pos" ? 4 : 5;
-  const pilha: { id: number; fase: number; processado: boolean }[] = [
-    { id: raiz, fase: 0, processado: false },
+  // ordens: muda só o valor de `target`, ou seja, em qual fase o nó é processado.
+  //   pré  -> target 0 (antes de despachar a esquerda)
+  //   em   -> target 1 (entre esquerda e direita)
+  //   pós  -> target 2 (depois dos dois filhos)
+  const target = order === "pre" ? 0 : order === "in" ? 1 : 2;
+  const processLine = order === "pre" ? 3 : order === "in" ? 4 : 5;
+  const leftLine = order === "pre" ? 4 : 3;
+  const rightLine = order === "post" ? 4 : 5;
+  const stack: { id: number; phase: number; processed: boolean }[] = [
+    { id: root, phase: 0, processed: false },
   ];
-  const idsNaPilha = () => pilha.map((q) => q.id);
+  const stackIds = () => stack.map((q) => q.id);
 
   out.push({
-    no: raiz, aux: idsNaPilha(), saida: [], linha: 0, acao: "entra",
-    nota: `Entro na raiz. No DFS a estrutura auxiliar é uma PILHA, e na versão recursiva ela é a própria pilha de chamadas do programa: cada nível que eu desço empilha um quadro.`,
+    node: root, aux: stackIds(), output: [], line: 0, action: "enter",
+    note: `Entro na raiz. No DFS a estrutura auxiliar é uma PILHA, e na versão recursiva ela é a própria pilha de chamadas do programa: cada nível que eu desço empilha um quadro.`,
   });
 
-  let guarda = 0;
-  while (pilha.length && guarda++ < 400) {
-    const topo = pilha[pilha.length - 1];
-    const no = nos[topo.id];
+  let guard = 0;
+  while (stack.length && guard++ < 400) {
+    const top = stack[stack.length - 1];
+    const node = nodes[top.id];
 
-    if (!topo.processado && topo.fase === alvo) {
-      saida.push(topo.id);
-      topo.processado = true;
-      const explica =
-        ordem === "pre"
+    if (!top.processed && top.phase === target) {
+      output.push(top.id);
+      top.processed = true;
+      const explanation =
+        order === "pre"
           ? `antes de olhar qualquer filho`
-          : ordem === "in"
+          : order === "in"
             ? `depois de resolver toda a subárvore esquerda e antes de tocar na direita`
             : `só depois que os dois filhos já saíram`;
       out.push({
-        no: topo.id, aux: idsNaPilha(), saida: [...saida], linha: linhaProcessa, acao: "processa",
-        nota: `Processo o ${nome(topo.id)} ${explica}. É a única linha que muda entre as três ordens, e é ela que decide a saída inteira.`,
+        node: top.id, aux: stackIds(), output: [...output], line: processLine, action: "process",
+        note: `Processo o ${name(top.id)} ${explanation}. É a única linha que muda entre as três ordens, e é ela que decide a saída inteira.`,
       });
       continue;
     }
 
-    if (topo.fase <= 1) {
-      const filho = topo.fase === 0 ? no.esq : no.dir;
-      const lado = topo.fase === 0 ? "esquerda" : "direita";
-      topo.fase++;
-      if (filho >= 0) {
-        pilha.push({ id: filho, fase: 0, processado: false });
+    if (top.phase <= 1) {
+      const child = top.phase === 0 ? node.left : node.right;
+      // "esquerda" e "direita" são o texto que entra na nota: conteúdo, não nome.
+      const side = top.phase === 0 ? "esquerda" : "direita";
+      top.phase++;
+      if (child >= 0) {
+        stack.push({ id: child, phase: 0, processed: false });
         out.push({
-          no: filho, aux: idsNaPilha(), saida: [...saida], linha: lado === "esquerda" ? linhaEsq : linhaDir, acao: "entra",
-          nota: `Desço para a ${lado} do ${nome(topo.id)} e entro no ${nome(filho)}. A pilha está com ${pilha.length} ${pilha.length === 1 ? "quadro" : "quadros"}: ela nunca passa da altura da árvore, e é por isso que o espaço do DFS é O(h), não O(n).`,
+          node: child, aux: stackIds(), output: [...output], line: side === "esquerda" ? leftLine : rightLine, action: "enter",
+          note: `Desço para a ${side} do ${name(top.id)} e entro no ${name(child)}. A pilha está com ${stack.length} ${stack.length === 1 ? "quadro" : "quadros"}: ela nunca passa da altura da árvore, e é por isso que o espaço do DFS é O(h), não O(n).`,
         });
       } else {
         out.push({
-          no: topo.id, aux: idsNaPilha(), saida: [...saida], linha: 2, acao: "sobe",
-          nota: `O ${nome(topo.id)} não tem filho à ${lado}: a chamada bate no caso base e volta na hora, sem empilhar nada.`,
+          node: top.id, aux: stackIds(), output: [...output], line: 2, action: "up",
+          note: `O ${name(top.id)} não tem filho à ${side}: a chamada bate no caso base e volta na hora, sem empilhar nada.`,
         });
       }
       continue;
     }
 
     // fase 2 e já processado: desempilha
-    pilha.pop();
-    const pai = pilha.length ? nos[pilha[pilha.length - 1].id] : null;
+    stack.pop();
+    const parent = stack.length ? nodes[stack[stack.length - 1].id] : null;
     out.push({
-      no: topo.id, aux: idsNaPilha(), saida: [...saida], linha: 5, acao: "sobe",
-      nota: pai
-        ? `Terminei o ${nome(topo.id)} e os dois filhos dele. Desempilho e volto para o pai, que continua exatamente de onde parou.`
+      node: top.id, aux: stackIds(), output: [...output], line: 5, action: "up",
+      note: parent
+        ? `Terminei o ${name(top.id)} e os dois filhos dele. Desempilho e volto para o pai, que continua exatamente de onde parou.`
         : `Desempilho a raiz: a pilha ficou vazia e o percurso acabou.`,
     });
   }
 
   out.push({
-    no: -1, aux: [], saida: [...saida], linha: linhaProcessa, acao: "fim", ok: true,
-    nota: `${ROTULO_ORDEM[ordem]}: ${saida.map(nome).join(", ")}. Foram ${saida.length} nós visitados uma vez cada, O(n) de tempo. O pico da pilha foi a altura da árvore, e não o número de nós.`,
+    node: -1, aux: [], output: [...output], line: processLine, action: "end", ok: true,
+    note: `${ORDER_LABEL[order]}: ${output.map(name).join(", ")}. Foram ${output.length} nós visitados uma vez cada, O(n) de tempo. O pico da pilha foi a altura da árvore, e não o número de nós.`,
   });
   return out;
 }
 
 export function TreeTraversalVisualizer() {
-  const [arvoreKey, setArvoreKey] = useState("encontro");
-  const [ordem, setOrdem] = useState<Ordem>("pre");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
+  const [treeKey, setTreeKey] = useState("article");
+  const [order, setOrder] = useState<Order>("pre");
+  const [step, setStep] = useState(0);
+  const [playing, setPlaying] = useState(false);
+  const [speed, setSpeed] = useState(4);
   const [expanded, setExpanded] = useState(false);
   const [mounted, setMounted] = useState(false);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => setMounted(true), []);
 
-  const arvore = useMemo(
-    () => ARVORES.find((a) => a.key === arvoreKey) ?? ARVORES[0],
-    [arvoreKey]
+  const tree = useMemo(
+    () => TREES.find((a) => a.key === treeKey) ?? TREES[0],
+    [treeKey]
   );
-  const pos = useMemo(() => posicionar(arvore.nos, arvore.raiz), [arvore]);
-  const passos = useMemo(() => gerarPassos(arvore.nos, arvore.raiz, ordem), [arvore, ordem]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const pos = useMemo(() => placeNodes(tree.nodes, tree.root), [tree]);
+  const steps = useMemo(() => generateSteps(tree.nodes, tree.root, order), [tree, order]);
+  const total = steps.length;
+  const idx = Math.min(step, total - 1);
+  const p = steps[idx];
 
-  const parar = useCallback(() => {
+  const stop = useCallback(() => {
     if (timer.current) { clearInterval(timer.current); timer.current = null; }
   }, []);
-  useEffect(() => () => parar(), [parar]);
+  useEffect(() => () => stop(), [stop]);
 
   useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
+    stop();
+    if (!playing) return;
+    timer.current = setInterval(() => setStep((s) => (s >= total - 1 ? s : s + 1)), SPEEDS[speed]);
+    return stop;
+  }, [playing, speed, total, stop]);
 
   useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
+    if (playing && idx >= total - 1) setPlaying(false);
+  }, [playing, idx, total]);
 
   useEffect(() => {
     if (!expanded) return;
@@ -327,41 +331,41 @@ export function TreeTraversalVisualizer() {
     return () => window.removeEventListener("keydown", onKey);
   }, [expanded]);
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const trocarOrdem = (o: Ordem) => { reiniciar(); setOrdem(o); };
-  const trocarArvore = (k: string) => { reiniciar(); setArvoreKey(k); };
+  const restart = () => { stop(); setPlaying(false); setStep(0); };
+  const pickOrder = (o: Order) => { restart(); setOrder(o); };
+  const pickTree = (k: string) => { restart(); setTreeKey(k); };
 
   const maxSlot = pos.reduce((m, q) => Math.max(m, q.x), 0);
-  const maxProf = pos.reduce((m, q) => Math.max(m, q.prof), 0);
-  const W = MARGEM * 2 + maxSlot * PASSO_X + NO_R * 2;
-  const H = TOPO * 2 + maxProf * PASSO_Y + NO_R * 2;
-  const cx = (id: number) => MARGEM + NO_R + pos[id].x * PASSO_X;
-  const cy = (id: number) => TOPO + NO_R + pos[id].prof * PASSO_Y;
+  const maxDepth = pos.reduce((m, q) => Math.max(m, q.depth), 0);
+  const W = MARGIN * 2 + maxSlot * STEP_X + NODE_R * 2;
+  const H = TOP * 2 + maxDepth * STEP_Y + NODE_R * 2;
+  const cx = (id: number) => MARGIN + NODE_R + pos[id].x * STEP_X;
+  const cy = (id: number) => TOP + NODE_R + pos[id].depth * STEP_Y;
 
-  const jaSaiu = useMemo(() => new Set(p.saida), [p.saida]);
-  const naAux = useMemo(() => new Set(p.aux), [p.aux]);
+  const alreadyOut = useMemo(() => new Set(p.output), [p.output]);
+  const inAux = useMemo(() => new Set(p.aux), [p.aux]);
 
-  const classeNo = (id: number) => {
+  const nodeClass = (id: number) => {
     const cls = ["tt-no"];
-    if (id === p.no) cls.push("on");
-    if (jaSaiu.has(id)) cls.push("saiu");
-    else if (naAux.has(id)) cls.push("aux");
+    if (id === p.node) cls.push("on");
+    if (alreadyOut.has(id)) cls.push("saiu");
+    else if (inAux.has(id)) cls.push("aux");
     return cls.join(" ");
   };
 
-  const ehBfs = ordem === "nivel";
-  const codigo = CODIGO[ordem];
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const notaCls = "viz-note" + (p.ok ? " ok" : "");
-  const picoAux = useMemo(() => passos.reduce((m, q) => Math.max(m, q.aux.length), 0), [passos]);
+  const isBfs = order === "level";
+  const code = CODE[order];
+  const stepPct = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (p.ok ? " ok" : "");
+  const auxPeak = useMemo(() => steps.reduce((m, q) => Math.max(m, q.aux.length), 0), [steps]);
 
-  const variaveis = [
-    { nome: "nó atual", valor: p.no >= 0 ? `${arvore.nos[p.no].v}` : "-" },
-    { nome: ehBfs ? "fila (tamanho)" : "pilha (altura)", valor: `${p.aux.length}` },
-    { nome: "processados", valor: `${p.saida.length} de ${arvore.nos.length}`, best: true },
+  const vars = [
+    { name: "nó atual", value: p.node >= 0 ? `${tree.nodes[p.node].value}` : "-" },
+    { name: isBfs ? "fila (tamanho)" : "pilha (altura)", value: `${p.aux.length}` },
+    { name: "processados", value: `${p.output.length} de ${tree.nodes.length}`, best: true },
   ];
 
-  const viz = (
+  const frame = (
     <figure className="viz" style={{ margin: 0 }}>
       <div className="viz-head">
         <div className="viz-head-title">
@@ -378,31 +382,31 @@ export function TreeTraversalVisualizer() {
 
       <div className="viz-body">
         <div className="bigo-chips">
-          {ORDENS.map((o) => (
+          {ORDERS.map((o) => (
             <button
               key={o}
-              className={`bigo-chip${ordem === o ? " on" : ""}`}
-              onClick={() => trocarOrdem(o)}
-              aria-pressed={ordem === o}
+              className={`bigo-chip${order === o ? " on" : ""}`}
+              onClick={() => pickOrder(o)}
+              aria-pressed={order === o}
             >
-              {ROTULO_ORDEM[o]}
+              {ORDER_LABEL[o]}
             </button>
           ))}
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
-          {ARVORES.map((a) => (
+          {TREES.map((a) => (
             <button
               key={a.key}
-              className={`bigo-chip${arvoreKey === a.key ? " on" : ""}`}
-              onClick={() => trocarArvore(a.key)}
-              aria-pressed={arvoreKey === a.key}
+              className={`bigo-chip${treeKey === a.key ? " on" : ""}`}
+              onClick={() => pickTree(a.key)}
+              aria-pressed={treeKey === a.key}
             >
-              {a.rotulo}
+              {a.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{arvore.legenda}</p>
+        <p className="tt-legenda-arvore">{tree.legend}</p>
 
         <div className="tt-arv-wrap">
           <svg
@@ -411,26 +415,26 @@ export function TreeTraversalVisualizer() {
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`${ROTULO_ORDEM[ordem]} sobre ${arvore.rotulo}. Passo ${idx + 1} de ${total}. ${p.nota} Saída até aqui: ${p.saida.map((i) => arvore.nos[i].v).join(", ") || "vazia"}.`}
+            aria-label={`${ORDER_LABEL[order]} sobre ${tree.label}. Passo ${idx + 1} de ${total}. ${p.note} Saída até aqui: ${p.output.map((i) => tree.nodes[i].value).join(", ") || "vazia"}.`}
           >
-            {arvore.nos.map((no, id) =>
-              [no.esq, no.dir]
+            {tree.nodes.map((node, id) =>
+              [node.left, node.right]
                 .filter((f) => f >= 0)
                 .map((f) => (
                   <line
                     key={`${id}-${f}`}
-                    className={`tt-aresta${jaSaiu.has(f) || naAux.has(f) ? " on" : ""}`}
+                    className={`tt-aresta${alreadyOut.has(f) || inAux.has(f) ? " on" : ""}`}
                     x1={cx(id)}
-                    y1={cy(id) + NO_R}
+                    y1={cy(id) + NODE_R}
                     x2={cx(f)}
-                    y2={cy(f) - NO_R}
+                    y2={cy(f) - NODE_R}
                   />
                 ))
             )}
-            {arvore.nos.map((no, id) => (
-              <g key={id} className={classeNo(id)}>
-                <circle cx={cx(id)} cy={cy(id)} r={NO_R} />
-                <text x={cx(id)} y={cy(id) + 4} textAnchor="middle">{no.v}</text>
+            {tree.nodes.map((node, id) => (
+              <g key={id} className={nodeClass(id)}>
+                <circle cx={cx(id)} cy={cy(id)} r={NODE_R} />
+                <text x={cx(id)} y={cy(id) + 4} textAnchor="middle">{node.value}</text>
               </g>
             ))}
           </svg>
@@ -439,15 +443,15 @@ export function TreeTraversalVisualizer() {
         <div className="tt-paineis">
           <div className="tt-painel">
             <div className="tt-painel-tit">
-              {ehBfs ? "Fila" : "Pilha"} <em>{ehBfs ? "sai pela frente (FIFO)" : "sai pelo topo (LIFO)"}</em>
+              {isBfs ? "Fila" : "Pilha"} <em>{isBfs ? "sai pela frente (FIFO)" : "sai pelo topo (LIFO)"}</em>
             </div>
-            <div className={`tt-aux${ehBfs ? " fila" : ""}`}>
+            <div className={`tt-aux${isBfs ? " fila" : ""}`}>
               {p.aux.length === 0 ? (
                 <span className="tt-vazio">vazia</span>
               ) : (
                 p.aux.map((id, i) => (
-                  <span key={`${id}-${i}`} className={`tt-aux-item${i === p.aux.length - 1 && !ehBfs ? " topo" : ""}${i === 0 && ehBfs ? " topo" : ""}`}>
-                    {arvore.nos[id].v}
+                  <span key={`${id}-${i}`} className={`tt-aux-item${i === p.aux.length - 1 && !isBfs ? " topo" : ""}${i === 0 && isBfs ? " topo" : ""}`}>
+                    {tree.nodes[id].value}
                   </span>
                 ))
               )}
@@ -455,15 +459,15 @@ export function TreeTraversalVisualizer() {
           </div>
           <div className="tt-painel">
             <div className="tt-painel-tit">
-              Saída <em>{ROTULO_ORDEM[ordem]}</em>
+              Saída <em>{ORDER_LABEL[order]}</em>
             </div>
             <div className="tt-saida">
-              {p.saida.length === 0 ? (
+              {p.output.length === 0 ? (
                 <span className="tt-vazio">nada processado ainda</span>
               ) : (
-                p.saida.map((id, i) => (
-                  <span key={`${id}-${i}`} className={`tt-saida-item${i === p.saida.length - 1 ? " novo" : ""}`}>
-                    {arvore.nos[id].v}
+                p.output.map((id, i) => (
+                  <span key={`${id}-${i}`} className={`tt-saida-item${i === p.output.length - 1 ? " novo" : ""}`}>
+                    {tree.nodes[id].value}
                   </span>
                 ))
               )}
@@ -471,14 +475,14 @@ export function TreeTraversalVisualizer() {
           </div>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
           <div className="viz-code">
-            <div className="viz-code-head">{ehBfs ? "por_nivel.py" : "percorre.py"}</div>
+            <div className="viz-code-head">{isBfs ? "por_nivel.py" : "percorre.py"}</div>
             <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
+              {code.map((txt, i) => (
+                <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
                   <span className="ln">{i + 1}</span>
                   {txt}
                 </div>
@@ -487,10 +491,10 @@ export function TreeTraversalVisualizer() {
           </div>
           <div className="viz-vars">
             <div className="viz-vars-head">Variáveis</div>
-            {variaveis.map((v) => (
-              <div className="viz-var" key={v.nome}>
-                <span className="viz-var-name">{v.nome}</span>
-                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.valor}</span>
+            {vars.map((v) => (
+              <div className="viz-var" key={v.name}>
+                <span className="viz-var-name">{v.name}</span>
+                <span className={`viz-var-val${v.best ? " best" : ""}`}>{v.value}</span>
               </div>
             ))}
           </div>
@@ -499,15 +503,15 @@ export function TreeTraversalVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>nós na árvore</span>
-            <strong>{arvore.nos.length}</strong>
+            <strong>{tree.nodes.length}</strong>
           </div>
           <div className="bigo-stat">
             <span>altura</span>
-            <strong>{maxProf + 1}</strong>
+            <strong>{maxDepth + 1}</strong>
           </div>
           <div className="bigo-stat">
-            <span>pico da {ehBfs ? "fila" : "pilha"}</span>
-            <strong>{picoAux}</strong>
+            <span>pico da {isBfs ? "fila" : "pilha"}</span>
+            <strong>{auxPeak}</strong>
           </div>
           <div className="bigo-stat">
             <span>passos até o fim</span>
@@ -516,19 +520,19 @@ export function TreeTraversalVisualizer() {
         </div>
 
         <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
+          <button className="viz-btn" title="Reiniciar" onClick={restart}>↺</button>
+          <button className="viz-btn" disabled={idx === 0} onClick={() => { stop(); setPlaying(false); setStep(Math.max(0, idx - 1)); }}>‹ Anterior</button>
+          <button className="viz-play" onClick={() => { if (playing) { setPlaying(false); return; } setStep(idx >= total - 1 ? 0 : idx); setPlaying(true); }}>
+            {playing ? "❚❚ Pausar" : "▶ Rodar"}
           </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
+          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { stop(); setPlaying(false); setStep(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
           <div className="viz-speed">
             <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
+            <input type="range" min={1} max={5} step={1} value={speed} onChange={(e) => setSpeed(parseInt(e.target.value, 10))} />
+            <span className="val">{SPEED_LABELS[speed]}</span>
           </div>
         </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
+        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${stepPct}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Troque a ordem sem reiniciar a cabeça: o caminho pela árvore é sempre o mesmo, o que muda é
@@ -541,10 +545,10 @@ export function TreeTraversalVisualizer() {
   if (expanded && mounted) {
     return createPortal(
       <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
+        {frame}
       </div>,
       document.body
     );
   }
-  return viz;
+  return frame;
 }

--- a/content/visualizers/TreeTraversalVisualizer.tsx
+++ b/content/visualizers/TreeTraversalVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TreeTraversalVisualizer, os quatro percursos sobre a MESMA árvore.
@@ -18,6 +19,10 @@ import { createPortal } from "react-dom";
 // O gerador é puro: simula a recursão com uma pilha explícita de quadros
 // (nó + fase) em vez de recursão de verdade, porque é isso que permite emitir
 // um passo por evento e navegar para frente e para trás de graça.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
 type TreeNode = { value: number; left: number; right: number };
@@ -132,8 +137,9 @@ const ORDER_LABEL: Record<Order, string> = {
 
 const ORDERS: Order[] = ["pre", "in", "post", "level"];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-const SPEED_LABELS = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// A marcha inicial era `useState(4)` — 1.5x, e não o 1x padrão do hook. Ela
+// vira `initialSpeed`, senão a peça passa a abrir mais devagar do que abria.
+const INITIAL_SPEED = 4;
 
 // Geometria
 const NODE_R = 17;
@@ -289,14 +295,6 @@ function generateSteps(nodes: TreeNode[], root: number, order: Order): Step[] {
 export function TreeTraversalVisualizer() {
   const [treeKey, setTreeKey] = useState("article");
   const [order, setOrder] = useState<Order>("pre");
-  const [step, setStep] = useState(0);
-  const [playing, setPlaying] = useState(false);
-  const [speed, setSpeed] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
 
   const tree = useMemo(
     () => TREES.find((a) => a.key === treeKey) ?? TREES[0],
@@ -305,35 +303,22 @@ export function TreeTraversalVisualizer() {
   const pos = useMemo(() => placeNodes(tree.nodes, tree.root), [tree]);
   const steps = useMemo(() => generateSteps(tree.nodes, tree.root, order), [tree, order]);
   const total = steps.length;
-  const idx = Math.min(step, total - 1);
+
+  const viz = useVisualizer({
+    title: "Visualizador · os quatro percursos sobre a mesma árvore",
+    total,
+    initialSpeed: INITIAL_SPEED,
+    // O que muda a altura da peça: a ordem (o código vai de 6 a 7 linhas) e a
+    // árvore (a altura do SVG é a PROFUNDIDADE — a degenerada tem 6 níveis
+    // contra 3 das outras duas, e são 186px de diferença).
+    measureOn: [order, treeKey],
+  });
+
+  const idx = viz.step;
   const p = steps[idx];
 
-  const stop = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => stop(), [stop]);
-
-  useEffect(() => {
-    stop();
-    if (!playing) return;
-    timer.current = setInterval(() => setStep((s) => (s >= total - 1 ? s : s + 1)), SPEEDS[speed]);
-    return stop;
-  }, [playing, speed, total, stop]);
-
-  useEffect(() => {
-    if (playing && idx >= total - 1) setPlaying(false);
-  }, [playing, idx, total]);
-
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  const restart = () => { stop(); setPlaying(false); setStep(0); };
-  const pickOrder = (o: Order) => { restart(); setOrder(o); };
-  const pickTree = (k: string) => { restart(); setTreeKey(k); };
+  const pickOrder = (o: Order) => { viz.reset(); setOrder(o); };
+  const pickTree = (k: string) => { viz.reset(); setTreeKey(k); };
 
   const maxSlot = pos.reduce((m, q) => Math.max(m, q.x), 0);
   const maxDepth = pos.reduce((m, q) => Math.max(m, q.depth), 0);
@@ -355,7 +340,6 @@ export function TreeTraversalVisualizer() {
 
   const isBfs = order === "level";
   const code = CODE[order];
-  const stepPct = Math.round(((idx + 1) / total) * 100);
   const noteClass = "viz-note" + (p.ok ? " ok" : "");
   const auxPeak = useMemo(() => steps.reduce((m, q) => Math.max(m, q.aux.length), 0), [steps]);
 
@@ -365,22 +349,11 @@ export function TreeTraversalVisualizer() {
     { name: "processados", value: `${p.output.length} de ${tree.nodes.length}`, best: true },
   ];
 
-  const frame = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · os quatro percursos sobre a mesma árvore</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {ORDERS.map((o) => (
             <button
@@ -478,18 +451,22 @@ export function TreeTraversalVisualizer() {
         <p className={noteClass}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{isBfs ? "por_nivel.py" : "percorre.py"}</div>
-            <div className="viz-code-body">
-              {code.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` é o que recolhe a ALTURA: zerar a trilha da
+              coluna sozinha tira só a largura (contrato §7). */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{isBfs ? "por_nivel.py" : "percorre.py"}</div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             {vars.map((v) => (
               <div className="viz-var" key={v.name}>
@@ -519,36 +496,13 @@ export function TreeTraversalVisualizer() {
           </div>
         </div>
 
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={restart}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { stop(); setPlaying(false); setStep(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (playing) { setPlaying(false); return; } setStep(idx >= total - 1 ? 0 : idx); setPlaying(true); }}>
-            {playing ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { stop(); setPlaying(false); setStep(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={speed} onChange={(e) => setSpeed(parseInt(e.target.value, 10))} />
-            <span className="val">{SPEED_LABELS[speed]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${stepPct}%` }} /></div>
-
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Troque a ordem sem reiniciar a cabeça: o caminho pela árvore é sempre o mesmo, o que muda é
           a linha em que <code>processa(no)</code> aparece. No BFS muda a estrutura, e aí muda o caminho.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {frame}
-      </div>,
-      document.body
-    );
-  }
-  return frame;
 }

--- a/tests/viz-arvores-binarias.spec.ts
+++ b/tests/viz-arvores-binarias.spec.ts
@@ -1,0 +1,189 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa do tópico `arvores-binarias`.
+//
+// O visualizador daqui é o caso mais incomum da série: um CLASSIFICADOR, com
+// painel expandido mas sem bloco de código, sem painel de variáveis e sem
+// reprodução nenhuma. Ele entra com `collapsible: false` e `total: 1`, e com
+// isso o `VizFooter` não desenha nada.
+//
+// Por isso os itens 2, 3 e 4 do mínimo da §8 (o bloco recolhível) não existem
+// aqui. No lugar deles vale a regra que o contrato põe no lugar: **nenhum botão
+// pode prometer esconder um bloco que o visualizador não tem** — e, pelo mesmo
+// motivo, nenhum contador de passo ou atalho de teclado pode prometer uma linha
+// do tempo que ele também não tem.
+
+const URL = "/topico/arvores-binarias/";
+// Folga de subpixel, igual à do hook.
+const SLACK = 8;
+
+async function abrirPainel(page: Page): Promise<Locator> {
+  await page.goto(URL);
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator("figure.viz").getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+// Lê um cartão de veredito pelo NOME, e devolve nome + selo + motivo juntos.
+// Ler o selo sozinho passaria verde com os vereditos trocados de lugar: o
+// conjunto de textos da tela continua idêntico e só a associação mente.
+function cartao(raiz: Locator, nome: string): Locator {
+  return raiz.locator(".bt-veredito").filter({
+    has: raiz.page().locator(".bt-veredito-nome", { hasText: new RegExp(`^${nome}$`) }),
+  });
+}
+
+test.describe("arvores-binarias · casca adaptativa", () => {
+  test("o cabeçalho fica parado e o ✕ Fechar continua à vista com o miolo rolado até o fim", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const vp = page.viewportSize();
+    expect(vp!.height, "a régua tem que ser a que eu pedi").toBe(600);
+
+    const painel = await abrirPainel(page);
+    // O estado mais alto medido: "Cheia, não completa" / "Balanceada" /
+    // "Degenerada" empatam em 261px de sobra a 1440x600.
+    await painel.getByRole("button", { name: "Degenerada", exact: true }).click();
+    await expect(cartao(painel, "Degenerada").locator(".bt-veredito-selo")).toHaveText("sim");
+
+    const fechar = painel.getByRole("button", { name: /Fechar/ });
+
+    const antes = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay figure.viz") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      const h = f.querySelector(".viz-head") as HTMLElement;
+      return {
+        sobraMiolo: b.scrollHeight - b.clientHeight,
+        sobraFigura: f.scrollHeight - f.clientHeight,
+        headTop: Math.round(h.getBoundingClientRect().top),
+      };
+    });
+
+    // A asserção da camada 1 vem ANTES da premissa, de propósito: a quebra que
+    // devolve a rolagem para a figura também zera a sobra do miolo, e com a
+    // premissa na frente o teste reprovaria dizendo "o miolo não estoura" —
+    // apontando para o lugar errado, e convidando quem vier depois a remover a
+    // premissa por parecer redundante.
+    expect(
+      antes.sobraFigura,
+      "a figura inteira não pode ser a área rolável: é isso que leva o cabeçalho embora"
+    ).toBeLessThanOrEqual(SLACK);
+    // Premissa: sem sobra para rolar, o teste vira decoração verde.
+    expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(
+      SLACK
+    );
+
+    const depois = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay figure.viz") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      const h = f.querySelector(".viz-head") as HTMLElement;
+      b.scrollTop = b.scrollHeight;
+      f.scrollTop = f.scrollHeight; // se a figura ainda rolar, ela rola aqui
+      return {
+        mioloRolou: b.scrollTop,
+        figuraRolou: f.scrollTop,
+        headTop: Math.round(h.getBoundingClientRect().top),
+      };
+    });
+
+    // As três juntas. Sem a terceira, a quebra que devolve a rolagem para a
+    // figura passa: o `.viz-body` fica em zero, o cabeçalho não se mexe, e o
+    // teste aprova exatamente o defeito que a camada 1 conserta.
+    expect(depois.mioloRolou, "quem rola é o miolo").toBeGreaterThan(0);
+    expect(depois.figuraRolou, "a figura NÃO rola").toBe(0);
+    expect(depois.headTop, "o cabeçalho não anda um pixel").toBe(antes.headTop);
+
+    // E o botão de fechar, que mora no cabeçalho, continua dentro da janela.
+    const caixa = (await fechar.boundingBox())!;
+    expect(caixa.y, "o ✕ Fechar não sai por cima da janela").toBeGreaterThanOrEqual(0);
+    expect(caixa.y + caixa.height, "nem por baixo").toBeLessThanOrEqual(600);
+  });
+
+  test("não existe botão prometendo mostrar ou ocultar um bloco que a peça não tem", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+    const cabeca = painel.locator(".viz-head");
+
+    // Nem no rótulo do hook ("Mostrar código" / "Ocultar código")...
+    await expect(cabeca.getByRole("button", { name: /Mostrar|Ocultar/i })).toHaveCount(0);
+    // ...nem com outro nome de bloco.
+    await expect(cabeca.locator("button.viz-toggle-codigo")).toHaveCount(0);
+    // E não há bloco recolhível nenhum no miolo para ele controlar.
+    await expect(painel.locator(".viz-code-slot, .viz-code")).toHaveCount(0);
+
+    // O cabeçalho tem exatamente um botão, e ele diz o que faz.
+    await expect(cabeca.getByRole("button")).toHaveCount(1);
+    await expect(cabeca.getByRole("button")).toHaveText(/Fechar/);
+  });
+
+  test("não aparece contador de passo nem atalho de teclado; o lugar do passo diz nós e altura", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+
+    // Sem linha do tempo: nada de reprodução, em lugar nenhum da peça.
+    await expect(painel.getByText(/passo \d+ de \d+/)).toHaveCount(0);
+    await expect(painel.locator(".viz-atalhos")).toHaveCount(0);
+    await expect(painel.locator(".viz-progress")).toHaveCount(0);
+    await expect(painel.locator(".viz-foot")).toHaveCount(0);
+    await expect(painel.getByRole("button", { name: /Rodar|Pausar|Anterior|Próximo/ })).toHaveCount(
+      0
+    );
+
+    // O que ocupa o lugar do contador é o número que resume o estado — com o
+    // rótulo junto, senão o número perde o contexto que o explicava.
+    await painel.getByRole("button", { name: "Perfeita", exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("7 nós · altura 3");
+    await painel.getByRole("button", { name: "Degenerada", exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("4 nós · altura 4");
+  });
+
+  test("os presets vivem no miolo e mudam veredito, selo e motivo do cartão certo", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+
+    // O contrato manda preset no miolo: no rodapé só mora reprodução — e aqui
+    // não há rodapé nenhum para eles caírem.
+    await expect(painel.locator(".viz-body .bigo-chips button")).toHaveCount(5);
+
+    await painel.getByRole("button", { name: "Degenerada", exact: true }).click();
+    // Nome, selo e motivo lidos no MESMO cartão: é o que pega vereditos
+    // trocados de lugar, que o guarda de idioma não vê por comparar conjunto.
+    await expect(cartao(painel, "Degenerada").locator(".bt-veredito-selo")).toHaveText("sim");
+    await expect(cartao(painel, "Degenerada").locator("p")).toContainText("Nenhum nó tem dois");
+    await expect(cartao(painel, "Cheia").locator(".bt-veredito-selo")).toHaveText("não");
+    await expect(cartao(painel, "Cheia").locator("p")).toContainText("tem um filho só");
+
+    await painel.getByRole("button", { name: "Perfeita", exact: true }).click();
+    await expect(cartao(painel, "Perfeita").locator(".bt-veredito-selo")).toHaveText("sim");
+    await expect(cartao(painel, "Degenerada").locator(".bt-veredito-selo")).toHaveText("não");
+    await expect(cartao(painel, "Cheia").locator(".bt-veredito-selo")).toHaveText("sim");
+  });
+
+  test("clicar num nó dentro do painel reclassifica a árvore e atualiza o número do cabeçalho", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+
+    await painel.getByRole("button", { name: "Perfeita", exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("7 nós · altura 3");
+    await expect(cartao(painel, "Completa").locator(".bt-veredito-selo")).toHaveText("sim");
+
+    // Liga a posição 7: um nível novo, com um filho só. A árvore deixa de ser
+    // perfeita e de ser cheia, e a altura sobe.
+    await painel.getByRole("button", { name: /^Posição 7,/ }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("8 nós · altura 4");
+    await expect(cartao(painel, "Perfeita").locator(".bt-veredito-selo")).toHaveText("não");
+    await expect(cartao(painel, "Cheia").locator(".bt-veredito-selo")).toHaveText("não");
+    await expect(cartao(painel, "Completa").locator(".bt-veredito-selo")).toHaveText("sim");
+  });
+});

--- a/tests/viz-bst.spec.ts
+++ b/tests/viz-bst.spec.ts
@@ -1,0 +1,413 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no visualizador da BST.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura.
+//
+// Antes da casca, a peça rolava INTEIRA dentro do painel expandido e o
+// `.viz-foot` nem existia — os controles moravam no miolo rolável. Medido: ao
+// rolar até o fim, o cabeçalho subia 288px (preset "pelo meio") e 520px
+// (preset "ordenado") numa janela de 900; 488/720 em 700; 588/820 em 600. O
+// `▶ Rodar` era desenhado com a base em 1087 e 1319px nas TRÊS janelas, ou
+// seja, até 719px abaixo do pé visível.
+//
+// O tópico tem um visualizador só, e ele tem as três camadas.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/bst/";
+
+// Janela de notebook de 16", que é o caso que motivou a casca. Nela a peça
+// passa do orçamento com o código à mostra (1149px contra 816).
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para o código caber aberto (orçamento 1316 contra 1149).
+const ALTA = { width: 1512, height: 1400 };
+// Apertada de propósito: garante que o miolo do painel tem o que rolar (188px
+// de sobra medidos) e que a medição REALMENTE discordaria de quem abre o
+// código na mão.
+const APERTADA = { width: 1512, height: 700 };
+
+const PRESET_BALANCEADO = "Inserindo pelo meio: 4 2 6 1 3 5 7";
+const PRESET_DEGENERADO = "Inserindo ordenado: 1 2 3 4 5 6 7";
+
+/** O passo mais alto da animação. NÃO é o passo 1 nem o último: é o 2 de 18. */
+const PASSO_PICO = 2;
+
+function noArtigo(page: Page): Locator {
+  return page.locator("article figure.viz").first();
+}
+
+/** A peça depois de expandida: ela é portada para fora do artigo. */
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto(URL);
+  // As fontes chegam com `display: swap`: medir antes é medir o fallback, e a
+  // casca só decide depois delas.
+  await page.evaluate(() => document.fonts.ready);
+  await expect(noArtigo(page)).toBeVisible();
+  // `data-anim` volta para "on" quando a casca terminou de medir e decidir. É o
+  // sinal que ela já publica; esperar por ele custa menos que um sono fixo e
+  // não vira flake com a máquina cheia.
+  await expect(noArtigo(page)).toHaveAttribute("data-anim", "on");
+}
+
+async function expandir(page: Page): Promise<Locator> {
+  await noArtigo(page).getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = noPainel(page);
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+async function altura(loc: Locator): Promise<number> {
+  return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+/**
+ * A altura depois que ela PARA de mudar.
+ *
+ * A transição da casca dura 0,32s — curta o bastante para o Playwright
+ * atravessar sem perceber, longa o bastante para mudar a conta. Um
+ * `expect.poll(...).toBeGreaterThan(orc)` fica verde no primeiro quadro em que
+ * a peça passa do orçamento, que aqui é o quadro ZERO (930 já passa de 816), e
+ * a leitura seguinte pega o meio do percurso: medido, 1048 em vez de 1149.
+ *
+ * E "duas leituras iguais" não basta: com amostragem de 50ms sobre uma
+ * transição de 320ms, dois quadros vizinhos arredondam para o mesmo inteiro no
+ * meio do caminho e a função devolve 1048. São precisas TRÊS iguais seguidas —
+ * 100ms sem mexer — para a altura estar mesmo parada.
+ */
+async function alturaEstavel(loc: Locator): Promise<number> {
+  let anterior = -1;
+  let iguais = 0;
+  for (let k = 0; k < 60; k++) {
+    const agora = await altura(loc);
+    iguais = agora === anterior ? iguais + 1 : 0;
+    if (iguais >= 3) return agora;
+    anterior = agora;
+    await loc.page().waitForTimeout(50);
+  }
+  return anterior;
+}
+
+/** O orçamento do artigo: a janela menos o cabeçalho fixo e um respiro. */
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const h =
+      parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+    return window.innerHeight - h - 24;
+  });
+}
+
+/**
+ * Lê uma ficha de estatística pelo ÍNDICE e confere o rótulo junto do valor.
+ *
+ * Ler os dois no mesmo cartão é o que pega a troca de posição: o guarda de
+ * idioma compara o CONJUNTO de textos, não onde cada um aparece, então dois
+ * campos invertidos passam verde por lá e mentem na tela.
+ */
+async function ficha(fig: Locator, i: number, rotulo: string, valor: string) {
+  const cartao = fig.locator(".bigo-stat").nth(i);
+  await expect(cartao.locator("span")).toHaveText(rotulo);
+  await expect(cartao.locator("strong")).toHaveText(valor);
+}
+
+/**
+ * Amostra o estado do bloco recolhível N vezes ao longo de `ms` e devolve as
+ * amostras que falharam.
+ *
+ * Quando a promessa é PERMANÊNCIA ("a escolha do aluno sobrevive"), uma espera
+ * fixa seguida de uma leitura olha um instante só. Amostrar responde a pergunta
+ * certa: nenhum instante da janela pode ter falhado.
+ */
+async function amostrarAberto(page: Page, fig: Locator, ms = 900, n = 9): Promise<string[]> {
+  const falhas: string[] = [];
+  for (let k = 0; k < n; k++) {
+    const alturaSlot = await altura(fig.locator(".viz-code-slot"));
+    const rotulo = (await fig.locator("button.viz-toggle-codigo").textContent()) ?? "";
+    if (alturaSlot <= 60 || rotulo !== "Ocultar código") {
+      falhas.push(`aos ${Math.round((k * ms) / n)}ms: slot=${alturaSlot}px, rótulo=${JSON.stringify(rotulo)}`);
+    }
+    await page.waitForTimeout(ms / n);
+  }
+  return falhas;
+}
+
+test.describe("bst · a invariante da BST", () => {
+  // §8.1: no expandido o cabeçalho e o rodapé ficam parados, e o botão que faz
+  // o algoritmo andar nunca sai da tela.
+  //
+  // As três asserções de rolagem não são cerimônia: um teste que rola o
+  // `.viz-body` sem provar que é ELE quem rola aprova justamente a quebra que
+  // devolve a rolagem para a figura inteira — ali o `scrollTop` do miolo fica
+  // em zero, o cabeçalho não se mexe, e o teste passa feliz.
+  //
+  // E o passo importa: a peça é mais alta no passo 2 que no 1 e que no último
+  // (950 contra 930 no artigo), então o teste anda até o PICO antes de medir.
+  test("expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({ page }) => {
+    await abrir(page, APERTADA);
+    const painel = await expandir(page);
+
+    // Até o pico, pela tecla: o `click()` do Playwright ROLA o contêiner para
+    // alcançar o alvo, e isso mudaria justamente o que vou medir.
+    const passo = painel.locator(".viz-step");
+    for (let k = 1; k < PASSO_PICO; k++) await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(/^passo 2 de \d+$/);
+
+    const miolo = painel.locator(".viz-body");
+    const cabeca = painel.locator(".viz-head");
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+    // 1. o miolo é o que estoura...
+    await expect
+      .poll(() => miolo.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .toBeGreaterThan(8);
+    expect(await miolo.evaluate((el) => Math.round(el.scrollTop))).toBe(0);
+
+    const topoAntes = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+    // O rótulo importa tanto quanto a posição: um botão no lugar certo dizendo
+    // a coisa errada ensina errado do mesmo jeito.
+    await expect(rodar).toHaveText("▶ Rodar");
+    await expect(rodar).toBeInViewport();
+
+    // 2. ...e é ele que rola, não a figura inteira.
+    await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await expect.poll(() => miolo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(8);
+    expect(await painel.evaluate((f) => Math.round(f.scrollTop))).toBe(0);
+
+    // 3. e o cabeçalho não saiu do lugar. (Antes da casca ele subia 488px
+    // nesta mesma janela de 700 de altura.)
+    const topoDepois = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+    expect(Math.abs(topoDepois - topoAntes)).toBeLessThanOrEqual(1);
+    await expect(rodar).toBeInViewport();
+    await expect(rodar).toHaveText("▶ Rodar");
+
+    // E o rodapé está colado no pé da figura, não empurrado para fora dela.
+    const folga = await painel.evaluate((f) => {
+      const foot = f.querySelector(".viz-foot") as HTMLElement;
+      return Math.round(f.getBoundingClientRect().bottom - foot.getBoundingClientRect().bottom);
+    });
+    expect(folga).toBeLessThanOrEqual(2);
+  });
+
+  // §8.2: em tela baixa a peça não cabe com o código à mostra, então ele
+  // recolhe — e o botão passa a dizer o que faria aparecer.
+  test("tela baixa: o botão diz 'Mostrar código' e o bloco está recolhido", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    const botao = fig.locator("button.viz-toggle-codigo");
+
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    // Recolhido de verdade: o slot perde a ALTURA, não só a largura. Zerar a
+    // trilha da coluna deixava a linha do grid com a altura do código.
+    await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeLessThanOrEqual(4);
+
+    const recolhida = await alturaEstavel(fig);
+    const orc = await orcamento(page);
+
+    // A premissa medida DENTRO do teste: com o código à mostra a peça não
+    // cabe. Sem ela, no dia em que a peça encolher isto vira decoração verde.
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    const aberta = await alturaEstavel(fig);
+    expect(aberta).toBeGreaterThan(orc);
+    // Recolher vale 199px medidos (1149 → 950). O teto aqui é regressão.
+    expect(aberta - recolhida).toBeGreaterThan(150);
+    // A árvore de 7 nós não cabe no artigo nem recolhida (950 contra 816): o
+    // que sobra é o desenho (436px), o percurso em ordem (135) e as fichas —
+    // conteúdo, não respiro, e a camada 2 não alcança o artigo (contrato §9).
+    expect(recolhida).toBeLessThan(1000);
+  });
+
+  // §8.3: onde cabe, o código já vem à mostra — a medição decide, não um
+  // breakpoint de largura. A janela aqui é MAIS ALTA, não mais larga.
+  test("tela alta: o código já vem aberto e o botão diz 'Ocultar código'", async ({ page }) => {
+    await abrir(page, ALTA);
+    const fig = noArtigo(page);
+    const botao = fig.locator("button.viz-toggle-codigo");
+
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "true");
+    await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+    // O bloco é mesmo o código DESTE visualizador, não um bloco qualquer.
+    await expect(fig.locator(".viz-code-head")).toHaveText("insere.py");
+  });
+
+  // §8.4: a escolha explícita do aluno vence a medição e não é desfeita por
+  // uma troca de estado que pediria medição nova.
+  test("a escolha do aluno sobrevive a uma troca de estado que pede medição nova", async ({ page }) => {
+    await abrir(page, APERTADA);
+    const fig = noArtigo(page);
+    const botao = fig.locator("button.viz-toggle-codigo");
+
+    await expect(botao).toHaveText("Mostrar código");
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+
+    // Trocar para o preset degenerado mexe nos DOIS valores de `measureOn` que
+    // importam aqui (o preset e o número de passos, 18 → 29) e muda a altura da
+    // peça em 251px. É uma troca que a medição discordaria mesmo.
+    await fig.getByRole("button", { name: PRESET_DEGENERADO, exact: true }).click();
+
+    // A entrada da medição mudou MESMO, e a leitura é do rótulo junto do valor.
+    await ficha(fig, 1, "altura", "7");
+
+    // A janela amostrada cobre a medição E a transição de 0,32s que viria
+    // depois dela. Exigir que NENHUMA amostra tenha falhado é o que separa
+    // "está aberto" de "continua aberto".
+    expect(await amostrarAberto(page, fig)).toEqual([]);
+  });
+
+  // §8.5: as teclas dirigem a animação dentro do painel.
+  test("expandido: as setas andam o passo e o espaço roda", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page);
+    const passo = painel.locator(".viz-step");
+
+    const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+    await expect(passo).toHaveText(`passo 1 de ${total}`);
+
+    // Uma asserção DEPOIS DE CADA TECLA: `→` seguido de `←` se cancelam, e um
+    // teste que só olha o fim aprova a quebra que ignora as duas.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo 2 de ${total}`);
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo 3 de ${total}`);
+    await page.keyboard.press("ArrowLeft");
+    await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("❚❚ Pausar");
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+
+  // A regra mais importante dos atalhos é o inverso deles: com o cursor num
+  // campo, seta é do campo e espaço é do campo. Sequestrar isso deixa o campo
+  // "Procurar" impossível de editar, o que é pior que não ter atalho.
+  //
+  // O campo é NUMÉRICO, onde `→` move o cursor sem mudar o valor. Então a régua
+  // não é o valor mudar: é o passo NÃO andar e a animação NÃO começar. E a seta
+  // é apertada DUAS VEZES na mesma direção, nunca ida e volta: um par de ações
+  // inversas devolve a peça ao estado de origem e fica verde com a quebra.
+  test("o campo 'Procurar' em edição manda na seta e no espaço", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page);
+    await painel.getByRole("button", { name: "buscar", exact: true }).click();
+
+    const campo = painel.locator("input.viz-input.k");
+    const passo = painel.locator(".viz-step");
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+    const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+    await campo.click();
+    const valor = await campo.inputValue();
+
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo 1 de ${total}`);
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo 1 de ${total}`);
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("▶ Rodar");
+    await expect(passo).toHaveText(`passo 1 de ${total}`);
+    // O campo continua editável e intacto: a seta foi para o cursor.
+    await expect(campo).toHaveValue(valor);
+  });
+
+  // No slider a seta é do slider — e a MARCHA DE ABERTURA é da peça, não do
+  // hook. Esta peça abre no "1.5x" (`initialSpeed: 4`), porque a construção tem
+  // de 18 a 29 passos e no 1x a reprodução inteira fica longa demais. Perder o
+  // `initialSpeed` na migração compila e não muda teste nenhum — por isso ele
+  // é afirmado aqui, pelo rótulo que o aluno lê.
+  test("a marcha de abertura é 1.5x e a seta no slider é do slider", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page);
+    const slider = painel.locator('input[type="range"]');
+    const passo = painel.locator(".viz-step");
+    const marcha = painel.locator(".viz-speed .val");
+
+    await expect(marcha).toHaveText("1.5x");
+
+    const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+    await slider.focus();
+    const antes = await slider.inputValue();
+    await page.keyboard.press("ArrowLeft");
+    // O slider andou uma marcha para baixo...
+    await expect(slider).not.toHaveValue(antes);
+    await expect(marcha).toHaveText("1x");
+    // ...e o passo não andou junto.
+    await expect(passo).toHaveText(`passo 1 de ${total}`);
+  });
+
+  // O que a MEDIÇÃO contrariou, virado teste.
+  //
+  // O palpite óbvio para o pior caso de altura de uma árvore é "mais nós". Aqui
+  // é falso: os dois presets têm os MESMOS 7 nós, e o que muda a altura é a
+  // PROFUNDIDADE. Medido: o SVG vai de 190px (altura 3) para 422px (altura 7),
+  // e a peça de 950 para 1201px no artigo — 232px de desenho a mais sem um nó a
+  // mais. É por isso que `measureOn` leva o preset, e não uma contagem de nós.
+  test("a árvore degenerada é mais alta que a balanceada com o mesmo número de nós", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    const desenho = fig.locator("svg.tt-arv");
+
+    await fig.getByRole("button", { name: PRESET_BALANCEADO, exact: true }).click();
+    await ficha(fig, 0, "nós", "7");
+    await ficha(fig, 1, "altura", "3");
+    const svgBalanceada = await altura(desenho);
+    const pecaBalanceada = await altura(fig);
+
+    await fig.getByRole("button", { name: PRESET_DEGENERADO, exact: true }).click();
+    // O mesmo número de nós, lido no rótulo junto do valor...
+    await ficha(fig, 0, "nós", "7");
+    // ...e mais que o dobro da altura.
+    await ficha(fig, 1, "altura", "7");
+    const svgDegenerada = await altura(desenho);
+    const pecaDegenerada = await altura(fig);
+
+    expect(svgDegenerada - svgBalanceada).toBeGreaterThan(200);
+    expect(pecaDegenerada - pecaBalanceada).toBeGreaterThan(200);
+
+    // E o desenho está no tamanho NATURAL, não esticado: por isso um teto de
+    // altura aqui destruiria conteúdo em vez de devolver vazio (contrato §3).
+    // Se algum dia o `.tt-arv` ganhar `width: 100%`, esta asserção avisa.
+    const esticao = await desenho.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const vb = (el as unknown as SVGSVGElement).viewBox.baseVal;
+      return { rend: Math.round(r.height), natural: vb.height };
+    });
+    expect(esticao.rend).toBe(esticao.natural);
+  });
+
+  // Buscar exatamente a raiz devolve UM passo, e aí o contrato §6 manda sumir
+  // com o contador, os atalhos e o rodapé inteiro. Isso é ~100px de peça a
+  // menos sem que o preset tenha mudado — é por isso que `steps.length` está no
+  // `measureOn`. E o caminho de volta continua na tela porque os presets e o
+  // seletor de modo moram no MIOLO, não no rodapé.
+  test("buscar a raiz devolve um passo só, some o rodapé e a volta continua no miolo", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    await fig.getByRole("button", { name: "buscar", exact: true }).click();
+    await fig.locator("input.viz-input.k").fill("4");
+
+    // Um passo só: sem linha do tempo não há reprodução nenhuma a desenhar.
+    await expect(fig.locator(".viz-step")).toHaveCount(0);
+    await expect(fig.locator(".viz-foot")).toHaveCount(0);
+    await expect(fig.getByRole("button", { name: /Rodar|Pausar/ })).toHaveCount(0);
+    // E a nota diz o que aconteceu, com o número de comparações.
+    await expect(fig.locator(".viz-note")).toHaveText(/Achei 4 em 1 comparação\./);
+
+    // O caminho de volta: os presets e o seletor de modo estão no miolo.
+    await fig.getByRole("button", { name: "construir", exact: true }).click();
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 18");
+    await expect(fig.getByRole("button", { name: /Rodar|Pausar/ })).toHaveCount(1);
+  });
+});

--- a/tests/viz-n-ary-trees.spec.ts
+++ b/tests/viz-n-ary-trees.spec.ts
@@ -1,0 +1,405 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no visualizador de Árvores n-árias.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura.
+//
+// Antes da casca, a peça inteira rolava dentro do painel expandido: medido, o
+// cabeçalho subia 371px em 1512x900, 571px em 1440x700 e 671px em 1440x600, e o
+// `▶ Rodar` era desenhado sempre em 1170px — 270, 470 e 570px ABAIXO do pé da
+// janela. O `.viz-foot` não existia; os controles moravam dentro do miolo.
+//
+// O tópico tem um visualizador só, e ele tem as três camadas: overlay, bloco de
+// código recolhível e painel de variáveis.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/n-ary-trees/";
+
+// Janela de notebook de 16", a régua do contrato. Nela a peça passa do
+// orçamento (816px) em todas as nove combinações de árvore e ordem: 1070px na
+// árvore do artigo e 1238px na do DOM, já com o código recolhido.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para a peça caber com o código à mostra: orçamento 1508px
+// contra 1432px no pior caso medido (árvore DOM, por nível, passo 17).
+const ALTA = { width: 1512, height: 1600 };
+// Apertada de propósito: garante sobra de rolagem no miolo do painel e uma
+// medição que REALMENTE discordaria de quem abre o código na mão.
+const APERTADA = { width: 1512, height: 700 };
+
+/** Os rótulos das marchas, na ordem do `input[type=range]` (o índice 0 não é usado). */
+const ROTULOS_MARCHA = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+
+// O passo do PICO de altura, medido andando a animação inteira nas nove
+// combinações: árvore DOM em por nível, passo 17 de 19 (1238px recolhida,
+// 1432px com o código aberto). O passo 1 mede 1206px — 32px a menos —, e o
+// teste de rolagem tem que morar no pico, não no primeiro passo.
+const PICO = { arvore: "Uma árvore DOM", ordem: "Por nível (BFS)", passo: 17, total: 19 };
+
+function noArtigo(page: Page): Locator {
+  return page.locator("article figure.viz-fit").first();
+}
+
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto(URL);
+  // As fontes chegam com `display: swap`: medir antes é medir o fallback.
+  await page.evaluate(() => document.fonts.ready);
+  const real = page.viewportSize();
+  expect(real).toEqual(viewport);
+  await expect(noArtigo(page)).toBeVisible();
+  // `data-anim` volta para "on" quando a casca terminou de medir e decidir.
+  await expect(noArtigo(page)).toHaveAttribute("data-anim", "on");
+}
+
+async function expandir(page: Page): Promise<Locator> {
+  await noArtigo(page).getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = noPainel(page);
+  await expect(painel).toBeVisible();
+  await expect(painel).toHaveAttribute("data-anim", "on");
+  return painel;
+}
+
+async function altura(loc: Locator): Promise<number> {
+  return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+/** O orçamento do artigo: a janela menos o cabeçalho fixo e um respiro. */
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const h = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+    return window.innerHeight - h - 24;
+  });
+}
+
+async function abrirCodigo(fig: Locator) {
+  const botao = fig.locator("button.viz-toggle-codigo");
+  if ((await botao.textContent()) === "Mostrar código") await botao.click();
+  await expect(botao).toHaveText("Ocultar código");
+}
+
+/**
+ * Amostra o estado do bloco recolhível N vezes ao longo de `ms` e devolve as
+ * amostras que falharam. Quando a promessa é PERMANÊNCIA, uma espera fixa
+ * seguida de uma leitura olha um instante só.
+ */
+async function amostrarAberto(page: Page, fig: Locator, ms = 900, n = 9): Promise<string[]> {
+  const falhas: string[] = [];
+  for (let k = 0; k < n; k++) {
+    const alturaSlot = await altura(fig.locator(".viz-code-slot"));
+    const rotulo = (await fig.locator("button.viz-toggle-codigo").textContent()) ?? "";
+    if (alturaSlot <= 60 || rotulo !== "Ocultar código") {
+      falhas.push(`aos ${Math.round((k * ms) / n)}ms: slot=${alturaSlot}px, rótulo=${JSON.stringify(rotulo)}`);
+    }
+    await page.waitForTimeout(ms / n);
+  }
+  return falhas;
+}
+
+// §8.1: no expandido o cabeçalho e o rodapé ficam parados, e o botão que faz o
+// algoritmo andar nunca sai da tela.
+//
+// As duas primeiras asserções não são cerimônia: um teste que rola o
+// `.viz-body` sem provar que é ELE quem rola aprova justamente a quebra que
+// devolve a rolagem para a figura inteira — ali o `scrollTop` do miolo fica em
+// zero, o cabeçalho não se mexe, e o teste passa feliz.
+test("n-ary: expandido, o cabeçalho e o rodapé não se mexem quando o miolo rola", async ({ page }) => {
+  await abrir(page, APERTADA);
+  const painel = await expandir(page);
+
+  // O pico de altura é a árvore DOM em por nível, no passo 17 — não o passo 1.
+  await painel.getByRole("button", { name: PICO.arvore, exact: true }).click();
+  await painel.getByRole("button", { name: PICO.ordem, exact: true }).click();
+  await abrirCodigo(painel);
+
+  const passo = painel.locator(".viz-step");
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  await expect(passo).toHaveText(`passo 1 de ${PICO.total}`);
+  for (let k = 1; k < PICO.passo; k++) await proximo.click();
+  await expect(passo).toHaveText(`passo ${PICO.passo} de ${PICO.total}`);
+
+  const miolo = painel.locator(".viz-body");
+  const cabeca = painel.locator(".viz-head");
+  const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+  // `click()` do Playwright ROLA o contêiner para alcançar o alvo. Dezesseis
+  // cliques no rodapé não podem ter rolado o miolo — se rolaram, o rodapé está
+  // dentro dele, que é a quebra que este teste existe para pegar.
+  expect(await miolo.evaluate((el) => Math.round(el.scrollTop))).toBe(0);
+
+  // 1. o miolo é o que estoura...
+  await expect.poll(() => miolo.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeGreaterThan(8);
+
+  const topoAntes = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+  // O rótulo importa tanto quanto a posição: botão no lugar certo dizendo a
+  // coisa errada ensina errado do mesmo jeito.
+  await expect(rodar).toHaveText("▶ Rodar");
+  await expect(rodar).toBeInViewport();
+
+  // 2. ...e é ele que rola, não a figura inteira.
+  await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+  await expect.poll(() => miolo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(8);
+  expect(await painel.evaluate((f) => Math.round(f.scrollTop))).toBe(0);
+
+  // 3. e o cabeçalho não saiu do lugar. (Antes da casca ele subia 571px nesta
+  // mesma janela de 700 de altura.)
+  const topoDepois = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+  expect(Math.abs(topoDepois - topoAntes)).toBeLessThanOrEqual(1);
+  await expect(rodar).toBeInViewport();
+  await expect(rodar).toHaveText("▶ Rodar");
+
+  // E o rodapé está colado no pé da figura, não empurrado para fora dela.
+  const folga = await painel.evaluate((f) => {
+    const foot = f.querySelector(".viz-foot") as HTMLElement;
+    return Math.round(f.getBoundingClientRect().bottom - foot.getBoundingClientRect().bottom);
+  });
+  expect(folga).toBeLessThanOrEqual(2);
+});
+
+// §8.2: em tela baixa a peça não cabe com o código à mostra, então ele recolhe
+// — e o botão passa a dizer o que faria aparecer.
+test("n-ary: tela baixa, o botão diz 'Mostrar código' e o bloco está recolhido", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const fig = noArtigo(page);
+  const botao = fig.locator("button.viz-toggle-codigo");
+
+  await expect(botao).toHaveText("Mostrar código");
+  await expect(botao).toHaveAttribute("aria-expanded", "false");
+  // Recolhido de verdade: o slot perde a ALTURA, não só a largura. Zerar a
+  // trilha da coluna deixava a linha do grid com a altura do código.
+  await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeLessThanOrEqual(4);
+
+  const recolhida = await altura(fig);
+  const orc = await orcamento(page);
+
+  // A premissa medida DENTRO do teste: com o código à mostra a peça não cabe.
+  await botao.click();
+  await expect(botao).toHaveText("Ocultar código");
+  await expect.poll(() => altura(fig)).toBeGreaterThan(orc);
+  const aberta = await altura(fig);
+  // O código são 6 ou 7 linhas de Python: recolher devolve 194px medidos.
+  expect(aberta - recolhida).toBeGreaterThan(120);
+
+  // A peça NÃO cabe nem recolhida: 1070px contra 816 na árvore do artigo. O
+  // que sobra não é bloco dispensável — é o desenho (346px na árvore mais
+  // alta), a tabela de comparação (268px), duas fileiras de chips (62px) e o
+  // respiro do miolo, que a camada 2 apertaria se alcançasse o fluxo do artigo
+  // (contrato §9). O teto aqui é regressão: recolher tem que continuar valendo.
+  expect(recolhida).toBeLessThan(1120);
+});
+
+// §8.3: onde cabe, o código já vem à mostra — a medição decide, não um
+// breakpoint de largura.
+test("n-ary: tela alta, o código já vem aberto e o botão diz 'Ocultar código'", async ({ page }) => {
+  await abrir(page, ALTA);
+  const fig = noArtigo(page);
+  const botao = fig.locator("button.viz-toggle-codigo");
+
+  await expect(botao).toHaveText("Ocultar código");
+  await expect(botao).toHaveAttribute("aria-expanded", "true");
+  await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+  // O bloco é mesmo o código DESTE visualizador, não um bloco qualquer.
+  await expect(fig.locator(".viz-code-head")).toHaveText("percorre.py");
+  await expect(fig.locator(".viz-code-body")).toContainText("for filho in no.filhos:");
+});
+
+// §8.4: a escolha explícita do aluno vence a medição e não é desfeita por uma
+// troca de estado que pediria medição nova.
+//
+// A troca escolhida muda MESMO a entrada da medição: a árvore do DOM tem dois
+// níveis a mais que a do artigo, e o desenho vai de 196 para 332px de altura.
+test("n-ary: a escolha do aluno sobrevive à troca de árvore, que pede medição nova", async ({ page }) => {
+  await abrir(page, APERTADA);
+  const fig = noArtigo(page);
+  const botao = fig.locator("button.viz-toggle-codigo");
+
+  await expect(botao).toHaveText("Mostrar código");
+  await botao.click();
+  await expect(botao).toHaveText("Ocultar código");
+  await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+
+  await fig.getByRole("button", { name: "Uma árvore DOM", exact: true }).click();
+
+  // A entrada da medição mudou MESMO — e a leitura é do rótulo junto com o
+  // valor, no mesmo cartão.
+  await expect(fig.locator(".tt-legenda-arvore")).toHaveText(
+    "HTML é uma árvore n-ária, e é por isso que querySelector é um percurso."
+  );
+  const ficha = fig.locator(".viz-var").filter({ hasText: "nó atual" });
+  await expect(ficha).toHaveCount(1);
+  await expect(ficha.locator(".viz-var-val")).toHaveText("html");
+
+  // A janela amostrada cobre a medição E a transição de 0,32s que viria depois
+  // dela. Exigir que NENHUMA amostra tenha falhado é o que separa "está aberto"
+  // de "continua aberto".
+  expect(await amostrarAberto(page, fig)).toEqual([]);
+});
+
+// §8.5: as teclas dirigem a animação dentro do painel.
+test("n-ary: expandido, as setas andam o passo e o espaço roda", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const painel = await expandir(page);
+  const passo = painel.locator(".viz-step");
+
+  const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+  await expect(passo).toHaveText(`passo 1 de ${total}`);
+
+  // Uma asserção DEPOIS DE CADA TECLA: `→` seguido de `←` se cancelam, e um
+  // teste que só olha o fim aprova a quebra que ignora as duas.
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+  await page.keyboard.press("ArrowRight");
+  await expect(passo).toHaveText(`passo 3 de ${total}`);
+  await page.keyboard.press("ArrowLeft");
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+
+  const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+  await page.keyboard.press("Space");
+  await expect(rodar).toHaveText("❚❚ Pausar");
+  await page.keyboard.press("Space");
+  await expect(rodar).toHaveText("▶ Rodar");
+});
+
+// O inverso dos atalhos: com um botão em foco, espaço é o BOTÃO. Este
+// visualizador não tem campo de texto, então o caso que vale aqui é este e o do
+// slider (abaixo). Uma ação só: um par de ações inversas ficaria verde com o
+// sequestro aplicado.
+test("n-ary: com um botão em foco, o espaço é o botão e não a reprodução", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const painel = await expandir(page);
+  const passo = painel.locator(".viz-step");
+  const proximo = painel.getByRole("button", { name: "Próximo ›" });
+  const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+  const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+  await proximo.focus();
+  await page.keyboard.press("Space");
+
+  // O botão foi acionado: o passo andou UM. E a reprodução não começou — se o
+  // espaço tivesse sido sequestrado, o rótulo diria "❚❚ Pausar".
+  await expect(passo).toHaveText(`passo 2 de ${total}`);
+  await expect(rodar).toHaveText("▶ Rodar");
+});
+
+// No slider a seta é do slider — e o rótulo da marcha é como o aluno confere
+// que ela andou. A marcha de ABERTURA é da peça (`initialSpeed: 4`), não a 3 do
+// hook: os percursos têm 19 e 28 passos e no 1x a reprodução fica longa demais.
+test("n-ary: a marcha abre em 1.5x e a seta no slider é do slider", async ({ page }) => {
+  await abrir(page, BAIXA);
+  const painel = await expandir(page);
+  const slider = painel.locator('input[type="range"]').first();
+  const passo = painel.locator(".viz-step");
+  const marcha = painel.locator(".viz-speed .val");
+
+  const total = (await passo.textContent())!.match(/de (\d+)/)![1];
+  await expect(marcha).toHaveText("1.5x");
+
+  // O clique no `input[type=range]` reposiciona a marcha pelo ponto clicado,
+  // então o valor de partida da seta é o de DEPOIS do clique.
+  await slider.click();
+  const antes = Number(await slider.inputValue());
+  await page.keyboard.press("ArrowRight");
+
+  await expect(slider).toHaveValue(String(antes + 1));
+  await expect(marcha).toHaveText(ROTULOS_MARCHA[antes + 1]);
+  await expect(passo).toHaveText(`passo 1 de ${total}`);
+});
+
+// ---------------------------------------------------------------------------
+// O que a medição deste tópico contrariou, agora como regressão.
+//
+// Em árvore n-ária a tentação é medir o pior caso pelo GRAU ou pelo número de
+// nós. As três árvores desta peça têm exatamente **nove nós** e grau máximo
+// **três** — e mesmo assim os desenhos têm alturas diferentes, porque o eixo
+// que vira altura é a PROFUNDIDADE. A do DOM tem quatro níveis contra dois das
+// outras duas: ela é a mais ALTA e, ao mesmo tempo, a mais ESTREITA, porque tem
+// menos folhas. Aumentar o grau alarga sem subir.
+//
+// É esse fato que sustenta `measureOn: [treeKey, ...]`: sem ele alguém trocaria
+// a árvore por uma contagem de nós ou de grau e mediria a coisa errada.
+// ---------------------------------------------------------------------------
+test("n-ary: a altura do desenho vem da profundidade, não do grau nem do número de nós", async ({ page }) => {
+  await abrir(page, ALTA);
+  const fig = noArtigo(page);
+  const svg = fig.locator("svg.tt-arv");
+
+  const medir = async (arvore: string) => {
+    await fig.getByRole("button", { name: arvore, exact: true }).click();
+    // Rótulo junto com o valor, no mesmo cartão: as três árvores têm o mesmo
+    // grau máximo e o mesmo número de nós, e é isso que dá sentido ao resto.
+    const grau = fig.locator(".viz-var").filter({ hasText: "grau máximo" });
+    await expect(grau.locator(".viz-var-val")).toHaveText("3");
+    const nos = fig.locator(".viz-var").filter({ hasText: "processados" });
+    await expect(nos.locator(".viz-var-val")).toHaveText("0 de 9");
+    return svg.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      return {
+        alt: Math.round(r.height),
+        larg: Math.round(r.width),
+        viewBox: el.getAttribute("viewBox"),
+      };
+    });
+  };
+
+  const artigo = await medir("A árvore do artigo");
+  const diretorios = await medir("Uma árvore de diretórios");
+  const dom = await medir("Uma árvore DOM");
+
+  // Mesmo número de nós, mesmo grau, mesma profundidade: mesma altura.
+  expect(diretorios.alt).toBe(artigo.alt);
+  // Dois níveis a mais: 136px a mais de desenho.
+  expect(dom.alt).toBeGreaterThan(artigo.alt + 100);
+  // E a mais alta é a mais ESTREITA: menos folhas, menos largura.
+  expect(dom.larg).toBeLessThan(artigo.larg);
+
+  // O desenho sai no tamanho NATURAL do viewBox — não há esticão, então não há
+  // vazio para um `max-height` devolver. Se alguém puser `width: 100%` no
+  // `.tt-arv`, isto reprova antes de o teto virar uma boa ideia.
+  const [, , vw, vh] = dom.viewBox!.split(" ").map(Number);
+  expect(dom.larg).toBe(vw);
+  expect(dom.alt).toBe(vh);
+});
+
+// ---------------------------------------------------------------------------
+// O guarda de idioma, agora como teste: identificador em inglês, tela em
+// português (contrato §0).
+//
+// Este arquivo tem rótulo de tela COLADO numa interpolação em quatro lugares —
+// a legenda da tabela, a coluna do grau, o "N de M" das variáveis e o "~" das
+// comparações —, que é o buraco silencioso do `scripts/guarda-idioma.py`: o
+// texto não está em string nenhuma e não casa com `>texto<`. Por isso a prova
+// destes casos está aqui, onde o navegador é quem responde.
+// ---------------------------------------------------------------------------
+test("n-ary: o Python da tela e os rótulos seguem em português", async ({ page }) => {
+  await abrir(page, ALTA);
+  const fig = noArtigo(page);
+
+  await expect(fig.locator(".viz-code-body")).toContainText("def percorre(no):");
+  await expect(fig.locator(".viz-code-body")).toContainText("for filho in no.filhos:  # era esq e dir");
+  await expect(fig.locator(".viz-vars")).toContainText("nó atual");
+  await expect(fig.locator(".viz-vars")).toContainText("grau máximo");
+  await expect(fig.locator(".tt-painel-tit").first()).toContainText("Pilha");
+  await expect(fig.locator(".tt-painel-tit").first()).toContainText("LIFO, altura da árvore");
+
+  // Rótulo colado numa interpolação, um por um: o guarda não vê nenhum destes.
+  await expect(fig.locator(".rec-comp caption")).toHaveText(
+    "Altura mínima para guardar 1.000.000 nós, por grau"
+  );
+  await expect(fig.locator(".viz-var").filter({ hasText: "processados" }).locator(".viz-var-val")).toHaveText(
+    "0 de 9"
+  );
+  // O til da terceira coluna também é texto colado a uma interpolação.
+  const primeiraLinha = fig.locator(".rec-comp tbody tr").first().locator("td");
+  await expect(primeiraLinha).toHaveText(["2", "20", "~20"]);
+
+  // E o código de por nível é o outro arquivo, com o rótulo certo.
+  await fig.getByRole("button", { name: "Por nível (BFS)", exact: true }).click();
+  await expect(fig.locator(".viz-code-head")).toHaveText("por_nivel.py");
+  await expect(fig.locator(".viz-code-body")).toContainText("fila = deque([raiz])");
+});

--- a/tests/viz-tree-traversals.spec.ts
+++ b/tests/viz-tree-traversals.spec.ts
@@ -1,0 +1,218 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no visualizador de percursos de árvore.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura. A régua aqui é sempre um número medido no
+// navegador (altura, posição, deslocamento) ou o texto que o aluno lê.
+//
+// Antes da casca, a figura INTEIRA rolava dentro do painel expandido, e o que
+// saía da tela eram os controles: medido no passo do pico, o `▶ Rodar` era
+// desenhado 287px (1512x900), 487px (1440x700) e 587px (1440x600) ABAIXO do pé
+// da janela. Depois, ele fica dentro em todas as três (−57, −52 e −49px), e
+// quem rola é o miolo.
+//
+// O tópico tem um visualizador só, e ele tem as três camadas: overlay, bloco de
+// código, painel de variáveis e controles. Nenhum arquivo ficou de fora.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/tree-traversals/";
+
+// Notebook de 16", o caso que motivou a casca. Nela a peça passa do orçamento
+// (855px de miolo padrão contra 816) e o código entra recolhido.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para caber com o código aberto (orçamento 1516px).
+const ALTA = { width: 1512, height: 1600 };
+// Apertada de propósito: garante que o miolo do painel tem o que rolar e que a
+// medição REALMENTE discordaria de quem abre o código na mão.
+const APERTADA = { width: 1440, height: 700 };
+
+// Folga de subpixel, a mesma do hook.
+const SLACK = 8;
+
+// O passo do PICO de altura, medido andando a animação inteira: com a árvore
+// degenerada em pré-ordem, os passos 1 a 12 empatam em 1041px e os 13 a 25
+// ficam 20px abaixo (a nota cai de duas linhas para uma). O 10 é pico e não é
+// nem o primeiro nem o último — a asserção "existe sobra para rolar" precisa de
+// um passo que tenha o que rolar.
+const PASSO_DO_PICO = 10;
+
+const ARVORE_ALTA = "Degenerada: a pilha vai ao fundo";
+
+async function abrirPainel(page: Page, tamanho: { width: number; height: number }) {
+  await page.setViewportSize(tamanho);
+  await page.goto(URL);
+  expect(page.viewportSize()).toEqual(tamanho);
+  await page.evaluate(() => document.fonts.ready);
+  await page.getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+/** O valor da ficha "altura" do painel de estatísticas — prova na TELA de que a árvore trocou. */
+async function alturaDaArvore(page: Page) {
+  return page
+    .locator(".bigo-stat", { has: page.locator("span", { hasText: /^altura$/ }) })
+    .locator("strong")
+    .innerText();
+}
+
+test.describe("percursos de árvore · casca adaptativa", () => {
+  test("o cabeçalho e os controles ficam parados quando o miolo rola", async ({ page }) => {
+    const painel = await abrirPainel(page, APERTADA);
+
+    // A árvore mais alta (6 níveis contra 3) e o passo do pico: é o estado que
+    // dá ao miolo o que rolar.
+    await page.getByRole("button", { name: ARVORE_ALTA }).click();
+    for (let i = 1; i < PASSO_DO_PICO; i++) {
+      await page.getByRole("button", { name: "Próximo ›" }).click();
+    }
+    await expect(painel.locator(".viz-step")).toHaveText(`passo ${PASSO_DO_PICO} de 26`);
+
+    // PREMISSA: o miolo estoura mesmo. Sem isto, o dia em que a peça encolher o
+    // teste vira decoração verde.
+    const sobra = await painel
+      .locator(".viz-body")
+      .evaluate((b) => b.scrollHeight - b.clientHeight);
+    expect(sobra).toBeGreaterThan(SLACK);
+
+    const antes = await painel.evaluate((f) => {
+      const r = f.getBoundingClientRect();
+      return {
+        cabecaTopo: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodapePe: Math.round(r.bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+      };
+    });
+    // A camada 1 é justamente cabeçalho colado no topo e rodapé colado no pé.
+    expect(antes.cabecaTopo).toBeLessThanOrEqual(2);
+    expect(antes.rodapePe).toBeLessThanOrEqual(2);
+
+    await painel.locator(".viz-body").evaluate((b) => { b.scrollTop = b.scrollHeight; });
+    await page.waitForTimeout(120);
+
+    const depois = await painel.evaluate((f) => {
+      const r = f.getBoundingClientRect();
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      return {
+        cabecaTopo: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodapePe: Math.round(r.bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+        bodyScrollTop: Math.round(body.scrollTop),
+        figuraScrollTop: Math.round(f.scrollTop),
+      };
+    });
+
+    // As três coisas juntas, porque duas delas sozinhas aprovam a quebra que
+    // devolve a rolagem para a figura inteira: o miolo estourou (acima), o
+    // miolo MESMO rolou, e a figura NÃO rolou.
+    expect(depois.bodyScrollTop).toBeGreaterThan(0);
+    expect(depois.figuraScrollTop).toBe(0);
+    expect(depois.cabecaTopo).toBe(antes.cabecaTopo);
+    expect(depois.rodapePe).toBe(antes.rodapePe);
+
+    // E o botão que faz o algoritmo andar continua À VISTA — não só alcançável:
+    // o `click()` do Playwright rola o contêiner para chegar no alvo, então
+    // clicar nele não provaria nada.
+    const rodar = painel.getByRole("button", { name: "▶ Rodar" });
+    const caixa = (await rodar.boundingBox())!;
+    expect(caixa.y).toBeGreaterThanOrEqual(0);
+    expect(caixa.y + caixa.height).toBeLessThanOrEqual(APERTADA.height);
+  });
+
+  test("em tela baixa o código vem recolhido, e o botão diz Mostrar código", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+    // O RÓTULO, não só o estado: botão que promete uma coisa e faz outra ensina
+    // errado do mesmo jeito.
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    await expect(painel).toHaveAttribute("data-codigo", "off");
+
+    // Recolhido de verdade: o slot fechou a ALTURA, não só a largura.
+    const alturaCodigo = await painel
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaCodigo).toBeLessThan(8);
+  });
+
+  test("em tela alta o código já vem aberto, e o botão diz Ocultar código", async ({ page }) => {
+    const painel = await abrirPainel(page, ALTA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "true");
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+
+    // E o código aberto é o do percurso selecionado, com o nome do arquivo.
+    await expect(painel.locator(".viz-code-head")).toHaveText("percorre.py");
+    const alturaCodigo = await painel
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaCodigo).toBeGreaterThan(80);
+  });
+
+  test("a escolha do aluno sobrevive à troca de árvore, que pediria medição nova", async ({ page }) => {
+    const painel = await abrirPainel(page, APERTADA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+
+    // Numa janela apertada a medição recolhe de saída: é o que dá o que
+    // contrariar.
+    await expect(botao).toHaveText("Mostrar código");
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+
+    // A troca precisa mexer numa entrada REAL da medição. A árvore está em
+    // `measureOn` e vale 186px de altura de SVG (3 níveis contra 6): é a troca
+    // com que a medição mais discordaria do aluno.
+    expect(await alturaDaArvore(page)).toBe("3");
+    await page.getByRole("button", { name: ARVORE_ALTA }).click();
+    // PROVA NA TELA de que a entrada da medição mudou mesmo.
+    await expect
+      .poll(async () => alturaDaArvore(page))
+      .toBe("6");
+
+    // "Está aberto agora" não é "continua aberto": amostra ao longo do
+    // intervalo em que a medição rodaria.
+    for (let i = 0; i < 6; i++) {
+      await page.waitForTimeout(80);
+      await expect(painel).toHaveAttribute("data-codigo", "on");
+    }
+    await expect(botao).toHaveText("Ocultar código");
+  });
+
+  test("as setas andam a animação, e o slider de velocidade fica com a tecla", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    const passo = painel.locator(".viz-step");
+    await expect(passo).toHaveText("passo 1 de 26");
+
+    // Uma ação só, nunca um par inverso: `ArrowRight` seguido de `ArrowLeft`
+    // devolve a peça ao estado de origem e fica verde com a quebra aplicada.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 2 de 26");
+
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+    // Com o cursor no slider, a seta é DO SLIDER. Sequestrar isso deixa o
+    // controle impossível de usar, o que é pior que não ter atalho.
+    const slider = painel.locator('input[type="range"]');
+    await slider.focus();
+    const passoAntes = await passo.innerText();
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await page.keyboard.press("ArrowRight");
+    await expect(painel.locator(".viz-speed .val")).toHaveText("2x");
+    await expect(passo).toHaveText(passoAntes);
+  });
+
+  test("a peça abre na marcha 1.5x, que é a dela e não a padrão do hook", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    // A marcha inicial era `useState(4)` antes da casca. Sem `initialSpeed` a
+    // peça abriria no "1x" do hook, e nenhum outro teste notaria.
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await expect(painel.locator('input[type="range"]')).toHaveValue("4");
+  });
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores do grupo **Árvores**:
quatro tópicos, **4 visualizadores adaptados**, com um agente por tópico em
paralelo e consolidação num PR só.

## O que entrou

| tópico | visualizador | camadas |
|---|---|---|
| `tree-traversals` | `TreeTraversalVisualizer` | as três |
| `arvores-binarias` | `BinaryTreeFormatos` | 1 e 2 — `collapsible: false` + `total: 1`, **sem rodapé nenhum** |
| `n-ary-trees` | `NAryTreeVisualizer` | as três |
| `bst` | `BSTVisualizer` | as três |

**4 de 4, nada fora do escopo.** O quinto tópico do grupo, `trie`, está `soon` e
não tem visualizador. **Zero linha de CSS nova** nas quatro.

## Medições

Janela **1512x900**, fontes carregadas, animação congelada, orçamento no artigo
= 816px. Cada peça medida **andando a animação inteira**, em todas as
combinações de preset.

| peça | artigo antes | depois | pior caso antes → depois |
|---|---|---|---|
| percursos | 1013 | **855** | 1225 → 1041 (degenerada) |
| formatos | 915–1025 | **911–1021** | — (classificador) |
| árvore n-ária | 1228 | **1070** | 1422 → 1238 |
| BST | 1159 | **950** | 1436 → 1202 (degenerada) |

**O defeito grande estava no painel expandido, e era o mesmo nas quatro:** a
sobra do miolo era **0** e quem rolava era a figura inteira, levando cabeçalho e
controles junto. Em 1440x600 o `▶ Rodar` era desenhado 570–673px **abaixo do pé
da janela**; nos formatos, o `✕ Fechar` — o único botão que fecha o painel —
subia até **234px acima do topo**. Depois, o cabeçalho não anda 1px em nenhuma
das três réguas e todo controle fica dentro da janela.

Três peças seguem acima do orçamento no artigo (855, 1070 e 1201 contra 816),
com o código já recolhido — limite do §9, reportado com a altura quebrada por
bloco em cada caso.

## Testes

**29 testes novos** em quatro arquivos disjuntos, **30 quebras provadas**, todas
compilando, com build visível e resumo imprimindo `failed` **e** `passed`.

**Suíte completa na branch integrada: 288 passed, 0 failed** (`--workers=2`, com
a máquina livre), leitura limpa na primeira tentativa.

## Verificação cruzada da consolidação

- **Diff do texto renderizado do build inteiro** (36.031 linhas, todas as
  páginas), `origin/main` contra esta branch: **zero linhas perdidas** na
  contagem líquida. As únicas adições são as afordâncias da casca nas três peças
  com bloco e linha do tempo. A página de `arvores-binarias` **não tem adição
  nenhuma** — é o build confirmando o que `collapsible: false` + `total: 1` + sem
  rodapé prometem.
- **Classe do #30 (marcha inicial perdida):** três das quatro peças tinham
  `useState(4)` na velocidade, e **as três carregaram `initialSpeed: 4`**. Varri
  também todas as peças já adaptadas: nenhuma perdida.
- **Classe do #28 (`stepBy` com aritmética):** nenhuma ocorrência.
- **Rodapé escrito à mão que o hook dispensa:** nenhum.
- **O bug do `newPage({ viewportSize })`:** nenhum teste novo o usa.

## Um caso novo: overlay sem controles nenhum

`BinaryTreeFormatos` é a primeira peça da série com painel expandido e **nenhum
controle** — sem bloco de código, sem painel de variáveis, sem reprodução. Saiu
com `collapsible: false` **e** `total: 1`, e sem `children` o `VizFooter` some
inteiro; os cinco presets seguem como chips do miolo, onde o contrato §6 os quer.

E ela **era** a que mais parecia não precisar de nada: a 1512x900 cabia nos sete
estados. O defeito só aparecia abaixo, e não era altura de miolo — era
`.viz-overlay .viz` com `max-height` + `overflow: auto` fazendo a figura inteira
rolar e levar o botão de fechar para fora da tela.

## Contrato (`content/visualizers/README.md`)

**Uma correção e três acréscimos**, todos medidos.

A correção é do enunciado que este contrato promoveu no #29: *"adotar a casca
deixa a peça mais alta no artigo, e quem não tem bloco paga"*. As três peças que
pagam (+28, +10, +10) têm `.viz-foot`, porque mesmo sem linha do tempo elas têm
controles próprios. `BinaryTreeFormatos` não tem rodapé nenhum, e ali a casca
**devolve 4px**, idênticos nos sete estados. **O custo é do rodapé, não da
adoção** — a pergunta é *esta peça tem rodapé?*, não *esta peça tem bloco?*.

Os acréscimos vão para a §3:

1. **Quatro casos novos na tabela do estado mais alto**, cada um atacando a
   intuição por um ângulo diferente: na n-ária, três árvores com 9 nós e grau 3
   dão 196/196/**332px** — a mais alta é a mais estreita, e o controle que parece
   o pior caso é o único que não mexe na altura; na BST não há campo para encher,
   os quatro presets têm sete nós e o desenho varia 2,2x pela **ordem de
   inserção**; nos formatos, nem contagem nem profundidade mandam — quem manda é
   o tamanho da prosa dos vereditos.
2. **Quinto passo da receita:** sem campo para encher, o pior caso está nos
   presets, e compare presets **do mesmo tamanho**.
3. **Ressalva na regra do pico:** confirme que existe pico antes de caçá-lo. Com
   `flex-wrap`, as fichas só viram altura depois que a linha quebra — no percurso
   de árvores a amplitude ao longo dos 26 passos é de 20px, e vem da nota ter uma
   ou duas linhas, não da pilha.

**A regra do #30 que impediu quatro consertos errados:** *"o desenho é grande"
não é "o desenho está esticado"*. As quatro peças mediram renderizado contra
`viewBox` — 362x388, 620x268, 496x332 e 402x190/306/422 — e as quatro deram
**esticão de 0px**. Nenhum teto de altura, nenhuma linha de CSS. Sem essa regra,
quatro agentes teriam encolhido o texto dos nós por semelhança de sintoma.

## Idioma

Identificadores traduzidos nos quatro componentes. O `guarda-idioma.py` **não é
prova em nenhum deles** (os dois buracos documentados no §0), então a prova foi
comparar o texto renderizado dos estados: **1.376 estados** somados (273 + 7 +
227 + 167), com diff vazio no miolo, mais o diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
