### PR TITLE
feat(apoie): muro de apoiadores com cards, mantido à mão até a API da APOIA.se liberar

### DIFF
--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -2,10 +2,13 @@
 //
 // PARCEIROS são mantidos à mão nesta lista (poucos, empresas).
 //
-// APOIADORES vêm da APOIA.se em tempo de build, via fetchSupporters(). Mostramos
-// só o nome, do apoio mais recente para o mais antigo. Sem as variáveis de
-// ambiente configuradas, ou sem ninguém apoiando ainda, a página /apoie cai no
-// convite "seja o primeiro" automaticamente. Nada aqui quebra o build.
+// APOIADORES: por enquanto também são mantidos à mão, em MANUAL_SUPPORTERS.
+// A integração com a APOIA.se ainda não foi aprovada por eles, então quem
+// publica um apoio novo adiciona o nome na lista abaixo, no mesmo PR (o mais
+// recente primeiro). O código da API continua aqui e liga sozinho quando as
+// variáveis de ambiente existirem: fetchSupporters() junta as duas fontes, a
+// manual primeiro, sem repetir nome. Lista vazia e API muda cai no convite
+// "seja o primeiro" automaticamente. Nada aqui quebra o build.
 //
 // Configuração (env local e secret no GitHub):
 //   APOIASE_TOKEN        token Bearer do painel da APOIA.se (dashboard)
@@ -23,8 +26,45 @@ export const PARTNERS: Partner[] = [
   // { name: "Empresa X", url: "https://empresa.com" },
 ];
 
-// Apoiadores que não vêm da APOIA.se (opcional). Aparecem primeiro na lista.
-const EXTRA_SUPPORTERS: Supporter[] = [];
+// Apoiadores mantidos à mão, do apoio mais recente para o mais antigo.
+// Aparecem antes de qualquer nome que venha da API.
+const MANUAL_SUPPORTERS: Supporter[] = [
+  { name: "Cristiano Cunha" },
+  { name: "Wilson Neto" },
+  { name: "Eduarda Martins" },
+];
+
+// Partículas de nome ("Maria da Silva") não valem como inicial: a sigla sai de
+// primeiro + último nome de verdade.
+const NAME_PARTICLES = new Set([
+  "de", "da", "do", "das", "dos", "e", "di", "du", "del", "della", "la", "van", "von",
+]);
+
+// Sigla do avatar do card: "Cristiano Cunha" vira "CC", "Ana" vira "A".
+// Espalha (`[...]`) em vez de indexar para não cortar caractere fora do BMP.
+export function initials(name: string): string {
+  const parts = name
+    .trim()
+    .split(/\s+/)
+    .filter((p) => p.length > 0 && !NAME_PARTICLES.has(p.toLowerCase()));
+  if (parts.length === 0) return "?";
+  const first = [...parts[0]][0] ?? "";
+  const last = parts.length > 1 ? ([...parts[parts.length - 1]][0] ?? "") : "";
+  return (first + last).toUpperCase();
+}
+
+// Remove nomes repetidos preservando a ordem (o primeiro a aparecer prevalece).
+function dedupeByName(list: Supporter[]): Supporter[] {
+  const seen = new Set<string>();
+  const out: Supporter[] = [];
+  for (const s of list) {
+    const key = s.name.trim().toLowerCase();
+    if (!key || seen.has(key)) continue;
+    seen.add(key);
+    out.push(s);
+  }
+  return out;
+}
 
 const API_BASE = "https://dashboard-api-v1.apoia.se/api/reports/backers";
 
@@ -88,7 +128,7 @@ function toList(json: unknown): Raw[] {
 export async function fetchSupporters(): Promise<Supporter[]> {
   const token = process.env.APOIASE_TOKEN;
   const campaign = process.env.APOIASE_CAMPAIGN_ID;
-  if (!token || !campaign) return [...EXTRA_SUPPORTERS];
+  if (!token || !campaign) return dedupeByName(MANUAL_SUPPORTERS);
 
   try {
     const res = await fetch(`${API_BASE}/${encodeURIComponent(campaign)}`, {
@@ -96,35 +136,28 @@ export async function fetchSupporters(): Promise<Supporter[]> {
       signal: AbortSignal.timeout(8000),
     });
     if (!res.ok) {
-      console.warn(`[apoia.se] resposta HTTP ${res.status}. Mostrando placeholder de apoiadores.`);
-      return [...EXTRA_SUPPORTERS];
+      console.warn(`[apoia.se] resposta HTTP ${res.status}. Mostrando só a lista manual de apoiadores.`);
+      return dedupeByName(MANUAL_SUPPORTERS);
     }
 
     const raw = toList(await res.json());
-    const parsed = raw
+    const names = raw
       .filter(isActive)
       .map((b) => ({ name: pickName(b), t: pickTime(b) }))
       .filter((b): b is { name: string; t: number } => b.name !== null)
-      .sort((a, b) => b.t - a.t); // mais recente primeiro
-
-    // Remove nomes repetidos, preservando a ordem (o mais recente prevalece).
-    const seen = new Set<string>();
-    const names: Supporter[] = [];
-    for (const b of parsed) {
-      const key = b.name.toLowerCase();
-      if (seen.has(key)) continue;
-      seen.add(key);
-      names.push({ name: b.name });
-    }
+      .sort((a, b) => b.t - a.t) // mais recente primeiro
+      .map((b) => ({ name: b.name }));
 
     // Diagnóstico: veio gente mas não reconhecemos o campo do nome. Sinaliza que
     // o formato da API mudou e o mapeamento em pickName precisa de ajuste.
     if (raw.length > 0 && names.length === 0) {
       console.warn(`[apoia.se] recebeu ${raw.length} apoios mas não reconheceu os campos de nome. Ajuste pickName().`);
     }
-    return [...EXTRA_SUPPORTERS, ...names];
+    // A lista manual vem primeiro e vence o desempate: quem já está aqui não
+    // aparece duas vezes quando a API passar a devolver o mesmo nome.
+    return dedupeByName([...MANUAL_SUPPORTERS, ...names]);
   } catch (err) {
-    console.warn("[apoia.se] falha ao buscar apoiadores. Mostrando placeholder.", err);
-    return [...EXTRA_SUPPORTERS];
+    console.warn("[apoia.se] falha ao buscar apoiadores. Mostrando só a lista manual.", err);
+    return dedupeByName(MANUAL_SUPPORTERS);
   }
 }

--- a/src/app/apoie/page.tsx
+++ b/src/app/apoie/page.tsx
@@ -65,7 +65,7 @@ export default async function ApoiePage() {
               <p className="gratidao-titulo">
                 <span className="gratidao-n">{supporters.length}</span>{" "}
                 {supporters.length === 1 ? "pessoa já apoia" : "pessoas já apoiam"}{" "}
-                o Craft &amp; Code Club.
+                a comunidade Craft &amp; Code Club.
               </p>
               <p className="gratidao-texto">
                 Cada apoio ajuda a manter o site no ar, os encontros acontecendo e o conteúdo livre e

--- a/src/app/apoie/page.tsx
+++ b/src/app/apoie/page.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { LINKS } from "@/lib/links";
-import { fetchSupporters, PARTNERS } from "./apoiadores";
+import { fetchSupporters, initials, PARTNERS } from "./apoiadores";
 
 export const metadata: Metadata = {
   title: "Seja um apoiador da Comunidade",
@@ -58,11 +58,52 @@ export default async function ApoiePage() {
           <span className="wall-sub">Pessoas que bancam o projeto</span>
         </div>
         {supporters.length > 0 ? (
-          <div className="apoiadores-grid">
-            {supporters.map((a) => (
-              <span key={a.name} className="apoiador-chip">{a.name}</span>
-            ))}
-          </div>
+          <>
+            {/* Painel de gratidão: o número vem da lista, não é escrito à mão. */}
+            <div className="gratidao">
+              <span className="gratidao-eyebrow">Gratidão</span>
+              <p className="gratidao-titulo">
+                <span className="gratidao-n">{supporters.length}</span>{" "}
+                {supporters.length === 1 ? "pessoa já apoia" : "pessoas já apoiam"}{" "}
+                o Craft &amp; Code Club.
+              </p>
+              <p className="gratidao-texto">
+                Cada apoio ajuda a manter o site no ar, os encontros acontecendo e o conteúdo livre e
+                aberto para quem chegar depois.
+              </p>
+              <ul className="gratidao-fatos">
+                <li>
+                  <strong>Conteúdo aberto</strong>
+                  <span>sem paywall e sem anúncios</span>
+                </li>
+                <li>
+                  <strong>Encontros</strong>
+                  <span>gratuitos e abertos a todo mundo</span>
+                </li>
+              </ul>
+            </div>
+
+            <div className="apoiadores-grid">
+              {supporters.map((a) => (
+                <div key={a.name} className="apoiador-card">
+                  <span className="apoiador-avatar" aria-hidden="true">{initials(a.name)}</span>
+                  <span className="apoiador-nome">{a.name}</span>
+                </div>
+              ))}
+              <a
+                className="apoiador-card apoiador-card-cta"
+                href={LINKS.apoiar}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <span className="apoiador-avatar" aria-hidden="true">+</span>
+                <span className="apoiador-corpo">
+                  <span className="apoiador-nome">Seu nome aqui</span>
+                  <span className="apoiador-cta-sub">Quero apoiar →</span>
+                </span>
+              </a>
+            </div>
+          </>
         ) : (
           <div className="wall-empty">
             <p>Ainda não há apoiadores por aqui. <strong style={{ color: "#fff" }}>Seja o primeiro</strong> a sustentar o maior guia de Estruturas de Dados e Algoritmos em português.</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1316,16 +1316,75 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 .wall-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 16px; }
 .wall-head h2 { margin: 0; font-size: 22px; font-weight: 600; letter-spacing: -0.02em; }
 .wall-sub { font-size: 13px; color: var(--ccc-muted); }
-.apoiadores-grid { display: flex; flex-wrap: wrap; gap: 10px; }
-.apoiador-chip { display: inline-flex; align-items: center; padding: 9px 15px; border: 1px solid var(--ccc-line); border-radius: 99px; background: var(--ccc-surface); color: var(--ccc-text); font-size: 14px; font-weight: 500; text-decoration: none; }
-.apoiador-chip:hover { border-color: rgba(59, 130, 246, 0.45); background: var(--ccc-surface-2); color: #fff; }
+
+/* Muro de apoiadores. Enquanto a API da APOIA.se não libera a lista, os nomes
+   vêm da lista manual em apoiadores.ts; o visual é o mesmo nos dois casos.
+   Âmbar aqui é regra de marca: apoio é âmbar, como o botão Apoiar da barra. */
+.gratidao {
+  position: relative; overflow: hidden;
+  padding: 26px 28px; margin-bottom: 14px;
+  border: 1px solid var(--ccc-line); border-radius: 16px;
+  background: radial-gradient(640px 260px at 6% -40%, rgba(245, 158, 11, 0.14), transparent 62%),
+              var(--ccc-surface);
+}
+.gratidao-eyebrow { display: block; font-size: 12px; font-weight: 600; letter-spacing: 0.09em; text-transform: uppercase; color: #fbbf24; }
+/* clamp porque o título é longo: em 30px fixos ele vira quatro linhas a 390px. */
+.gratidao-titulo { margin: 12px 0 10px; max-width: 22ch; font-size: clamp(22px, 4.6vw, 30px); font-weight: 600; line-height: 1.2; letter-spacing: -0.025em; color: #fff; text-wrap: balance; }
+.gratidao-n { color: var(--ccc-coffee); }
+.gratidao-texto { margin: 0; max-width: 58ch; font-size: 15px; line-height: 1.6; color: #a9bcd4; text-wrap: pretty; }
+.gratidao-fatos { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin: 20px 0 0; padding: 0; list-style: none; }
+.gratidao-fatos li { min-width: 0; padding: 14px 16px; border: 1px solid var(--ccc-line); border-radius: 12px; background: rgba(255, 255, 255, 0.02); }
+.gratidao-fatos strong { display: block; font-size: 14.5px; font-weight: 600; color: #fff; }
+.gratidao-fatos span { display: block; margin-top: 3px; font-size: 13px; line-height: 1.5; color: var(--ccc-muted); }
+
+/* 158px cabe quatro por linha na coluna de 820px da página (três apoiadores
+   mais o convite), e quebra sozinho conforme a lista cresce. */
+.apoiadores-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(158px, 1fr)); gap: 12px; }
+.apoiador-card {
+  position: relative; overflow: hidden;
+  display: flex; flex-direction: column; justify-content: space-between; gap: 16px;
+  min-height: 138px; padding: 18px;
+  border: 1px solid var(--ccc-line); border-radius: 14px; background: var(--ccc-surface);
+  color: var(--ccc-text); text-decoration: none;
+  transition: border-color 0.18s ease, background 0.18s ease, transform 0.18s ease;
+}
+/* brilho âmbar que acende no hover, atrás do conteúdo */
+.apoiador-card::after {
+  content: ""; position: absolute; inset: 0; pointer-events: none;
+  background: radial-gradient(240px 140px at 100% 0%, rgba(245, 158, 11, 0.12), transparent 70%);
+  opacity: 0; transition: opacity 0.18s ease;
+}
+.apoiador-card:hover { border-color: rgba(245, 158, 11, 0.42); background: var(--ccc-surface-2); transform: translateY(-2px); }
+.apoiador-card:hover::after { opacity: 1; }
+.apoiador-avatar {
+  position: relative; z-index: 1;
+  display: grid; place-items: center; width: 46px; height: 46px; flex: none;
+  border-radius: 13px; background: linear-gradient(150deg, #fbbf24, #f59e0b);
+  box-shadow: 0 8px 20px rgba(245, 158, 11, 0.26);
+  font-size: 15px; font-weight: 700; letter-spacing: 0.01em; color: #201400;
+}
+.apoiador-corpo { position: relative; z-index: 1; display: flex; flex-direction: column; gap: 3px; min-width: 0; }
+.apoiador-nome { position: relative; z-index: 1; font-size: 15px; font-weight: 600; letter-spacing: -0.01em; line-height: 1.3; color: #fff; overflow-wrap: anywhere; }
+/* Último card do muro: o convite para entrar nele. */
+.apoiador-card-cta { border-style: dashed; background: rgba(245, 158, 11, 0.04); }
+.apoiador-card-cta:hover { background: rgba(245, 158, 11, 0.09); }
+.apoiador-card-cta .apoiador-avatar { background: rgba(245, 158, 11, 0.14); border: 1px dashed rgba(245, 158, 11, 0.5); box-shadow: none; font-size: 22px; font-weight: 500; color: #fcd34d; }
+.apoiador-card-cta .apoiador-nome { color: #fcd34d; }
+.apoiador-cta-sub { font-size: 12.5px; font-weight: 500; color: var(--ccc-muted); }
+.apoiador-card-cta:hover .apoiador-cta-sub { color: #dcc9a8; }
 .parceiros-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
 .parceiro-card { display: grid; place-items: center; min-height: 84px; padding: 18px; border: 1px solid var(--ccc-line); border-radius: 12px; background: var(--ccc-surface); color: var(--ccc-text); font-size: 15px; font-weight: 600; text-decoration: none; text-align: center; }
 .parceiro-card:hover { border-color: rgba(59, 130, 246, 0.45); background: var(--ccc-surface-2); color: #fff; }
 .wall-empty { display: flex; flex-direction: column; align-items: flex-start; gap: 14px; padding: 24px 26px; border: 1px dashed var(--ccc-line); border-radius: 14px; background: rgba(255, 255, 255, 0.015); }
 .wall-empty p { margin: 0; font-size: 14.5px; line-height: 1.6; color: #a9bcd4; max-width: 60ch; }
 @media (max-width: 700px) {
-  .parceiros-grid { grid-template-columns: 1fr 1fr; }
+  .parceiros-grid { grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); }
+  .gratidao { padding: 22px 18px; }
+  .gratidao-fatos { grid-template-columns: minmax(0, 1fr); gap: 10px; }
+  /* dois cards por linha a 360px: 150px é o menor tamanho em que "Cristiano
+     Cunha" ainda cabe em duas linhas sem apertar o avatar. */
+  .apoiadores-grid { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 10px; }
+  .apoiador-card { min-height: 124px; padding: 15px; }
 }
 
 /* footer */

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -56,6 +56,33 @@ test("página de apoio mostra apoiadores, parceiros e o link de doação", async
   await expect(page.getByRole("link", { name: /Quero apoiar/ }).first()).toHaveAttribute("href", /apoia\.se\/craftcodeclub/);
 });
 
+// O muro é montado da lista manual em apoiadores.ts enquanto a API da APOIA.se
+// não libera os nomes. O que o teste prende é o contrato do muro, não os nomes:
+// um card por apoiador, mais o card-convite, e a contagem do painel batendo com
+// a quantidade de cards (já saiu "3 pessoas" com quatro nomes na lista).
+test("muro de apoiadores: um card por pessoa, contagem batendo e convite no fim", async ({ page }) => {
+  await page.goto("/apoie/");
+  const cards = page.locator(".apoiador-card:not(.apoiador-card-cta)");
+  const quantos = await cards.count();
+  expect(quantos).toBeGreaterThan(0);
+
+  const plural = quantos === 1 ? "pessoa já apoia" : "pessoas já apoiam";
+  await expect(page.locator(".gratidao-titulo")).toHaveText(
+    `${quantos} ${plural} o Craft & Code Club.`
+  );
+
+  // sigla do avatar: primeiro e último nome, sem a partícula do meio
+  const primeiro = cards.first();
+  const nome = (await primeiro.locator(".apoiador-nome").innerText()).trim();
+  const partes = nome.split(/\s+/).filter((p) => !["de", "da", "do", "das", "dos", "e"].includes(p.toLowerCase()));
+  const sigla = (partes[0][0] + (partes.length > 1 ? partes[partes.length - 1][0] : "")).toUpperCase();
+  await expect(primeiro.locator(".apoiador-avatar")).toHaveText(sigla);
+
+  const convite = page.locator(".apoiador-card-cta");
+  await expect(convite).toHaveAttribute("href", /apoia\.se\/craftcodeclub/);
+  await expect(convite).toContainText("Seu nome aqui");
+});
+
 test("Two Pointers é uma página completa com os três visualizadores e problemas", async ({ page }) => {
   await page.goto("/topico/two-pointers/");
   // um visualizador por sabor da técnica: convergente, ritmos diferentes e Floyd

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -68,7 +68,7 @@ test("muro de apoiadores: um card por pessoa, contagem batendo e convite no fim"
 
   const plural = quantos === 1 ? "pessoa já apoia" : "pessoas já apoiam";
   await expect(page.locator(".gratidao-titulo")).toHaveText(
-    `${quantos} ${plural} o Craft & Code Club.`
+    `${quantos} ${plural} a comunidade Craft & Code Club.`
   );
 
   // sigla do avatar: primeiro e último nome, sem a partícula do meio


### PR DESCRIPTION
## Por quê

A integração com a APOIA.se ainda não foi aprovada por eles, então a lista de apoiadores não tem de onde vir automaticamente. Em vez de deixar a página no estado "seja o primeiro" com gente já apoiando, os nomes passam a ser mantidos à mão até a API liberar.

## O que muda

**`src/app/apoie/apoiadores.ts`**
- Os nomes saem de `MANUAL_SUPPORTERS`, uma lista no próprio arquivo (do apoio mais recente para o mais antigo). Quem publica um apoio novo adiciona o nome ali, no mesmo PR.
- O código da API continua onde estava e volta a valer sozinho quando `APOIASE_TOKEN` / `APOIASE_CAMPAIGN_ID` existirem: `fetchSupporters()` junta as duas fontes, manual primeiro, com dedupe por nome — ninguém aparece duas vezes quando a API entrar.
- `initials()` monta a sigla do avatar a partir do primeiro e do último nome, ignorando partículas ("Maria da Silva" → MS).

**`src/app/apoie/page.tsx`**
- Painel de gratidão acima do muro, com a contagem vinda do tamanho da lista (singular/plural automático, número nenhum escrito à mão).
- Os chips viram cards: sigla em avatar âmbar, nome embaixo. Âmbar porque apoio é âmbar no projeto, como o botão Apoiar da barra.
- Fechando a fila, um card-convite "Seu nome aqui → Quero apoiar" apontando para a campanha: a página agradece e converte, em vez de só agradecer.

**`src/app/globals.css`** — classes novas (`.gratidao*`, `.apoiador-card*`). Grid `auto-fill`: quatro cards por linha na coluna de 820px, dois a 360/390px. Nada compartilhado foi tocado.

**`tests/navegacao.spec.ts`** — teste novo prendendo o contrato do muro (um card por pessoa, contagem do painel batendo com o número de cards, sigla do avatar, link do convite), não os nomes: a lista cresce sem quebrar teste.

## Verificação

- `npm run build` passa (59 páginas).
- Testes de `/apoie` passam (`npx playwright test tests/navegacao.spec.ts -g "apoi"`).
- Zero overflow horizontal medido a 360, 390, 768 e 1280px.

> Nota sobre a suíte cheia nesta máquina: aparecem ~5 falhas de timeout aleatórias em specs de visualizador. Rodei a suíte na `main` limpa (com as mudanças deste PR guardadas) e as mesmas falhas aparecem lá, em specs diferentes a cada rodada, e todas passam quando rodadas isoladas — é contenção da máquina local, não deste PR. O CI é quem dá a palavra final.

## Quando a API for aprovada

Nada a desfazer: basta configurar os secrets. A lista manual continua valendo como fonte extra e o visual não muda.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXaFoweFjfFr5Mn3ywaspp
