### PR TITLE
fix(deploy): imagem de OG servida como image/png, não octet-stream

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,23 @@
+# Cabeçalhos do Cloudflare Pages. O arquivo mora em `public/`, que o Next copia
+# inteiro para a raiz do `out/` no export; o Pages lê o `_headers` da raiz do
+# deploy e não serve o arquivo em si.
+#
+# Por que existe: as imagens de Open Graph são as únicas rotas do site que o
+# Next exporta SEM extensão (`out/opengraph-image`, e uma por rota que tem card
+# próprio). O Pages deriva o MIME da extensão, então sem esta regra elas saem
+# como `application/octet-stream` — e junto vai um `x-content-type-options:
+# nosniff`, que proíbe o cliente de adivinhar o tipo. Ou seja: o scraper que
+# respeita o header recebe um binário anônimo que ele não pode tratar como
+# imagem, e o card não renderiza. O `og:image:type` do HTML diz `image/png`,
+# mas quem manda no que chega pela rede é este cabeçalho.
+#
+# A regra da raiz e a de segmento são separadas de propósito: `/*/` exige pelo
+# menos um segmento antes, então não cobriria `/opengraph-image` sozinha. A
+# segunda pega qualquer rota que ganhe card próprio depois, sem precisar voltar
+# aqui.
+
+/opengraph-image
+  Content-Type: image/png
+
+/*/opengraph-image
+  Content-Type: image/png


### PR DESCRIPTION
## O que muda

Acrescenta `public/_headers` para o Cloudflare Pages servir as imagens de Open Graph como `image/png`. Hoje elas saem como `application/octet-stream`, o que provavelmente é o motivo de os cards não renderizarem direito ao compartilhar o site.

## Tipo

- [ ] `feat` novo conteúdo/tópico/visualizador
- [x] `fix` correção
- [ ] `docs` documentação
- [ ] `refactor` / `style` / `perf`
- [ ] `ci` / `build` / `chore`

## O problema

As imagens de OG são as **únicas** rotas que o Next exporta sem extensão. Conferido no `out/`:

```
out/opengraph-image
out/roadmap/opengraph-image
out/introducao/opengraph-image
```

O Cloudflare Pages deriva o MIME da extensão do arquivo. Sem extensão e sem `_headers` (o projeto não tinha nenhum), cai no genérico. Medido em **produção**, depois do deploy do #31:

```
$ curl -sI https://dsa.craftcodeclub.io/opengraph-image
HTTP/2 200
content-type: application/octet-stream
x-content-type-options: nosniff
```

O `nosniff` é o que fecha a porta: ele proíbe o cliente de adivinhar o tipo pelo conteúdo. Um scraper que respeita o header recebe um binário anônimo que não tem permissão de tratar como imagem. O HTML já declara `og:image:type: image/png`, mas quem manda no que chega pela rede é o cabeçalho HTTP, e ele discordava.

As três respondem 200 com tamanhos distintos (70 KB / 67 KB / 67 KB), ou seja, as imagens em si estão certas e são mesmo diferentes uma da outra. O defeito é só de entrega.

## Isso não veio do #31

O `src/app/opengraph-image.tsx` existe desde `5fca93f`, o primeiro commit do site, e sempre foi servido assim. O #31 não causou; só multiplicou por três e colocou luz no assunto, já que agora o card por rota é parte do que a gente promete.

Vale a ressalva prática: revalidar o cache do LinkedIn **antes** desta correção provavelmente não ia adiantar, porque o problema não era cache, era o `Content-Type`.

## As duas regras

```
/opengraph-image
  Content-Type: image/png

/*/opengraph-image
  Content-Type: image/png
```

Separadas de propósito: `/*/` exige pelo menos um segmento antes, então sozinha não cobriria a raiz. A segunda pega qualquer rota que ganhe card próprio depois, sem precisar voltar aqui.

`public/` é copiado inteiro para a raiz do `out/` no export, e o Pages lê o `_headers` da raiz do deploy sem servir o arquivo em si. Confirmado que ele chega lá: `out/_headers`, 1154 bytes.

## Verificação

- [x] `npm run build` passa, e o `_headers` aparece em `out/_headers`
- [x] `npm test` passa (265 testes, `PORT=3117 --workers=3`)
- [x] Segui o padrão de [Conventional Commits](https://conventionalcommits.org/)
- [x] Sem o caractere travessão (`—`) na copy do site
- [x] Li o [guia de contribuição](../CONTRIBUTING.md)

A suíte local não consegue provar esta correção: ela serve o `out/` por um `http.server` de Python, que tem a própria tabela de MIME e ignora o `_headers`. Quem prova é o **preview do Cloudflare deste PR** — vou medir o `content-type` nele e colar o resultado aqui antes de pedir merge.

## Depois do merge

Aí sim vale rodar o [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) e o [Facebook Sharing Debugger](https://developers.facebook.com/tools/debug/), com o `Content-Type` já correto na origem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLsDN8doSymkf4AYKfknPK
