### PR TITLE
fix(nav): trocar de tópico volta ao topo na hora, sem animação cancelável

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,9 +30,17 @@ export const metadata: Metadata = {
   },
 };
 
+// `data-scroll-behavior="smooth"` no `<html>` é como o Next sabe que o CSS deste
+// site tem `html { scroll-behavior: smooth }`. Sem o atributo ele nem tenta
+// desligar a rolagem suave ao trocar de rota: o "volta pro topo" da navegação
+// vira uma animação de mais de um segundo saindo do fim de uma página de ~18000px,
+// e qualquer toque no trackpad no meio do caminho cancela a animação e deixa o
+// leitor parado no meio do artigo novo — a rolagem que "às vezes vai, às vezes
+// não". Com o atributo, o Next zera a rolagem na hora e devolve o `smooth` logo em
+// seguida, então as âncoras do índice "Nesta página" continuam suaves.
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pt-BR">
+    <html lang="pt-BR" data-scroll-behavior="smooth">
       <head>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="" />

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -552,6 +552,77 @@ test("índice 'Nesta página' fica grudado ao rolar o artigo", async ({ page }) 
   expect(depois.height).toBeLessThanOrEqual(page.viewportSize()!.height);
 });
 
+// ---------------------------------------------------------------------------
+// Rolagem ao trocar de página.
+//
+// O Next só desliga a rolagem suave durante a troca de rota se o `<html>` levar
+// `data-scroll-behavior="smooth"` (é assim que ele sabe que o CSS do site pediu
+// `scroll-behavior: smooth`). Sem o atributo, o "volta pro topo" saía do fim de
+// um artigo de ~18000px ANIMADO, levava mais de um segundo — e qualquer toque no
+// trackpad no meio do caminho cancelava a animação, deixando o leitor parado no
+// meio do artigo novo. Era a rolagem que "às vezes vai, às vezes não".
+//
+// Por isso os dois testes medem a TRAJETÓRIA, e não a posição final: com a
+// animação, o fim também é o topo — só que um segundo depois e cancelável.
+// ---------------------------------------------------------------------------
+
+/** Todas as posições de rolagem por quadro enquanto `acao` acontece. */
+async function trajetoriaDaRolagem(
+  page: import("@playwright/test").Page,
+  acao: () => Promise<void>,
+  ms = 1600
+) {
+  await page.evaluate((limite) => {
+    const w = window as unknown as { __traj: number[] };
+    w.__traj = [];
+    const t0 = performance.now();
+    const tick = () => {
+      w.__traj.push(Math.round(window.scrollY));
+      if (performance.now() - t0 < limite) requestAnimationFrame(tick);
+    };
+    requestAnimationFrame(tick);
+  }, ms);
+  await acao();
+  await page.waitForTimeout(ms + 200);
+  return page.evaluate(() => (window as unknown as { __traj: number[] }).__traj);
+}
+
+const irParaOFimDaPagina = async (page: import("@playwright/test").Page) => {
+  await page.evaluate(() => window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" }));
+  await page.waitForFunction(() => window.scrollY > 1000);
+};
+
+test("clicar em Próximo volta ao topo de uma vez, não numa animação cancelável", async ({ page }) => {
+  await page.goto("/topico/arrays/");
+  await irParaOFimDaPagina(page);
+
+  const proximo = page.locator(".prevnext a.next");
+  const destino = await proximo.getAttribute("href");
+  const traj = await trajetoriaDaRolagem(page, () => proximo.click());
+
+  await expect(page).toHaveURL(new RegExp(`${destino}$`));
+  await expect(page.getByRole("heading", { level: 1, name: "Strings" })).toBeVisible();
+
+  const posicoes = [...new Set(traj)];
+  expect(traj[traj.length - 1], "a página nova não abriu no topo").toBe(0);
+  // Salto: fim → topo. Uma animação passaria por dezenas de posições no meio
+  // (medido antes da correção: mais de 60), e é nesse meio que o trackpad do
+  // leitor cancelava a rolagem. A folga cobre o ajuste do navegador quando a
+  // página nova é mais curta e a rolagem é limitada antes do salto.
+  expect(posicoes.length, `rolagem animada: passou por ${posicoes.length} posições`).toBeLessThanOrEqual(3);
+});
+
+test("a âncora do índice 'Nesta página' continua rolando suave", async ({ page }) => {
+  // O atributo no `<html>` não pode custar o `scroll-behavior: smooth` do site:
+  // ele existe para as âncoras do índice, que ficam ásperas sem a animação.
+  await page.goto("/topico/pilhas/");
+  const traj = await trajetoriaDaRolagem(page, () => page.locator(".toc-links a").nth(2).click());
+
+  const posicoes = [...new Set(traj)];
+  expect(posicoes.length, "a âncora saltou em vez de rolar suave").toBeGreaterThan(5);
+  expect(traj[traj.length - 1], "a âncora não saiu do topo").toBeGreaterThan(0);
+});
+
 test("código Python sai colorido do build, com selo discreto da linguagem", async ({ page }) => {
   await page.goto("/topico/prefix-sum/");
   // pega o bloco Python pelo conteúdo, não pela ordem: um bloco de outra


### PR DESCRIPTION
## O que acontecia

Ao clicar em **Próximo ›** no fim de um artigo, a página seguinte às vezes abria no
topo e às vezes abria no meio. Não era aleatório: o `<html>` não tinha
`data-scroll-behavior="smooth"`, o atributo pelo qual o Next descobre que o CSS do
site pede `scroll-behavior: smooth`. Sem ele, o Next nem tenta desligar a rolagem
suave durante a troca de rota (é o que faz o `disableSmoothScrollDuringRouteTransition`).

Resultado medido antes da correção, saindo do fim de `/topico/arrays/` (~17000px):

- o "volta pro topo" virava uma **animação de mais de um segundo**, passando por
  mais de 60 posições intermediárias;
- qualquer toque no trackpad no meio do caminho **cancelava a animação** e deixava
  o leitor parado no meio do artigo novo — o "às vezes vai, às vezes não";
- e o fim da animação parava em **y=60**, não em 0: como o `scrollTop = 0` também
  era animado, a verificação seguinte do Next achava o elemento fora da tela e
  chamava o `scrollIntoView` de reserva, que encaixa o topo do artigo debaixo do
  cabeçalho fixo (a trilha "Manipulação de Bits / Binários Negativos" sumia).

## O que mudou

Uma linha: `data-scroll-behavior="smooth"` no `<html>`. O Next passa a zerar a
rolagem na hora e devolver o `smooth` logo em seguida.

Medido depois, em 8 tópicos, vindo do **Próximo ›**, do **menu lateral** e do
**roadmap**: `y=0` no mesmo quadro, sempre. As âncoras do índice "Nesta página"
continuam suaves (92 posições intermediárias), e voltar no histórico continua
devolvendo o leitor à posição de antes.

## Testes

Dois testes novos em `tests/navegacao.spec.ts` que medem a **trajetória** da
rolagem, e não a posição final — com a animação o fim também é o topo, só que um
segundo depois e cancelável:

- `clicar em Próximo volta ao topo de uma vez, não numa animação cancelável`
- `a âncora do índice 'Nesta página' continua rolando suave`

Um cobre o outro de propósito: assim ninguém conserta um lado às custas do outro.

`npm run build` e `npm test` passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TqHnsb7XKWfY25yB8Te8t
