### PR TITLE
feat(menu): o menu lateral abre onde o leitor está e lembra o que ele escolheu

### DIFF
--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -2,28 +2,115 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { GROUPS, TOTAL_TOPICS, isEmptyTopic } from "@content/roadmap";
 import { LINKS } from "@/lib/links";
 import { useProgress } from "@/components/ProgressProvider";
+
+// Grupos abertos no menu lateral, salvos no navegador (mesma ideia do progresso:
+// sem login, sem servidor).
+const KEY_MENU = "ccc-dsa-menu";
+
+/** Ids válidos hoje. Grupo renomeado ou removido sai do que estava salvo. */
+const IDS_DE_GRUPO = new Set(GROUPS.map((g) => g.id));
+
+function lerAbertos(): Record<string, boolean> | null {
+  try {
+    const raw = localStorage.getItem(KEY_MENU);
+    if (!raw) return null;
+    const lista = JSON.parse(raw);
+    if (!Array.isArray(lista)) return null;
+    const mapa: Record<string, boolean> = {};
+    for (const id of lista) if (typeof id === "string" && IDS_DE_GRUPO.has(id)) mapa[id] = true;
+    return mapa;
+  } catch {
+    return null;
+  }
+}
+
+function gravarAbertos(abertos: Record<string, boolean>) {
+  try {
+    localStorage.setItem(KEY_MENU, JSON.stringify(GROUPS.filter((g) => abertos[g.id]).map((g) => g.id)));
+  } catch {
+    /* modo privado / storage cheio, só ignora */
+  }
+}
+
+/** Compara rotas ignorando a barra final (`trailingSlash: true` no next.config). */
+const mesmaRota = (a: string | null | undefined, b: string) =>
+  !!a && a.replace(/\/+$/, "") === b.replace(/\/+$/, "");
 
 export function Shell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { hydrated, isTopico, toggleTopico, contarTopicos } = useProgress();
 
+  const slugAtivo = pathname?.startsWith("/topico/") ? pathname.split("/")[2] : null;
+
+  // Onde o leitor está: o grupo do tópico aberto ou o grupo da página de
+  // introdução dele. É o único grupo que o menu abre por conta própria.
+  const grupoDaRota = useMemo(() => {
+    const porTopico = slugAtivo && GROUPS.find((g) => g.topics.some((t) => t.slug === slugAtivo));
+    if (porTopico) return porTopico.id;
+    const porIntro = GROUPS.find((g) => g.intro && mesmaRota(pathname, g.intro.href));
+    return porIntro?.id ?? null;
+  }, [slugAtivo, pathname]);
+
   const [busca, setBusca] = useState("");
-  const [abertos, setAbertos] = useState<Record<string, boolean>>({ introducao: true, "arrays-strings": true });
+  // Primeira renderização (a mesma no HTML estático e na hidratação): o grupo da
+  // rota, ou o primeiro grupo em páginas que não são de tópico (home, roadmap,
+  // apoiar), para o menu nunca abrir todo fechado para quem chega agora. O que
+  // estava salvo entra logo depois, no efeito — ler o localStorage aqui daria
+  // divergência de hidratação.
+  const [abertos, setAbertos] = useState<Record<string, boolean>>(() => ({
+    [grupoDaRota ?? GROUPS[0].id]: true,
+  }));
   const [mobileNav, setMobileNav] = useState(false);
   const [menu, setMenu] = useState(false);
+  const [restaurado, setRestaurado] = useState(false);
+  const listaRef = useRef<HTMLDivElement>(null);
 
-  const slugAtivo = pathname?.startsWith("/topico/") ? pathname.split("/")[2] : null;
+  // Devolve o menu como o leitor deixou, mais o grupo de onde ele está agora —
+  // esse nunca fica fechado. Quem tem histórico não recebe o grupo de abertura
+  // junto: ele é o padrão de quem chega sem nada salvo, não um grupo fixo.
+  // Roda uma vez, na montagem, e por isso lê o `grupoDaRota` da primeira
+  // renderização; a partir daí quem cuida da troca de rota é o efeito abaixo.
+  useEffect(() => {
+    const salvos = lerAbertos();
+    if (salvos) setAbertos(grupoDaRota ? { ...salvos, [grupoDaRota]: true } : salvos);
+    setRestaurado(true);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Salva depois de restaurar, nunca antes: gravar o estado inicial apagaria a
+  // escolha do leitor com o padrão da rota antes mesmo de ele ver o menu.
+  useEffect(() => {
+    if (restaurado) gravarAbertos(abertos);
+  }, [abertos, restaurado]);
 
   // Abre automaticamente o grupo do tópico aberto.
   useEffect(() => {
-    if (!slugAtivo) return;
-    const g = GROUPS.find((grp) => grp.topics.some((t) => t.slug === slugAtivo));
-    if (g) setAbertos((a) => ({ ...a, [g.id]: true }));
-  }, [slugAtivo]);
+    if (grupoDaRota) setAbertos((a) => ({ ...a, [grupoDaRota]: true }));
+  }, [grupoDaRota]);
+
+  // Com os outros grupos fechados, o tópico atual pode ficar fora da parte
+  // visível do menu — e aí o leitor não vê onde está. Rola só o container do
+  // menu (nunca a página, que o `scrollIntoView` levaria junto) e só quando
+  // precisa. `block: nearest` na mão: distância mínima, sem centralizar nada.
+  useEffect(() => {
+    const lista = listaRef.current;
+    const atual = lista?.querySelector<HTMLElement>(".side-item.on");
+    if (!lista || !atual) return;
+    const item = atual.getBoundingClientRect();
+    const caixa = lista.getBoundingClientRect();
+    if (item.top < caixa.top) lista.scrollTop -= caixa.top - item.top + 8;
+    else if (item.bottom > caixa.bottom) lista.scrollTop += item.bottom - caixa.bottom + 8;
+    // `restaurado` está nas dependências porque os grupos salvos entram depois
+    // da primeira pintura: eles empurram o tópico atual para baixo, e sem uma
+    // segunda passada a conta acima teria sido feita sobre o menu errado.
+    // `mobileNav` porque no celular o menu é uma gaveta com `display: none`: ao
+    // carregar a página ele não tem medida nenhuma, e a conta só vale quando o
+    // leitor abre a gaveta.
+  }, [grupoDaRota, slugAtivo, pathname, restaurado, mobileNav]);
 
   // Fecha o menu lateral ao navegar (mobile).
   useEffect(() => setMobileNav(false), [pathname]);
@@ -42,7 +129,9 @@ export function Shell({ children }: { children: React.ReactNode }) {
     [b, abertos]
   );
 
-  const navOn = (href: string) => pathname === href;
+  // Com `trailingSlash: true`, a rota chega como "/roadmap/": comparar com o
+  // href cru deixava Roadmap, Apoiar e Introdução sem o destaque de "você está aqui".
+  const navOn = (href: string) => mesmaRota(pathname, href);
 
   return (
     <div className="shell">
@@ -137,20 +226,31 @@ export function Shell({ children }: { children: React.ReactNode }) {
           />
         </div>
 
-        <div className="side-scroll">
+        <div className="side-scroll" ref={listaRef}>
           {grupos.map((g) => {
             const feitos = contarTopicos(g.topics.map((t) => t.slug));
             return (
               <div className="side-group" key={g.id}>
-                <button className="side-group-btn" onClick={() => setAbertos((a) => ({ ...a, [g.id]: !a[g.id] }))}>
-                  <span className={`side-caret${g.aberto ? " open" : ""}`}>▸</span>
+                {/* `aria-expanded` porque o triângulo é a única pista de aberto/fechado,
+                    e ele é decoração: sem o atributo, quem usa leitor de tela ouve só
+                    "Grafos, botão" e não sabe se está abrindo ou fechando o grupo. */}
+                <button
+                  className="side-group-btn"
+                  aria-expanded={g.aberto}
+                  onClick={() => setAbertos((a) => ({ ...a, [g.id]: !a[g.id] }))}
+                >
+                  <span className={`side-caret${g.aberto ? " open" : ""}`} aria-hidden="true">▸</span>
                   <span style={{ flex: 1 }}>{g.name}</span>
                   <span className="side-count">{feitos}/{g.topics.length}</span>
                 </button>
                 {g.aberto && (
                   <div className="side-items">
                     {g.intro && (
-                      <Link href={g.intro.href} className={`side-item${navOn(g.intro.href) ? " on" : ""}`}>
+                      <Link
+                        href={g.intro.href}
+                        className={`side-item${navOn(g.intro.href) ? " on" : ""}`}
+                        aria-current={navOn(g.intro.href) ? "page" : undefined}
+                      >
                         <span className="side-intro-ico" aria-hidden="true">✦</span>
                         <span className="side-item-name">{g.intro.name}</span>
                       </Link>
@@ -162,7 +262,12 @@ export function Shell({ children }: { children: React.ReactNode }) {
                       // artigo ou visualização, o tópico é navegável como qualquer outro.
                       const vazio = isEmptyTopic(t);
                       return (
-                        <Link key={t.slug} href={`/topico/${t.slug}`} className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}>
+                        <Link
+                          key={t.slug}
+                          href={`/topico/${t.slug}`}
+                          className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}
+                          aria-current={ativo ? "page" : undefined}
+                        >
                           <span
                             className={`side-check${feito ? " done" : ""}`}
                             role="checkbox"

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -574,6 +574,100 @@ test("código Python sai colorido do build, com selo discreto da linguagem", asy
   await expect(semSelo.locator(".code-lang")).toHaveCount(0);
 });
 
+// ---------------------------------------------------------------------------
+// Menu lateral: quais grupos abrem.
+//
+// Antes, o estado inicial era `{ introducao: true, "arrays-strings": true }`
+// escrito no componente: toda recarga reabria esse par, em qualquer página, e o
+// que o leitor tinha aberto ou fechado se perdia. Agora o menu abre o grupo de
+// onde o leitor está (regra que não muda) e devolve o que ele mesmo escolheu.
+// ---------------------------------------------------------------------------
+
+/** Nomes dos grupos com o triângulo aberto, na ordem do menu. */
+const gruposAbertos = (page: import("@playwright/test").Page) =>
+  page.locator(".side-group").evaluateAll((gs) =>
+    gs
+      .filter((g) => g.querySelector(".side-caret.open"))
+      .map((g) => g.querySelector(".side-group-btn span:nth-child(2)")?.textContent ?? "")
+  );
+
+test("o menu abre o grupo da página, não um par fixo de grupos", async ({ page }) => {
+  await page.goto("/topico/arrays/");
+  // Arrays e Strings porque é onde o leitor está; Introdução não entra de carona.
+  expect(await gruposAbertos(page)).toEqual(["Arrays e Strings"]);
+
+  // Em um tópico do fim da lista, o mesmo: só o grupo dele. O storage é limpo
+  // porque a visita acima já virou histórico — e histórico o menu devolve de
+  // propósito (é o outro teste); aqui o que se mede é a primeira visita.
+  await page.evaluate(() => localStorage.clear());
+  await page.goto("/topico/backtracking/");
+  expect(await gruposAbertos(page)).toEqual(["Backtracking"]);
+});
+
+test("o menu lembra os grupos que o leitor abriu, e o da página abre junto", async ({ page }) => {
+  await page.goto("/topico/arrays/");
+  await page.locator(".side-group-btn", { hasText: "Grafos" }).click();
+  await expect(page.locator(".side-item[href='/topico/dijkstra/']")).toBeVisible();
+
+  // F5 na mesma página: a escolha volta, e o grupo da rota continua aberto.
+  await page.reload();
+  expect(await gruposAbertos(page)).toEqual(["Arrays e Strings", "Grafos"]);
+
+  // Fechar também é escolha: o grupo fica fechado depois da recarga.
+  await page.locator(".side-group-btn", { hasText: "Grafos" }).click();
+  await page.reload();
+  expect(await gruposAbertos(page)).toEqual(["Arrays e Strings"]);
+});
+
+test("o grupo da página atual abre mesmo que estivesse fechado", async ({ page }) => {
+  // Cenário do leitor que fechou tudo e depois abriu um tópico de outro grupo.
+  await page.addInitScript(() => localStorage.setItem("ccc-dsa-menu", JSON.stringify(["hashing"])));
+  await page.goto("/topico/dijkstra/");
+  expect(await gruposAbertos(page)).toEqual(["Hashing", "Grafos"]);
+  await expect(page.locator(".side-item.on")).toHaveText(/Dijkstra/);
+});
+
+test("quem chega sem histórico vê o primeiro grupo aberto, e só ele", async ({ page }) => {
+  await page.goto("/");
+  expect(await gruposAbertos(page)).toEqual(["Introdução"]);
+
+  // E o grupo de abertura é só o padrão de quem não tem nada salvo: em página
+  // sem grupo próprio (home, roadmap, apoiar), quem já escolheu vê a escolha
+  // dele, e não a dele mais a Introdução de brinde.
+  await page.evaluate(() => localStorage.setItem("ccc-dsa-menu", JSON.stringify(["grafos"])));
+  await page.goto("/");
+  expect(await gruposAbertos(page)).toEqual(["Grafos"]);
+});
+
+test("o menu rola sozinho até o tópico atual quando ele fica fora da vista", async ({ page }) => {
+  // Com os outros grupos fechados, um tópico do fim da lista ainda pode cair
+  // abaixo da dobra do menu — e aí o leitor não vê onde está.
+  await page.setViewportSize({ width: 1440, height: 700 });
+  await page.goto("/topico/negative-binary/");
+  const dentro = await page.evaluate(() => {
+    const lista = document.querySelector(".side-scroll")!;
+    const atual = lista.querySelector(".side-item.on")!;
+    const a = atual.getBoundingClientRect();
+    const c = lista.getBoundingClientRect();
+    return { visivel: a.top >= c.top - 1 && a.bottom <= c.bottom + 1, rolou: lista.scrollTop > 0 };
+  });
+  expect(dentro.rolou, "o menu deveria ter rolado para alcançar o tópico").toBe(true);
+  expect(dentro.visivel, "o tópico atual ficou fora da parte visível do menu").toBe(true);
+  // e quem rolou foi o menu, não a página
+  expect(await page.evaluate(() => window.scrollY)).toBe(0);
+});
+
+test("Roadmap, Apoiar e Introdução mostram onde o leitor está", async ({ page }) => {
+  // Regressão: com `trailingSlash: true` a rota chega como "/roadmap/", e a
+  // comparação crua com o href deixava a barra do topo sempre apagada.
+  await page.goto("/roadmap/");
+  await expect(page.locator(".nav-left a.on")).toHaveText("Roadmap");
+  await page.goto("/apoie/");
+  await expect(page.locator(".nav-right a.on")).toContainText("Apoiar");
+  await page.goto("/introducao/");
+  await expect(page.locator(".side-item.on")).toHaveText(/Introdução/);
+});
+
 test("selo NOVO segue a tag isNew, não a existência de visualizador", async ({ page }) => {
   const marcados = ALL_TOPICS.filter((t) => t.isNew);
   await page.goto("/topico/big-o/");
@@ -1356,6 +1450,13 @@ test("o selo em breve aparece em quem não tem vídeo, artigo nem visualização
   // O menu lateral só renderiza o grupo aberto, então a conferência é por grupo.
   // Ler de ALL_TOPICS em vez de fixar uma lista faz o teste sobreviver ao dia
   // em que qualquer um destes tópicos for publicado.
+  //
+  // O menu lembra os grupos abertos entre visitas, e este teste passa por vários
+  // grupos: sem zerar essa memória a cada carga, os selos dos grupos anteriores
+  // continuariam na tela e entrariam na conta. Aqui o assunto é o selo, não a
+  // memória do menu (que tem testes próprios).
+  await page.addInitScript(() => localStorage.removeItem("ccc-dsa-menu"));
+
   const conferirGrupo = async (slug: string) => {
     await page.goto(`/topico/${slug}/`);
     const grupo = ALL_TOPICS.find((t) => t.slug === slug)!.group;


### PR DESCRIPTION
## O que acontecia

O estado inicial do menu lateral era escrito no componente:

```ts
const [abertos, setAbertos] = useState({ introducao: true, "arrays-strings": true });
```

Toda recarga reabria esse par, em qualquer página, e o que o leitor tinha aberto ou
fechado se perdia. Quem estudava Grafos recarregava e via Introdução e Arrays e
Strings abertos de novo, com o grupo dele empurrado para baixo.

## Como ficou

- **abre o grupo da página atual** — a regra que já existia e que não muda. Vale
  para o tópico e para a página de introdução do grupo;
- **lembra os grupos que o leitor abriu**, salvos em `ccc-dsa-menu` como o
  progresso já faz: sem login, sem servidor. Id de grupo que não existe mais é
  descartado na leitura, então renomear grupo não deixa lixo;
- **quem chega sem histórico** vê o primeiro grupo aberto (o menu nunca aparece
  todo fechado); **quem tem histórico** vê só o que escolheu — o grupo de abertura
  é o padrão de quem não tem nada salvo, não um grupo fixo;
- **o menu rola sozinho até o tópico atual** quando ele fica fora da vista. Com os
  outros grupos fechados, um tópico do fim da lista some abaixo da dobra. Rola só o
  container do menu, nunca a página (por isso a conta é na mão, e não
  `scrollIntoView`), e só quando precisa. No celular a conta roda quando a gaveta
  abre, que é quando ela tem medida.

O estado inicial continua derivado da rota, e não do `localStorage`: o HTML
estático e a hidratação renderizam a mesma coisa, e o que estava salvo entra no
efeito logo depois.

## De quebra

Duas coisas que estavam apagadas e apareceram ao mexer aqui:

- `navOn` comparava a rota crua com o href. Com `trailingSlash: true`, a rota chega
  como `"/roadmap/"` e nunca batia com `"/roadmap"`: **Roadmap, Apoiar e Introdução
  nunca acendiam** o destaque de "você está aqui";
- acessibilidade do menu: o botão de grupo ganhou `aria-expanded` (o triângulo é
  decoração, e sem o atributo o leitor de tela ouve só "Grafos, botão") e o item
  atual ganhou `aria-current="page"`.

## Testes

Seis testes novos em `tests/navegacao.spec.ts`: o grupo da página, a memória do
que o leitor abriu e fechou, o grupo da rota abrindo mesmo com histórico em
contrário, o padrão de quem chega sem histórico, o menu rolando até o tópico atual
sem levar a página junto, e o destaque das rotas com barra final.

O teste do selo "em breve" passa por vários grupos e contava com o menu abrindo só
o grupo da rota; agora ele limpa a memória do menu a cada carga, porque o assunto
dele é o selo, não a memória (que tem testes próprios).

Conferido também no celular (390x844): a gaveta abre já mostrando o tópico atual,
a página não rola junto e não há estouro de largura.

`npm run build` e `npm test` passando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012TqHnsb7XKWfY25yB8Te8t
