### PR TITLE
feat(viz): casca adaptativa no grupo Grafos

### DIFF
--- a/content/visualizers/AStarVisualizer.tsx
+++ b/content/visualizers/AStarVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // AStarVisualizer, a heurística em cima de uma grade.
@@ -17,23 +18,27 @@ import { createPortal } from "react-dom";
 //   Guloso    f = h          (ignora o custo já pago, e por isso erra)
 // O modo guloso existe para provar que a soma importa: ele é rápido e às vezes
 // devolve um caminho pior, que é exatamente o preço de jogar fora o g.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-const L = 14; // colunas
-const A = 9;  // linhas
-const CEL = 26;
+const COLS = 14; // colunas
+const ROWS = 9;  // linhas
+const CELL = 26;
 
-type Modo = "astar" | "dijkstra" | "guloso";
+type Mode = "astar" | "dijkstra" | "greedy";
 
-type Preset = { key: string; rotulo: string; paredes: string; dica: string };
+type Preset = { key: string; label: string; walls: string; hint: string };
 
 // Mapas em texto: '#' é parede. Ler assim deixa o mapa editável de olho.
 const PRESETS: Preset[] = [
   {
-    key: "muro",
-    rotulo: "Um muro no meio",
-    dica: "O caso didático: o A* vai direto até o muro, contorna e segue. O Dijkstra explora para trás também, sem motivo.",
-    paredes: [
+    key: "wall",
+    label: "Um muro no meio",
+    hint: "O caso didático: o A* vai direto até o muro, contorna e segue. O Dijkstra explora para trás também, sem motivo.",
+    walls: [
       "..............",
       "..............",
       ".......#......",
@@ -46,10 +51,10 @@ const PRESETS: Preset[] = [
     ].join("\n"),
   },
   {
-    key: "labirinto",
-    rotulo: "Labirinto",
-    dica: "Com becos sem saída, a heurística ainda ajuda, mas menos: ela aponta para o alvo e a parede diz que não dá.",
-    paredes: [
+    key: "maze",
+    label: "Labirinto",
+    hint: "Com becos sem saída, a heurística ainda ajuda, mas menos: ela aponta para o alvo e a parede diz que não dá.",
+    walls: [
       "..............",
       ".####.####....",
       ".#......#.....",
@@ -62,17 +67,20 @@ const PRESETS: Preset[] = [
     ].join("\n"),
   },
   {
-    key: "aberto",
-    rotulo: "Campo aberto",
-    dica: "Sem obstáculo nenhum, o A* praticamente desenha a linha reta e o Dijkstra abre um círculo. É a diferença no estado puro.",
-    paredes: Array(A).fill(".".repeat(L)).join("\n"),
+    key: "open",
+    label: "Campo aberto",
+    hint: "Sem obstáculo nenhum, o A* praticamente desenha a linha reta e o Dijkstra abre um círculo. É a diferença no estado puro.",
+    walls: Array(ROWS).fill(".".repeat(COLS)).join("\n"),
   },
 ];
 
-const INICIO: [number, number] = [4, 1];
-const ALVO: [number, number] = [4, 12];
+const START: [number, number] = [4, 1];
+const GOAL: [number, number] = [4, 12];
 
-const CODIGO = [
+// O Python da tela é CONTEÚDO em português (`inicio`, `alvo`, `vizinhos`,
+// `fila`, `novo`): as notas do passo a passo citam esses nomes. Traduzir aqui
+// desalinha o código da aula que o explica.
+const CODE = [
   "import heapq",
   "",
   "def a_estrela(inicio, alvo, vizinhos, h):",
@@ -89,201 +97,182 @@ const CODIGO = [
   "                heapq.heappush(fila, (novo + h(v), v))",
 ];
 
-type Passo = {
-  atual: [number, number] | null;
-  fechados: string[];
-  fronteira: string[];
+type Step = {
+  current: [number, number] | null;
+  closed: string[];
+  frontier: string[];
   g: Record<string, number>;
-  caminho: string[];
-  nota: string;
+  path: string[];
+  note: string;
   ok?: boolean;
 };
 
-const chave = (r: number, c: number) => `${r},${c}`;
-const manhattan = (r: number, c: number) => Math.abs(r - ALVO[0]) + Math.abs(c - ALVO[1]);
+const cellKey = (r: number, c: number) => `${r},${c}`;
+const manhattan = (r: number, c: number) => Math.abs(r - GOAL[0]) + Math.abs(c - GOAL[1]);
 
-function parseParedes(txt: string): boolean[][] {
-  const linhas = txt.split("\n");
-  return Array.from({ length: A }, (_, r) =>
-    Array.from({ length: L }, (_, c) => (linhas[r]?.[c] ?? ".") === "#")
+function parseWalls(txt: string): boolean[][] {
+  const lines = txt.split("\n");
+  return Array.from({ length: ROWS }, (_, r) =>
+    Array.from({ length: COLS }, (_, c) => (lines[r]?.[c] ?? ".") === "#")
   );
 }
 
-function gerarPassos(paredes: boolean[][], modo: Modo): Passo[] {
-  const out: Passo[] = [];
-  const g: Record<string, number> = { [chave(...INICIO)]: 0 };
-  const pai: Record<string, string> = {};
-  const fechados = new Set<string>();
-  let fila: { f: number; r: number; c: number }[] = [
-    { f: modo === "dijkstra" ? 0 : manhattan(...INICIO), r: INICIO[0], c: INICIO[1] },
+function buildSteps(walls: boolean[][], mode: Mode): Step[] {
+  const out: Step[] = [];
+  const g: Record<string, number> = { [cellKey(...START)]: 0 };
+  const parent: Record<string, string> = {};
+  const closed = new Set<string>();
+  const queue: { f: number; r: number; c: number }[] = [
+    { f: mode === "dijkstra" ? 0 : manhattan(...START), r: START[0], c: START[1] },
   ];
 
-  const prioridade = (custo: number, r: number, c: number) =>
-    modo === "dijkstra" ? custo : modo === "guloso" ? manhattan(r, c) : custo + manhattan(r, c);
+  const priority = (cost: number, r: number, c: number) =>
+    mode === "dijkstra" ? cost : mode === "greedy" ? manhattan(r, c) : cost + manhattan(r, c);
 
-  const snap = (atual: [number, number] | null, nota: string, caminho: string[] = [], ok = false): Passo => ({
-    atual,
-    fechados: [...fechados],
-    fronteira: fila.map((q) => chave(q.r, q.c)),
+  const snap = (current: [number, number] | null, note: string, path: string[] = [], ok = false): Step => ({
+    current,
+    closed: [...closed],
+    frontier: queue.map((q) => cellKey(q.r, q.c)),
     g: { ...g },
-    caminho,
-    nota,
+    path,
+    note,
     ok,
   });
 
-  const nomeModo = modo === "astar" ? "A*" : modo === "dijkstra" ? "Dijkstra" : "Guloso";
-  out.push(snap(INICIO, `${nomeModo}: começo na origem. ${
-    modo === "dijkstra"
+  const modeName = mode === "astar" ? "A*" : mode === "dijkstra" ? "Dijkstra" : "Guloso";
+  out.push(snap(START, `${modeName}: começo na origem. ${
+    mode === "dijkstra"
       ? "A prioridade é só o custo já pago (g). O algoritmo não sabe onde fica o alvo, então explora igualmente em todas as direções."
-      : modo === "guloso"
+      : mode === "greedy"
         ? "A prioridade é só a estimativa até o alvo (h). Rápido, mas ele ignora o quanto já gastou, e por isso pode devolver caminho pior."
         : "A prioridade é g + h: o que já paguei mais o que estimo faltar. É essa soma que mantém o caminho ótimo e ainda aponta para o alvo."
   }`));
 
-  let guarda = 0;
-  let achou = false;
-  while (fila.length && guarda++ < 4000) {
-    fila.sort((x, y) => x.f - y.f);
-    const { r, c } = fila.shift() as { f: number; r: number; c: number };
-    const k = chave(r, c);
-    if (fechados.has(k)) continue;
-    fechados.add(k);
+  let guard = 0;
+  let found = false;
+  while (queue.length && guard++ < 4000) {
+    queue.sort((x, y) => x.f - y.f);
+    const { r, c } = queue.shift() as { f: number; r: number; c: number };
+    const k = cellKey(r, c);
+    if (closed.has(k)) continue;
+    closed.add(k);
 
-    if (r === ALVO[0] && c === ALVO[1]) {
-      const caminho: string[] = [];
+    if (r === GOAL[0] && c === GOAL[1]) {
+      const path: string[] = [];
       let cur = k;
-      while (cur) { caminho.push(cur); cur = pai[cur]; }
-      achou = true;
-      out.push(snap([r, c], `Cheguei ao alvo com custo ${g[k]}, depois de expandir ${fechados.size} células. ${
-        modo === "guloso"
+      while (cur) { path.push(cur); cur = parent[cur]; }
+      found = true;
+      out.push(snap([r, c], `Cheguei ao alvo com custo ${g[k]}, depois de expandir ${closed.size} células. ${
+        mode === "greedy"
           ? "O guloso chegou rápido, mas nada garante que este seja o caminho mais barato: ele nunca olhou para o custo já pago."
           : "Este é o caminho mais barato possível, e os dois algoritmos que somam o g concordam nesse número."
-      }`, caminho.reverse(), true));
+      }`, path.reverse(), true));
       break;
     }
 
     for (const [dr, dc] of [[-1, 0], [1, 0], [0, -1], [0, 1]]) {
       const nr = r + dr, nc = c + dc;
-      if (nr < 0 || nr >= A || nc < 0 || nc >= L || paredes[nr][nc]) continue;
-      const nk = chave(nr, nc);
-      const novo = g[k] + 1;
-      if (g[nk] === undefined || novo < g[nk]) {
-        g[nk] = novo;
-        pai[nk] = k;
-        fila.push({ f: prioridade(novo, nr, nc), r: nr, c: nc });
+      if (nr < 0 || nr >= ROWS || nc < 0 || nc >= COLS || walls[nr][nc]) continue;
+      const nk = cellKey(nr, nc);
+      const tentative = g[k] + 1;
+      if (g[nk] === undefined || tentative < g[nk]) {
+        g[nk] = tentative;
+        parent[nk] = k;
+        queue.push({ f: priority(tentative, nr, nc), r: nr, c: nc });
       }
     }
     // um passo por expansão, para a animação não ficar longa demais
-    out.push(snap([r, c], `Expando (${r}, ${c}): g = ${g[k]}${modo !== "dijkstra" ? `, h = ${manhattan(r, c)}${modo === "astar" ? `, f = ${g[k] + manhattan(r, c)}` : ""}` : ""}. ${fechados.size} ${fechados.size === 1 ? "célula expandida" : "células expandidas"} até aqui.`));
+    out.push(snap([r, c], `Expando (${r}, ${c}): g = ${g[k]}${mode !== "dijkstra" ? `, h = ${manhattan(r, c)}${mode === "astar" ? `, f = ${g[k] + manhattan(r, c)}` : ""}` : ""}. ${closed.size} ${closed.size === 1 ? "célula expandida" : "células expandidas"} até aqui.`));
   }
 
-  if (!achou) {
+  if (!found) {
     out.push(snap(null, `A fronteira esvaziou sem alcançar o alvo: não existe caminho neste mapa.`, [], true));
   }
   return out;
 }
 
-const VELOCIDADES = [0, 400, 240, 140, 80, 40];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// O ritmo é desta peça: um passo é uma expansão de célula, e a animação chega a
+// 119 passos no preset mais longo. As marchas do hook são lentas demais aqui.
+const SPEEDS = [0, 400, 240, 140, 80, 40];
 
 export function AStarVisualizer() {
-  const [presetKey, setPresetKey] = useState("muro");
-  const [modo, setModo] = useState<Modo>("astar");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [presetKey, setPresetKey] = useState("wall");
+  const [mode, setMode] = useState<Mode>("astar");
 
-  useEffect(() => setMounted(true), []);
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const paredes = useMemo(() => parseParedes(preset.paredes), [preset]);
-  const passos = useMemo(() => gerarPassos(paredes, modo), [paredes, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const walls = useMemo(() => parseWalls(preset.walls), [preset]);
+  const steps = useMemo(() => buildSteps(walls, mode), [walls, mode]);
+
+  const viz = useVisualizer({
+    title: "Visualizador · A*, Dijkstra e Guloso no mesmo mapa",
+    total: steps.length,
+    speeds: SPEEDS,
+    // a peça abria em 1.5x antes da casca, e continua abrindo
+    initialSpeed: 4,
+    // O que muda a altura: o preset troca a DICA (uma ou duas linhas) e o modo
+    // troca a NOTA. O desenho tem altura constante — a grade é COLS × ROWS ×
+    // CELL, três constantes deste arquivo, e nada na tela mexe nelas.
+    measureOn: [presetKey, mode],
+  });
+
+  const p = steps[viz.step];
 
   // comparação honesta: roda os três no mesmo mapa e conta expansões
-  const comparacao = useMemo(() => {
-    return (["dijkstra", "astar", "guloso"] as Modo[]).map((m) => {
-      const ps = gerarPassos(paredes, m);
+  const comparison = useMemo(() => {
+    return (["dijkstra", "astar", "greedy"] as Mode[]).map((m) => {
+      const ps = buildSteps(walls, m);
       const f = ps[ps.length - 1];
-      return { modo: m, expandidas: f.fechados.length, custo: f.caminho.length ? f.caminho.length - 1 : null };
+      return { mode: m, expandedCells: f.closed.length, cost: f.path.length ? f.path.length - 1 : null };
     });
-  }, [paredes]);
+  }, [walls]);
 
-  const parar = useCallback(() => { if (timer.current) { clearInterval(timer.current); timer.current = null; } }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const closedSet = useMemo(() => new Set(p.closed), [p.closed]);
+  const frontierSet = useMemo(() => new Set(p.frontier), [p.frontier]);
+  const pathSet = useMemo(() => new Set(p.path), [p.path]);
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const fechados = useMemo(() => new Set(p.fechados), [p.fechados]);
-  const fronteira = useMemo(() => new Set(p.fronteira), [p.fronteira]);
-  const caminho = useMemo(() => new Set(p.caminho), [p.caminho]);
-  const pct = Math.round(((idx + 1) / total) * 100);
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* O número que resume o estado vai antes do "passo N de M". */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">{p.closed.length} expandidas</span>
+      </VizHeader>
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · A*, Dijkstra e Guloso no mesmo mapa</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">{p.fechados.length} expandidas · passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>{expanded ? "✕ Fechar" : "⤢ Expandir"}</button>
-        </div>
-      </div>
-
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className={`bigo-chip${modo === "astar" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("astar"); }} aria-pressed={modo === "astar"}>A*: f = g + h</button>
-          <button className={`bigo-chip${modo === "dijkstra" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("dijkstra"); }} aria-pressed={modo === "dijkstra"}>Dijkstra: f = g</button>
-          <button className={`bigo-chip na${modo === "guloso" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("guloso"); }} aria-pressed={modo === "guloso"}>Guloso: f = h</button>
+          <button className={`bigo-chip${mode === "astar" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("astar"); }} aria-pressed={mode === "astar"}>A*: f = g + h</button>
+          <button className={`bigo-chip${mode === "dijkstra" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("dijkstra"); }} aria-pressed={mode === "dijkstra"}>Dijkstra: f = g</button>
+          <button className={`bigo-chip na${mode === "greedy" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("greedy"); }} aria-pressed={mode === "greedy"}>Guloso: f = h</button>
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { reiniciar(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="tt-arv-wrap">
-          <svg className="tt-arv" width={L * CEL + 2} height={A * CEL + 2} viewBox={`0 0 ${L * CEL + 2} ${A * CEL + 2}`}
-            role="img" aria-label={`Grade ${A} por ${L}. ${p.nota}`}>
-            {Array.from({ length: A }, (_, r) =>
-              Array.from({ length: L }, (_, c) => {
-                const k = chave(r, c);
-                const ehInicio = r === INICIO[0] && c === INICIO[1];
-                const ehAlvo = r === ALVO[0] && c === ALVO[1];
+          <svg className="tt-arv" width={COLS * CELL + 2} height={ROWS * CELL + 2} viewBox={`0 0 ${COLS * CELL + 2} ${ROWS * CELL + 2}`}
+            role="img" aria-label={`Grade ${ROWS} por ${COLS}. ${p.note}`}>
+            {Array.from({ length: ROWS }, (_, r) =>
+              Array.from({ length: COLS }, (_, c) => {
+                const k = cellKey(r, c);
+                const isStart = r === START[0] && c === START[1];
+                const isGoal = r === GOAL[0] && c === GOAL[1];
                 let cls = "as-cel";
-                if (paredes[r][c]) cls += " parede";
-                else if (ehInicio) cls += " inicio";
-                else if (ehAlvo) cls += " alvo";
-                else if (caminho.has(k)) cls += " caminho";
-                else if (p.atual && p.atual[0] === r && p.atual[1] === c) cls += " atual";
-                else if (fechados.has(k)) cls += " fechado";
-                else if (fronteira.has(k)) cls += " fronteira";
+                if (walls[r][c]) cls += " parede";
+                else if (isStart) cls += " inicio";
+                else if (isGoal) cls += " alvo";
+                else if (pathSet.has(k)) cls += " caminho";
+                else if (p.current && p.current[0] === r && p.current[1] === c) cls += " atual";
+                else if (closedSet.has(k)) cls += " fechado";
+                else if (frontierSet.has(k)) cls += " fronteira";
                 return (
                   <g key={k} className={cls}>
-                    <rect x={c * CEL + 1} y={r * CEL + 1} width={CEL - 2} height={CEL - 2} rx={4} />
-                    {(ehInicio || ehAlvo) && (
-                      <text x={c * CEL + CEL / 2} y={r * CEL + CEL / 2 + 4} textAnchor="middle">{ehInicio ? "I" : "F"}</text>
+                    <rect x={c * CELL + 1} y={r * CELL + 1} width={CELL - 2} height={CELL - 2} rx={4} />
+                    {(isStart || isGoal) && (
+                      <text x={c * CELL + CELL / 2} y={r * CELL + CELL / 2 + 4} textAnchor="middle">{isStart ? "I" : "F"}</text>
                     )}
                   </g>
                 );
@@ -299,44 +288,31 @@ export function AStarVisualizer() {
           <span><i className="as-i parede" />parede</span>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">a_estrela.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === (modo === "astar" ? 13 : 6) ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">a_estrela.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === (mode === "astar" ? 13 : 6) ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">No mapa atual</div>
-            {comparacao.map((c) => (
-              <div className="viz-var" key={c.modo}>
-                <span className="viz-var-name">{c.modo === "astar" ? "A*" : c.modo === "dijkstra" ? "Dijkstra" : "Guloso"}</span>
-                <span className={`viz-var-val${c.modo === modo ? " best" : ""}`}>
-                  {c.expandidas} células · custo {c.custo ?? "-"}
+            {comparison.map((c) => (
+              <div className="viz-var" key={c.mode}>
+                <span className="viz-var-name">{c.mode === "astar" ? "A*" : c.mode === "dijkstra" ? "Dijkstra" : "Guloso"}</span>
+                <span className={`viz-var-val${c.mode === mode ? " best" : ""}`}>
+                  {c.expandedCells} células · custo {c.cost ?? "-"}
                 </span>
               </div>
             ))}
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pct}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           O painel da direita roda os três no mesmo mapa e conta. Compare duas colunas: A* e Dijkstra
@@ -344,14 +320,8 @@ export function AStarVisualizer() {
           único que pode devolver um caminho mais caro.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>{viz}</div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/AStarVisualizer.tsx
+++ b/content/visualizers/AStarVisualizer.tsx
@@ -234,7 +234,11 @@ export function AStarVisualizer() {
     <figure {...viz.figureProps} style={{ margin: 0 }}>
       {/* O número que resume o estado vai antes do "passo N de M". */}
       <VizHeader viz={viz}>
-        <span className="viz-step">{p.closed.length} expandidas</span>
+        {/* O `·` fica AQUI porque o `VizHeader` não tem como prefixar o
+            contador: os dois viram `.viz-step` irmãos, separados só pelo gap.
+            Sem ele o cabeçalho perde o separador que o componente tinha —
+            medido no diff do build. Mesma solução do Bellman-Ford e do MST. */}
+        <span className="viz-step">{p.closed.length} expandidas ·</span>
       </VizHeader>
 
       <div {...viz.bodyProps}>

--- a/content/visualizers/BellmanFordVisualizer.tsx
+++ b/content/visualizers/BellmanFordVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BellmanFordVisualizer, as rodadas e a rodada que sobra.
@@ -17,7 +18,7 @@ import { createPortal } from "react-dom";
 // acende exatamente a aresta que provou isso.
 // ---------------------------------------------------------------------------
 
-const ROT = ["A", "B", "C", "D", "E"];
+const LABELS = ["A", "B", "C", "D", "E"];
 const POS = [
   { x: 40, y: 120 },
   { x: 140, y: 40 },
@@ -26,33 +27,35 @@ const POS = [
   { x: 250, y: 200 },
 ];
 
-type Aresta = { de: number; para: number; peso: number };
-const A = (de: number, para: number, peso: number): Aresta => ({ de, para, peso });
+type Edge = { from: number; to: number; weight: number };
+const E = (from: number, to: number, weight: number): Edge => ({ from, to, weight });
 
-type Preset = { key: string; rotulo: string; arestas: Aresta[]; dica: string };
+type Preset = { key: string; label: string; edges: Edge[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "negativo",
-    rotulo: "Com peso negativo (funciona)",
-    arestas: [A(0, 1, 6), A(0, 2, 7), A(1, 3, 5), A(1, 2, 8), A(2, 3, -3), A(2, 4, 9), A(3, 4, 7), A(1, 4, -4)],
-    dica: "Onde o Dijkstra erraria. Bellman-Ford não fecha ninguém, então uma aresta negativa descoberta tarde ainda consegue corrigir tudo.",
+    key: "negative",
+    label: "Com peso negativo (funciona)",
+    edges: [E(0, 1, 6), E(0, 2, 7), E(1, 3, 5), E(1, 2, 8), E(2, 3, -3), E(2, 4, 9), E(3, 4, 7), E(1, 4, -4)],
+    hint: "Onde o Dijkstra erraria. Bellman-Ford não fecha ninguém, então uma aresta negativa descoberta tarde ainda consegue corrigir tudo.",
   },
   {
-    key: "ciclo",
-    rotulo: "Ciclo negativo (detecta)",
-    arestas: [A(0, 1, 4), A(1, 2, -6), A(2, 3, 3), A(3, 1, 1), A(0, 4, 5), A(2, 4, 2)],
-    dica: "O ciclo B → C → D → B soma -6 + 3 + 1 = -2. Dar mais uma volta sempre barateia, então o mínimo não existe. A rodada extra prova isso.",
+    key: "cycle",
+    label: "Ciclo negativo (detecta)",
+    edges: [E(0, 1, 4), E(1, 2, -6), E(2, 3, 3), E(3, 1, 1), E(0, 4, 5), E(2, 4, 2)],
+    hint: "O ciclo B → C → D → B soma -6 + 3 + 1 = -2. Dar mais uma volta sempre barateia, então o mínimo não existe. A rodada extra prova isso.",
   },
   {
-    key: "positivo",
-    rotulo: "Só pesos positivos",
-    arestas: [A(0, 1, 4), A(0, 2, 2), A(2, 1, 1), A(1, 3, 5), A(2, 4, 8), A(3, 4, 2)],
-    dica: "Aqui o Dijkstra daria a mesma resposta, muito mais rápido. Bellman-Ford é o plano B, não o plano A.",
+    key: "positive",
+    label: "Só pesos positivos",
+    edges: [E(0, 1, 4), E(0, 2, 2), E(2, 1, 1), E(1, 3, 5), E(2, 4, 8), E(3, 4, 2)],
+    hint: "Aqui o Dijkstra daria a mesma resposta, muito mais rápido. Bellman-Ford é o plano B, não o plano A.",
   },
 ];
 
-const CODIGO = [
+// Python de tela: é conteúdo didático, e os nomes daqui são os que as notas
+// explicam em português. Não traduza junto com os identificadores.
+const CODE = [
   "def bellman_ford(inicio, vertices, arestas):",
   "    dist = {v: inf for v in vertices}",
   "    dist[inicio] = 0",
@@ -68,54 +71,54 @@ const CODIGO = [
   "    return dist",
 ];
 
-type Passo = {
-  rodada: number;
-  aresta: Aresta | null;
+type Step = {
+  round: number;
+  edge: Edge | null;
   dist: (number | null)[];
-  historico: (number | null)[][];
-  melhorou: boolean;
-  linha: number;
-  nota: string;
+  history: (number | null)[][];
+  improved: boolean;
+  line: number;
+  note: string;
   ok?: boolean;
-  alerta?: boolean;
+  alert?: boolean;
 };
 
-function gerarPassos(arestas: Aresta[]): Passo[] {
-  const V = ROT.length;
-  const dist: (number | null)[] = ROT.map(() => null);
+function buildSteps(edges: Edge[]): Step[] {
+  const V = LABELS.length;
+  const dist: (number | null)[] = LABELS.map(() => null);
   dist[0] = 0;
-  const historico: (number | null)[][] = [[...dist]];
-  const out: Passo[] = [];
-  const snap = (rodada: number, aresta: Aresta | null, melhorou: boolean, linha: number, nota: string, extra: Partial<Passo> = {}): Passo => ({
-    rodada, aresta, dist: [...dist], historico: historico.map((h) => [...h]), melhorou, linha, nota, ...extra,
+  const history: (number | null)[][] = [[...dist]];
+  const out: Step[] = [];
+  const snap = (round: number, edge: Edge | null, improved: boolean, line: number, note: string, extra: Partial<Step> = {}): Step => ({
+    round, edge, dist: [...dist], history: history.map((h) => [...h]), improved, line, note, ...extra,
   });
 
-  out.push(snap(0, null, false, 2, `${ROT[0]} vale 0 e todo o resto vale infinito. Bellman-Ford não tem fila nem escolha: ele vai relaxar todas as ${arestas.length} arestas, ${V - 1} vezes seguidas.`));
+  out.push(snap(0, null, false, 2, `${LABELS[0]} vale 0 e todo o resto vale infinito. Bellman-Ford não tem fila nem escolha: ele vai relaxar todas as ${edges.length} arestas, ${V - 1} vezes seguidas.`));
 
   for (let r = 1; r <= V - 1; r++) {
-    let mudouNaRodada = false;
-    for (const a of arestas) {
-      const du = dist[a.de];
+    let changed = false;
+    for (const e of edges) {
+      const du = dist[e.from];
       if (du === null) {
-        out.push(snap(r, a, false, 6, `Rodada ${r}: ainda não sei chegar em ${ROT[a.de]}, então a aresta ${ROT[a.de]} → ${ROT[a.para]} não me diz nada por enquanto. Numa rodada futura ela vai valer.`));
+        out.push(snap(r, e, false, 6, `Rodada ${r}: ainda não sei chegar em ${LABELS[e.from]}, então a aresta ${LABELS[e.from]} → ${LABELS[e.to]} não me diz nada por enquanto. Numa rodada futura ela vai valer.`));
         continue;
       }
-      const novo = du + a.peso;
-      const atual = dist[a.para];
-      if (atual === null || novo < atual) {
-        dist[a.para] = novo;
-        mudouNaRodada = true;
-        out.push(snap(r, a, true, 7, `Rodada ${r}: relaxo ${ROT[a.de]} → ${ROT[a.para]}. ${du} ${a.peso < 0 ? "-" : "+"} ${Math.abs(a.peso)} = ${novo}, melhor que ${atual === null ? "infinito" : atual}. Atualizo.`));
+      const candidate = du + e.weight;
+      const current = dist[e.to];
+      if (current === null || candidate < current) {
+        dist[e.to] = candidate;
+        changed = true;
+        out.push(snap(r, e, true, 7, `Rodada ${r}: relaxo ${LABELS[e.from]} → ${LABELS[e.to]}. ${du} ${e.weight < 0 ? "-" : "+"} ${Math.abs(e.weight)} = ${candidate}, melhor que ${current === null ? "infinito" : current}. Atualizo.`));
       } else {
-        out.push(snap(r, a, false, 6, `Rodada ${r}: testo ${ROT[a.de]} → ${ROT[a.para]}: ${du} ${a.peso < 0 ? "-" : "+"} ${Math.abs(a.peso)} = ${novo}, que não bate os ${atual} que já tenho. Sigo.`));
+        out.push(snap(r, e, false, 6, `Rodada ${r}: testo ${LABELS[e.from]} → ${LABELS[e.to]}: ${du} ${e.weight < 0 ? "-" : "+"} ${Math.abs(e.weight)} = ${candidate}, que não bate os ${current} que já tenho. Sigo.`));
       }
     }
-    historico.push([...dist]);
-    out.push(snap(r, null, mudouNaRodada, 4,
-      mudouNaRodada
+    history.push([...dist]);
+    out.push(snap(r, null, changed, 4,
+      changed
         ? `Fim da rodada ${r}. Garantia do algoritmo: todo caminho mínimo que usa até ${r} ${r === 1 ? "aresta" : "arestas"} já está correto na tabela. A informação anda exatamente uma aresta por rodada.`
         : `Fim da rodada ${r} e nada mudou. Se uma rodada inteira não melhora nada, nenhuma próxima vai: dá para parar aqui, e é assim que a otimização por early exit funciona.`));
-    if (!mudouNaRodada) break;
+    if (!changed) break;
   }
 
   // Rodada extra: detecção de ciclo negativo.
@@ -125,118 +128,98 @@ function gerarPassos(arestas: Aresta[]): Passo[] {
   // positivo. Hoje isso não acontece (se a origem da aresta é alcançável, o
   // destino também foi relaxado nas rodadas anteriores), mas depender dessa
   // sutileza para não reportar ciclo inexistente é frágil demais.
-  let culpada: Aresta | null = null;
-  for (const a of arestas) {
-    const du = dist[a.de];
-    const dv = dist[a.para];
+  let culprit: Edge | null = null;
+  for (const e of edges) {
+    const du = dist[e.from];
+    const dv = dist[e.to];
     if (du === null || dv === null) continue; // só compara número com número
-    if (du + a.peso < dv) { culpada = a; break; }
+    if (du + e.weight < dv) { culprit = e; break; }
   }
 
-  if (culpada) {
-    out.push(snap(V, culpada, true, 10,
-      `RODADA EXTRA: a aresta ${ROT[culpada.de]} → ${ROT[culpada.para]} AINDA melhora, depois de ${V - 1} rodadas. Isso é impossível num grafo sadio, porque nenhum caminho mínimo usa mais de ${V - 1} arestas. A única explicação é ciclo negativo: dar mais uma volta barateia para sempre, e o mínimo não existe.`,
-      { alerta: true }));
+  if (culprit) {
+    out.push(snap(V, culprit, true, 10,
+      `RODADA EXTRA: a aresta ${LABELS[culprit.from]} → ${LABELS[culprit.to]} AINDA melhora, depois de ${V - 1} rodadas. Isso é impossível num grafo sadio, porque nenhum caminho mínimo usa mais de ${V - 1} arestas. A única explicação é ciclo negativo: dar mais uma volta barateia para sempre, e o mínimo não existe.`,
+      { alert: true }));
   } else {
-    const resumo = ROT.map((r, i) => `${r}=${dist[i] === null ? "∞" : dist[i]}`).join("  ");
+    const summary = LABELS.map((l, i) => `${l}=${dist[i] === null ? "∞" : dist[i]}`).join("  ");
     out.push(snap(V, null, false, 12,
-      `RODADA EXTRA: nenhuma aresta melhora, então não existe ciclo negativo e a resposta é final. Distâncias a partir de ${ROT[0]}: ${resumo}.`,
+      `RODADA EXTRA: nenhuma aresta melhora, então não existe ciclo negativo e a resposta é final. Distâncias a partir de ${LABELS[0]}: ${summary}.`,
       { ok: true }));
   }
   return out;
 }
 
-const VELOCIDADES = [0, 1200, 800, 550, 350, 200];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// A marcha desta peça é a própria: um relaxamento é rápido de ler, e o padrão
+// do hook (1400..250) arrasta demais numa animação de 30 passos.
+const SPEEDS = [0, 1200, 800, 550, 350, 200];
 
 export function BellmanFordVisualizer() {
-  const [presetKey, setPresetKey] = useState("negativo");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("negative");
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.arestas), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => buildSteps(preset.edges), [preset]);
 
-  const parar = useCallback(() => { if (timer.current) { clearInterval(timer.current); timer.current = null; } }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · Bellman-Ford, rodada a rodada, a partir de A",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O eixo da altura desta peça é o TEXTO, e quem troca o texto é o preset: a
+    // dica tem 18 ou 37px e a nota vai de 22 a 63px. O desenho não entra porque
+    // as coordenadas estão em `POS` — os três presets desenham a mesma caixa de
+    // 250px —, e a tabela de rodadas não alcança o desenho nem cheia (203 de
+    // 264px), então nem ela nem o passo mudam a decisão.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const pct = Math.round(((idx + 1) / total) * 100);
+  const s = steps[viz.step];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · Bellman-Ford, rodada a rodada, a partir de A</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">rodada {p.rodada} · passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>{expanded ? "✕ Fechar" : "⤢ Expandir"}</button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* A rodada continua à esquerda do "passo N de M", que agora é do hook. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">rodada {s.round} ·</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "ciclo" ? " na" : ""}`} onClick={() => { reiniciar(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "cycle" ? " na" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="gr-split">
           <div className="tt-arv-wrap" style={{ margin: 0 }}>
             <svg className="tt-arv" width={300} height={250} viewBox="0 0 300 250" role="img"
-              aria-label={`Grafo dirigido com pesos. Bellman-Ford, rodada ${p.rodada}. ${p.nota}`}>
+              aria-label={`Grafo dirigido com pesos. Bellman-Ford, rodada ${s.round}. ${s.note}`}>
               <defs>
                 <marker id="seta-bf" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
                   <path d="M 0 0 L 8 4 L 0 8 z" fill="rgba(59,130,246,0.75)" />
                 </marker>
               </defs>
-              {preset.arestas.map((a) => {
-                const ativa = p.aresta && p.aresta.de === a.de && p.aresta.para === a.para;
-                const dx = POS[a.para].x - POS[a.de].x, dy = POS[a.para].y - POS[a.de].y;
+              {preset.edges.map((e) => {
+                const active = s.edge && s.edge.from === e.from && s.edge.to === e.to;
+                const dx = POS[e.to].x - POS[e.from].x, dy = POS[e.to].y - POS[e.from].y;
                 const d = Math.sqrt(dx * dx + dy * dy) || 1, r = 19;
-                const mx = (POS[a.de].x + POS[a.para].x) / 2, my = (POS[a.de].y + POS[a.para].y) / 2;
+                const mx = (POS[e.from].x + POS[e.to].x) / 2, my = (POS[e.from].y + POS[e.to].y) / 2;
                 return (
-                  <g key={`${a.de}-${a.para}`}>
-                    <line className={`tt-aresta${ativa ? (p.alerta ? " erro" : " ativa") : ""}`}
-                      x1={POS[a.de].x + (dx / d) * r} y1={POS[a.de].y + (dy / d) * r}
-                      x2={POS[a.para].x - (dx / d) * r} y2={POS[a.para].y - (dy / d) * r}
+                  <g key={`${e.from}-${e.to}`}>
+                    <line className={`tt-aresta${active ? (s.alert ? " erro" : " ativa") : ""}`}
+                      x1={POS[e.from].x + (dx / d) * r} y1={POS[e.from].y + (dy / d) * r}
+                      x2={POS[e.to].x - (dx / d) * r} y2={POS[e.to].y - (dy / d) * r}
                       markerEnd="url(#seta-bf)" />
-                    <text className={`gr-peso${a.peso < 0 ? " neg" : ""}`} x={mx} y={my - 4} textAnchor="middle">{a.peso}</text>
+                    <text className={`gr-peso${e.weight < 0 ? " neg" : ""}`} x={mx} y={my - 4} textAnchor="middle">{e.weight}</text>
                   </g>
                 );
               })}
-              {ROT.map((r, i) => {
-                const ativo = !!p.aresta && (p.aresta.de === i || p.aresta.para === i);
+              {LABELS.map((label, i) => {
+                const active = !!s.edge && (s.edge.from === i || s.edge.to === i);
                 return (
-                  <g key={r} className={`tt-no${ativo ? " on" : p.dist[i] !== null ? " saiu" : ""}`}>
+                  <g key={label} className={`tt-no${active ? " on" : s.dist[i] !== null ? " saiu" : ""}`}>
                     <circle cx={POS[i].x} cy={POS[i].y} r={17} />
-                    <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{r}</text>
+                    <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{label}</text>
                   </g>
                 );
               })}
@@ -249,62 +232,49 @@ export function BellmanFordVisualizer() {
               <thead>
                 <tr>
                   <th>rodada</th>
-                  {ROT.map((r) => <th key={r}>{r}</th>)}
+                  {LABELS.map((label) => <th key={label}>{label}</th>)}
                 </tr>
               </thead>
               <tbody>
-                {p.historico.map((linha, r) => (
-                  <tr key={r} className={r === p.historico.length - 1 ? "on" : undefined}>
+                {s.history.map((row, r) => (
+                  <tr key={r} className={r === s.history.length - 1 ? "on" : undefined}>
                     <th>{r === 0 ? "início" : r}</th>
-                    {linha.map((v, i) => {
-                      const anterior = r > 0 ? p.historico[r - 1][i] : null;
-                      const mudou = r > 0 && v !== anterior;
-                      return <td key={i} className={`bf-cel${mudou ? " mudou" : ""}${v === null ? " inf" : ""}`}>{v === null ? "∞" : v}</td>;
+                    {row.map((v, i) => {
+                      const previous = r > 0 ? s.history[r - 1][i] : null;
+                      const changed = r > 0 && v !== previous;
+                      return <td key={i} className={`bf-cel${changed ? " mudou" : ""}${v === null ? " inf" : ""}`}>{v === null ? "∞" : v}</td>;
                     })}
                   </tr>
                 ))}
                 <tr className="on">
                   <th>agora</th>
-                  {p.dist.map((v, i) => <td key={i} className={`bf-cel${v === null ? " inf" : ""}`}>{v === null ? "∞" : v}</td>)}
+                  {s.dist.map((v, i) => <td key={i} className={`bf-cel${v === null ? " inf" : ""}`}>{v === null ? "∞" : v}</td>)}
                 </tr>
               </tbody>
             </table>
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : p.alerta ? " invalid" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : s.alert ? " invalid" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">bellman_ford.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">bellman_ford.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            <div className="viz-var"><span className="viz-var-name">rodada</span><span className="viz-var-val best">{p.rodada} de {ROT.length - 1}</span></div>
-            <div className="viz-var"><span className="viz-var-name">arestas por rodada</span><span className="viz-var-val">{preset.arestas.length}</span></div>
-            <div className="viz-var"><span className="viz-var-name">relaxamentos totais</span><span className="viz-var-val">{(ROT.length - 1) * preset.arestas.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">rodada</span><span className="viz-var-val best">{s.round} de {LABELS.length - 1}</span></div>
+            <div className="viz-var"><span className="viz-var-name">arestas por rodada</span><span className="viz-var-val">{preset.edges.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">relaxamentos totais</span><span className="viz-var-val">{(LABELS.length - 1) * preset.edges.length}</span></div>
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pct}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Olhe a tabela de rodadas de cima para baixo: cada linha corrige os caminhos que usam mais
@@ -312,14 +282,8 @@ export function BellmanFordVisualizer() {
           bastam, e é literalmente daí que sai o número.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>{viz}</div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/DijkstraVisualizer.tsx
+++ b/content/visualizers/DijkstraVisualizer.tsx
@@ -40,19 +40,19 @@ const A = (from: number, to: number, weight: number): Edge => ({ from, to, weigh
 
 const PRESETS: Preset[] = [
   {
-    key: "classico",
+    key: "classic",
     label: "Grafo com pesos",
     edges: [A(0, 1, 4), A(0, 2, 2), A(1, 3, 5), A(2, 1, 1), A(2, 4, 8), A(3, 5, 3), A(4, 5, 2), A(3, 4, 2)],
     hint: "Repare no A→B: o caminho direto custa 4, mas passar por C custa 2+1 = 3. É o relaxamento que descobre isso.",
   },
   {
-    key: "armadilha",
+    key: "trap",
     label: "A tentação do caminho direto",
     edges: [A(0, 1, 10), A(0, 2, 1), A(2, 3, 1), A(3, 1, 1), A(1, 5, 1), A(2, 4, 7), A(4, 5, 1)],
     hint: "A aresta A→B custa 10 e parece ruim. O desvio A→C→D→B custa 3. Guloso não quer dizer míope: Dijkstra acha o desvio.",
   },
   {
-    key: "negativo",
+    key: "negative",
     label: "Com peso negativo (quebra)",
     // Montado para FALHAR de verdade: B fecha valendo 1, e só depois o C
     // (que fecha com 2) revela a aresta C→B de peso -2, que daria 0.
@@ -161,7 +161,7 @@ function generateSteps(edges: Edge[], negative: boolean): Step[] {
 const SPEEDS = [0, 1500, 1000, 700, 450, 260];
 
 export function DijkstraVisualizer() {
-  const [presetKey, setPresetKey] = useState("classico");
+  const [presetKey, setPresetKey] = useState("classic");
 
   const preset = useMemo(() => PRESETS.find((pr) => pr.key === presetKey) ?? PRESETS[0], [presetKey]);
   const steps = useMemo(() => generateSteps(preset.edges, !!preset.negative), [preset]);

--- a/content/visualizers/DijkstraVisualizer.tsx
+++ b/content/visualizers/DijkstraVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // DijkstraVisualizer, o guloso que fecha um vértice por vez.
@@ -16,9 +17,13 @@ import { createPortal } from "react-dom";
 // o vértice fecha com um valor, e uma aresta descoberta depois provaria que
 // existia caminho melhor. Não é bug de implementação, é a hipótese do algoritmo
 // sendo violada, e é a ponte para Bellman-Ford.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-const ROT = ["A", "B", "C", "D", "E", "F"];
+const LABELS = ["A", "B", "C", "D", "E", "F"];
 const POS = [
   { x: 40, y: 130 },
   { x: 135, y: 40 },
@@ -28,27 +33,27 @@ const POS = [
   { x: 330, y: 130 },
 ];
 
-type Aresta = { de: number; para: number; peso: number };
-type Preset = { key: string; rotulo: string; arestas: Aresta[]; dica: string; negativo?: boolean };
+type Edge = { from: number; to: number; weight: number };
+type Preset = { key: string; label: string; edges: Edge[]; hint: string; negative?: boolean };
 
-const A = (de: number, para: number, peso: number): Aresta => ({ de, para, peso });
+const A = (from: number, to: number, weight: number): Edge => ({ from, to, weight });
 
 const PRESETS: Preset[] = [
   {
     key: "classico",
-    rotulo: "Grafo com pesos",
-    arestas: [A(0, 1, 4), A(0, 2, 2), A(1, 3, 5), A(2, 1, 1), A(2, 4, 8), A(3, 5, 3), A(4, 5, 2), A(3, 4, 2)],
-    dica: "Repare no A→B: o caminho direto custa 4, mas passar por C custa 2+1 = 3. É o relaxamento que descobre isso.",
+    label: "Grafo com pesos",
+    edges: [A(0, 1, 4), A(0, 2, 2), A(1, 3, 5), A(2, 1, 1), A(2, 4, 8), A(3, 5, 3), A(4, 5, 2), A(3, 4, 2)],
+    hint: "Repare no A→B: o caminho direto custa 4, mas passar por C custa 2+1 = 3. É o relaxamento que descobre isso.",
   },
   {
     key: "armadilha",
-    rotulo: "A tentação do caminho direto",
-    arestas: [A(0, 1, 10), A(0, 2, 1), A(2, 3, 1), A(3, 1, 1), A(1, 5, 1), A(2, 4, 7), A(4, 5, 1)],
-    dica: "A aresta A→B custa 10 e parece ruim. O desvio A→C→D→B custa 3. Guloso não quer dizer míope: Dijkstra acha o desvio.",
+    label: "A tentação do caminho direto",
+    edges: [A(0, 1, 10), A(0, 2, 1), A(2, 3, 1), A(3, 1, 1), A(1, 5, 1), A(2, 4, 7), A(4, 5, 1)],
+    hint: "A aresta A→B custa 10 e parece ruim. O desvio A→C→D→B custa 3. Guloso não quer dizer míope: Dijkstra acha o desvio.",
   },
   {
     key: "negativo",
-    rotulo: "Com peso negativo (quebra)",
+    label: "Com peso negativo (quebra)",
     // Montado para FALHAR de verdade: B fecha valendo 1, e só depois o C
     // (que fecha com 2) revela a aresta C→B de peso -2, que daria 0.
     //
@@ -57,13 +62,15 @@ const PRESETS: Preset[] = [
     // reprocessado, então quem foi relaxado a partir dele (D, e por consequência
     // F) fica com valor velho. Conferido contra Bellman-Ford: D sai 4 quando o
     // correto é 3, e F sai 5 quando o correto é 4.
-    arestas: [A(0, 1, 1), A(0, 2, 2), A(2, 1, -2), A(1, 3, 3), A(3, 5, 1), A(2, 4, 4), A(4, 5, 1)],
-    dica: "A aresta C→B vale -2. O B fecha valendo 1 antes de ninguém ver essa aresta, e o Dijkstra nunca REPROCESSA um fechado: a tabela até corrige o B, mas D e F ficam com valor velho e a resposta final sai errada neles.",
-    negativo: true,
+    edges: [A(0, 1, 1), A(0, 2, 2), A(2, 1, -2), A(1, 3, 3), A(3, 5, 1), A(2, 4, 4), A(4, 5, 1)],
+    hint: "A aresta C→B vale -2. O B fecha valendo 1 antes de ninguém ver essa aresta, e o Dijkstra nunca REPROCESSA um fechado: a tabela até corrige o B, mas D e F ficam com valor velho e a resposta final sai errada neles.",
+    negative: true,
   },
 ];
 
-const CODIGO = [
+// O Python da tela é CONTEÚDO em português (`fila`, `fechados`, `inicio`): as
+// notas do passo a passo citam esses nomes para explicar o que a linha faz.
+const CODE = [
   "import heapq",
   "",
   "def dijkstra(inicio, g):",
@@ -81,168 +88,148 @@ const CODIGO = [
   "                heapq.heappush(fila, (dist[v], v))",
 ];
 
-type Passo = {
-  no: number;
-  aresta: [number, number] | null;
+type Step = {
+  node: number;
+  edge: [number, number] | null;
   dist: (number | null)[];
-  fila: { d: number; v: number }[];
-  fechados: number[];
-  linha: number;
-  nota: string;
+  queue: { d: number; v: number }[];
+  closed: number[];
+  line: number;
+  note: string;
   ok?: boolean;
-  alerta?: boolean;
+  alert?: boolean;
 };
 
-function gerarPassos(arestas: Aresta[], negativo: boolean): Passo[] {
-  const g: { v: number; peso: number }[][] = ROT.map(() => []);
-  for (const a of arestas) g[a.de].push({ v: a.para, peso: a.peso });
+function generateSteps(edges: Edge[], negative: boolean): Step[] {
+  const g: { v: number; weight: number }[][] = LABELS.map(() => []);
+  for (const e of edges) g[e.from].push({ v: e.to, weight: e.weight });
 
-  const dist: (number | null)[] = ROT.map(() => null);
+  const dist: (number | null)[] = LABELS.map(() => null);
   dist[0] = 0;
-  const fechados = new Set<number>();
-  let fila: { d: number; v: number }[] = [{ d: 0, v: 0 }];
-  const out: Passo[] = [];
-  const snap = (no: number, linha: number, nota: string, aresta: [number, number] | null = null, extra: Partial<Passo> = {}): Passo => ({
-    no, aresta, dist: [...dist], fila: [...fila].sort((x, y) => x.d - y.d), fechados: [...fechados], linha, nota, ...extra,
+  const closed = new Set<number>();
+  const queue: { d: number; v: number }[] = [{ d: 0, v: 0 }];
+  const out: Step[] = [];
+  const snap = (node: number, line: number, note: string, edge: [number, number] | null = null, extra: Partial<Step> = {}): Step => ({
+    node, edge, dist: [...dist], queue: [...queue].sort((x, y) => x.d - y.d), closed: [...closed], line, note, ...extra,
   });
 
-  out.push(snap(0, 5, `Começo em ${ROT[0]} com distância 0, e todo o resto em infinito. "Infinito" quer dizer "ainda não sei chegar lá", não "é impossível".`));
+  out.push(snap(0, 5, `Começo em ${LABELS[0]} com distância 0, e todo o resto em infinito. "Infinito" quer dizer "ainda não sei chegar lá", não "é impossível".`));
 
-  let guarda = 0;
-  let quebrou = false;
-  while (fila.length && guarda++ < 300) {
-    fila.sort((x, y) => x.d - y.d);
-    const { d, v: u } = fila.shift() as { d: number; v: number };
-    if (fechados.has(u)) {
-      out.push(snap(u, 9, `${ROT[u]} já está fechado, então descarto esta cópia da fila. Cópias velhas aparecem porque a gente empurra sem remover a anterior, e ignorá-las é mais barato que procurá-las.`));
+  let guard = 0;
+  let broke = false;
+  while (queue.length && guard++ < 300) {
+    queue.sort((x, y) => x.d - y.d);
+    const { d, v: u } = queue.shift() as { d: number; v: number };
+    if (closed.has(u)) {
+      out.push(snap(u, 9, `${LABELS[u]} já está fechado, então descarto esta cópia da fila. Cópias velhas aparecem porque a gente empurra sem remover a anterior, e ignorá-las é mais barato que procurá-las.`));
       continue;
     }
-    fechados.add(u);
-    out.push(snap(u, 10, `Tiro o MENOR da fila: ${ROT[u]}, com ${d}. Fecho ele. A aposta do Dijkstra é esta: como todo peso é ${negativo ? "supostamente " : ""}não negativo, nenhum caminho que ainda não explorei poderia chegar em ${ROT[u]} por menos de ${d}${negativo ? ", e é exatamente essa aposta que o peso negativo quebra" : ""}.`, null, negativo ? {} : {}));
+    closed.add(u);
+    out.push(snap(u, 10, `Tiro o MENOR da fila: ${LABELS[u]}, com ${d}. Fecho ele. A aposta do Dijkstra é esta: como todo peso é ${negative ? "supostamente " : ""}não negativo, nenhum caminho que ainda não explorei poderia chegar em ${LABELS[u]} por menos de ${d}${negative ? ", e é exatamente essa aposta que o peso negativo quebra" : ""}.`));
 
-    for (const { v, peso } of g[u]) {
-      const atual = dist[v];
-      const novo = (d ?? 0) + peso;
-      if (atual === null || novo < atual) {
-        const eraFechado = fechados.has(v);
-        dist[v] = novo;
-        if (!eraFechado) fila.push({ d: novo, v });
+    for (const { v, weight } of g[u]) {
+      const current = dist[v];
+      const relaxed = (d ?? 0) + weight;
+      if (current === null || relaxed < current) {
+        const wasClosed = closed.has(v);
+        dist[v] = relaxed;
+        if (!wasClosed) queue.push({ d: relaxed, v });
         out.push(snap(v, 12,
-          eraFechado
-            ? `PROBLEMA: por ${ROT[u]} eu chego em ${ROT[v]} com ${novo}, melhor que os ${atual} que já estavam lá. Mas ${ROT[v]} JÁ ESTÁ FECHADO, e o Dijkstra não volta em vértice fechado. A resposta final vai sair errada.`
-            : atual === null
-              ? `Relaxo ${ROT[u]} → ${ROT[v]}: era infinito, agora sei chegar com ${d} + ${peso} = ${novo}. Coloco ${ROT[v]} na fila.`
-              : `Relaxo ${ROT[u]} → ${ROT[v]}: ${d} + ${peso} = ${novo}, melhor que os ${atual} que eu tinha. Atualizo e reempurro na fila.`,
+          wasClosed
+            ? `PROBLEMA: por ${LABELS[u]} eu chego em ${LABELS[v]} com ${relaxed}, melhor que os ${current} que já estavam lá. Mas ${LABELS[v]} JÁ ESTÁ FECHADO, e o Dijkstra não volta em vértice fechado. A resposta final vai sair errada.`
+            : current === null
+              ? `Relaxo ${LABELS[u]} → ${LABELS[v]}: era infinito, agora sei chegar com ${d} + ${weight} = ${relaxed}. Coloco ${LABELS[v]} na fila.`
+              : `Relaxo ${LABELS[u]} → ${LABELS[v]}: ${d} + ${weight} = ${relaxed}, melhor que os ${current} que eu tinha. Atualizo e reempurro na fila.`,
           [u, v],
-          eraFechado ? { alerta: true } : {}));
-        if (eraFechado) quebrou = true;
+          wasClosed ? { alert: true } : {}));
+        if (wasClosed) broke = true;
       } else {
-        out.push(snap(v, 12, `Testo ${ROT[u]} → ${ROT[v]}: ${d} + ${peso} = ${novo}, que não é melhor que os ${atual} que já tenho. Não mexo em nada.`, [u, v]));
+        out.push(snap(v, 12, `Testo ${LABELS[u]} → ${LABELS[v]}: ${d} + ${weight} = ${relaxed}, que não é melhor que os ${current} que já tenho. Não mexo em nada.`, [u, v]));
       }
     }
   }
 
-  const resumo = ROT.map((r, i) => `${r}=${dist[i] === null ? "∞" : dist[i]}`).join("  ");
+  const summary = LABELS.map((r, i) => `${r}=${dist[i] === null ? "∞" : dist[i]}`).join("  ");
   out.push(snap(-1, 7,
-    quebrou
-      ? `Terminou com ${resumo}. Só que a execução passou por um vértice já fechado que melhorou depois: o resultado NÃO é confiável. Com peso negativo, a hipótese do Dijkstra cai, e o algoritmo certo é Bellman-Ford.`
-      : `Terminou. Distâncias mínimas a partir de ${ROT[0]}: ${resumo}. Cada vértice fechou uma vez só, e nenhum precisou ser revisitado.`,
-    null, quebrou ? { alerta: true } : { ok: true }));
+    broke
+      ? `Terminou com ${summary}. Só que a execução passou por um vértice já fechado que melhorou depois: o resultado NÃO é confiável. Com peso negativo, a hipótese do Dijkstra cai, e o algoritmo certo é Bellman-Ford.`
+      : `Terminou. Distâncias mínimas a partir de ${LABELS[0]}: ${summary}. Cada vértice fechou uma vez só, e nenhum precisou ser revisitado.`,
+    null, broke ? { alert: true } : { ok: true }));
   return out;
 }
 
-const VELOCIDADES = [0, 1500, 1000, 700, 450, 260];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1500, 1000, 700, 450, 260];
 
 export function DijkstraVisualizer() {
   const [presetKey, setPresetKey] = useState("classico");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
-  const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.arestas, !!preset.negativo), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const preset = useMemo(() => PRESETS.find((pr) => pr.key === presetKey) ?? PRESETS[0], [presetKey]);
+  const steps = useMemo(() => generateSteps(preset.edges, !!preset.negative), [preset]);
+  const total = steps.length;
 
-  const parar = useCallback(() => { if (timer.current) { clearInterval(timer.current); timer.current = null; } }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · Dijkstra fechando um vértice por vez, a partir de A",
+    total,
+    speeds: SPEEDS,
+    // A peça já abria em 1.5x, e a marcha inicial é parte do que ela é.
+    initialSpeed: 4,
+    // O que muda a altura desta peça é o preset: cada um tem outra sequência de
+    // notas, e a NOTA é o único bloco que cresce (22 a 63px, medido). A fila de
+    // prioridade e a tabela de distâncias são fileiras de fichas de altura fixa
+    // (34px em todos os passos dos três presets): elas nunca quebram linha.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const fechados = useMemo(() => new Set(p.fechados), [p.fechados]);
-  const naFila = useMemo(() => new Set(p.fila.map((q) => q.v)), [p.fila]);
-  const pct = Math.round(((idx + 1) / total) * 100);
+  const p = steps[viz.step];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · Dijkstra fechando um vértice por vez, a partir de A</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>{expanded ? "✕ Fechar" : "⤢ Expandir"}</button>
-        </div>
-      </div>
+  const closed = useMemo(() => new Set(p.closed), [p.closed]);
+  const inQueue = useMemo(() => new Set(p.queue.map((q) => q.v)), [p.queue]);
 
-      <div className="viz-body">
+  const pickPreset = (key: string) => { viz.reset(); setPresetKey(key); };
+
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.negativo ? " na" : ""}`} onClick={() => { reiniciar(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.negative ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="gr-split">
           <div className="tt-arv-wrap" style={{ margin: 0 }}>
             <svg className="tt-arv" width={370} height={270} viewBox="0 0 370 270" role="img"
-              aria-label={`Grafo com pesos. Dijkstra a partir de A, passo ${idx + 1} de ${total}. ${p.nota}`}>
+              aria-label={`Grafo com pesos. Dijkstra a partir de A, passo ${viz.step + 1} de ${total}. ${p.note}`}>
               <defs>
                 <marker id="seta-dij" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
                   <path d="M 0 0 L 8 4 L 0 8 z" fill="rgba(59,130,246,0.75)" />
                 </marker>
               </defs>
-              {preset.arestas.map((a) => {
-                const ativa = p.aresta && p.aresta[0] === a.de && p.aresta[1] === a.para;
-                const dx = POS[a.para].x - POS[a.de].x, dy = POS[a.para].y - POS[a.de].y;
-                const d = Math.sqrt(dx * dx + dy * dy) || 1, r = 19;
-                const mx = (POS[a.de].x + POS[a.para].x) / 2, my = (POS[a.de].y + POS[a.para].y) / 2;
+              {preset.edges.map((e) => {
+                const active = p.edge && p.edge[0] === e.from && p.edge[1] === e.to;
+                const dx = POS[e.to].x - POS[e.from].x, dy = POS[e.to].y - POS[e.from].y;
+                const len = Math.sqrt(dx * dx + dy * dy) || 1, r = 19;
+                const mx = (POS[e.from].x + POS[e.to].x) / 2, my = (POS[e.from].y + POS[e.to].y) / 2;
                 return (
-                  <g key={`${a.de}-${a.para}`}>
-                    <line className={`tt-aresta${ativa ? " ativa" : fechados.has(a.de) ? " on" : ""}`}
-                      x1={POS[a.de].x + (dx / d) * r} y1={POS[a.de].y + (dy / d) * r}
-                      x2={POS[a.para].x - (dx / d) * r} y2={POS[a.para].y - (dy / d) * r}
+                  <g key={`${e.from}-${e.to}`}>
+                    <line className={`tt-aresta${active ? " ativa" : closed.has(e.from) ? " on" : ""}`}
+                      x1={POS[e.from].x + (dx / len) * r} y1={POS[e.from].y + (dy / len) * r}
+                      x2={POS[e.to].x - (dx / len) * r} y2={POS[e.to].y - (dy / len) * r}
                       markerEnd="url(#seta-dij)" />
-                    <text className={`gr-peso${a.peso < 0 ? " neg" : ""}`} x={mx} y={my - 4} textAnchor="middle">{a.peso}</text>
+                    <text className={`gr-peso${e.weight < 0 ? " neg" : ""}`} x={mx} y={my - 4} textAnchor="middle">{e.weight}</text>
                   </g>
                 );
               })}
-              {ROT.map((r, i) => {
+              {LABELS.map((r, i) => {
                 const cls = ["tt-no"];
-                if (i === p.no) cls.push("on");
-                else if (fechados.has(i)) cls.push("saiu");
-                else if (naFila.has(i)) cls.push("aux");
+                if (i === p.node) cls.push("on");
+                else if (closed.has(i)) cls.push("saiu");
+                else if (inQueue.has(i)) cls.push("aux");
                 return (
                   <g key={r} className={cls.join(" ")}>
                     <circle cx={POS[i].x} cy={POS[i].y} r={17} />
@@ -257,8 +244,8 @@ export function DijkstraVisualizer() {
             <div className="tt-painel">
               <div className="tt-painel-tit">Distância provisória <em>a partir de A</em></div>
               <div className="gr-dists">
-                {ROT.map((r, i) => (
-                  <span key={r} className={`gr-dist-item${p.dist[i] === null ? " off" : ""}${fechados.has(i) ? " fechado" : ""}`}>
+                {LABELS.map((r, i) => (
+                  <span key={r} className={`gr-dist-item${p.dist[i] === null ? " off" : ""}${closed.has(i) ? " fechado" : ""}`}>
                     <i>{r}</i>{p.dist[i] === null ? "∞" : p.dist[i]}
                   </span>
                 ))}
@@ -267,55 +254,47 @@ export function DijkstraVisualizer() {
             <div className="tt-painel">
               <div className="tt-painel-tit">Fila de prioridade <em>sai sempre o menor</em></div>
               <div className="tt-aux">
-                {p.fila.length === 0 ? <span className="tt-vazio">vazia</span> : p.fila.map((q, i) => (
-                  <span key={`${q.v}-${i}`} className={`tt-aux-item${i === 0 ? " topo" : ""}`}>{ROT[q.v]}:{q.d}</span>
+                {p.queue.length === 0 ? <span className="tt-vazio">vazia</span> : p.queue.map((q, i) => (
+                  <span key={`${q.v}-${i}`} className={`tt-aux-item${i === 0 ? " topo" : ""}`}>{LABELS[q.v]}:{q.d}</span>
                 ))}
               </div>
             </div>
             <div className="tt-painel">
               <div className="tt-painel-tit">Fechados <em>não mudam mais</em></div>
               <div className="tt-saida">
-                {p.fechados.length === 0 ? <span className="tt-vazio">nenhum</span> : p.fechados.map((v, i) => (
-                  <span key={v} className={`tt-saida-item${i === p.fechados.length - 1 ? " novo" : ""}`}>{ROT[v]}</span>
+                {p.closed.length === 0 ? <span className="tt-vazio">nenhum</span> : p.closed.map((v, i) => (
+                  <span key={v} className={`tt-saida-item${i === p.closed.length - 1 ? " novo" : ""}`}>{LABELS[v]}</span>
                 ))}
               </div>
             </div>
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : p.alerta ? " invalid" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : p.alert ? " invalid" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">dijkstra.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr. O código
+              fica no DOM mesmo recolhido — é isso que permite medir o pior caso
+              —, e o `inert` o tira do teclado e dos leitores de tela. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">dijkstra.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            <div className="viz-var"><span className="viz-var-name">vértice atual</span><span className="viz-var-val">{p.no >= 0 ? ROT[p.no] : "-"}</span></div>
-            <div className="viz-var"><span className="viz-var-name">fechados</span><span className="viz-var-val best">{p.fechados.length} de {ROT.length}</span></div>
-            <div className="viz-var"><span className="viz-var-name">na fila</span><span className="viz-var-val">{p.fila.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">vértice atual</span><span className="viz-var-val">{p.node >= 0 ? LABELS[p.node] : "-"}</span></div>
+            <div className="viz-var"><span className="viz-var-name">fechados</span><span className="viz-var-val best">{p.closed.length} de {LABELS.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">na fila</span><span className="viz-var-val">{p.queue.length}</span></div>
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pct}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Acompanhe a coluna dos fechados: uma vez que um vértice entra ali, o valor dele é final.
@@ -323,14 +302,10 @@ export function DijkstraVisualizer() {
           quebrar tudo. Rode o terceiro preset até o fim.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>{viz}</div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/GrafoDfsBfs.tsx
+++ b/content/visualizers/GrafoDfsBfs.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // GrafoDfsBfs, o mesmo grafo, a mesma origem, duas estruturas.
@@ -18,9 +19,15 @@ import { createPortal } from "react-dom";
 // A distância do BFS é registrada na hora de ENFILEIRAR (não na de processar),
 // que é o detalhe que evita contar o mesmo vértice duas vezes e é onde a
 // maioria das implementações erra.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-const ROT = ["A", "B", "C", "D", "E", "F", "G"];
+// Os rótulos dos vértices são o que o aluno lê no desenho, nas notas e nos
+// painéis: conteúdo, não identificador.
+const LABELS = ["A", "B", "C", "D", "E", "F", "G"];
 const POS = [
   { x: 40, y: 40 },
   { x: 150, y: 40 },
@@ -31,30 +38,33 @@ const POS = [
   { x: 265, y: 240 },
 ];
 
-type Preset = { key: string; rotulo: string; arestas: [number, number][]; dica: string };
+type Preset = { key: string; label: string; edges: [number, number][]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "ciclo",
-    rotulo: "Com ciclo",
-    arestas: [[0, 1], [0, 3], [1, 2], [1, 4], [3, 4], [3, 5], [4, 6], [5, 6], [2, 4]],
-    dica: "Tem mais de um caminho entre vários pares. É onde a diferença entre DFS e BFS aparece, e onde o conjunto de visitados vira obrigatório.",
+    key: "cycle",
+    label: "Com ciclo",
+    edges: [[0, 1], [0, 3], [1, 2], [1, 4], [3, 4], [3, 5], [4, 6], [5, 6], [2, 4]],
+    hint: "Tem mais de um caminho entre vários pares. É onde a diferença entre DFS e BFS aparece, e onde o conjunto de visitados vira obrigatório.",
   },
   {
-    key: "arvore",
-    rotulo: "Sem ciclo (é uma árvore)",
-    arestas: [[0, 1], [0, 3], [1, 2], [3, 4], [3, 5], [4, 6]],
-    dica: "Grafo conexo sem ciclo é exatamente uma árvore. Aqui os dois percursos viram os da árvore, e o conjunto de visitados fica supérfluo.",
+    key: "tree",
+    label: "Sem ciclo (é uma árvore)",
+    edges: [[0, 1], [0, 3], [1, 2], [3, 4], [3, 5], [4, 6]],
+    hint: "Grafo conexo sem ciclo é exatamente uma árvore. Aqui os dois percursos viram os da árvore, e o conjunto de visitados fica supérfluo.",
   },
   {
-    key: "desconexo",
-    rotulo: "Desconexo",
-    arestas: [[0, 1], [1, 2], [3, 4], [4, 6], [5, 6]],
-    dica: "Dois componentes separados. Partindo de A você nunca alcança D, E, F, G: um percurso só não cobre o grafo inteiro.",
+    key: "disconnected",
+    label: "Desconexo",
+    edges: [[0, 1], [1, 2], [3, 4], [4, 6], [5, 6]],
+    hint: "Dois componentes separados. Partindo de A você nunca alcança D, E, F, G: um percurso só não cobre o grafo inteiro.",
   },
 ];
 
-const CODIGO = {
+// O Python da tela é conteúdo didático em português, e continua em português:
+// `visitados`, `pilha`, `fila` e os comentários são o que o aluno lê e o que as
+// notas do passo a passo explicam.
+const CODE = {
   dfs: [
     "def dfs(inicio, g):",
     "    visitados = {inicio}",
@@ -81,186 +91,167 @@ const CODIGO = {
   ],
 };
 
-type Modo = "dfs" | "bfs";
+// `dfs` e `bfs` também são o nome do arquivo que aparece no cabeçalho do bloco
+// de código (`dfs.py`), então o valor é conteúdo além de identificador.
+type Mode = "dfs" | "bfs";
 
-type Passo = {
-  no: number;
+type Step = {
+  node: number;
   aux: number[];
-  visitados: number[];
-  ordem: number[];
+  visited: number[];
+  order: number[];
   dist: (number | null)[];
-  aresta: [number, number] | null;
-  linha: number;
-  nota: string;
+  edge: [number, number] | null;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-function adjacencia(arestas: [number, number][]): number[][] {
-  const g: number[][] = ROT.map(() => []);
-  for (const [a, b] of arestas) { g[a].push(b); g[b].push(a); }
+// A marcha inicial era `useState(4)` — 1.5x, e não o 1x padrão do hook. Ela
+// vira `initialSpeed`, senão a peça passa a abrir mais devagar do que abria.
+const INITIAL_SPEED = 4;
+
+function adjacency(edges: [number, number][]): number[][] {
+  const g: number[][] = LABELS.map(() => []);
+  for (const [a, b] of edges) { g[a].push(b); g[b].push(a); }
   for (const l of g) l.sort((x, y) => x - y);
   return g;
 }
 
-function gerarPassos(arestas: [number, number][], modo: Modo, inicio: number): Passo[] {
-  const g = adjacencia(arestas);
-  const out: Passo[] = [];
-  const visitados = new Set<number>([inicio]);
-  const dist: (number | null)[] = ROT.map(() => null);
-  dist[inicio] = 0;
-  const ordem: number[] = [];
-  const aux: number[] = [inicio];
+function generateSteps(edges: [number, number][], mode: Mode, start: number): Step[] {
+  const g = adjacency(edges);
+  const out: Step[] = [];
+  const visited = new Set<number>([start]);
+  const dist: (number | null)[] = LABELS.map(() => null);
+  dist[start] = 0;
+  const order: number[] = [];
+  const aux: number[] = [start];
 
-  const snap = (no: number, linha: number, nota: string, aresta: [number, number] | null = null, ok = false): Passo => ({
-    no, aux: [...aux], visitados: [...visitados], ordem: [...ordem], dist: [...dist], aresta, linha, nota, ok,
+  const snap = (node: number, line: number, note: string, edge: [number, number] | null = null, ok = false): Step => ({
+    node, aux: [...aux], visited: [...visited], order: [...order], dist: [...dist], edge, line, note, ok,
   });
 
-  out.push(snap(inicio, 2, `Começo em ${ROT[inicio]}. Já marco a origem como visitada antes do laço: em grafo, "visitado" não é enfeite, é o que impede o percurso de girar em ciclo para sempre.`));
+  out.push(snap(start, 2, `Começo em ${LABELS[start]}. Já marco a origem como visitada antes do laço: em grafo, "visitado" não é enfeite, é o que impede o percurso de girar em ciclo para sempre.`));
 
-  let guarda = 0;
-  while (aux.length && guarda++ < 300) {
-    const u = modo === "dfs" ? (aux.pop() as number) : (aux.shift() as number);
-    ordem.push(u);
-    out.push(snap(u, 4, modo === "dfs"
-      ? `Tiro ${ROT[u]} do TOPO da pilha. Pilha devolve o último que entrou, então eu sempre continuo pelo ramo mais recente: o percurso afunda.`
-      : `Tiro ${ROT[u]} da FRENTE da fila, a ${dist[u]} ${dist[u] === 1 ? "aresta" : "arestas"} da origem. Fila devolve o mais antigo, então eu só desço de nível depois de esgotar o atual.`));
+  let guard = 0;
+  while (aux.length && guard++ < 300) {
+    const u = mode === "dfs" ? (aux.pop() as number) : (aux.shift() as number);
+    order.push(u);
+    out.push(snap(u, 4, mode === "dfs"
+      ? `Tiro ${LABELS[u]} do TOPO da pilha. Pilha devolve o último que entrou, então eu sempre continuo pelo ramo mais recente: o percurso afunda.`
+      : `Tiro ${LABELS[u]} da FRENTE da fila, a ${dist[u]} ${dist[u] === 1 ? "aresta" : "arestas"} da origem. Fila devolve o mais antigo, então eu só desço de nível depois de esgotar o atual.`));
 
     for (const v of g[u]) {
-      if (visitados.has(v)) {
-        out.push(snap(u, 7, `${ROT[v]} é vizinho de ${ROT[u]}, mas já está em visitados: ignoro. Sem esta linha, este grafo com ciclo travaria o programa.`, [u, v]));
+      if (visited.has(v)) {
+        out.push(snap(u, 7, `${LABELS[v]} é vizinho de ${LABELS[u]}, mas já está em visitados: ignoro. Sem esta linha, este grafo com ciclo travaria o programa.`, [u, v]));
         continue;
       }
-      visitados.add(v);
+      visited.add(v);
       dist[v] = (dist[u] ?? 0) + 1;
       aux.push(v);
       out.push(snap(v, 9,
-        modo === "dfs"
-          ? `${ROT[v]} é novo: marco como visitado e empilho. Ele vai ser o próximo a sair, na frente de qualquer coisa que já estivesse na pilha.`
-          : `${ROT[v]} é novo: marco como visitado JÁ e enfileiro, com distância ${dist[v]}. Marcar ao enfileirar (e não ao processar) é o que impede o mesmo vértice de entrar duas vezes na fila.`,
+        mode === "dfs"
+          ? `${LABELS[v]} é novo: marco como visitado e empilho. Ele vai ser o próximo a sair, na frente de qualquer coisa que já estivesse na pilha.`
+          : `${LABELS[v]} é novo: marco como visitado JÁ e enfileiro, com distância ${dist[v]}. Marcar ao enfileirar (e não ao processar) é o que impede o mesmo vértice de entrar duas vezes na fila.`,
         [u, v]));
     }
   }
 
-  const alcancados = ordem.length;
-  const faltaram = ROT.length - alcancados;
+  const reached = order.length;
+  const missing = LABELS.length - reached;
   out.push(snap(-1, 3,
-    `${modo === "dfs" ? "DFS" : "BFS"} terminou: ${ordem.map((i) => ROT[i]).join(", ")}. ${
-      faltaram > 0
-        ? `Alcancei ${alcancados} de ${ROT.length} vértices: os outros ${faltaram} estão em outro componente, e para cobrir o grafo inteiro seria preciso reiniciar o percurso a partir de um vértice ainda não visitado.`
-        : modo === "bfs"
+    `${mode === "dfs" ? "DFS" : "BFS"} terminou: ${order.map((i) => LABELS[i]).join(", ")}. ${
+      missing > 0
+        ? `Alcancei ${reached} de ${LABELS.length} vértices: os outros ${missing} estão em outro componente, e para cobrir o grafo inteiro seria preciso reiniciar o percurso a partir de um vértice ainda não visitado.`
+        : mode === "bfs"
           ? `A coluna de distância é o prêmio: cada valor é o MENOR número de arestas da origem até o vértice. O DFS visita os mesmos vértices e não te dá isso.`
           : `Visitei os mesmos vértices que o BFS visitaria, mas em outra ordem, e sem nenhuma garantia sobre distância.`
     }`, null, true));
   return out;
 }
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
 export function GrafoDfsBfs() {
-  const [presetKey, setPresetKey] = useState("ciclo");
-  const [modo, setModo] = useState<Modo>("bfs");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("cycle");
+  const [mode, setMode] = useState<Mode>("bfs");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.arestas, modo, 0), [preset, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(preset.edges, mode, 0), [preset, mode]);
+  const total = steps.length;
 
-  const parar = useCallback(() => {
-    if (timer.current) { clearInterval(timer.current); timer.current = null; }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · DFS e BFS no mesmo grafo, a partir de A",
+    total,
+    initialSpeed: INITIAL_SPEED,
+    // O que muda a altura da peça: o modo (a nota do BFS é mais longa que a do
+    // DFS e ganha uma linha) e o preset (a dica do "Desconexo" é mais curta que
+    // a dos outros dois, e valem 19px no artigo). O desenho tem altura fixa: o
+    // SVG é sempre 305x285, com os mesmos 7 vértices nas mesmas posições.
+    measureOn: [mode, presetKey],
+  });
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const visitados = useMemo(() => new Set(p.visitados), [p.visitados]);
-  const processados = useMemo(() => new Set(p.ordem), [p.ordem]);
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const picoAux = useMemo(() => passos.reduce((m, q) => Math.max(m, q.aux.length), 0), [passos]);
+  const idx = viz.step;
+  const p = steps[idx];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · DFS e BFS no mesmo grafo, a partir de A</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const pickMode = (m: Mode) => { viz.reset(); setMode(m); };
+  const pickPreset = (k: string) => { viz.reset(); setPresetKey(k); };
 
-      <div className="viz-body">
+  const visited = useMemo(() => new Set(p.visited), [p.visited]);
+  const processed = useMemo(() => new Set(p.order), [p.order]);
+  const auxPeak = useMemo(() => steps.reduce((m, q) => Math.max(m, q.aux.length), 0), [steps]);
+
+  const isDfs = mode === "dfs";
+
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className={`bigo-chip${modo === "bfs" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("bfs"); }} aria-pressed={modo === "bfs"}>
+          <button className={`bigo-chip${mode === "bfs" ? " on" : ""}`} onClick={() => pickMode("bfs")} aria-pressed={mode === "bfs"}>
             BFS (fila)
           </button>
-          <button className={`bigo-chip${modo === "dfs" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("dfs"); }} aria-pressed={modo === "dfs"}>
+          <button className={`bigo-chip${isDfs ? " on" : ""}`} onClick={() => pickMode("dfs")} aria-pressed={isDfs}>
             DFS (pilha)
           </button>
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { reiniciar(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="gr-split">
           <div className="tt-arv-wrap" style={{ margin: 0 }}>
             <svg
               className="tt-arv" width={305} height={285} viewBox="0 0 305 285"
               role="img"
-              aria-label={`Grafo com 7 vértices. ${modo === "bfs" ? "BFS" : "DFS"} a partir de A, passo ${idx + 1} de ${total}. ${p.nota}`}
+              aria-label={`Grafo com 7 vértices. ${mode === "bfs" ? "BFS" : "DFS"} a partir de A, passo ${idx + 1} de ${total}. ${p.note}`}
             >
-              {preset.arestas.map(([a, b]) => {
-                const emUso = p.aresta && ((p.aresta[0] === a && p.aresta[1] === b) || (p.aresta[0] === b && p.aresta[1] === a));
-                const usada = processados.has(a) && processados.has(b);
+              {preset.edges.map(([a, b]) => {
+                const inUse = p.edge && ((p.edge[0] === a && p.edge[1] === b) || (p.edge[0] === b && p.edge[1] === a));
+                const used = processed.has(a) && processed.has(b);
                 return (
                   <line
                     key={`${a}-${b}`}
-                    className={`tt-aresta${emUso ? " ativa" : usada ? " on" : ""}`}
+                    className={`tt-aresta${inUse ? " ativa" : used ? " on" : ""}`}
                     x1={POS[a].x} y1={POS[a].y} x2={POS[b].x} y2={POS[b].y}
                   />
                 );
               })}
-              {ROT.map((r, i) => {
+              {LABELS.map((label, i) => {
                 const cls = ["tt-no"];
-                if (i === p.no) cls.push("on");
-                else if (processados.has(i)) cls.push("saiu");
-                else if (visitados.has(i)) cls.push("aux");
+                if (i === p.node) cls.push("on");
+                else if (processed.has(i)) cls.push("saiu");
+                else if (visited.has(i)) cls.push("aux");
                 return (
-                  <g key={r} className={cls.join(" ")}>
+                  <g key={label} className={cls.join(" ")}>
                     <circle cx={POS[i].x} cy={POS[i].y} r={17} />
-                    <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{r}</text>
-                    {modo === "bfs" && p.dist[i] !== null && (
+                    <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{label}</text>
+                    {mode === "bfs" && p.dist[i] !== null && (
                       <text className="gr-dist" x={POS[i].x + 20} y={POS[i].y - 12}>{p.dist[i]}</text>
                     )}
                   </g>
@@ -272,30 +263,30 @@ export function GrafoDfsBfs() {
           <div style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 10 }}>
             <div className="tt-painel">
               <div className="tt-painel-tit">
-                {modo === "dfs" ? "Pilha" : "Fila"} <em>{modo === "dfs" ? "sai o último (LIFO)" : "sai o primeiro (FIFO)"}</em>
+                {isDfs ? "Pilha" : "Fila"} <em>{isDfs ? "sai o último (LIFO)" : "sai o primeiro (FIFO)"}</em>
               </div>
               <div className="tt-aux">
                 {p.aux.length === 0 ? <span className="tt-vazio">vazia</span> : p.aux.map((id, i) => (
-                  <span key={`${id}-${i}`} className={`tt-aux-item${(modo === "dfs" ? i === p.aux.length - 1 : i === 0) ? " topo" : ""}`}>{ROT[id]}</span>
+                  <span key={`${id}-${i}`} className={`tt-aux-item${(isDfs ? i === p.aux.length - 1 : i === 0) ? " topo" : ""}`}>{LABELS[id]}</span>
                 ))}
               </div>
             </div>
             <div className="tt-painel">
               <div className="tt-painel-tit">Ordem de processamento</div>
               <div className="tt-saida">
-                {p.ordem.length === 0 ? <span className="tt-vazio">nada ainda</span> : p.ordem.map((id, i) => (
-                  <span key={`${id}-${i}`} className={`tt-saida-item${i === p.ordem.length - 1 ? " novo" : ""}`}>{ROT[id]}</span>
+                {p.order.length === 0 ? <span className="tt-vazio">nada ainda</span> : p.order.map((id, i) => (
+                  <span key={`${id}-${i}`} className={`tt-saida-item${i === p.order.length - 1 ? " novo" : ""}`}>{LABELS[id]}</span>
                 ))}
               </div>
             </div>
             <div className="tt-painel">
               <div className="tt-painel-tit">
-                Distância da origem <em>{modo === "bfs" ? "mínima, em arestas" : "o DFS não garante mínima"}</em>
+                Distância da origem <em>{mode === "bfs" ? "mínima, em arestas" : "o DFS não garante mínima"}</em>
               </div>
               <div className="gr-dists">
-                {ROT.map((r, i) => (
-                  <span key={r} className={`gr-dist-item${p.dist[i] === null ? " off" : ""}`}>
-                    <i>{r}</i>{p.dist[i] === null ? "∞" : p.dist[i]}
+                {LABELS.map((label, i) => (
+                  <span key={label} className={`gr-dist-item${p.dist[i] === null ? " off" : ""}`}>
+                    <i>{label}</i>{p.dist[i] === null ? "∞" : p.dist[i]}
                   </span>
                 ))}
               </div>
@@ -303,49 +294,38 @@ export function GrafoDfsBfs() {
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo}.py</div>
-            <div className="viz-code-body">
-              {CODIGO[modo].map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>{txt}
-                </div>
-              ))}
+          {/* O `.viz-code-slot` é o que recolhe a ALTURA: zerar a trilha da
+              coluna sozinha tira só a largura (contrato §7). */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode}.py</div>
+              <div className="viz-code-body">
+                {CODE[mode].map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>{txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            <div className="viz-var"><span className="viz-var-name">vértice atual</span><span className="viz-var-val">{p.no >= 0 ? ROT[p.no] : "-"}</span></div>
-            <div className="viz-var"><span className="viz-var-name">visitados</span><span className="viz-var-val">{p.visitados.length} de {ROT.length}</span></div>
-            <div className="viz-var"><span className="viz-var-name">{modo === "dfs" ? "pilha" : "fila"}</span><span className="viz-var-val">{p.aux.length}</span></div>
-            <div className="viz-var"><span className="viz-var-name">processados</span><span className="viz-var-val best">{p.ordem.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">vértice atual</span><span className="viz-var-val">{p.node >= 0 ? LABELS[p.node] : "-"}</span></div>
+            <div className="viz-var"><span className="viz-var-name">visitados</span><span className="viz-var-val">{p.visited.length} de {LABELS.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">{isDfs ? "pilha" : "fila"}</span><span className="viz-var-val">{p.aux.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">processados</span><span className="viz-var-val best">{p.order.length}</span></div>
           </div>
         </div>
 
         <div className="bigo-stats">
-          <div className="bigo-stat"><span>vértices</span><strong>{ROT.length}</strong></div>
-          <div className="bigo-stat"><span>arestas</span><strong>{preset.arestas.length}</strong></div>
-          <div className="bigo-stat"><span>pico da {modo === "dfs" ? "pilha" : "fila"}</span><strong>{picoAux}</strong></div>
+          <div className="bigo-stat"><span>vértices</span><strong>{LABELS.length}</strong></div>
+          <div className="bigo-stat"><span>arestas</span><strong>{preset.edges.length}</strong></div>
+          <div className="bigo-stat"><span>pico da {isDfs ? "pilha" : "fila"}</span><strong>{auxPeak}</strong></div>
           <div className="bigo-stat"><span>complexidade</span><strong>O(V + E)</strong></div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Rode o BFS até o fim e anote as distâncias. Depois rode o DFS e compare a ordem: os mesmos
@@ -353,16 +333,8 @@ export function GrafoDfsBfs() {
           <code> pop() </code> por <code> popleft() </code> troca o algoritmo inteiro.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/GrafoRepresentacao.tsx
+++ b/content/visualizers/GrafoRepresentacao.tsx
@@ -47,13 +47,13 @@ const PRESETS: Preset[] = [
     hint: "O caso mais comum do mundo real: cada vértice tem poucos vizinhos. A matriz fica quase toda em zero.",
   },
   {
-    key: "denso",
+    key: "dense",
     label: "Denso",
     edges: [[0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [1, 2], [1, 3], [1, 5], [2, 3], [2, 4], [3, 4], [3, 5], [4, 5]],
     hint: "Muitas arestas por vértice. Aqui a matriz para de desperdiçar e passa a ganhar da lista na consulta.",
   },
   {
-    key: "completo",
+    key: "complete",
     label: "Completo",
     edges: (() => {
       const a: [number, number][] = [];
@@ -63,7 +63,7 @@ const PRESETS: Preset[] = [
     hint: "Todo mundo ligado a todo mundo: V(V-1)/2 = 15 arestas. É o teto, e é onde a matriz fica cheia.",
   },
   {
-    key: "caminho",
+    key: "path",
     label: "Caminho (o mínimo conexo)",
     edges: [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]],
     hint: "V-1 arestas: o mínimo para conectar tudo sem ciclo. Uma árvore é exatamente isto.",

--- a/content/visualizers/GrafoRepresentacao.tsx
+++ b/content/visualizers/GrafoRepresentacao.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // GrafoRepresentacao, matriz e lista de adjacência lado a lado.
@@ -15,10 +15,17 @@ import { createPortal } from "react-dom";
 // vértices, então clicar nela deixa explícito o que a matriz é: um espaço
 // reservado para toda aresta possível, ocupada ou não. Grafo esparso deixa
 // quase tudo em zero, e o desperdício aparece sozinho.
+//
+// Sobre a casca: não há linha do tempo (`total: 1`) nem bloco dispensável para
+// recolher (`collapsible: false`) — o desenho, a matriz e a lista SÃO o
+// conteúdo. Da casca ele usa o que lhe cabe: o painel expandido com o
+// cabeçalho parado enquanto o miolo rola. Os presets e o seletor de tipo
+// continuam sendo controles do miolo, e não do rodapé, porque no rodapé só
+// mora reprodução — e aqui não há rodapé nenhum.
 // ---------------------------------------------------------------------------
 
-const ROT = ["A", "B", "C", "D", "E", "F"];
-const V = ROT.length;
+const LABELS = ["A", "B", "C", "D", "E", "F"];
+const V = LABELS.length;
 
 // Posições fixas: hexágono, para nenhuma aresta passar por cima de vértice.
 const POS: { x: number; y: number }[] = [
@@ -30,132 +37,128 @@ const POS: { x: number; y: number }[] = [
   { x: 36, y: 96 },
 ];
 
-type Preset = { key: string; rotulo: string; arestas: [number, number][]; dica: string };
+type Preset = { key: string; label: string; edges: [number, number][]; hint: string };
 
 const PRESETS: Preset[] = [
   {
     key: "social",
-    rotulo: "Esparso (rede social)",
-    arestas: [[0, 1], [0, 5], [1, 2], [2, 3], [3, 4], [4, 5], [1, 4]],
-    dica: "O caso mais comum do mundo real: cada vértice tem poucos vizinhos. A matriz fica quase toda em zero.",
+    label: "Esparso (rede social)",
+    edges: [[0, 1], [0, 5], [1, 2], [2, 3], [3, 4], [4, 5], [1, 4]],
+    hint: "O caso mais comum do mundo real: cada vértice tem poucos vizinhos. A matriz fica quase toda em zero.",
   },
   {
     key: "denso",
-    rotulo: "Denso",
-    arestas: [[0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [1, 2], [1, 3], [1, 5], [2, 3], [2, 4], [3, 4], [3, 5], [4, 5]],
-    dica: "Muitas arestas por vértice. Aqui a matriz para de desperdiçar e passa a ganhar da lista na consulta.",
+    label: "Denso",
+    edges: [[0, 1], [0, 2], [0, 3], [0, 4], [0, 5], [1, 2], [1, 3], [1, 5], [2, 3], [2, 4], [3, 4], [3, 5], [4, 5]],
+    hint: "Muitas arestas por vértice. Aqui a matriz para de desperdiçar e passa a ganhar da lista na consulta.",
   },
   {
     key: "completo",
-    rotulo: "Completo",
-    arestas: (() => {
+    label: "Completo",
+    edges: (() => {
       const a: [number, number][] = [];
       for (let i = 0; i < V; i++) for (let j = i + 1; j < V; j++) a.push([i, j]);
       return a;
     })(),
-    dica: "Todo mundo ligado a todo mundo: V(V-1)/2 = 15 arestas. É o teto, e é onde a matriz fica cheia.",
+    hint: "Todo mundo ligado a todo mundo: V(V-1)/2 = 15 arestas. É o teto, e é onde a matriz fica cheia.",
   },
   {
     key: "caminho",
-    rotulo: "Caminho (o mínimo conexo)",
-    arestas: [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]],
-    dica: "V-1 arestas: o mínimo para conectar tudo sem ciclo. Uma árvore é exatamente isto.",
+    label: "Caminho (o mínimo conexo)",
+    edges: [[0, 1], [1, 2], [2, 3], [3, 4], [4, 5]],
+    hint: "V-1 arestas: o mínimo para conectar tudo sem ciclo. Uma árvore é exatamente isto.",
   },
 ];
 
-function matrizDe(arestas: [number, number][], dirigido: boolean): number[][] {
+function matrixFrom(edges: [number, number][], directed: boolean): number[][] {
   const m = Array.from({ length: V }, () => new Array(V).fill(0));
-  for (const [a, b] of arestas) {
+  for (const [a, b] of edges) {
     m[a][b] = 1;
-    if (!dirigido) m[b][a] = 1;
+    if (!directed) m[b][a] = 1;
   }
   return m;
 }
 
 export function GrafoRepresentacao() {
   const [presetKey, setPresetKey] = useState("social");
-  const [dirigido, setDirigido] = useState(false);
-  const [m, setM] = useState<number[][]>(() => matrizDe(PRESETS[0].arestas, false));
-  const [foco, setFoco] = useState<number | null>(null);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
+  const [directed, setDirected] = useState(false);
+  const [matrix, setMatrix] = useState<number[][]>(() => matrixFrom(PRESETS[0].edges, false));
+  const [focused, setFocused] = useState<number | null>(null);
 
-  useEffect(() => setMounted(true), []);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · o mesmo grafo em matriz e em lista de adjacência",
+    // Não é uma animação: a matriz é editável e o resultado é imediato. Com
+    // `total: 1` somem o contador de passo, os atalhos e a barra de progresso.
+    total: 1,
+    // Não há bloco dispensável: o desenho, a matriz e a lista SÃO o conteúdo.
+    // Sem isso o cabeçalho prometeria esconder um bloco que não existe.
+    collapsible: false,
+    // `measureOn` fica de fora de propósito: com `collapsible: false` não há
+    // decisão a tomar, e o hook nem espera as fontes. Passar a lista seria
+    // anunciar uma medição que não acontece.
+  });
 
-  const aplicar = (p: Preset, dir = dirigido) => {
+  const applyPreset = (p: Preset, dir = directed) => {
     setPresetKey(p.key);
-    setM(matrizDe(p.arestas, dir));
+    setMatrix(matrixFrom(p.edges, dir));
   };
 
-  const trocarDirigido = (v: boolean) => {
-    setDirigido(v);
-    setM((atual) => {
-      if (v) return atual.map((l) => [...l]);
+  const changeDirected = (v: boolean) => {
+    setDirected(v);
+    setMatrix((current) => {
+      if (v) return current.map((row) => [...row]);
       // ao voltar para não dirigido, espelha para manter a simetria
-      const novo = atual.map((l) => [...l]);
-      for (let i = 0; i < V; i++) for (let j = 0; j < V; j++) if (novo[i][j]) novo[j][i] = 1;
-      return novo;
+      const next = current.map((row) => [...row]);
+      for (let i = 0; i < V; i++) for (let j = 0; j < V; j++) if (next[i][j]) next[j][i] = 1;
+      return next;
     });
   };
 
-  const alternar = (i: number, j: number) => {
+  const toggleEdge = (i: number, j: number) => {
     if (i === j) return; // laço: fora do escopo deste visualizador
     setPresetKey("");
-    setM((atual) => {
-      const novo = atual.map((l) => [...l]);
-      const valor = novo[i][j] ? 0 : 1;
-      novo[i][j] = valor;
-      if (!dirigido) novo[j][i] = valor;
-      return novo;
+    setMatrix((current) => {
+      const next = current.map((row) => [...row]);
+      const value = next[i][j] ? 0 : 1;
+      next[i][j] = value;
+      if (!directed) next[j][i] = value;
+      return next;
     });
   };
 
-  const { arestas, grau } = useMemo(() => {
-    const arestas: [number, number][] = [];
-    const grau = new Array(V).fill(0);
+  const { edges, degree } = useMemo(() => {
+    const edges: [number, number][] = [];
+    const degree = new Array(V).fill(0);
     for (let i = 0; i < V; i++) {
       for (let j = 0; j < V; j++) {
-        if (!m[i][j]) continue;
-        grau[i]++;
-        if (dirigido || i < j) arestas.push([i, j]);
+        if (!matrix[i][j]) continue;
+        degree[i]++;
+        if (directed || i < j) edges.push([i, j]);
       }
     }
-    return { arestas, grau };
-  }, [m, dirigido]);
+    return { edges, degree };
+  }, [matrix, directed]);
 
-  const E = arestas.length;
-  const maxE = dirigido ? V * (V - 1) : (V * (V - 1)) / 2;
-  const densidade = Math.round((E / maxE) * 100);
-  const custoMatriz = V * V;
-  const custoLista = V + (dirigido ? E : 2 * E);
-  const dica = PRESETS.find((p) => p.key === presetKey)?.dica;
+  const E = edges.length;
+  const maxE = directed ? V * (V - 1) : (V * (V - 1)) / 2;
+  const density = Math.round((E / maxE) * 100);
+  const matrixCost = V * V;
+  const listCost = V + (directed ? E : 2 * E);
+  const hint = PRESETS.find((p) => p.key === presetKey)?.hint;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o mesmo grafo em matriz e em lista de adjacência</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">V = {V} · E = {E} · densidade {densidade}%</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo não há "passo N de M"; o número que resume o
+          estado entra no lugar dele, com o rótulo junto. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">V = {V} · E = {E} · densidade {density}%</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((p) => (
-            <button key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => aplicar(p)} aria-pressed={presetKey === p.key}>
-              {p.rotulo}
+            <button key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => applyPreset(p)} aria-pressed={presetKey === p.key}>
+              {p.label}
             </button>
           ))}
         </div>
@@ -164,10 +167,10 @@ export function GrafoRepresentacao() {
           <div className="viz-field">
             <span>Tipo</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${dirigido ? "" : " on"}`} onClick={() => trocarDirigido(false)} aria-pressed={!dirigido}>
+              <button className={`sub-modo-btn${directed ? "" : " on"}`} onClick={() => changeDirected(false)} aria-pressed={!directed}>
                 não dirigido
               </button>
-              <button className={`sub-modo-btn${dirigido ? " on" : ""}`} onClick={() => trocarDirigido(true)} aria-pressed={dirigido}>
+              <button className={`sub-modo-btn${directed ? " on" : ""}`} onClick={() => changeDirected(true)} aria-pressed={directed}>
                 dirigido
               </button>
             </div>
@@ -175,7 +178,7 @@ export function GrafoRepresentacao() {
         </div>
 
         <p className="tt-legenda-arvore">
-          {dica ?? "Clique numa célula da matriz para ligar ou desligar a aresta. No modo não dirigido a célula espelhada acompanha, e é essa simetria que faz metade da matriz ser redundante."}
+          {hint ?? "Clique numa célula da matriz para ligar ou desligar a aresta. No modo não dirigido a célula espelhada acompanha, e é essa simetria que faz metade da matriz ser redundante."}
         </p>
 
         <div className="gr-split">
@@ -186,17 +189,17 @@ export function GrafoRepresentacao() {
               height={324}
               viewBox="0 0 300 324"
               role="img"
-              aria-label={`Grafo ${dirigido ? "dirigido" : "não dirigido"} com ${V} vértices e ${E} arestas, densidade ${densidade} por cento.`}
+              aria-label={`Grafo ${directed ? "dirigido" : "não dirigido"} com ${V} vértices e ${E} arestas, densidade ${density} por cento.`}
             >
-              {dirigido && (
+              {directed && (
                 <defs>
                   <marker id="seta-gr" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
                     <path d="M 0 0 L 8 4 L 0 8 z" fill="rgba(59,130,246,0.75)" />
                   </marker>
                 </defs>
               )}
-              {arestas.map(([a, b]) => {
-                const aceso = foco !== null && (a === foco || b === foco);
+              {edges.map(([a, b]) => {
+                const lit = focused !== null && (a === focused || b === focused);
                 // encurta a linha para a ponta da seta não entrar no círculo
                 const dx = POS[b].x - POS[a].x;
                 const dy = POS[b].y - POS[a].y;
@@ -205,24 +208,24 @@ export function GrafoRepresentacao() {
                 return (
                   <line
                     key={`${a}-${b}`}
-                    className={`tt-aresta${aceso ? " on" : ""}`}
+                    className={`tt-aresta${lit ? " on" : ""}`}
                     x1={POS[a].x + (dx / d) * r}
                     y1={POS[a].y + (dy / d) * r}
                     x2={POS[b].x - (dx / d) * r}
                     y2={POS[b].y - (dy / d) * r}
-                    markerEnd={dirigido ? "url(#seta-gr)" : undefined}
+                    markerEnd={directed ? "url(#seta-gr)" : undefined}
                   />
                 );
               })}
-              {ROT.map((r, i) => (
+              {LABELS.map((label, i) => (
                 <g
-                  key={r}
-                  className={`tt-no${foco === i ? " on" : ""}`}
-                  onMouseEnter={() => setFoco(i)}
-                  onMouseLeave={() => setFoco(null)}
+                  key={label}
+                  className={`tt-no${focused === i ? " on" : ""}`}
+                  onMouseEnter={() => setFocused(i)}
+                  onMouseLeave={() => setFocused(null)}
                 >
                   <circle cx={POS[i].x} cy={POS[i].y} r={17} />
-                  <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{r}</text>
+                  <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{label}</text>
                 </g>
               ))}
             </svg>
@@ -234,20 +237,20 @@ export function GrafoRepresentacao() {
               <thead>
                 <tr>
                   <th />
-                  {ROT.map((r) => <th key={r}>{r}</th>)}
+                  {LABELS.map((label) => <th key={label}>{label}</th>)}
                 </tr>
               </thead>
               <tbody>
-                {m.map((linha, i) => (
-                  <tr key={i} className={foco === i ? "on" : undefined}>
-                    <th onMouseEnter={() => setFoco(i)} onMouseLeave={() => setFoco(null)}>{ROT[i]}</th>
-                    {linha.map((v, j) => (
+                {matrix.map((row, i) => (
+                  <tr key={i} className={focused === i ? "on" : undefined}>
+                    <th onMouseEnter={() => setFocused(i)} onMouseLeave={() => setFocused(null)}>{LABELS[i]}</th>
+                    {row.map((v, j) => (
                       <td key={j}>
                         <button
                           className={`gr-cel${v ? " on" : ""}${i === j ? " diag" : ""}`}
-                          onClick={() => alternar(i, j)}
+                          onClick={() => toggleEdge(i, j)}
                           disabled={i === j}
-                          aria-label={`Aresta de ${ROT[i]} para ${ROT[j]}: ${v ? "existe" : "não existe"}`}
+                          aria-label={`Aresta de ${LABELS[i]} para ${LABELS[j]}: ${v ? "existe" : "não existe"}`}
                           aria-pressed={!!v}
                         >
                           {v}
@@ -264,12 +267,12 @@ export function GrafoRepresentacao() {
         <div className="gr-painel" style={{ marginTop: 12 }}>
           <div className="tt-painel-tit">Lista de adjacência <em>só o que existe</em></div>
           <div className="gr-lista">
-            {ROT.map((r, i) => (
-              <div key={r} className={`gr-linha${foco === i ? " on" : ""}`} onMouseEnter={() => setFoco(i)} onMouseLeave={() => setFoco(null)}>
-                <span className="gr-linha-no">{r}</span>
+            {LABELS.map((label, i) => (
+              <div key={label} className={`gr-linha${focused === i ? " on" : ""}`} onMouseEnter={() => setFocused(i)} onMouseLeave={() => setFocused(null)}>
+                <span className="gr-linha-no">{label}</span>
                 <span className="gr-seta">→</span>
-                {m[i].map((v, j) => (v ? <span key={j} className="gr-viz-item">{ROT[j]}</span> : null))}
-                {grau[i] === 0 && <span className="tt-vazio">sem vizinhos</span>}
+                {matrix[i].map((v, j) => (v ? <span key={j} className="gr-viz-item">{LABELS[j]}</span> : null))}
+                {degree[i] === 0 && <span className="tt-vazio">sem vizinhos</span>}
               </div>
             ))}
           </div>
@@ -278,28 +281,20 @@ export function GrafoRepresentacao() {
         <div className="bigo-stats">
           <div className="bigo-stat"><span>vértices (V)</span><strong>{V}</strong></div>
           <div className="bigo-stat"><span>arestas (E)</span><strong>{E} de {maxE}</strong></div>
-          <div className="bigo-stat"><span>memória da matriz</span><strong>{custoMatriz} células</strong></div>
-          <div className="bigo-stat"><span>memória da lista</span><strong>{custoLista} entradas</strong></div>
-          <div className="bigo-stat"><span>células em zero</span><strong>{custoMatriz - (dirigido ? E : 2 * E) - V}</strong></div>
+          <div className="bigo-stat"><span>memória da matriz</span><strong>{matrixCost} células</strong></div>
+          <div className="bigo-stat"><span>memória da lista</span><strong>{listCost} entradas</strong></div>
+          <div className="bigo-stat"><span>células em zero</span><strong>{matrixCost - (directed ? E : 2 * E) - V}</strong></div>
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           A matriz custa V² sempre, ligada ou não a aresta. A lista custa{" "}
-          {dirigido ? "V + E (dirigido: cada aresta aparece uma vez só)" : "V + 2E (não dirigido: cada aresta aparece nos dois vizinhos)"},
+          {directed ? "V + E (dirigido: cada aresta aparece uma vez só)" : "V + 2E (não dirigido: cada aresta aparece nos dois vizinhos)"},
           então ela só perde quando o grafo é quase completo. Com 6 vértices a diferença é pequena;
           com 1 milhão de vértices, a matriz pediria 10¹² células e simplesmente não cabe.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/MstVisualizer.tsx
+++ b/content/visualizers/MstVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // MstVisualizer, Kruskal e Prim chegando no mesmo total por caminhos opostos.
@@ -20,9 +21,14 @@ import { createPortal } from "react-dom";
 // O contador de peso total é o mesmo nos dois no fim, e é esse número que
 // fecha o argumento de que a MST é única em peso mesmo quando as escolhas
 // diferem.
+//
+// Identificadores em inglês, tela em português (contrato §0). O Python que
+// aparece no bloco de código e as notas do passo a passo são CONTEÚDO: eles
+// continuam falando de `pai`, `acha`, `arestas`, `peso` e `fila`, que é o
+// vocabulário que as notas explicam em português logo ao lado.
 // ---------------------------------------------------------------------------
 
-const ROT = ["A", "B", "C", "D", "E", "F"];
+const LABELS = ["A", "B", "C", "D", "E", "F"];
 const POS = [
   { x: 45, y: 45 },
   { x: 165, y: 30 },
@@ -32,35 +38,37 @@ const POS = [
   { x: 285, y: 175 },
 ];
 
-type Aresta = { a: number; b: number; peso: number };
-const E = (a: number, b: number, peso: number): Aresta => ({ a, b, peso });
+type Edge = { a: number; b: number; weight: number };
+const E = (a: number, b: number, weight: number): Edge => ({ a, b, weight });
 
-type Preset = { key: string; rotulo: string; arestas: Aresta[]; dica: string };
+type Preset = { key: string; label: string; edges: Edge[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "classico",
-    rotulo: "Rede de cabos",
-    arestas: [E(0, 1, 4), E(0, 3, 1), E(1, 2, 3), E(1, 4, 7), E(3, 4, 2), E(2, 5, 5), E(4, 5, 6), E(1, 3, 8), E(2, 4, 9)],
-    dica: "Cada aresta é o custo de puxar um cabo. A MST é o jeito mais barato de deixar todo mundo conectado.",
+    key: "classic",
+    label: "Rede de cabos",
+    edges: [E(0, 1, 4), E(0, 3, 1), E(1, 2, 3), E(1, 4, 7), E(3, 4, 2), E(2, 5, 5), E(4, 5, 6), E(1, 3, 8), E(2, 4, 9)],
+    hint: "Cada aresta é o custo de puxar um cabo. A MST é o jeito mais barato de deixar todo mundo conectado.",
   },
   {
-    key: "empate",
-    rotulo: "Com pesos repetidos",
-    arestas: [E(0, 1, 2), E(0, 3, 2), E(1, 2, 2), E(3, 4, 2), E(2, 5, 3), E(4, 5, 3), E(1, 4, 5)],
-    dica: "Vários pesos iguais: Kruskal e Prim podem escolher arestas DIFERENTES e ainda assim chegar ao mesmo peso total.",
+    key: "ties",
+    label: "Com pesos repetidos",
+    edges: [E(0, 1, 2), E(0, 3, 2), E(1, 2, 2), E(3, 4, 2), E(2, 5, 3), E(4, 5, 3), E(1, 4, 5)],
+    hint: "Vários pesos iguais: Kruskal e Prim podem escolher arestas DIFERENTES e ainda assim chegar ao mesmo peso total.",
   },
   {
-    key: "caro",
-    rotulo: "Uma ponte cara e obrigatória",
-    arestas: [E(0, 1, 1), E(1, 3, 2), E(0, 3, 2), E(2, 5, 1), E(2, 4, 2), E(4, 5, 2), E(1, 2, 20)],
-    dica: "Dois grupos baratos ligados por uma única aresta de peso 20. Ela é horrível e entra assim mesmo: sem ela o grafo se parte.",
+    key: "bridge",
+    label: "Uma ponte cara e obrigatória",
+    edges: [E(0, 1, 1), E(1, 3, 2), E(0, 3, 2), E(2, 5, 1), E(2, 4, 2), E(4, 5, 2), E(1, 2, 20)],
+    hint: "Dois grupos baratos ligados por uma única aresta de peso 20. Ela é horrível e entra assim mesmo: sem ela o grafo se parte.",
   },
 ];
 
-type Modo = "kruskal" | "prim";
+type Mode = "kruskal" | "prim";
 
-const CODIGO: Record<Modo, string[]> = {
+// `kruskal` e `prim` são valor de union E texto de tela: o cabeçalho do bloco é
+// `{mode}.py`, então eles saem renderizados como `kruskal.py` e `prim.py`.
+const CODE: Record<Mode, string[]> = {
   kruskal: [
     "def kruskal(n, arestas):",
     "    arestas.sort(key=lambda e: e.peso)   # o guloso mora aqui",
@@ -99,187 +107,167 @@ const CODIGO: Record<Modo, string[]> = {
   ],
 };
 
-type Passo = {
-  aresta: Aresta | null;
-  escolhidas: number[];      // índices em arestasOrdenadas / arestas
-  rejeitadas: number[];
-  componente: number[];      // cor de cada vértice
-  dentro: number[];
+type Step = {
+  edge: Edge | null;
+  chosen: number[];      // índices em sortedEdges / edges
+  rejected: number[];
+  component: number[];   // cor de cada vértice
+  inside: number[];
   total: number;
-  linha: number;
-  nota: string;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-function gerarPassos(arestasIn: Aresta[], modo: Modo): Passo[] {
-  const V = ROT.length;
-  const out: Passo[] = [];
+function buildSteps(edgesIn: Edge[], mode: Mode): Step[] {
+  const V = LABELS.length;
+  const out: Step[] = [];
 
-  if (modo === "kruskal") {
-    const arestas = [...arestasIn].sort((x, y) => x.peso - y.peso);
-    const pai = Array.from({ length: V }, (_, i) => i);
-    const acha = (x: number): number => { while (pai[x] !== x) { pai[x] = pai[pai[x]]; x = pai[x]; } return x; };
-    const escolhidas: number[] = [];
-    const rejeitadas: number[] = [];
+  if (mode === "kruskal") {
+    const edges = [...edgesIn].sort((x, y) => x.weight - y.weight);
+    const parent = Array.from({ length: V }, (_, i) => i);
+    const find = (x: number): number => { while (parent[x] !== x) { parent[x] = parent[parent[x]]; x = parent[x]; } return x; };
+    const chosen: number[] = [];
+    const rejected: number[] = [];
     let total = 0;
-    const comp = () => ROT.map((_, i) => acha(i));
-    const snap = (aresta: Aresta | null, linha: number, nota: string, extra: Partial<Passo> = {}): Passo =>
-      ({ aresta, escolhidas: [...escolhidas], rejeitadas: [...rejeitadas], componente: comp(), dentro: [], total, linha, nota, ...extra });
+    const comp = () => LABELS.map((_, i) => find(i));
+    const snap = (edge: Edge | null, line: number, note: string, extra: Partial<Step> = {}): Step =>
+      ({ edge, chosen: [...chosen], rejected: [...rejected], component: comp(), inside: [], total, line, note, ...extra });
 
-    out.push(snap(null, 1, `Kruskal começa ordenando TODAS as arestas por peso: ${arestas.map((e) => e.peso).join(", ")}. A partir daqui é só percorrer essa lista de cima para baixo, e a única decisão é aceitar ou recusar.`));
+    out.push(snap(null, 1, `Kruskal começa ordenando TODAS as arestas por peso: ${edges.map((e) => e.weight).join(", ")}. A partir daqui é só percorrer essa lista de cima para baixo, e a única decisão é aceitar ou recusar.`));
 
-    for (let i = 0; i < arestas.length; i++) {
-      const e = arestas[i];
-      const ra = acha(e.a), rb = acha(e.b);
+    for (let i = 0; i < edges.length; i++) {
+      const e = edges[i];
+      const ra = find(e.a), rb = find(e.b);
       if (ra === rb) {
-        rejeitadas.push(i);
-        out.push(snap(e, 12, `${ROT[e.a]} e ${ROT[e.b]} já estão no mesmo grupo (mesma cor). Aceitar a aresta de peso ${e.peso} fecharia um ciclo, e ciclo não acrescenta conexão nenhuma. Recuso.`));
+        rejected.push(i);
+        out.push(snap(e, 12, `${LABELS[e.a]} e ${LABELS[e.b]} já estão no mesmo grupo (mesma cor). Aceitar a aresta de peso ${e.weight} fecharia um ciclo, e ciclo não acrescenta conexão nenhuma. Recuso.`));
       } else {
-        pai[ra] = rb;
-        escolhidas.push(i);
-        total += e.peso;
-        out.push(snap(e, 13, `${ROT[e.a]} e ${ROT[e.b]} estão em grupos diferentes: a aresta de peso ${e.peso} conecta duas partes que estavam soltas. Aceito, e os dois grupos viram um só. Total: ${total}.`));
+        parent[ra] = rb;
+        chosen.push(i);
+        total += e.weight;
+        out.push(snap(e, 13, `${LABELS[e.a]} e ${LABELS[e.b]} estão em grupos diferentes: a aresta de peso ${e.weight} conecta duas partes que estavam soltas. Aceito, e os dois grupos viram um só. Total: ${total}.`));
       }
-      if (escolhidas.length === V - 1) break;
+      if (chosen.length === V - 1) break;
     }
-    out.push(snap(null, 15, `MST completa com ${escolhidas.length} arestas (sempre V-1 = ${V - 1}) e peso total ${total}. Repare que a árvore foi crescendo em pedaços soltos, que só no fim viraram uma coisa só.`, { ok: true }));
+    out.push(snap(null, 15, `MST completa com ${chosen.length} arestas (sempre V-1 = ${V - 1}) e peso total ${total}. Repare que a árvore foi crescendo em pedaços soltos, que só no fim viraram uma coisa só.`, { ok: true }));
     return out;
   }
 
   // Prim
-  const adj: { v: number; peso: number; idx: number }[][] = ROT.map(() => []);
-  arestasIn.forEach((e, i) => { adj[e.a].push({ v: e.b, peso: e.peso, idx: i }); adj[e.b].push({ v: e.a, peso: e.peso, idx: i }); });
-  const dentro = new Set<number>([0]);
-  const escolhidas: number[] = [];
-  const rejeitadas: number[] = [];
+  const adj: { v: number; weight: number; idx: number }[][] = LABELS.map(() => []);
+  edgesIn.forEach((e, i) => { adj[e.a].push({ v: e.b, weight: e.weight, idx: i }); adj[e.b].push({ v: e.a, weight: e.weight, idx: i }); });
+  const inside = new Set<number>([0]);
+  const chosen: number[] = [];
+  const rejected: number[] = [];
   let total = 0;
-  let fila: { peso: number; u: number; v: number; idx: number }[] = adj[0].map((x) => ({ peso: x.peso, u: 0, v: x.v, idx: x.idx }));
-  const snap = (aresta: Aresta | null, linha: number, nota: string, extra: Partial<Passo> = {}): Passo =>
-    ({ aresta, escolhidas: [...escolhidas], rejeitadas: [...rejeitadas], componente: ROT.map((_, i) => (dentro.has(i) ? 0 : i + 1)), dentro: [...dentro], total, linha, nota, ...extra });
+  const queue: { weight: number; u: number; v: number; idx: number }[] = adj[0].map((x) => ({ weight: x.weight, u: 0, v: x.v, idx: x.idx }));
+  const snap = (edge: Edge | null, line: number, note: string, extra: Partial<Step> = {}): Step =>
+    ({ edge, chosen: [...chosen], rejected: [...rejected], component: LABELS.map((_, i) => (inside.has(i) ? 0 : i + 1)), inside: [...inside], total, line, note, ...extra });
 
-  out.push(snap(null, 3, `Prim começa com um vértice só, ${ROT[0]}, e vai fazer a árvore CRESCER. A fila guarda as arestas que saem da árvore para fora dela: ${fila.map((f) => `${ROT[f.u]}${ROT[f.v]}:${f.peso}`).join(", ")}.`));
+  out.push(snap(null, 3, `Prim começa com um vértice só, ${LABELS[0]}, e vai fazer a árvore CRESCER. A fila guarda as arestas que saem da árvore para fora dela: ${queue.map((f) => `${LABELS[f.u]}${LABELS[f.v]}:${f.weight}`).join(", ")}.`));
 
-  let guarda = 0;
-  while (fila.length && dentro.size < V && guarda++ < 300) {
-    fila.sort((x, y) => x.peso - y.peso);
-    const f = fila.shift() as { peso: number; u: number; v: number; idx: number };
-    if (dentro.has(f.v)) {
-      rejeitadas.push(f.idx);
-      out.push(snap(arestasIn[f.idx], 9, `A aresta ${ROT[f.u]}-${ROT[f.v]} (peso ${f.peso}) era a mais barata da fila, mas ${ROT[f.v]} já entrou na árvore por outro caminho. Descarto: pegá-la faria ciclo.`));
+  let guard = 0;
+  while (queue.length && inside.size < V && guard++ < 300) {
+    queue.sort((x, y) => x.weight - y.weight);
+    const f = queue.shift() as { weight: number; u: number; v: number; idx: number };
+    if (inside.has(f.v)) {
+      rejected.push(f.idx);
+      out.push(snap(edgesIn[f.idx], 9, `A aresta ${LABELS[f.u]}-${LABELS[f.v]} (peso ${f.weight}) era a mais barata da fila, mas ${LABELS[f.v]} já entrou na árvore por outro caminho. Descarto: pegá-la faria ciclo.`));
       continue;
     }
-    dentro.add(f.v);
-    escolhidas.push(f.idx);
-    total += f.peso;
-    out.push(snap(arestasIn[f.idx], 11, `A mais barata que sai da árvore é ${ROT[f.u]}-${ROT[f.v]}, peso ${f.peso}. ${ROT[f.v]} entra na árvore. Total: ${total}. A árvore nunca se parte: ela é sempre uma peça só, crescendo.`));
+    inside.add(f.v);
+    chosen.push(f.idx);
+    total += f.weight;
+    out.push(snap(edgesIn[f.idx], 11, `A mais barata que sai da árvore é ${LABELS[f.u]}-${LABELS[f.v]}, peso ${f.weight}. ${LABELS[f.v]} entra na árvore. Total: ${total}. A árvore nunca se parte: ela é sempre uma peça só, crescendo.`));
     for (const x of adj[f.v]) {
-      if (!dentro.has(x.v)) fila.push({ peso: x.peso, u: f.v, v: x.v, idx: x.idx });
+      if (!inside.has(x.v)) queue.push({ weight: x.weight, u: f.v, v: x.v, idx: x.idx });
     }
   }
-  out.push(snap(null, 13, `MST completa com ${escolhidas.length} arestas e peso total ${total}. O caminho foi outro, o resultado é o mesmo número.`, { ok: true }));
+  out.push(snap(null, 13, `MST completa com ${chosen.length} arestas e peso total ${total}. O caminho foi outro, o resultado é o mesmo número.`, { ok: true }));
   return out;
 }
 
-const CORES = ["#3b82f6", "#a78bfa", "#6ee7b7", "#fcd34d", "#f472b6", "#22d3ee"];
-const VELOCIDADES = [0, 1500, 1000, 700, 450, 260];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const COLORS = ["#3b82f6", "#a78bfa", "#6ee7b7", "#fcd34d", "#f472b6", "#22d3ee"];
+const SPEEDS = [0, 1500, 1000, 700, 450, 260];
 
 export function MstVisualizer() {
-  const [presetKey, setPresetKey] = useState("classico");
-  const [modo, setModo] = useState<Modo>("kruskal");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [presetKey, setPresetKey] = useState("classic");
+  const [mode, setMode] = useState<Mode>("kruskal");
 
-  useEffect(() => setMounted(true), []);
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const arestasOrdenadas = useMemo(() => [...preset.arestas].sort((x, y) => x.peso - y.peso), [preset]);
-  const passos = useMemo(() => gerarPassos(preset.arestas, modo), [preset, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const sortedEdges = useMemo(() => [...preset.edges].sort((x, y) => x.weight - y.weight), [preset]);
+  const steps = useMemo(() => buildSteps(preset.edges, mode), [preset, mode]);
 
-  const totais = useMemo(() => ({
-    kruskal: gerarPassos(preset.arestas, "kruskal").slice(-1)[0].total,
-    prim: gerarPassos(preset.arestas, "prim").slice(-1)[0].total,
+  const viz = useVisualizer({
+    title: "Visualizador · Kruskal e Prim no mesmo grafo",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O eixo da altura desta peça é o TEXTO. O desenho tem altura constante (as
+    // coordenadas estão em `POS`, e o SVG renderiza 330x230 = viewBox nas três
+    // réguas), e a lista de arestas vive na coluna ao lado dele: mesmo no preset
+    // de 9 arestas ela chega a 175px contra os 244 do desenho, 69px antes de
+    // encostar. Quem move a peça é a dica (18 ou 37px) e a nota (22 ou 42px) —
+    // ou seja, o preset e o modo.
+    measureOn: [presetKey, mode],
+  });
+
+  const s = steps[viz.step];
+  const list = mode === "kruskal" ? sortedEdges : preset.edges;
+  const chosen = useMemo(() => new Set(s.chosen), [s.chosen]);
+  const rejected = useMemo(() => new Set(s.rejected), [s.rejected]);
+
+  const totals = useMemo(() => ({
+    kruskal: buildSteps(preset.edges, "kruskal").slice(-1)[0].total,
+    prim: buildSteps(preset.edges, "prim").slice(-1)[0].total,
   }), [preset]);
 
-  const parar = useCallback(() => { if (timer.current) { clearInterval(timer.current); timer.current = null; } }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const colorOf = (i: number) => (mode === "prim"
+    ? (s.inside.includes(i) ? COLORS[0] : "#3d4c61")
+    : COLORS[s.component[i] % COLORS.length]);
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const lista = modo === "kruskal" ? arestasOrdenadas : preset.arestas;
-  const escolhidas = useMemo(() => new Set(p.escolhidas), [p.escolhidas]);
-  const rejeitadas = useMemo(() => new Set(p.rejeitadas), [p.rejeitadas]);
-  const pct = Math.round(((idx + 1) / total) * 100);
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* O peso continua à esquerda do "passo N de M", que agora é do hook. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">peso {s.total} ·</span>
+      </VizHeader>
 
-  const corDe = (i: number) => (modo === "prim"
-    ? (p.dentro.includes(i) ? CORES[0] : "#3d4c61")
-    : CORES[p.componente[i] % CORES.length]);
-
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · Kruskal e Prim no mesmo grafo</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">peso {p.total} · passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>{expanded ? "✕ Fechar" : "⤢ Expandir"}</button>
-        </div>
-      </div>
-
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className={`bigo-chip${modo === "kruskal" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("kruskal"); }} aria-pressed={modo === "kruskal"}>Kruskal: ordena arestas</button>
-          <button className={`bigo-chip${modo === "prim" ? " on" : ""}`} onClick={() => { reiniciar(); setModo("prim"); }} aria-pressed={modo === "prim"}>Prim: cresce de um vértice</button>
+          <button className={`bigo-chip${mode === "kruskal" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("kruskal"); }} aria-pressed={mode === "kruskal"}>Kruskal: ordena arestas</button>
+          <button className={`bigo-chip${mode === "prim" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("prim"); }} aria-pressed={mode === "prim"}>Prim: cresce de um vértice</button>
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { reiniciar(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>{pr.rotulo}</button>
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>{pr.label}</button>
           ))}
         </div>
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="gr-split">
           <div className="tt-arv-wrap" style={{ margin: 0 }}>
             <svg className="tt-arv" width={330} height={230} viewBox="0 0 330 230" role="img"
-              aria-label={`Grafo com pesos. ${modo === "kruskal" ? "Kruskal" : "Prim"}, peso acumulado ${p.total}. ${p.nota}`}>
-              {preset.arestas.map((e, i) => {
-                const idxLista = modo === "kruskal" ? arestasOrdenadas.indexOf(e) : i;
-                const naMst = escolhidas.has(idxLista);
-                const rej = rejeitadas.has(idxLista);
-                const ativa = p.aresta === e;
+              aria-label={`Grafo com pesos. ${mode === "kruskal" ? "Kruskal" : "Prim"}, peso acumulado ${s.total}. ${s.note}`}>
+              {preset.edges.map((e, i) => {
+                const listIdx = mode === "kruskal" ? sortedEdges.indexOf(e) : i;
+                const inMst = chosen.has(listIdx);
+                const rej = rejected.has(listIdx);
+                const active = s.edge === e;
                 const mx = (POS[e.a].x + POS[e.b].x) / 2, my = (POS[e.a].y + POS[e.b].y) / 2;
                 return (
                   <g key={`${e.a}-${e.b}`}>
-                    <line className={`tt-aresta${naMst ? " mst" : rej ? " rejeitada" : ativa ? " ativa" : ""}`}
+                    <line className={`tt-aresta${inMst ? " mst" : rej ? " rejeitada" : active ? " ativa" : ""}`}
                       x1={POS[e.a].x} y1={POS[e.a].y} x2={POS[e.b].x} y2={POS[e.b].y} />
-                    <text className="gr-peso" x={mx} y={my - 3} textAnchor="middle">{e.peso}</text>
+                    <text className="gr-peso" x={mx} y={my - 3} textAnchor="middle">{e.weight}</text>
                   </g>
                 );
               })}
-              {ROT.map((r, i) => (
-                <g key={r} className="tt-no mst-no">
-                  <circle cx={POS[i].x} cy={POS[i].y} r={16} style={{ fill: corDe(i) + "44", stroke: corDe(i) }} />
-                  <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{r}</text>
+              {LABELS.map((label, i) => (
+                <g key={label} className="tt-no mst-no">
+                  <circle cx={POS[i].x} cy={POS[i].y} r={16} style={{ fill: colorOf(i) + "44", stroke: colorOf(i) }} />
+                  <text x={POS[i].x} y={POS[i].y + 4} textAnchor="middle">{label}</text>
                 </g>
               ))}
             </svg>
@@ -287,57 +275,44 @@ export function MstVisualizer() {
 
           <div className="gr-painel">
             <div className="tt-painel-tit">
-              {modo === "kruskal" ? "Arestas ordenadas por peso" : "Arestas do grafo"}{" "}
-              <em>{modo === "kruskal" ? "percorridas de cima para baixo" : "Prim escolhe pela fronteira"}</em>
+              {mode === "kruskal" ? "Arestas ordenadas por peso" : "Arestas do grafo"}{" "}
+              <em>{mode === "kruskal" ? "percorridas de cima para baixo" : "Prim escolhe pela fronteira"}</em>
             </div>
             <div className="mst-lista">
-              {lista.map((e, i) => (
-                <span key={`${e.a}-${e.b}`} className={`mst-item${escolhidas.has(i) ? " ok" : rejeitadas.has(i) ? " rej" : ""}`}>
-                  {ROT[e.a]}{ROT[e.b]} <b>{e.peso}</b>
+              {list.map((e, i) => (
+                <span key={`${e.a}-${e.b}`} className={`mst-item${chosen.has(i) ? " ok" : rejected.has(i) ? " rej" : ""}`}>
+                  {LABELS[e.a]}{LABELS[e.b]} <b>{e.weight}</b>
                 </span>
               ))}
             </div>
             <p className="bt-array-nota" style={{ marginTop: 10 }}>
-              {modo === "kruskal"
+              {mode === "kruskal"
                 ? "Verde entrou na MST, riscada foi recusada por formar ciclo. O union-find é quem responde 'já estão no mesmo grupo?' em tempo quase constante."
                 : "Prim não ordena a lista inteira: ele mantém só as arestas que saem da árvore atual, numa fila de prioridade."}
             </p>
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{modo}.py</div>
-            <div className="viz-code-body">
-              {CODIGO[modo].map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{mode}.py</div>
+              <div className="viz-code-body">
+                {CODE[mode].map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">No mesmo grafo</div>
-            <div className="viz-var"><span className="viz-var-name">Kruskal</span><span className={`viz-var-val${modo === "kruskal" ? " best" : ""}`}>peso {totais.kruskal}</span></div>
-            <div className="viz-var"><span className="viz-var-name">Prim</span><span className={`viz-var-val${modo === "prim" ? " best" : ""}`}>peso {totais.prim}</span></div>
-            <div className="viz-var"><span className="viz-var-name">arestas na MST</span><span className="viz-var-val">{p.escolhidas.length} de {ROT.length - 1}</span></div>
+            <div className="viz-var"><span className="viz-var-name">Kruskal</span><span className={`viz-var-val${mode === "kruskal" ? " best" : ""}`}>peso {totals.kruskal}</span></div>
+            <div className="viz-var"><span className="viz-var-name">Prim</span><span className={`viz-var-val${mode === "prim" ? " best" : ""}`}>peso {totals.prim}</span></div>
+            <div className="viz-var"><span className="viz-var-name">arestas na MST</span><span className="viz-var-val">{s.chosen.length} de {LABELS.length - 1}</span></div>
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pct}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Rode os dois no mesmo preset e compare o peso final: é sempre igual. No preset com pesos
@@ -345,14 +320,8 @@ export function MstVisualizer() {
           do mesmo grafo podem ser diferentes; o peso, não.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>{viz}</div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -230,6 +230,21 @@ O que fazer em vez disso, na ordem:
    compare presets do mesmo tamanho, senão você mede a contagem em vez do eixo.
    Numa BST os quatro presets têm sete nós e a altura do desenho varia 2,2x
    entre eles.
+6. **E ele pode estar na AUSÊNCIA de preset.** Se a peça deixa o aluno montar a
+   entrada à mão, esse estado não é alcançado por botão nenhum e escapa da
+   varredura. Medido no `GrafoRepresentacao`: os oito estados de preset dão a
+   **mesma altura ao pixel**, e o mais alto é o grafo editado, onde a dica cai
+   num fallback de 171 caracteres contra 100 do maior `hint`.
+7. **O pior caso pode ser a SOMA de dois blocos com sinais trocados**, e aí
+   nenhum deles sozinho aponta para o estado certo. No `TopoSortVisualizer` o
+   preset mais alto é o de **menos arestas**, por 2px: a dica dele é 19px mais
+   curta e a nota final 21px mais alta.
+8. **O que cresce AO LADO de algo constante e mais alto não é altura.** Numa
+   linha de `.gr-split` a altura é o **máximo** dos dois lados, então uma coluna
+   que cresce ainda tem folga até alcançar a vizinha. Medido no
+   `BellmanFordVisualizer`: a tabela cresce 88px (2→6 linhas) e **para 61px
+   antes** do desenho; no `MstVisualizer`, a lista de arestas cresce 32px e para
+   69px antes. **Meça a distância até o vizinho, não a taxa de crescimento.**
 
 ### E o estado mais alto não é o último passo: pode ser o do meio
 
@@ -252,6 +267,14 @@ não uma constante. Medido no percurso de árvores: 6 fichas cabem numa linha, e
 amplitude ao longo dos 26 passos é de **20px** — que vêm da nota ter uma ou duas
 linhas, não da pilha. Um relatório que anunciasse "o pico está no meio" ali
 estaria certo por acidente e errado no motivo.
+
+**E o passo do pico pode mudar com a LARGURA da janela**, porque a nota quebra em
+outro lugar: no `BellmanFordVisualizer` o pico é o passo 1 a 1512px e o passo 10
+a 1440px. **Mas isso só vale se a coluna do artigo ainda não estiver no
+`max-width`** — quando ela está, 1512 e 1440 são a **mesma** régua para a peça, e
+só o orçamento muda. Medido no `MstVisualizer`: 18 combinações com alturas
+idênticas ao pixel nas duas larguras. Confira qual dos dois casos é o seu antes
+de multiplicar o número de medições por três.
 
 Isso volta na decisão de `measureOn`, com uma segunda pergunta além da do
 `hash-table` ("os dois extremos caem do mesmo lado do orçamento?"): **se a
@@ -277,6 +300,34 @@ texto junto. Dois desenhos grandes desta série pareciam o mesmo caso e não era
 
 **Compare os dois números antes de escrever o teto.** Se forem iguais, ou se o
 renderizado for menor, não há vazio a devolver — o caminho é outro.
+
+### O perfil de altura de um visualizador de grafo
+
+Os sete tópicos de Grafos foram adaptados por sete agentes independentes, e os
+sete mediram a mesma coisa. Vale como atalho — não para pular a medição, mas
+para saber onde ela vai dar:
+
+| o que se mediu | resultado, em 7 de 7 |
+|---|---|
+| altura do desenho ao trocar preset | **constante**, ao pixel (189px em 756 amostras no `TopoSort`; 366x236 em 514 estados no `AStar`) |
+| esticão do SVG (renderizado × `viewBox`) | **0px**. Nenhum teto de altura, **nenhuma linha de CSS** nos sete |
+| estruturas auxiliares (fila, pilha, tabela, união) | **34px** ou parecido, sempre — chegam a 3 ou 4 fichas e o `flex-wrap` nunca quebra |
+| o que de fato move a peça | **a prosa**: a nota do passo e a dica do preset |
+
+O motivo é estrutural: **o grafo tem um número fixo de vértices declarado no
+arquivo**, e os presets trocam as arestas, não a contagem. Onde há grade, a
+mesma coisa por outro caminho — no `AStarVisualizer`, `COLS = 14`, `ROWS = 9` e
+`CELL = 26` são constantes, e os presets mudam *quais* células são parede, nunca
+*quantas* existem.
+
+**E o critério não é "posicionado à mão ou gerado por código".** Uma grade
+gerada por laço tem altura tão fixa quanto sete vértices numa constante. A
+pergunta certa é:
+
+> **Existe caminho da tela até o número que gera as linhas?**
+
+Se o aluno não consegue mudar a dimensão por nenhum controle, ela não é eixo, e
+procurar pior caso ali é procurar no lugar errado.
 
 ### O corolário que fecha a §3
 
@@ -641,13 +692,18 @@ camada 2 não alcança o artigo (limite acima). Medido:
 | `PrefixSumTradeoff` (`collapsible: false`, `total: 1`, rodapé à mão) | 731px | **741px** (+10) |
 | `SkipListNiveis` (`collapsible: false`, `total: 1`, controles próprios) | 915px | **925px** (+10) |
 | **`BinaryTreeFormatos`** (`collapsible: false`, `total: 1`, **sem rodapé nenhum**) | 915–1025px | **911–1021px (−4)** |
+| **`GrafoRepresentacao`** (idem, peça sem parentesco com a anterior) | 1021–1069px | **1017–1065px (−4)** |
 
-**E a última linha inverte o sinal, o que corrige o enunciado desta seção.** O
-custo não é de adotar a casca: é de **ter um `.viz-foot`**. As três primeiras
-peças pagam porque, mesmo sem linha do tempo, elas têm controles próprios no
-rodapé. A quarta não tem rodapé nenhum — `total: 1` **e** sem `children` fazem o
-`VizFooter` sumir inteiro —, e aí a casca **devolve** 4px, idênticos nos sete
-estados medidos.
+**E as duas últimas linhas invertem o sinal, o que corrige o enunciado desta
+seção.** O custo não é de adotar a casca: é de **ter um `.viz-foot`**. As três
+primeiras peças pagam porque, mesmo sem linha do tempo, elas têm controles
+próprios no rodapé. As duas últimas não têm rodapé nenhum — `total: 1` **e** sem
+`children` fazem o `VizFooter` sumir inteiro —, e aí a casca **devolve** 4px.
+
+**São 4px nas duas, em peças sem nenhum parentesco**, em todos os estados e em
+todas as réguas: 10 estados × 3 réguas numa, 7 estados na outra. Repetir o
+mesmo número em dois lugares independentes confirma o **mecanismo** (o
+`padding-bottom` que passa de 18 para 14) e não só a medição.
 
 Quem citar o `+28` ou o `+10` sem medir a própria peça vai escrever o contrário
 do que ela faz. A pergunta é *esta peça tem rodapé?*, não *esta peça tem bloco?*.
@@ -679,3 +735,34 @@ Quando o passo 0 já estoura o orçamento, a peça recolhe de saída e o problem
 aparece. Quando ele cabe por pouco, o código fica aberto e a peça passa do
 orçamento no meio da animação. **Não tente resolver pelo componente** — pôr o
 passo em `measureOn` é o remédio pior que a doença, pelo critério da §3.
+
+### A casca cria um eixo de altura próprio: a linha do cabeçalho
+
+`.viz-fit .viz-head-right` é `flex-wrap: wrap`, e a adaptação põe mais um botão
+ali (o de mostrar/ocultar o bloco). Quando o conteúdo do cabeçalho cresce o
+bastante, a linha **quebra** e o `.viz-head` dobra de altura.
+
+Medido no `AStarVisualizer`: 53 → **81px** em 19 dos 514 estados — os passos 101
+a 119, onde o contador ganha um dígito, e **só a 1440px de largura**. É pouco, e
+é um eixo que não existia antes da casca: o componente não tem controle nenhum
+sobre ele.
+
+Duas consequências práticas: **inclua na varredura um estado com o contador de
+três dígitos**, se a sua peça chegar lá; e, se a peça passar do orçamento por
+menos de 30px, confira se não é isto antes de procurar no miolo.
+
+### `children` do `VizHeader` numa peça COM linha do tempo
+
+O contrato §6 já diz que um número que resume o estado entra como `children` do
+`VizHeader`, no lugar do "passo N de M". Os cinco visualizadores que faziam isso
+tinham todos `total: 1` — o número **substituía** o contador.
+
+Numa peça com linha do tempo os dois coexistem, e aí eles viram **dois
+`.viz-step` irmãos**, separados pelo `gap` do `.viz-head-right` em vez do
+separador que o componente escrevia à mão. Medido no `AStarVisualizer`: o `·`
+entre "N expandidas" e "passo N de M" **desaparece** do texto renderizado — é a
+única diferença em 514 estados comparados campo a campo.
+
+Não há como o `VizHeader` prefixar o contador. **Se o separador for para valer,
+termine os seus `children` com ele** (`rodada {s.round} ·`), que é o que o
+`BellmanFordVisualizer` faz. E declare a mudança no relatório: é texto de tela.

--- a/content/visualizers/TopoSortVisualizer.tsx
+++ b/content/visualizers/TopoSortVisualizer.tsx
@@ -37,19 +37,19 @@ type Preset = { key: string; label: string; edges: [number, number][]; hint: str
 
 const PRESETS: Preset[] = [
   {
-    key: "curso",
+    key: "course",
     label: "Pré-requisitos de um curso",
     edges: [[0, 1], [1, 2], [0, 3], [1, 3], [2, 4], [4, 5], [6, 5], [3, 4]],
     hint: "Uma aresta A → B quer dizer 'A é pré-requisito de B'. A ordenação topológica é uma ordem válida de fazer as matérias.",
   },
   {
-    key: "paralelo",
+    key: "parallel",
     label: "Muita coisa independente",
     edges: [[0, 1], [6, 3], [1, 2], [4, 5]],
     hint: "Vários vértices com grau de entrada zero desde o começo: existem MUITAS ordens válidas, e a fila mostra os candidatos empatados.",
   },
   {
-    key: "ciclo",
+    key: "cycle",
     label: "Com ciclo (impossível)",
     edges: [[0, 1], [1, 2], [2, 4], [4, 1], [0, 3], [6, 5]],
     hint: "C1 → C2 → Est → C1 é um ciclo: cada um espera o outro. Não existe ordem válida, e o Kahn descobre isso sozinho.",
@@ -149,7 +149,7 @@ function generateSteps(edges: [number, number][]): Step[] {
 const INITIAL_SPEED = 4;
 
 export function TopoSortVisualizer() {
-  const [presetKey, setPresetKey] = useState("curso");
+  const [presetKey, setPresetKey] = useState("course");
 
   const preset = useMemo(() => PRESETS.find((pr) => pr.key === presetKey) ?? PRESETS[0], [presetKey]);
   const steps = useMemo(() => generateSteps(preset.edges), [preset]);
@@ -181,7 +181,7 @@ export function TopoSortVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "ciclo" ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "cycle" ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/TopoSortVisualizer.tsx
+++ b/content/visualizers/TopoSortVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // TopoSortVisualizer, Kahn com o grau de entrada à vista.
@@ -17,8 +18,11 @@ import { createPortal } from "react-dom";
 // ciclo não é um extra do Kahn, é uma consequência de graça.
 // ---------------------------------------------------------------------------
 
-const ROT = ["Álgebra", "Cálculo I", "Cálculo II", "Física", "Estatística", "ML", "Programação"];
-const CURTO = ["Alg", "C1", "C2", "Fis", "Est", "ML", "Prog"];
+const LABELS = ["Álgebra", "Cálculo I", "Cálculo II", "Física", "Estatística", "ML", "Programação"];
+const SHORT = ["Alg", "C1", "C2", "Fis", "Est", "ML", "Prog"];
+// Layout POSICIONADO, não calculado: as sete coordenadas são constantes, então o
+// desenho tem a mesma altura em todo preset e em todo passo. Medido: 175px, que
+// é exatamente a altura do `viewBox`.
 const POS = [
   { x: 45, y: 40 },
   { x: 150, y: 40 },
@@ -29,33 +33,36 @@ const POS = [
   { x: 45, y: 130 },
 ];
 
-type Preset = { key: string; rotulo: string; arestas: [number, number][]; dica: string };
+type Preset = { key: string; label: string; edges: [number, number][]; hint: string };
 
 const PRESETS: Preset[] = [
   {
     key: "curso",
-    rotulo: "Pré-requisitos de um curso",
-    arestas: [[0, 1], [1, 2], [0, 3], [1, 3], [2, 4], [4, 5], [6, 5], [3, 4]],
-    dica: "Uma aresta A → B quer dizer 'A é pré-requisito de B'. A ordenação topológica é uma ordem válida de fazer as matérias.",
+    label: "Pré-requisitos de um curso",
+    edges: [[0, 1], [1, 2], [0, 3], [1, 3], [2, 4], [4, 5], [6, 5], [3, 4]],
+    hint: "Uma aresta A → B quer dizer 'A é pré-requisito de B'. A ordenação topológica é uma ordem válida de fazer as matérias.",
   },
   {
     key: "paralelo",
-    rotulo: "Muita coisa independente",
-    arestas: [[0, 1], [6, 3], [1, 2], [4, 5]],
-    dica: "Vários vértices com grau de entrada zero desde o começo: existem MUITAS ordens válidas, e a fila mostra os candidatos empatados.",
+    label: "Muita coisa independente",
+    edges: [[0, 1], [6, 3], [1, 2], [4, 5]],
+    hint: "Vários vértices com grau de entrada zero desde o começo: existem MUITAS ordens válidas, e a fila mostra os candidatos empatados.",
   },
   {
     key: "ciclo",
-    rotulo: "Com ciclo (impossível)",
-    arestas: [[0, 1], [1, 2], [2, 4], [4, 1], [0, 3], [6, 5]],
-    dica: "C1 → C2 → Est → C1 é um ciclo: cada um espera o outro. Não existe ordem válida, e o Kahn descobre isso sozinho.",
+    label: "Com ciclo (impossível)",
+    edges: [[0, 1], [1, 2], [2, 4], [4, 1], [0, 3], [6, 5]],
+    hint: "C1 → C2 → Est → C1 é um ciclo: cada um espera o outro. Não existe ordem válida, e o Kahn descobre isso sozinho.",
   },
 ];
 
 // Snippet autocontido de propósito: a lista de adjacência é construída aqui
 // dentro, no mesmo laço que conta o grau. Sem isso, o `adj[u]` lá embaixo
 // apareceria do nada e o exemplo não rodaria se alguém copiasse.
-const CODIGO = [
+//
+// É código PYTHON que o aluno lê na tela, em português: `grau`, `fila` e
+// `ordem` são conteúdo didático, não identificadores deste arquivo.
+const CODE = [
   "def kahn(vertices, arestas):",
   "    adj = {v: [] for v in vertices}",
   "    grau = {v: 0 for v in vertices}",
@@ -76,162 +83,142 @@ const CODIGO = [
   "        raise CicloDetectado()",
 ];
 
-type Passo = {
-  no: number;
-  aresta: [number, number] | null;
-  grau: number[];
-  fila: number[];
-  ordem: number[];
-  linha: number;
-  nota: string;
+type Step = {
+  node: number;
+  edge: [number, number] | null;
+  degree: number[];
+  queue: number[];
+  order: number[];
+  line: number;
+  note: string;
   ok?: boolean;
-  alerta?: boolean;
+  alert?: boolean;
 };
 
-function gerarPassos(arestas: [number, number][]): Passo[] {
-  const V = ROT.length;
-  const adj: number[][] = ROT.map(() => []);
-  const grau = new Array(V).fill(0);
-  for (const [u, v] of arestas) { adj[u].push(v); grau[v]++; }
+function generateSteps(edges: [number, number][]): Step[] {
+  const V = LABELS.length;
+  const adj: number[][] = LABELS.map(() => []);
+  const degree = new Array(V).fill(0);
+  for (const [u, v] of edges) { adj[u].push(v); degree[v]++; }
 
-  const fila: number[] = [];
-  const ordem: number[] = [];
-  const out: Passo[] = [];
-  const snap = (no: number, linha: number, nota: string, aresta: [number, number] | null = null, extra: Partial<Passo> = {}): Passo =>
-    ({ no, aresta, grau: [...grau], fila: [...fila], ordem: [...ordem], linha, nota, ...extra });
+  const queue: number[] = [];
+  const order: number[] = [];
+  const out: Step[] = [];
+  const snap = (node: number, line: number, note: string, edge: [number, number] | null = null, extra: Partial<Step> = {}): Step =>
+    ({ node, edge, degree: [...degree], queue: [...queue], order: [...order], line, note, ...extra });
 
   // Dois passos em vez de um: a preparação faz duas coisas distintas (contar os
   // graus e montar a fila inicial), e juntá-las obrigava a nota a descrever uma
   // linha enquanto o destaque acendia a outra.
   out.push(snap(-1, 5, `Conto quantas arestas CHEGAM em cada vértice: é o grau de entrada, ou seja, quantos pré-requisitos ainda faltam para ele poder acontecer.`));
-  for (let i = 0; i < V; i++) if (grau[i] === 0) fila.push(i);
-  out.push(snap(-1, 7, `Agora monto a fila inicial com quem já está em zero: ${fila.map((i) => ROT[i]).join(", ") || "ninguém"}. Esses não dependem de nada e podem começar imediatamente.`));
+  for (let i = 0; i < V; i++) if (degree[i] === 0) queue.push(i);
+  out.push(snap(-1, 7, `Agora monto a fila inicial com quem já está em zero: ${queue.map((i) => LABELS[i]).join(", ") || "ninguém"}. Esses não dependem de nada e podem começar imediatamente.`));
 
-  let guarda = 0;
-  while (fila.length && guarda++ < 300) {
-    const u = fila.shift() as number;
-    ordem.push(u);
-    // `linha` é ÍNDICE em CODIGO (0-based); o painel numera a partir de 1. O 10
+  let guard = 0;
+  while (queue.length && guard++ < 300) {
+    const u = queue.shift() as number;
+    order.push(u);
+    // `line` é ÍNDICE em CODE (0-based); o painel numera a partir de 1. O 10
     // aqui é `u = fila.popleft()`, que aparece como linha 11 na tela e é a ação
     // que a nota descreve primeiro.
-    out.push(snap(u, 10, `Tiro ${ROT[u]} da fila: o grau de entrada dele é zero, então nenhum pré-requisito está pendente. Ele entra na ordem final na posição ${ordem.length}.`));
+    out.push(snap(u, 10, `Tiro ${LABELS[u]} da fila: o grau de entrada dele é zero, então nenhum pré-requisito está pendente. Ele entra na ordem final na posição ${order.length}.`));
 
     for (const v of adj[u]) {
-      grau[v]--;
-      if (grau[v] === 0) {
-        fila.push(v);
-        out.push(snap(v, 15, `Como ${ROT[u]} saiu, o grau de ${ROT[v]} cai para 0: o último pré-requisito dele foi cumprido. Entra na fila.`, [u, v]));
+      degree[v]--;
+      if (degree[v] === 0) {
+        queue.push(v);
+        out.push(snap(v, 15, `Como ${LABELS[u]} saiu, o grau de ${LABELS[v]} cai para 0: o último pré-requisito dele foi cumprido. Entra na fila.`, [u, v]));
       } else {
-        out.push(snap(v, 13, `Grau de ${ROT[v]} cai para ${grau[v]}: ainda faltam ${grau[v]} ${grau[v] === 1 ? "pré-requisito" : "pré-requisitos"}, então ele continua esperando.`, [u, v]));
+        out.push(snap(v, 13, `Grau de ${LABELS[v]} cai para ${degree[v]}: ainda faltam ${degree[v]} ${degree[v] === 1 ? "pré-requisito" : "pré-requisitos"}, então ele continua esperando.`, [u, v]));
       }
     }
   }
 
-  if (ordem.length < V) {
-    const presos = ROT.map((_, i) => i).filter((i) => !ordem.includes(i));
+  if (order.length < V) {
+    const stuck = LABELS.map((_, i) => i).filter((i) => !order.includes(i));
     out.push(snap(-1, 17,
-      `A fila esvaziou com só ${ordem.length} de ${V} vértices na ordem. Os que sobraram (${presos.map((i) => ROT[i]).join(", ")}) têm grau de entrada maior que zero e ninguém mais para zerá-lo: eles dependem uns dos outros em ciclo. Não existe ordem válida, e o que sobrou É o ciclo.`,
-      null, { alerta: true }));
+      `A fila esvaziou com só ${order.length} de ${V} vértices na ordem. Os que sobraram (${stuck.map((i) => LABELS[i]).join(", ")}) têm grau de entrada maior que zero e ninguém mais para zerá-lo: eles dependem uns dos outros em ciclo. Não existe ordem válida, e o que sobrou É o ciclo.`,
+      null, { alert: true }));
   } else {
-    out.push(snap(-1, 16, `Ordem topológica completa: ${ordem.map((i) => ROT[i]).join(" → ")}. Toda aresta do grafo aponta da esquerda para a direita nessa lista, que é exatamente a definição.`, null, { ok: true }));
+    out.push(snap(-1, 16, `Ordem topológica completa: ${order.map((i) => LABELS[i]).join(" → ")}. Toda aresta do grafo aponta da esquerda para a direita nessa lista, que é exatamente a definição.`, null, { ok: true }));
   }
   return out;
 }
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// A marcha inicial é a da peça, não a do hook: ela sempre abriu em 1.5x.
+const INITIAL_SPEED = 4;
 
 export function TopoSortVisualizer() {
   const [presetKey, setPresetKey] = useState("curso");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  useEffect(() => setMounted(true), []);
-  const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.arestas), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const preset = useMemo(() => PRESETS.find((pr) => pr.key === presetKey) ?? PRESETS[0], [presetKey]);
+  const steps = useMemo(() => generateSteps(preset.edges), [preset]);
 
-  const parar = useCallback(() => { if (timer.current) { clearInterval(timer.current); timer.current = null; } }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => { if (tocando && idx >= total - 1) setTocando(false); }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · Kahn, com o grau de entrada à vista",
+    total: steps.length,
+    initialSpeed: INITIAL_SPEED,
+    // O preset é a ÚNICA entrada do aluno, e é o que muda a altura: a dica cai
+    // de duas linhas para uma entre presets (37px contra 18 no fluxo do artigo).
+    // O desenho não entra porque as posições são constantes, e as três fichas
+    // auxiliares medem 34px em todos os passos dos três presets. O passo, que é
+    // o que mais mexe na nota, o hook não enxerga de propósito (contrato §9).
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => { parar(); setTocando(false); setPasso(0); };
-  const saiu = useMemo(() => new Set(p.ordem), [p.ordem]);
-  const naFila = useMemo(() => new Set(p.fila), [p.fila]);
-  const pct = Math.round(((idx + 1) / total) * 100);
+  const idx = viz.step;
+  const p = steps[idx];
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · Kahn, com o grau de entrada à vista</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">passo {idx + 1} de {total}</span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>{expanded ? "✕ Fechar" : "⤢ Expandir"}</button>
-        </div>
-      </div>
+  const pickPreset = (key: string) => { viz.reset(); setPresetKey(key); };
 
-      <div className="viz-body">
+  const done = useMemo(() => new Set(p.order), [p.order]);
+  const inQueue = useMemo(() => new Set(p.queue), [p.queue]);
+
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "ciclo" ? " na" : ""}`} onClick={() => { reiniciar(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "ciclo" ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="gr-split">
           <div className="tt-arv-wrap" style={{ margin: 0 }}>
             <svg className="tt-arv" width={400} height={175} viewBox="0 0 400 175" role="img"
-              aria-label={`Grafo dirigido de pré-requisitos. ${p.nota}`}>
+              aria-label={`Grafo dirigido de pré-requisitos. ${p.note}`}>
               <defs>
                 <marker id="seta-topo" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
                   <path d="M 0 0 L 8 4 L 0 8 z" fill="rgba(59,130,246,0.75)" />
                 </marker>
               </defs>
-              {preset.arestas.map(([u, v]) => {
-                const ativa = p.aresta && p.aresta[0] === u && p.aresta[1] === v;
+              {preset.edges.map(([u, v]) => {
+                const active = p.edge && p.edge[0] === u && p.edge[1] === v;
                 const dx = POS[v].x - POS[u].x, dy = POS[v].y - POS[u].y;
                 const d = Math.sqrt(dx * dx + dy * dy) || 1, r = 22;
                 return (
-                  <line key={`${u}-${v}`} className={`tt-aresta${ativa ? " ativa" : saiu.has(u) ? " on" : ""}`}
+                  <line key={`${u}-${v}`} className={`tt-aresta${active ? " ativa" : done.has(u) ? " on" : ""}`}
                     x1={POS[u].x + (dx / d) * r} y1={POS[u].y + (dy / d) * r}
                     x2={POS[v].x - (dx / d) * r} y2={POS[v].y - (dy / d) * r}
                     markerEnd="url(#seta-topo)" />
                 );
               })}
-              {CURTO.map((r, i) => {
+              {SHORT.map((s, i) => {
                 const cls = ["tt-no", "topo-no"];
-                if (i === p.no) cls.push("on");
-                else if (saiu.has(i)) cls.push("saiu");
-                else if (naFila.has(i)) cls.push("aux");
+                if (i === p.node) cls.push("on");
+                else if (done.has(i)) cls.push("saiu");
+                else if (inQueue.has(i)) cls.push("aux");
                 return (
-                  <g key={r} className={cls.join(" ")}>
+                  <g key={s} className={cls.join(" ")}>
                     <circle cx={POS[i].x} cy={POS[i].y} r={20} />
-                    <text x={POS[i].x} y={POS[i].y + 1} textAnchor="middle">{r}</text>
+                    <text x={POS[i].x} y={POS[i].y + 1} textAnchor="middle">{s}</text>
                     <text className="topo-grau" x={POS[i].x} y={POS[i].y + 13} textAnchor="middle">
-                      {saiu.has(i) ? "✓" : p.grau[i]}
+                      {done.has(i) ? "✓" : p.degree[i]}
                     </text>
                   </g>
                 );
@@ -243,9 +230,9 @@ export function TopoSortVisualizer() {
             <div className="tt-painel">
               <div className="tt-painel-tit">Grau de entrada <em>pré-requisitos que faltam</em></div>
               <div className="gr-dists">
-                {ROT.map((r, i) => (
-                  <span key={r} className={`gr-dist-item${saiu.has(i) ? " fechado" : p.grau[i] === 0 ? "" : " off"}`}>
-                    <i>{CURTO[i]}</i>{saiu.has(i) ? "✓" : p.grau[i]}
+                {LABELS.map((r, i) => (
+                  <span key={r} className={`gr-dist-item${done.has(i) ? " fechado" : p.degree[i] === 0 ? "" : " off"}`}>
+                    <i>{SHORT[i]}</i>{done.has(i) ? "✓" : p.degree[i]}
                   </span>
                 ))}
               </div>
@@ -253,55 +240,44 @@ export function TopoSortVisualizer() {
             <div className="tt-painel">
               <div className="tt-painel-tit">Fila <em>grau zero, prontos para sair</em></div>
               <div className="tt-aux">
-                {p.fila.length === 0 ? <span className="tt-vazio">vazia</span> : p.fila.map((v, i) => (
-                  <span key={`${v}-${i}`} className={`tt-aux-item${i === 0 ? " topo" : ""}`}>{CURTO[v]}</span>
+                {p.queue.length === 0 ? <span className="tt-vazio">vazia</span> : p.queue.map((v, i) => (
+                  <span key={`${v}-${i}`} className={`tt-aux-item${i === 0 ? " topo" : ""}`}>{SHORT[v]}</span>
                 ))}
               </div>
             </div>
             <div className="tt-painel">
               <div className="tt-painel-tit">Ordem final</div>
               <div className="tt-saida">
-                {p.ordem.length === 0 ? <span className="tt-vazio">nada ainda</span> : p.ordem.map((v, i) => (
-                  <span key={v} className={`tt-saida-item${i === p.ordem.length - 1 ? " novo" : ""}`}>{CURTO[v]}</span>
+                {p.order.length === 0 ? <span className="tt-vazio">nada ainda</span> : p.order.map((v, i) => (
+                  <span key={v} className={`tt-saida-item${i === p.order.length - 1 ? " novo" : ""}`}>{SHORT[v]}</span>
                 ))}
               </div>
             </div>
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : p.alerta ? " invalid" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : p.alert ? " invalid" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">kahn.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
-              ))}
+          {/* O `.viz-code-slot` é o que recolhe a ALTURA: zerar a trilha da
+              coluna sozinha tira só a largura (contrato §7). */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">kahn.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}><span className="ln">{i + 1}</span>{txt}</div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            <div className="viz-var"><span className="viz-var-name">na ordem</span><span className="viz-var-val best">{p.ordem.length} de {ROT.length}</span></div>
-            <div className="viz-var"><span className="viz-var-name">na fila</span><span className="viz-var-val">{p.fila.length}</span></div>
-            <div className="viz-var"><span className="viz-var-name">arestas</span><span className="viz-var-val">{preset.arestas.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">na ordem</span><span className="viz-var-val best">{p.order.length} de {LABELS.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">na fila</span><span className="viz-var-val">{p.queue.length}</span></div>
+            <div className="viz-var"><span className="viz-var-name">arestas</span><span className="viz-var-val">{preset.edges.length}</span></div>
           </div>
         </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>↺</button>
-          <button className="viz-btn" disabled={idx === 0} onClick={() => { parar(); setTocando(false); setPasso(Math.max(0, idx - 1)); }}>‹ Anterior</button>
-          <button className="viz-play" onClick={() => { if (tocando) { setTocando(false); return; } setPasso(idx >= total - 1 ? 0 : idx); setTocando(true); }}>
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button className="viz-btn" disabled={idx === total - 1} onClick={() => { parar(); setTocando(false); setPasso(Math.min(idx + 1, total - 1)); }}>Próximo ›</button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress"><div className="viz-progress-fill" style={{ width: `${pct}%` }} /></div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Quando a fila tem mais de um vértice ao mesmo tempo, existe mais de uma ordem válida:
@@ -309,14 +285,8 @@ export function TopoSortVisualizer() {
           o ciclo. Rode o terceiro preset até o fim.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>{viz}</div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/tests/viz-a-star.spec.ts
+++ b/tests/viz-a-star.spec.ts
@@ -1,0 +1,320 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa do visualizador de A*.
+//
+// Os números que decidiram o escopo, medidos com `document.fonts.ready`
+// cumprido, a animação parada e andando os 514 estados (3 modos × 3 presets,
+// de 13 a 119 passos cada) nas três réguas:
+//
+//   · no artigo (orçamento 816px a 1512x900): 1084–1123px antes, 766–805
+//     depois. A peça passava do orçamento em TODOS os 514 estados; recolhida,
+//     cabe em todos. Forçada aberta ela volta a 1114px — 10px a mais que os
+//     1104 de antes, que é o custo do `.viz-foot` (contrato §9);
+//   · no painel, quem rolava era a FIGURA (323px de sobra a 1512x900, 523 a
+//     1440x700, 623 a 1440x600), levando cabeçalho e controles junto: rolando
+//     até o fim o cabeçalho subia −323, −523 e −623px, e o `▶ Rodar` era
+//     desenhado 222, 422 e 522px ABAIXO do pé visível da janela. Depois quem
+//     rola é o miolo (0, 41 e 136px), o cabeçalho anda 0px e o `▶ Rodar` fica
+//     131, 52 e 49px DENTRO da janela.
+//
+// O eixo da altura desta peça NÃO é a grade. A grade é gerada por código, mas
+// as três dimensões dela são constantes deste arquivo (`COLS = 14`,
+// `ROWS = 9`, `CELL = 26`), então o SVG mede 366x236 — igual ao `viewBox` — nos
+// 514 estados e nas três janelas. Quem gera as linhas é a PROSA: a dica
+// (18 ou 37px, conforme o preset) e a nota (22 ou 42px, conforme o passo).
+// Por isso o passo do pico é onde a nota quebra em duas linhas, e no painel
+// isso acontece num único estado dos 514: o ÚLTIMO passo do modo Guloso.
+
+const SLACK = 8;
+const GULOSO = "Guloso: f = h";
+const ABERTO = "Campo aberto";
+const MURO = "Um muro no meio";
+
+function figura(page: Page): Locator {
+  return page.locator("article figure.viz");
+}
+
+function painel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+/** O cabeçalho tem dois `.viz-step`: o contador da peça e o do hook. */
+function passo(alvo: Locator): Locator {
+  return alvo.locator(".viz-step", { hasText: "passo" });
+}
+
+function expandidas(alvo: Locator): Locator {
+  return alvo.locator(".viz-step", { hasText: "expandidas" });
+}
+
+async function abrir(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  expect(page.viewportSize(), `a janela pedida foi ${w}x${h}`).toEqual({ width: w, height: h });
+  await page.goto("/topico/a-star/");
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+}
+
+async function andarAte(alvo: Locator, n: number) {
+  const proximo = alvo.getByRole("button", { name: "Próximo ›" });
+  for (let i = 1; i < n; i++) await proximo.click();
+}
+
+/**
+ * Altura que PAROU. Três leituras iguais não bastam nesta peça: a linha do grid
+ * vale `max(bloco, painel de variáveis)`, então enquanto o bloco cresce por
+ * baixo dos 172px do painel irmão a figura não se mexe. Medido: 13 quadros
+ * idênticos em 860px numa transição cujo valor final é 1114. Por isso a
+ * estabilidade só conta depois de a transição de 0,32s ter passado.
+ */
+async function alturaEstavel(alvo: Locator): Promise<number> {
+  const page = alvo.page();
+  await page.waitForTimeout(450);
+  let iguais = 0;
+  let ultima = -1;
+  for (let i = 0; i < 60; i++) {
+    const h = Math.round((await alvo.boundingBox())!.height);
+    if (h === ultima) {
+      if (++iguais >= 2) return h;
+    } else {
+      iguais = 0;
+      ultima = h;
+    }
+    await page.waitForTimeout(50);
+  }
+  return ultima;
+}
+
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const raw = getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h");
+    return window.innerHeight - (parseFloat(raw) || 60) - 24;
+  });
+}
+
+test.describe("a-star · casca adaptativa", () => {
+  test("no painel o miolo rola sozinho: cabeçalho e ▶ Rodar não saem do lugar", async ({ page }) => {
+    await abrir(page, 1440, 600);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: GULOSO }).click();
+    await fig.getByRole("button", { name: ABERTO }).click();
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(pan).toBeVisible();
+
+    // O passo do PICO, e aqui ele é o último: a nota do guloso que chegou ao
+    // alvo é a única das 514 que quebra em duas linhas dentro do painel.
+    await andarAte(pan, 13);
+    await expect(passo(pan)).toHaveText("passo 13 de 13");
+    await alturaEstavel(pan);
+
+    // O `click()` do Playwright rola o contêiner para alcançar o alvo, então a
+    // leitura de referência sai com as duas rolagens zeradas.
+    const antes = await pan.evaluate((f) => {
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      f.scrollTop = 0;
+      body.scrollTop = 0;
+      const r = f.getBoundingClientRect();
+      return {
+        sobraMiolo: body.scrollHeight - body.clientHeight,
+        sobraFigura: f.scrollHeight - f.clientHeight,
+        cabeca: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodarBase: Math.round(f.querySelector(".viz-play")!.getBoundingClientRect().bottom),
+      };
+    });
+
+    // Premissa: existe o que rolar, e quem rola é o miolo. Sem as duas, a
+    // quebra que devolve a rolagem para a figura passa verde.
+    expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(SLACK);
+    expect(antes.sobraFigura, "quem rola é o miolo, não a figura").toBeLessThanOrEqual(SLACK);
+
+    const depois = await pan.evaluate((f) => {
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      body.scrollTop = body.scrollHeight;
+      const r = f.getBoundingClientRect();
+      return {
+        mioloRolou: Math.round(body.scrollTop),
+        figuraRolou: Math.round(f.scrollTop),
+        cabeca: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodarBase: Math.round(f.querySelector(".viz-play")!.getBoundingClientRect().bottom),
+        janela: window.innerHeight,
+      };
+    });
+
+    expect(depois.mioloRolou, "o miolo rolou de verdade").toBeGreaterThan(0);
+    expect(depois.figuraRolou, "a figura inteira não rola").toBe(0);
+    expect(depois.cabeca, "o cabeçalho não se mexeu").toBe(antes.cabeca);
+    expect(depois.cabeca, "o cabeçalho está colado no topo da figura").toBeLessThanOrEqual(2);
+    expect(depois.rodarBase, "os controles não se mexeram").toBe(antes.rodarBase);
+    expect(depois.rodarBase, "o ▶ Rodar continua dentro da janela").toBeLessThanOrEqual(depois.janela);
+    // Rótulo além de posição: botão no lugar certo dizendo outra coisa ensina
+    // errado do mesmo jeito.
+    await expect(pan.locator(".viz-play")).toHaveText("▶ Rodar");
+  });
+
+  test("a 1512x900 a peça não caberia, então o código vem recolhido e o botão diz Mostrar código", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    const botao = fig.getByRole("button", { name: /código/ });
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+
+    const alturaCodigo = Math.round(
+      await fig.locator(".viz-code").evaluate((el) => el.getBoundingClientRect().height)
+    );
+    // Zerar a trilha da COLUNA tira a largura e não a altura: quem fecha a linha
+    // é o `.viz-code-slot` (grid 1fr→0fr). Sem ele o bloco continua com os 408px
+    // inteiros e a peça não encolhe um pixel.
+    expect(alturaCodigo, "o bloco recolhido não pode ocupar altura").toBeLessThanOrEqual(2);
+
+    const altura = await alturaEstavel(fig);
+    expect(altura, "recolhida, a peça cabe no orçamento da janela").toBeLessThanOrEqual(await orcamento(page));
+  });
+
+  test("numa janela alta o código já vem aberto, com o rótulo Ocultar código", async ({ page }) => {
+    await abrir(page, 1512, 1400);
+    const fig = figura(page);
+    const botao = fig.getByRole("button", { name: /código/ });
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-code-head")).toHaveText("a_estrela.py");
+
+    const altura = await alturaEstavel(fig);
+    expect(altura, "com esta janela a peça cabe aberta — é por isso que ela abre").toBeLessThanOrEqual(
+      await orcamento(page)
+    );
+  });
+
+  test("a escolha do aluno sobrevive à troca de preset, que é o que dispara medição nova", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    const botao = fig.getByRole("button", { name: /código/ });
+    await expect(botao).toHaveText("Mostrar código");
+
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+
+    // "Campo aberto" muda `measureOn` E a altura: a dica dele ocupa duas linhas
+    // em vez de uma (37px contra 18). Aberta, a peça passa do orçamento, ou
+    // seja, a medição QUER recolher — é isso que faz o teste valer.
+    await fig.getByRole("button", { name: ABERTO }).click();
+    await expect(fig.locator(".tt-legenda-arvore")).toContainText("Sem obstáculo nenhum");
+    await expect(passo(fig)).toHaveText("passo 1 de 13");
+
+    const alta = await alturaEstavel(fig);
+    expect(alta, "aberta, a peça passa do orçamento — a medição discordaria do aluno").toBeGreaterThan(
+      await orcamento(page)
+    );
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(botao).toHaveText("Ocultar código");
+  });
+
+  test("as setas andam a animação dentro do painel", async ({ page }) => {
+    await abrir(page, 1440, 700);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: ABERTO }).click();
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(passo(pan)).toHaveText("passo 1 de 13");
+
+    // Duas vezes na MESMA direção: um par de ações inversas devolve a peça ao
+    // estado de origem e fica verde com a quebra aplicada.
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await expect(passo(pan)).toHaveText("passo 3 de 13");
+
+    await page.keyboard.press("Space");
+    await expect(pan.locator(".viz-play")).toHaveText("❚❚ Pausar");
+  });
+
+  test("com o cursor no controle de velocidade, a seta é do slider e não do passo", async ({ page }) => {
+    await abrir(page, 1440, 700);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: ABERTO }).click();
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(passo(pan)).toHaveText("passo 1 de 13");
+
+    await pan.locator(".viz-speed input[type=range]").focus();
+    await page.keyboard.press("ArrowLeft");
+
+    await expect(pan.locator(".viz-speed .val"), "a seta mexeu na marcha, que é de quem estava em foco").toHaveText("1x");
+    await expect(passo(pan), "e não andou o passo").toHaveText("passo 1 de 13");
+  });
+
+  test("a marcha inicial da peça é 1.5x, não o 1x padrão do hook", async ({ page }) => {
+    await abrir(page, 1440, 700);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(pan.locator(".viz-speed .val")).toHaveText("1.5x");
+    await expect(pan.locator(".viz-speed input[type=range]")).toHaveValue("4");
+  });
+
+  test("a grade tem altura constante: mesmo tamanho do viewBox nos três presets e nos três modos", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    const svg = fig.locator("svg.tt-arv");
+    const ler = () =>
+      svg.evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        const vb = (el.getAttribute("viewBox") || "").split(/\s+/).map(Number);
+        return { w: Math.round(r.width), h: Math.round(r.height), vw: vb[2], vh: vb[3] };
+      });
+
+    const base = await ler();
+    // Teto de altura (§7) só devolve VAZIO, e só há vazio quando o renderizado é
+    // maior que o natural. Aqui são iguais, então um `max-height` encolheria o
+    // desenho pelo `preserveAspectRatio`. É por isso que este tópico não escreveu
+    // uma linha de CSS.
+    expect(base.w, "o desenho sai no tamanho natural do viewBox").toBe(base.vw);
+    expect(base.h).toBe(base.vh);
+
+    // E a grade não é o eixo da altura: ela é gerada por código, mas as três
+    // dimensões vêm de constantes do arquivo. Nenhum controle do aluno a move.
+    for (const preset of [MURO, "Labirinto", ABERTO]) {
+      for (const modo of ["A*: f = g + h", "Dijkstra: f = g", GULOSO]) {
+        await fig.getByRole("button", { name: modo }).click();
+        await fig.getByRole("button", { name: preset }).click();
+        await expect(fig.getByRole("button", { name: preset })).toHaveAttribute("aria-pressed", "true");
+        const m = await ler();
+        expect(m, `${modo} / ${preset} desenha a mesma grade`).toEqual(base);
+      }
+    }
+  });
+
+  test("o contador do cabeçalho é a expansão em curso, e no fim bate com o que o painel credita ao modo", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: GULOSO }).click();
+    await fig.getByRole("button", { name: MURO }).click();
+    await expect(passo(fig)).toHaveText("passo 1 de 27");
+
+    // O cartão do modo escolhido, lido pelo destaque — rótulo e valor juntos, no
+    // mesmo cartão: o guarda de idioma compara o CONJUNTO de textos e não onde
+    // cada um aparece, então trocar dois campos de lugar passa verde por lá.
+    // `has:` é resolvido DENTRO de cada `.viz-var`, então o locator interno tem
+    // que sair de `page` — um encadeado a partir de `fig` não casa com nada.
+    const escolhido = fig.locator(".viz-var").filter({ has: page.locator(".viz-var-val.best") });
+    await expect(escolhido.locator(".viz-var-name")).toHaveText("Guloso");
+    const valor = await escolhido.locator(".viz-var-val").innerText();
+    const casou = /^(\d+) células · custo (\d+)$/.exec(valor.trim());
+    expect(casou, `o cartão do modo diz "N células · custo C", e veio "${valor}"`).not.toBeNull();
+    const totalDoModo = Number(casou![1]);
+    expect(totalDoModo, "o guloso expande alguma coisa neste mapa").toBeGreaterThan(1);
+
+    // No passo 1 o cabeçalho conta o que já expandiu, que ainda é menos que o
+    // total — sem isto, um cabeçalho que copiasse o total passaria nos dois.
+    const inicio = Number((await expandidas(fig).innerText()).replace(/\D+/g, ""));
+    expect(inicio, "no primeiro passo ainda não se expandiu tudo").toBeLessThan(totalDoModo);
+
+    await andarAte(fig, 27);
+    await expect(passo(fig)).toHaveText("passo 27 de 27");
+    await expect(
+      expandidas(fig),
+      "no fim o cabeçalho conta as mesmas expansões que o painel credita ao modo"
+    ).toHaveText(`${totalDoModo} expandidas`);
+  });
+});

--- a/tests/viz-a-star.spec.ts
+++ b/tests/viz-a-star.spec.ts
@@ -312,9 +312,13 @@ test.describe("a-star · casca adaptativa", () => {
 
     await andarAte(fig, 27);
     await expect(passo(fig)).toHaveText("passo 27 de 27");
+    // O `·` do fim é do CHILDREN, não do hook: com linha do tempo os dois viram
+    // `.viz-step` irmãos separados só pelo gap, e sem ele o cabeçalho perde o
+    // separador que o componente tinha (contrato §9). Asserir o texto exato faz
+    // este teste guardar as duas coisas — a contagem e o separador.
     await expect(
       expandidas(fig),
-      "no fim o cabeçalho conta as mesmas expansões que o painel credita ao modo"
-    ).toHaveText(`${totalDoModo} expandidas`);
+      "no fim o cabeçalho conta as mesmas expansões que o painel credita ao modo, com o separador"
+    ).toHaveText(`${totalDoModo} expandidas ·`);
   });
 });

--- a/tests/viz-bellman-ford.spec.ts
+++ b/tests/viz-bellman-ford.spec.ts
@@ -1,0 +1,304 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// A casca adaptativa do BellmanFordVisualizer.
+//
+// Todo número aqui foi MEDIDO no build antes de virar asserção, e o que dá para
+// escrever como invariante entre dois lugares da tela está escrito assim. O
+// motivo é concreto: "são V-1 = 4 rodadas" é o que todo mundo sabe sobre
+// Bellman-Ford, e nesta peça dois dos três presets param na rodada **2**, por
+// early exit. Um teste com o 4 escrito na mão passaria verde ensinando errado.
+
+const ARTIGO = "article figure.viz-fit";
+const PAINEL = ".viz-overlay-fit figure.viz-fit";
+
+/** Folga de subpixel, o mesmo valor que o hook usa para decidir. */
+const SLACK = 8;
+
+async function abrirTopico(page: Page) {
+  await page.goto("/topico/bellman-ford/");
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator(ARTIGO).scrollIntoViewIfNeeded();
+  // A decisão da casca roda em dois passes de layout depois das fontes; sem
+  // esperar por ela, `data-codigo` ainda é o "on" do primeiro render.
+  await expect(page.locator(ARTIGO)).toHaveAttribute("data-anim", "on");
+}
+
+/** Altura da figura, o orçamento da janela e o estado do bloco recolhível. */
+const LER = (sel: string) => {
+  const f = document.querySelector(sel) as HTMLElement;
+  const code = f.querySelector(".viz-code") as HTMLElement;
+  const hh = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+  return {
+    figura: Math.round(f.getBoundingClientRect().height),
+    orcamento: Math.round(window.innerHeight - hh - 24),
+    codigo: f.getAttribute("data-codigo"),
+    alturaCodigo: Math.round(code.getBoundingClientRect().height),
+  };
+};
+
+const passoAtual = (raiz: string) => {
+  const txt = [...document.querySelectorAll(`${raiz} .viz-step`)].map((e) => e.textContent).join(" ");
+  const m = txt.match(/passo (\d+) de (\d+)/);
+  if (!m) throw new Error(`o contador de passo nao casou: "${txt}"`);
+  return { passo: parseInt(m[1], 10), total: parseInt(m[2], 10) };
+};
+
+test.describe("bellman-ford", () => {
+  // ---------------------------------------------------------------- camada 1
+  test.describe("camada 1", () => {
+    test.use({ viewport: { width: 1440, height: 600 } });
+
+    test("cabecalho e rodape ficam parados quando o miolo rola ate o fim", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+
+      // O preset do ciclo negativo é o que tem a nota mais longa (medido: 63px
+      // contra 22 no mínimo), e o pico de altura dele é o ÚLTIMO passo — o da
+      // rodada extra. É lá que o miolo tem o que rolar.
+      await page.getByRole("button", { name: "Ciclo negativo (detecta)", exact: true }).click();
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+
+      const proximo = painel.getByRole("button", { name: "Próximo ›" });
+      const { total } = await page.evaluate(passoAtual, PAINEL);
+      for (let i = 1; i < total; i++) await proximo.click();
+      await expect(painel.locator(".viz-step").last()).toHaveText(`passo ${total} de ${total}`);
+
+      // PRÉ-CONDIÇÃO: sem sobra para rolar, o teste inteiro é decoração verde.
+      const antes = await page.evaluate((sel) => {
+        const f = document.querySelector(sel) as HTMLElement;
+        const b = f.querySelector(".viz-body") as HTMLElement;
+        // O click() do Playwright já rolou o contêiner para alcançar o botão.
+        b.scrollTop = 0;
+        return {
+          sobra: b.scrollHeight - b.clientHeight,
+          headTop: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - f.getBoundingClientRect().top),
+          footBottom: Math.round(f.getBoundingClientRect().bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+        };
+      }, PAINEL);
+      expect(antes.sobra, "o miolo precisa ter o que rolar").toBeGreaterThan(SLACK);
+
+      const depois = await page.evaluate((sel) => {
+        const f = document.querySelector(sel) as HTMLElement;
+        const b = f.querySelector(".viz-body") as HTMLElement;
+        b.scrollTop = b.scrollHeight;
+        const play = f.querySelector(".viz-play") as HTMLElement;
+        return {
+          bodyScrollTop: Math.round(b.scrollTop),
+          figScrollTop: Math.round(f.scrollTop),
+          headTop: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - f.getBoundingClientRect().top),
+          footBottom: Math.round(f.getBoundingClientRect().bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+          playAbaixoDaJanela: Math.round(play.getBoundingClientRect().bottom - window.innerHeight),
+        };
+      }, PAINEL);
+
+      // Quem rolou foi o MIOLO, e não a figura: sem esta dupla o teste aprova a
+      // quebra que devolve a rolagem para a figura inteira.
+      expect(depois.bodyScrollTop, "o miolo tem que ser quem rola").toBeGreaterThan(0);
+      expect(depois.figScrollTop, "a figura nao pode rolar").toBe(0);
+      expect(depois.headTop, "o cabecalho andou junto com o miolo").toBe(antes.headTop);
+      expect(depois.footBottom, "o rodape andou junto com o miolo").toBe(antes.footBottom);
+      expect(depois.playAbaixoDaJanela, "o ▶ Rodar caiu para fora da janela").toBeLessThanOrEqual(0);
+
+      // E o botão continua dizendo o que faz, com a animação parada.
+      await expect(painel.locator(".viz-play")).toHaveText("▶ Rodar");
+    });
+  });
+
+  // ------------------------------------------------- camada 3: tela baixa
+  test.describe("tela baixa", () => {
+    test.use({ viewport: { width: 1440, height: 700 } });
+
+    test("o codigo vem recolhido e o botao diz o que some", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 700 });
+      await abrirTopico(page);
+
+      const m = await page.evaluate(LER, ARTIGO);
+      expect(m.codigo, "a medicao devia ter recolhido o codigo").toBe("off");
+      // Recolher a COLUNA tira largura, não altura: é o `.viz-code-slot` que
+      // fecha a linha do grid. Medido: 2px fechado contra 383px aberto.
+      expect(m.alturaCodigo, "o bloco continua ocupando altura").toBeLessThan(SLACK);
+
+      await expect(page.locator(`${ARTIGO} .viz-toggle-codigo`)).toHaveText("Mostrar código");
+      await expect(page.locator(`${ARTIGO} .viz-code`)).toHaveAttribute("aria-hidden", "true");
+    });
+
+    test("a escolha do aluno vence a medicao na troca de preset", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 700 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Mostrar código");
+      await artigo.locator(".viz-toggle-codigo").click();
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+      await expect(artigo.locator(".viz-code")).not.toHaveAttribute("aria-hidden", "true");
+
+      // O preset É a entrada da medição (`measureOn: [presetKey]`), e ele muda a
+      // dica e a nota — que é onde a altura desta peça mora. Sem trocar um
+      // estado que a medição enxerga, a escolha "sobrevive" sem nada ameaçá-la.
+      const dicaAntes = await artigo.locator(".tt-legenda-arvore").textContent();
+      await page.getByRole("button", { name: "Ciclo negativo (detecta)", exact: true }).click();
+      await expect(artigo.locator(".tt-legenda-arvore")).not.toHaveText(dicaAntes!);
+
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+      const m = await page.evaluate(LER, ARTIGO);
+      expect(m.codigo, "a medicao desfez a escolha do aluno").toBe("on");
+      // E a medição discordava mesmo: com o código aberto a peça passa do
+      // orçamento desta janela. É por isso que o miolo rola no expandido.
+      expect(m.figura, "a medicao nem queria recolher aqui").toBeGreaterThan(m.orcamento);
+    });
+  });
+
+  // -------------------------------------------------- camada 3: tela alta
+  test.describe("tela alta", () => {
+    test.use({ viewport: { width: 1512, height: 1200 } });
+
+    test("o codigo ja vem aberto quando cabe", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 1200 });
+      await abrirTopico(page);
+
+      const m = await page.evaluate(LER, ARTIGO);
+      expect(m.codigo, "a medicao recolheu o codigo numa janela onde ele cabe").toBe("on");
+      expect(m.alturaCodigo, "o bloco esta aberto mas sem altura").toBeGreaterThan(300);
+      expect(m.figura, "a peca aberta nao cabia no orcamento desta janela").toBeLessThanOrEqual(m.orcamento);
+      await expect(page.locator(`${ARTIGO} .viz-toggle-codigo`)).toHaveText("Ocultar código");
+    });
+  });
+
+  // ----------------------------------------- camada 3: o que ela devolve
+  test.describe("orcamento", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("recolher o codigo e o que faz a peca caber no artigo", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+
+      const fechado = await page.evaluate(LER, ARTIGO);
+      expect(fechado.codigo).toBe("off");
+      expect(fechado.figura, "recolhida, a peca ainda passa do orcamento").toBeLessThanOrEqual(fechado.orcamento);
+
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Mostrar código");
+      await artigo.locator(".viz-toggle-codigo").click();
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+      // A transição da casca dura 0,32s: sem esperar o valor ESTABILIZAR, a
+      // leitura pega a altura do meio do caminho.
+      await expect
+        .poll(async () => (await page.evaluate(LER, ARTIGO)).alturaCodigo)
+        .toBeGreaterThan(300);
+
+      const aberto = await page.evaluate(LER, ARTIGO);
+      expect(aberto.figura, "abrir o codigo devia estourar o orcamento").toBeGreaterThan(aberto.orcamento);
+      expect(aberto.figura - fechado.figura, "o bloco recolhivel devolve pouca altura").toBeGreaterThan(300);
+    });
+  });
+
+  // ------------------------------------------------------- teclado e marcha
+  test.describe("teclado", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("as setas andam o passo e o slider de velocidade nao perde a seta", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+
+      // A marcha desta peça é a dela (`initialSpeed: 4` sobre os SPEEDS
+      // próprios). Já se perdeu num rename sem nenhum teste pegar.
+      await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+
+      // UMA ação por asserção: um par de ações inversas volta ao estado de
+      // origem e fica verde mesmo com a tecla sendo roubada.
+      const inicio = await page.evaluate(passoAtual, PAINEL);
+      await painel.locator(".viz-speed input[type=range]").focus();
+      await page.keyboard.press("ArrowRight");
+      await expect(painel.locator(".viz-speed .val"), "a seta nao chegou ao slider").toHaveText("2x");
+      expect((await page.evaluate(passoAtual, PAINEL)).passo, "a casca roubou a seta de quem edita").toBe(inicio.passo);
+
+      // Fora do campo, a mesma tecla é da animação.
+      await painel.locator(".viz-head-title").click();
+      await page.keyboard.press("ArrowRight");
+      await expect(painel.locator(".viz-step").last()).toHaveText(`passo ${inicio.passo + 1} de ${inicio.total}`);
+
+      // Espaço roda e pausa, e o rótulo do botão diz qual dos dois.
+      await page.keyboard.press(" ");
+      await expect(painel.locator(".viz-play")).toHaveText("❚❚ Pausar");
+      await page.keyboard.press(" ");
+      await expect(painel.locator(".viz-play")).toHaveText("▶ Rodar");
+    });
+  });
+
+  // ------------------------------------------------- o que a peca ENSINA
+  test.describe("rodadas", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("a tabela de rodadas bate com o contador de rodada, e o early exit aparece", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+      const proximo = artigo.getByRole("button", { name: "Próximo ›" });
+
+      const { total } = await page.evaluate(passoAtual, ARTIGO);
+      let fins = 0;
+      let ultimaRodadaFechada = 0;
+
+      for (let i = 1; i <= total; i++) {
+        const tela = await page.evaluate((sel) => {
+          const f = document.querySelector(sel) as HTMLElement;
+          const cab = [...f.querySelectorAll(".viz-step")].map((e) => e.textContent).join(" ");
+          return {
+            nota: f.querySelector(".viz-note")!.textContent!,
+            rodadaCab: parseInt(cab.match(/rodada (\d+)/)![1], 10),
+            varRodada: f.querySelector(".viz-var .viz-var-val")!.textContent!,
+            linhas: [...f.querySelectorAll(".bf-tab tbody tr > th")].map((e) => e.textContent!),
+          };
+        }, ARTIGO);
+
+        // O painel de variáveis e o cabeçalho contam a MESMA rodada. Invariante
+        // entre dois lugares da tela, sem nenhum número escrito na mão.
+        expect(tela.varRodada, `passo ${i}: cabecalho e painel discordam da rodada`).toMatch(
+          new RegExp(`^${tela.rodadaCab} de `)
+        );
+
+        const fim = tela.nota.match(/^Fim da rodada (\d+)/);
+        if (fim) {
+          fins++;
+          const n = parseInt(fim[1], 10);
+          expect(tela.rodadaCab, `passo ${i}: a nota fecha a rodada ${n} e o cabecalho diz outra`).toBe(n);
+          // A tabela guarda o histórico: uma linha "início", uma por rodada
+          // fechada, e a linha "agora". A última numerada é a rodada da nota.
+          const numeradas = tela.linhas.filter((t) => /^\d+$/.test(t));
+          expect(numeradas.at(-1), `passo ${i}: a ultima linha da tabela nao e a rodada ${n}`).toBe(String(n));
+          expect(numeradas.length, `passo ${i}: a tabela tem linha demais ou de menos`).toBe(n);
+          expect(tela.linhas[0]).toBe("início");
+          expect(tela.linhas.at(-1)).toBe("agora");
+          ultimaRodadaFechada = n;
+        }
+
+        if (i < total) await proximo.click();
+      }
+
+      // O último passo é sempre a rodada extra, e ela é a razão de o algoritmo
+      // existir.
+      await expect(artigo.locator(".viz-note")).toContainText("RODADA EXTRA");
+
+      // E aqui está o número que eu ia escrever errado: o preset padrão promete
+      // V-1 rodadas no painel ("N de 4") e para na 2, por early exit. Os dois
+      // números saem da TELA, não da minha cabeça.
+      const prometidas = await page.evaluate((sel) => {
+        const t = document.querySelector(`${sel} .viz-var .viz-var-val`)!.textContent!;
+        return parseInt(t.match(/de (\d+)/)![1], 10);
+      }, ARTIGO);
+      expect(fins, "nenhuma rodada fechou").toBeGreaterThan(0);
+      expect(
+        ultimaRodadaFechada,
+        "o early exit sumiu: este preset passou a rodar as V-1 rodadas inteiras"
+      ).toBeLessThan(prometidas);
+      await expect(artigo.locator(".bf-tab tbody tr > th").nth(ultimaRodadaFechada)).toHaveText(
+        String(ultimaRodadaFechada)
+      );
+    });
+  });
+});

--- a/tests/viz-dfs-bfs.spec.ts
+++ b/tests/viz-dfs-bfs.spec.ts
@@ -1,0 +1,261 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no visualizador de DFS e BFS sobre o mesmo grafo.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura. A régua aqui é sempre um número medido no
+// navegador (altura, posição, deslocamento) ou o texto que o aluno lê.
+//
+// Antes da casca, quem rolava no painel expandido era a FIGURA INTEIRA, e ela
+// levava o cabeçalho junto: rolando até o fim, o `✕ Fechar` e o contador de
+// passo iam parar 280px (1512x900), 480px (1440x700) e 571px (1440x600) ACIMA
+// do topo do painel. E o `▶ Rodar`, sem rolar nada, era desenhado 180–200,
+// 380–400 e 471–491px ABAIXO do pé da janela. Depois, o cabeçalho fica a 1px do
+// topo nas três réguas, quem rola é o miolo, e o `▶ Rodar` sai dentro da janela
+// (−92, −52 e −49px).
+//
+// O tópico tem um visualizador só, e ele tem as três camadas: overlay, bloco de
+// código, painel de variáveis e controles. Nenhum arquivo ficou de fora.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/dfs-bfs/";
+
+// Notebook de 16", o caso que motivou a casca. Nela a peça pede 1132px de um
+// orçamento de 816 com o código aberto, e o código entra recolhido.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para caber com o código aberto (orçamento 1516px).
+const ALTA = { width: 1512, height: 1600 };
+// Apertada de propósito: é onde o miolo do painel tem o que rolar (120–140px de
+// sobra com o código recolhido) e onde a medição REALMENTE discordaria de quem
+// abre o código na mão.
+const APERTADA = { width: 1440, height: 700 };
+
+// Folga de subpixel, a mesma do hook.
+const SLACK = 8;
+
+// Andando a animação inteira nos seis estados (2 modos × 3 presets) e nas três
+// réguas, a amplitude de altura da peça é de **20px** — e ela vem da NOTA ter
+// uma ou duas linhas, não da estrutura auxiliar: a pilha/fila é uma fileira
+// `flex-wrap` que nunca passa de 4 fichas num contêiner que comporta muito
+// mais. Não existe "passo do pico" a caçar aqui. O passo 27 é o máximo no BFS
+// por 20px, e o que sustenta o teste de rolagem é a PREMISSA medida
+// (`scrollHeight - clientHeight > SLACK`), não a escolha do passo.
+const ULTIMO_PASSO = 27;
+
+const PRESET_ALTO = "Com ciclo";
+
+async function abrirPainel(page: Page, tamanho: { width: number; height: number }) {
+  await page.setViewportSize(tamanho);
+  await page.goto(URL);
+  expect(page.viewportSize()).toEqual(tamanho);
+  await page.evaluate(() => document.fonts.ready);
+  await page.getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+/** A ficha "pico da fila"/"pico da pilha", com o rótulo e o valor juntos. */
+function fichaDoPico(painel: ReturnType<Page["locator"]>) {
+  return painel.locator(".bigo-stat", { hasText: /^pico da/ });
+}
+
+/** A linha do painel de variáveis cujo nome é "pilha" ou "fila". */
+function linhaDaEstrutura(painel: ReturnType<Page["locator"]>) {
+  return painel.locator(".viz-var", { hasText: /^(pilha|fila)/ });
+}
+
+/**
+ * O número da linha "pilha"/"fila" tem que bater com quantas fichas o painel da
+ * estrutura desenha. São dois lugares que dizem a mesma coisa por caminhos
+ * diferentes, e é a discordância entre eles que denuncia campo trocado.
+ */
+async function conferirValorContraAsFichas(painel: ReturnType<Page["locator"]>) {
+  const valor = await linhaDaEstrutura(painel).locator(".viz-var-val").innerText();
+  const fichas = await painel.locator(".tt-aux .tt-aux-item").count();
+  expect(Number(valor)).toBe(fichas);
+}
+
+test.describe("DFS e BFS no grafo · casca adaptativa", () => {
+  test("o cabeçalho e os controles ficam parados quando o miolo rola", async ({ page }) => {
+    const painel = await abrirPainel(page, APERTADA);
+    await page.getByRole("button", { name: PRESET_ALTO, exact: true }).click();
+
+    // Vai até o último passo, que é o mais alto do BFS. São 26 cliques num
+    // controle do RODAPÉ: se ele estivesse dentro do miolo, o `click()` do
+    // Playwright teria rolado o contêiner para alcançá-lo, e o `scrollTop`
+    // abaixo não fecharia em zero. É uma asserção de graça.
+    for (let i = 1; i < ULTIMO_PASSO; i++) {
+      await painel.getByRole("button", { name: "Próximo ›" }).click();
+    }
+    await expect(painel.locator(".viz-step")).toHaveText(`passo ${ULTIMO_PASSO} de ${ULTIMO_PASSO}`);
+    expect(await painel.locator(".viz-body").evaluate((b) => Math.round(b.scrollTop))).toBe(0);
+
+    // PREMISSA: o miolo estoura mesmo. Sem isto, o dia em que a peça encolher o
+    // teste vira decoração verde.
+    const sobra = await painel
+      .locator(".viz-body")
+      .evaluate((b) => b.scrollHeight - b.clientHeight);
+    expect(sobra).toBeGreaterThan(SLACK);
+
+    const antes = await painel.evaluate((f) => {
+      const r = f.getBoundingClientRect();
+      return {
+        cabecaTopo: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodapePe: Math.round(r.bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+      };
+    });
+    // A camada 1 é justamente cabeçalho colado no topo e rodapé colado no pé.
+    expect(antes.cabecaTopo).toBeLessThanOrEqual(2);
+    expect(antes.rodapePe).toBeLessThanOrEqual(2);
+
+    await painel.locator(".viz-body").evaluate((b) => { b.scrollTop = b.scrollHeight; });
+    await page.waitForTimeout(120);
+
+    const depois = await painel.evaluate((f) => {
+      const r = f.getBoundingClientRect();
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      return {
+        cabecaTopo: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodapePe: Math.round(r.bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+        bodyScrollTop: Math.round(body.scrollTop),
+        figuraScrollTop: Math.round(f.scrollTop),
+      };
+    });
+
+    // As três coisas juntas, porque duas delas sozinhas aprovam a quebra que
+    // devolve a rolagem para a figura inteira: o miolo estourou (acima), o
+    // miolo MESMO rolou, e a figura NÃO rolou.
+    expect(depois.bodyScrollTop).toBeGreaterThan(0);
+    expect(depois.figuraScrollTop).toBe(0);
+    expect(depois.cabecaTopo).toBe(antes.cabecaTopo);
+    expect(depois.rodapePe).toBe(antes.rodapePe);
+
+    // E o botão que faz o algoritmo andar continua À VISTA — não só alcançável:
+    // o `click()` do Playwright rola o contêiner para chegar no alvo, então
+    // clicar nele não provaria nada.
+    const rodar = painel.getByRole("button", { name: "▶ Rodar" });
+    const caixa = (await rodar.boundingBox())!;
+    expect(caixa.y).toBeGreaterThanOrEqual(0);
+    expect(caixa.y + caixa.height).toBeLessThanOrEqual(APERTADA.height);
+  });
+
+  test("em tela baixa o código vem recolhido, e o botão diz Mostrar código", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+    // O RÓTULO, não só o estado: botão que promete uma coisa e faz outra ensina
+    // errado do mesmo jeito.
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    await expect(painel).toHaveAttribute("data-codigo", "off");
+
+    // Recolhido de verdade: o slot fechou a ALTURA, não só a largura da coluna.
+    const alturaCodigo = await painel
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaCodigo).toBeLessThan(8);
+  });
+
+  test("em tela alta o código já vem aberto, e o botão diz Ocultar código", async ({ page }) => {
+    const painel = await abrirPainel(page, ALTA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "true");
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+
+    // E o código aberto é o do modo selecionado, com o nome do arquivo. O
+    // visualizador abre no BFS.
+    await expect(painel.locator(".viz-code-head")).toHaveText("bfs.py");
+    const alturaCodigo = await painel
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaCodigo).toBeGreaterThan(80);
+  });
+
+  test("a escolha do aluno sobrevive à troca de modo, que pediria medição nova", async ({ page }) => {
+    const painel = await abrirPainel(page, APERTADA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+
+    // Numa janela apertada a medição recolhe de saída: é o que dá o que
+    // contrariar. Com o código aberto o miolo pede ~390px a mais do que tem.
+    await expect(botao).toHaveText("Mostrar código");
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+
+    // A troca precisa mexer numa entrada REAL da medição: o modo está em
+    // `measureOn`. PROVA NA TELA de que ele mudou mesmo — o arquivo do bloco de
+    // código e o rótulo da estrutura auxiliar.
+    await expect(painel.locator(".viz-code-head")).toHaveText("bfs.py");
+    await page.getByRole("button", { name: "DFS (pilha)", exact: true }).click();
+    await expect(painel.locator(".viz-code-head")).toHaveText("dfs.py");
+
+    // "Está aberto agora" não é "continua aberto": amostra ao longo do
+    // intervalo em que a medição rodaria.
+    for (let i = 0; i < 6; i++) {
+      await page.waitForTimeout(80);
+      await expect(painel).toHaveAttribute("data-codigo", "on");
+    }
+    await expect(botao).toHaveText("Ocultar código");
+  });
+
+  test("as setas andam a animação, e o slider de velocidade fica com a tecla", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    const passo = painel.locator(".viz-step");
+    await expect(passo).toHaveText("passo 1 de 27");
+
+    // Uma ação só, nunca um par inverso: `ArrowRight` seguido de `ArrowLeft`
+    // devolve a peça ao estado de origem e fica verde com a quebra aplicada.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 2 de 27");
+
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+    // Com o cursor no slider, a seta é DO SLIDER. Sequestrar isso deixa o
+    // controle impossível de usar, o que é pior que não ter atalho.
+    const slider = painel.locator('input[type="range"]');
+    await slider.focus();
+    const passoAntes = await passo.innerText();
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await page.keyboard.press("ArrowRight");
+    await expect(painel.locator(".viz-speed .val")).toHaveText("2x");
+    await expect(passo).toHaveText(passoAntes);
+  });
+
+  test("a peça abre na marcha 1.5x, que é a dela e não a padrão do hook", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    // A marcha inicial era `useState(4)` antes da casca. Sem `initialSpeed` a
+    // peça abriria no "1x" do hook, e nenhum outro teste notaria.
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await expect(painel.locator('input[type="range"]')).toHaveValue("4");
+  });
+
+  test("o rótulo da estrutura auxiliar acompanha o modo, e vem colado no valor", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+
+    // Este é o ponto cego do `guarda-idioma.py` neste arquivo: `pico da {isDfs ?
+    // "pilha" : "fila"}` é rótulo de tela colado numa interpolação JSX, e ele
+    // não é visto por lá. Rótulo e valor lidos JUNTOS, na mesma ficha, é o que
+    // pega a troca silenciosa.
+    await expect(fichaDoPico(painel)).toContainText("pico da fila");
+    await expect(painel.locator(".tt-painel-tit").first()).toContainText("Fila");
+    await expect(painel.locator(".tt-painel-tit").first()).toContainText("sai o primeiro (FIFO)");
+    await expect(linhaDaEstrutura(painel)).toContainText("fila");
+    // Medido: no preset "Com ciclo" o pico é 3 nos dois modos.
+    await expect(fichaDoPico(painel).locator("strong")).toHaveText("3");
+    await conferirValorContraAsFichas(painel);
+
+    await page.getByRole("button", { name: "DFS (pilha)", exact: true }).click();
+    await expect(fichaDoPico(painel)).toContainText("pico da pilha");
+    await expect(painel.locator(".tt-painel-tit").first()).toContainText("Pilha");
+    await expect(painel.locator(".tt-painel-tit").first()).toContainText("sai o último (LIFO)");
+    await expect(linhaDaEstrutura(painel)).toContainText("pilha");
+    await expect(fichaDoPico(painel).locator("strong")).toHaveText("3");
+    await conferirValorContraAsFichas(painel);
+  });
+});

--- a/tests/viz-dijkstra.spec.ts
+++ b/tests/viz-dijkstra.spec.ts
@@ -1,0 +1,256 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa do visualizador de Dijkstra.
+//
+// Os números que decidiram o escopo, medidos com `document.fonts.ready`
+// cumprido e a animação parada, andando os três presets passo a passo:
+//
+//   · no artigo, a 1512x900 (orçamento 816px): 1071–1130px antes, 679–743
+//     depois. A peça passava do orçamento em TODOS os passos dos três presets;
+//   · no painel expandido, quem rolava era a FIGURA (294 a 633px de sobra,
+//     conforme a janela), levando cabeçalho e controles junto: o `▶ Rodar` era
+//     desenhado 193px (1512x900), 393px (1440x700) e 493px (1440x600) abaixo do
+//     pé visível da janela. Depois é o miolo que rola, e o `▶ Rodar` fica
+//     dentro da janela em todas.
+//
+// O eixo da altura desta peça é a NOTA (22 a 63px), não a fila de prioridade
+// nem a tabela de distâncias: as duas são fileiras de fichas de 34px em todos
+// os passos dos três presets — medido, elas nunca quebram linha. Por isso o
+// passo do pico é onde a nota tem três linhas.
+
+const SLACK = 8;
+const NEGATIVO = "Com peso negativo (quebra)";
+// O passo mais alto dos três presets: a nota de três linhas do relaxamento
+// A→C. 743px no artigo a 1440x600, contra 702 do passo mais baixo.
+const PASSO_PICO = 2;
+
+function figura(page: Page): Locator {
+  return page.locator("article figure.viz");
+}
+
+function painel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  expect(page.viewportSize(), `a janela pedida foi ${w}x${h}`).toEqual({ width: w, height: h });
+  await page.goto("/topico/dijkstra/");
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+}
+
+/** Altura que PAROU: três leituras iguais seguidas, não duas. */
+async function alturaEstavel(alvo: Locator): Promise<number> {
+  let iguais = 0;
+  let ultima = -1;
+  for (let i = 0; i < 60; i++) {
+    const h = Math.round((await alvo.boundingBox())!.height);
+    if (h === ultima) {
+      if (++iguais >= 2) return h;
+    } else {
+      iguais = 0;
+      ultima = h;
+    }
+    await alvo.page().waitForTimeout(50);
+  }
+  return ultima;
+}
+
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const raw = getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h");
+    return window.innerHeight - (parseFloat(raw) || 60) - 24;
+  });
+}
+
+test.describe("dijkstra · casca adaptativa", () => {
+  test("no painel o miolo rola sozinho: cabeçalho e ▶ Rodar não saem do lugar", async ({ page }) => {
+    await abrir(page, 1440, 600);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: NEGATIVO }).click();
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(pan).toBeVisible();
+    for (let i = 1; i < PASSO_PICO; i++) await pan.getByRole("button", { name: "Próximo ›" }).click();
+    await expect(pan.locator(".viz-step")).toHaveText(`passo ${PASSO_PICO} de 15`);
+    await alturaEstavel(pan);
+
+    // O `click()` do Playwright rola o contêiner para alcançar o alvo, então a
+    // primeira leitura tem que ser feita com as duas rolagens zeradas.
+    const antes = await pan.evaluate((f) => {
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      f.scrollTop = 0;
+      body.scrollTop = 0;
+      const r = f.getBoundingClientRect();
+      return {
+        sobraMiolo: body.scrollHeight - body.clientHeight,
+        sobraFigura: f.scrollHeight - f.clientHeight,
+        cabeca: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodarBase: Math.round(f.querySelector(".viz-play")!.getBoundingClientRect().bottom),
+      };
+    });
+
+    // Premissa: existe o que rolar. Sem isto o teste vira decoração verde no dia
+    // em que a peça encolher.
+    expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(SLACK);
+    expect(antes.sobraFigura, "quem rola é o miolo, não a figura").toBeLessThanOrEqual(SLACK);
+
+    const depois = await pan.evaluate((f) => {
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      body.scrollTop = body.scrollHeight;
+      const r = f.getBoundingClientRect();
+      return {
+        mioloRolou: Math.round(body.scrollTop),
+        figuraRolou: Math.round(f.scrollTop),
+        cabeca: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodarBase: Math.round(f.querySelector(".viz-play")!.getBoundingClientRect().bottom),
+        janela: window.innerHeight,
+      };
+    });
+
+    expect(depois.mioloRolou, "o miolo rolou de verdade").toBeGreaterThan(0);
+    expect(depois.figuraRolou, "a figura inteira não rola").toBe(0);
+    expect(depois.cabeca, "o cabeçalho não se mexeu").toBe(antes.cabeca);
+    expect(depois.cabeca, "o cabeçalho está colado no topo da figura").toBeLessThanOrEqual(2);
+    expect(depois.rodarBase, "os controles não se mexeram").toBe(antes.rodarBase);
+    expect(depois.rodarBase, "o ▶ Rodar continua dentro da janela").toBeLessThanOrEqual(depois.janela);
+    // Rótulo, não só posição: um botão no lugar certo dizendo outra coisa
+    // ensina errado do mesmo jeito.
+    await expect(pan.locator(".viz-play")).toHaveText("▶ Rodar");
+  });
+
+  test("a 1512x900 a peça não caberia, então o código vem recolhido e o botão diz Mostrar código", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    const botao = fig.getByRole("button", { name: /código/ });
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+
+    const alturaCodigo = Math.round(
+      await fig.locator(".viz-code").evaluate((el) => el.getBoundingClientRect().height)
+    );
+    // Zerar a trilha da COLUNA tira a largura e não a altura: é o `.viz-code-slot`
+    // (grid 1fr→0fr) que fecha a linha. Sem ele o bloco continua com a altura
+    // inteira e a peça não encolhe um pixel.
+    expect(alturaCodigo, "o bloco recolhido não pode ocupar altura").toBeLessThanOrEqual(2);
+
+    const altura = await alturaEstavel(fig);
+    expect(altura, "recolhida, a peça cabe no orçamento da janela").toBeLessThanOrEqual(await orcamento(page));
+  });
+
+  test("numa janela alta o código já vem aberto, com o rótulo Ocultar código", async ({ page }) => {
+    await abrir(page, 1512, 1400);
+    const fig = figura(page);
+    const botao = fig.getByRole("button", { name: /código/ });
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-code-head")).toBeVisible();
+
+    const altura = await alturaEstavel(fig);
+    const orc = await orcamento(page);
+    expect(altura, "com esta janela a peça cabe aberta — é por isso que ela abre").toBeLessThanOrEqual(orc);
+  });
+
+  test("a escolha do aluno sobrevive à troca de preset, que é o que dispara medição nova", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    const botao = fig.getByRole("button", { name: /código/ });
+    await expect(botao).toHaveText("Mostrar código");
+
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+
+    // Trocar de preset muda `measureOn` e a peça aberta passa do orçamento —
+    // ou seja, a medição QUER recolher. É por isso que este preset serve de
+    // teste e um que só mudasse o alvo não serviria.
+    await fig.getByRole("button", { name: NEGATIVO }).click();
+    await expect(fig.locator(".tt-legenda-arvore")).toContainText("A aresta C→B vale -2");
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 15");
+
+    const alta = await alturaEstavel(fig);
+    expect(alta, "aberta, a peça passa do orçamento — a medição discordaria do aluno").toBeGreaterThan(
+      await orcamento(page)
+    );
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(botao).toHaveText("Ocultar código");
+  });
+
+  test("as setas andam a animação dentro do painel", async ({ page }) => {
+    await abrir(page, 1440, 700);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(pan.locator(".viz-step")).toHaveText("passo 1 de 17");
+
+    // Duas vezes na MESMA direção: um par de ações inversas devolve a peça ao
+    // estado de origem e fica verde com a quebra aplicada.
+    await page.keyboard.press("ArrowRight");
+    await page.keyboard.press("ArrowRight");
+    await expect(pan.locator(".viz-step")).toHaveText("passo 3 de 17");
+
+    await page.keyboard.press("Space");
+    await expect(pan.locator(".viz-play")).toHaveText("❚❚ Pausar");
+  });
+
+  test("com o cursor no controle de velocidade, a seta é do slider e não do passo", async ({ page }) => {
+    await abrir(page, 1440, 700);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    const marcha = pan.locator(".viz-speed .val");
+    await expect(pan.locator(".viz-step")).toHaveText("passo 1 de 17");
+
+    await pan.locator(".viz-speed input[type=range]").focus();
+    await page.keyboard.press("ArrowLeft");
+
+    await expect(marcha, "a seta mexeu na marcha, que é de quem estava em foco").toHaveText("1x");
+    await expect(pan.locator(".viz-step"), "e não andou o passo").toHaveText("passo 1 de 17");
+  });
+
+  test("a marcha inicial da peça é 1.5x, não o 1x padrão do hook", async ({ page }) => {
+    await abrir(page, 1440, 700);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: /Expandir/ }).click();
+    const pan = painel(page);
+    await expect(pan.locator(".viz-speed .val")).toHaveText("1.5x");
+    await expect(pan.locator(".viz-speed input[type=range]")).toHaveValue("4");
+  });
+
+  test("o desenho do grafo sai no tamanho natural do viewBox: não há esticão a devolver", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const medida = await figura(page)
+      .locator("svg.tt-arv")
+      .evaluate((el) => {
+        const r = el.getBoundingClientRect();
+        const vb = (el.getAttribute("viewBox") || "").split(/\s+/).map(Number);
+        return { w: Math.round(r.width), h: Math.round(r.height), vw: vb[2], vh: vb[3] };
+      });
+    // Teto de altura só devolve VAZIO, e só existe vazio quando o renderizado é
+    // maior que o natural. Aqui são iguais: um `max-height` encolheria o texto
+    // dos vértices pelo `preserveAspectRatio`. É por isso que este tópico não
+    // escreveu uma linha de CSS.
+    expect(medida.w).toBe(medida.vw);
+    expect(medida.h).toBe(medida.vh);
+  });
+
+  test("o painel de variáveis conta os fechados, com rótulo e valor no mesmo cartão", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = figura(page);
+    await fig.getByRole("button", { name: NEGATIVO }).click();
+    for (let i = 0; i < 3; i++) await fig.getByRole("button", { name: "Próximo ›" }).click();
+
+    const fechados = fig.locator(".tt-saida .tt-saida-item");
+    const quantos = await fechados.count();
+    expect(quantos, "neste passo já há vértice fechado").toBeGreaterThan(0);
+
+    // Rótulo e valor lidos JUNTOS, no mesmo cartão: o guarda de idioma compara o
+    // conjunto de textos e não onde cada um aparece, então trocar dois campos de
+    // lugar passa verde por lá. Aqui não passa.
+    const cartao = fig.locator(".viz-var").filter({ hasText: "fechados" });
+    await expect(cartao.locator(".viz-var-name")).toHaveText("fechados");
+    await expect(cartao.locator(".viz-var-val")).toHaveText(`${quantos} de 6`);
+  });
+});

--- a/tests/viz-grafos-intro.spec.ts
+++ b/tests/viz-grafos-intro.spec.ts
@@ -1,0 +1,224 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Casca adaptativa do tópico `grafos-intro`.
+//
+// O `GrafoRepresentacao` é um EDITOR, não uma animação: você liga e desliga
+// arestas na matriz e o desenho, a lista e os dois custos respondem na hora.
+// Não há bloco de código, não há painel de variáveis e não há linha de
+// controles. Ele entra com `collapsible: false` e `total: 1`, e com isso o
+// `VizFooter` não desenha nada — nem `.viz-foot`.
+//
+// Por isso os itens 2, 3 e 4 do mínimo da §8 (os que falam do bloco
+// recolhível) não existem aqui. No lugar deles vale a regra que o contrato põe
+// no lugar — **nenhum botão pode prometer esconder um bloco que o visualizador
+// não tem** —, estendida pelo mesmo motivo ao resto do que ele não promete:
+// nenhum contador de passo, nenhum atalho de teclado e nenhum botão de
+// reprodução para uma linha do tempo que não existe.
+
+const URL = "/topico/grafos-intro/";
+// Folga de subpixel, igual à do hook.
+const SLACK = 8;
+
+async function abrirPainel(page: Page): Promise<Locator> {
+  await page.goto(URL);
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator("article figure.viz").getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+// Lê um cartão de custo pelo RÓTULO e devolve o cartão inteiro, para o valor
+// ser lido ao lado do rótulo dele. Ler o número sozinho passaria verde com dois
+// cartões trocados de lugar: o conjunto de textos da tela fica idêntico e só a
+// associação mente — que é justamente o buraco que o guarda de idioma tem por
+// construção.
+function cartao(painel: Locator, rotulo: string): Locator {
+  return painel.locator(".bigo-stat").filter({
+    has: painel.page().getByText(rotulo, { exact: true }),
+  });
+}
+
+test.describe("grafos-intro · casca adaptativa", () => {
+  test("o cabeçalho fica parado e o ✕ Fechar continua à vista com o miolo rolado até o fim", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const vp = page.viewportSize();
+    expect(vp!.height, "a régua tem que ser a que eu pedi").toBe(600);
+
+    const painel = await abrirPainel(page);
+    // Preset no topo do miolo de propósito: `click()` do Playwright ROLA o
+    // contêiner para alcançar o alvo, e clicar mais abaixo sujaria a medição
+    // que vem a seguir. Os quatro presets empatam em altura (412px de sobra a
+    // 1440x600); "Completo" é o que deixa os dois custos iguais.
+    await painel.getByRole("button", { name: "Completo", exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("V = 6 · E = 15 · densidade 100%");
+    await expect(
+      painel.locator(".viz-body"),
+      "o clique no preset não pode ter rolado o miolo"
+    ).toHaveJSProperty("scrollTop", 0);
+
+    const fechar = painel.getByRole("button", { name: /Fechar/ });
+
+    const antes = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay figure.viz") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      const h = f.querySelector(".viz-head") as HTMLElement;
+      return {
+        sobraMiolo: b.scrollHeight - b.clientHeight,
+        sobraFigura: f.scrollHeight - f.clientHeight,
+        headTop: Math.round(h.getBoundingClientRect().top),
+      };
+    });
+
+    // A asserção da camada 1 vem ANTES da premissa, de propósito: a quebra que
+    // devolve a rolagem para a figura também zera a sobra do miolo, e com a
+    // premissa na frente o teste reprovaria dizendo "o miolo não estoura" —
+    // apontando para o lugar errado, e convidando quem vier depois a remover a
+    // premissa por parecer redundante.
+    expect(
+      antes.sobraFigura,
+      "a figura inteira não pode ser a área rolável: é isso que leva o cabeçalho embora"
+    ).toBeLessThanOrEqual(SLACK);
+    // Premissa: sem sobra para rolar, o teste vira decoração verde.
+    expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(
+      SLACK
+    );
+
+    const depois = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay figure.viz") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      const h = f.querySelector(".viz-head") as HTMLElement;
+      b.scrollTop = b.scrollHeight;
+      f.scrollTop = f.scrollHeight; // se a figura ainda rolar, ela rola aqui
+      return {
+        mioloRolou: b.scrollTop,
+        figuraRolou: f.scrollTop,
+        headTop: Math.round(h.getBoundingClientRect().top),
+      };
+    });
+
+    // As três juntas. Sem a terceira, a quebra que devolve a rolagem para a
+    // figura passa: o `.viz-body` fica em zero, o cabeçalho não se mexe, e o
+    // teste aprova exatamente o defeito que a camada 1 conserta.
+    expect(depois.mioloRolou, "quem rola é o miolo").toBeGreaterThan(0);
+    expect(depois.figuraRolou, "a figura NÃO rola").toBe(0);
+    expect(depois.headTop, "o cabeçalho não anda um pixel").toBe(antes.headTop);
+
+    // E o botão de fechar, que mora no cabeçalho, continua dentro da janela.
+    const caixa = (await fechar.boundingBox())!;
+    expect(caixa.y, "o ✕ Fechar não sai por cima da janela").toBeGreaterThanOrEqual(0);
+    expect(caixa.y + caixa.height, "nem por baixo").toBeLessThanOrEqual(600);
+  });
+
+  test("não existe botão prometendo mostrar ou ocultar um bloco que a peça não tem", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+    const cabeca = painel.locator(".viz-head");
+
+    // Nem com o rótulo do hook ("Mostrar código" / "Ocultar código")...
+    await expect(cabeca.getByRole("button", { name: /Mostrar|Ocultar/i })).toHaveCount(0);
+    // ...nem com outro nome de bloco.
+    await expect(cabeca.locator("button.viz-toggle-codigo")).toHaveCount(0);
+    // E não há bloco recolhível nenhum no miolo para ele controlar.
+    await expect(painel.locator(".viz-code-slot, .viz-code")).toHaveCount(0);
+
+    // O cabeçalho tem exatamente um botão, e ele diz o que faz.
+    await expect(cabeca.getByRole("button")).toHaveCount(1);
+    await expect(cabeca.getByRole("button")).toHaveText(/Fechar/);
+  });
+
+  test("não há contador de passo, rodapé, atalho de teclado nem reprodução; o lugar do passo diz V, E e densidade", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+
+    // Sem linha do tempo: nada de reprodução, em lugar nenhum da peça.
+    await expect(painel.getByText(/passo \d+ de \d+/)).toHaveCount(0);
+    await expect(painel.locator(".viz-atalhos")).toHaveCount(0);
+    await expect(painel.locator(".viz-progress")).toHaveCount(0);
+    await expect(painel.locator(".viz-foot")).toHaveCount(0);
+    await expect(painel.getByRole("button", { name: /Rodar|Pausar|Anterior|Próximo/ })).toHaveCount(
+      0
+    );
+    // Nenhum controle anuncia tecla: atalho prometido é atalho que o aluno
+    // tenta, e aqui não há passo para andar.
+    await expect(painel.locator("[aria-keyshortcuts]")).toHaveCount(0);
+
+    // O que ocupa o lugar do contador é o número que resume o estado — com o
+    // rótulo junto, senão o número perde o contexto que o explicava.
+    await expect(painel.locator(".viz-step")).toHaveText("V = 6 · E = 7 · densidade 47%");
+
+    // Ligar o modo dirigido não joga aresta fora: a matriz simétrica que estava
+    // na tela vira 14 arcos, dois por aresta, contra um teto que também dobrou
+    // — é por isso que a densidade não se mexe.
+    await painel.getByRole("button", { name: "dirigido", exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("V = 6 · E = 14 · densidade 47%");
+
+    // Já reaplicar o preset monta o grafo dirigido de verdade: 7 arcos de 30.
+    await painel.getByRole("button", { name: "Esparso (rede social)", exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText("V = 6 · E = 7 · densidade 23%");
+  });
+
+  test("os presets vivem no miolo e mudam os dois custos de memória no cartão certo", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+
+    // O contrato manda preset no miolo: no rodapé só mora reprodução — e aqui
+    // não há rodapé nenhum para eles caírem.
+    await expect(painel.locator(".viz-body .bigo-chips button")).toHaveCount(4);
+    await expect(painel.locator(".viz-body .sub-modo button")).toHaveCount(2);
+
+    // Rótulo e valor lidos no MESMO cartão. Esparso: a lista custa 20 entradas
+    // contra 36 células da matriz, e sobram 16 células em zero.
+    await expect(cartao(painel, "memória da matriz").locator("strong")).toHaveText("36 células");
+    await expect(cartao(painel, "memória da lista").locator("strong")).toHaveText("20 entradas");
+    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("16");
+
+    // Completo: os dois custos empatam e não sobra célula nenhuma em zero.
+    await painel.getByRole("button", { name: "Completo", exact: true }).click();
+    await expect(cartao(painel, "arestas (E)").locator("strong")).toHaveText("15 de 15");
+    await expect(cartao(painel, "memória da matriz").locator("strong")).toHaveText("36 células");
+    await expect(cartao(painel, "memória da lista").locator("strong")).toHaveText("36 entradas");
+    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("0");
+  });
+
+  test("clicar numa célula dentro do painel liga a aresta, espelha a simétrica e atualiza cabeçalho, lista e custo", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 600 });
+    const painel = await abrirPainel(page);
+
+    // No preset esparso A não é vizinho de C. O rótulo da célula carrega o
+    // estado junto do nome, então lê-lo já é ler valor e rótulo no mesmo lugar.
+    const aParaC = painel.getByRole("button", { name: "Aresta de A para C: não existe" });
+    const cParaA = painel.getByRole("button", { name: "Aresta de C para A: não existe" });
+    await expect(aParaC).toHaveCount(1);
+    await expect(cParaA).toHaveCount(1);
+    await expect(painel.locator(".viz-step")).toHaveText("V = 6 · E = 7 · densidade 47%");
+    await expect(painel.locator(".gr-linha").first().locator(".gr-viz-item")).toHaveText([
+      "B",
+      "F",
+    ]);
+
+    await aParaC.click();
+
+    // Uma aresta a mais, e no modo não dirigido a célula espelhada acompanha —
+    // que é a simetria de que a aula fala.
+    await expect(painel.getByRole("button", { name: "Aresta de A para C: existe" })).toHaveCount(1);
+    await expect(painel.getByRole("button", { name: "Aresta de C para A: existe" })).toHaveCount(1);
+    await expect(painel.locator(".viz-step")).toHaveText("V = 6 · E = 8 · densidade 53%");
+    await expect(painel.locator(".gr-linha").first().locator(".gr-viz-item")).toHaveText([
+      "B",
+      "C",
+      "F",
+    ]);
+    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("14");
+  });
+});

--- a/tests/viz-mst.spec.ts
+++ b/tests/viz-mst.spec.ts
@@ -1,0 +1,356 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// A casca adaptativa do MstVisualizer (Kruskal e Prim no mesmo grafo).
+//
+// Todo número aqui foi MEDIDO no build antes de virar asserção, e o que dá para
+// escrever como invariante entre dois lugares da tela está escrito assim. O
+// motivo é concreto: "a MST tem sempre V-1 = 5 arestas" é o que a própria peça
+// ensina, e a nota final até diz isso — mas escrever o 5 na mão faria o teste
+// aprovar qualquer regressão que mudasse as DUAS pontas juntas. O que ele exige
+// é que o cartão "arestas na MST", as fichas verdes da lista e a nota do passo
+// digam o mesmo número, por três caminhos diferentes.
+
+const ARTIGO = "article figure.viz-fit";
+const PAINEL = ".viz-overlay-fit figure.viz-fit";
+
+/** Folga de subpixel: o mesmo valor que o hook usa para decidir. */
+const SLACK = 8;
+
+async function abrirTopico(page: Page) {
+  await page.goto("/topico/mst/");
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator(ARTIGO).scrollIntoViewIfNeeded();
+  // A decisão da casca roda em dois passes de layout depois das fontes; sem
+  // esperar por ela, `data-codigo` ainda é o "on" do primeiro render.
+  await expect(page.locator(ARTIGO)).toHaveAttribute("data-anim", "on");
+}
+
+/** Estado do bloco recolhível: o rótulo do botão E a altura que ele ocupa. */
+const LER_BLOCO = (sel: string) => {
+  const f = document.querySelector(sel) as HTMLElement;
+  const btn = [...f.querySelectorAll(".viz-head button")].find((b) => /código/.test(b.textContent || ""));
+  return {
+    codigo: f.getAttribute("data-codigo"),
+    rotulo: btn ? (btn.textContent || "").trim() : "«sem botão»",
+    expanded: btn ? btn.getAttribute("aria-expanded") : null,
+    alturaCodigo: Math.round((f.querySelector(".viz-code") as HTMLElement).getBoundingClientRect().height),
+    figura: Math.round(f.getBoundingClientRect().height),
+  };
+};
+
+/** Lê um cartão do painel de variáveis pelo RÓTULO, e devolve rótulo e valor juntos. */
+const CARTAO = ([sel, nome]: [string, string]) => {
+  const f = document.querySelector(sel) as HTMLElement;
+  const linha = [...f.querySelectorAll(".viz-var")].find(
+    (v) => (v.querySelector(".viz-var-name")?.textContent || "").trim() === nome
+  );
+  if (!linha) {
+    const havia = [...f.querySelectorAll(".viz-var-name")].map((n) => n.textContent).join(" | ");
+    throw new Error(`cartão "${nome}" não existe. Rótulos na tela: ${havia}`);
+  }
+  const val = linha.querySelector(".viz-var-val") as HTMLElement;
+  return { nome, valor: (val.textContent || "").trim(), destacado: val.className.includes("best") };
+};
+
+/**
+ * Altura do bloco recolhível depois que ela PAROU.
+ *
+ * `toHaveAttribute("data-codigo", "on")` fica verde no primeiro quadro, e a
+ * transição da casca dura 0,32s: ler ali devolve os 2px do estado recolhido
+ * para um bloco que está indo para 459. E duas leituras iguais não são "parou"
+ * — uma transição passa por patamares. Exige TRÊS.
+ */
+async function alturaCodigoEstavel(page: Page, sel: string) {
+  let iguais = 0;
+  let anterior = Number.NaN;
+  for (let i = 0; i < 60; i++) {
+    const h = await page.evaluate(
+      (s) => Math.round((document.querySelector(`${s} .viz-code`) as HTMLElement).getBoundingClientRect().height),
+      sel
+    );
+    iguais = h === anterior ? iguais + 1 : 0;
+    anterior = h;
+    if (iguais >= 2) return h;
+    await page.waitForTimeout(50);
+  }
+  throw new Error(`a altura do bloco não estabilizou (última leitura: ${anterior})`);
+}
+
+const contador = (sel: string) => {
+  const txt = [...document.querySelectorAll(`${sel} .viz-step`)].map((e) => e.textContent).join(" ");
+  const m = txt.match(/passo (\d+) de (\d+)/);
+  if (!m) throw new Error(`o contador de passo não casou: "${txt}"`);
+  return { passo: parseInt(m[1], 10), total: parseInt(m[2], 10) };
+};
+
+/**
+ * Espera o painel estar PRONTO para o teclado, não só visível.
+ *
+ * `toBeVisible()` prova que o portal foi montado; o listener de `keydown` é
+ * registrado num efeito passivo, que roda depois da pintura. A tecla enviada
+ * nessa janela não faz nada e some sem erro — foi o que reprovou este teste uma
+ * vez com a máquina cheia. O contrato §5 diz que o foco entra no painel ao
+ * abrir, e o efeito do foco está declarado ANTES do efeito do teclado: o React
+ * descarrega os efeitos de um commit numa passada só, em ordem, então foco
+ * dentro do painel prova que o listener já está no lugar.
+ */
+async function painelPronto(page: Page) {
+  await expect
+    .poll(() => page.evaluate(() => !!document.activeElement?.closest(".viz-overlay-fit")), {
+      message: "o foco tem que entrar no painel ao abrir",
+    })
+    .toBe(true);
+}
+
+async function irAoFim(page: Page, raiz: string) {
+  const { total } = await page.evaluate(contador, raiz);
+  const proximo = page.locator(raiz).getByRole("button", { name: "Próximo ›" });
+  for (let i = 1; i < total; i++) await proximo.click();
+  await expect(page.locator(raiz).locator(".viz-step").last()).toHaveText(`passo ${total} de ${total}`);
+  return total;
+}
+
+test.describe("mst", () => {
+  // ------------------------------------------------------------------ camada 1
+  test.describe("camada 1", () => {
+    test.use({ viewport: { width: 1440, height: 600 } });
+
+    test("o rodape fica parado no pe do painel e o Rodar nao sai da janela", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+
+      // PRÉ-CONDIÇÃO: sem sobra para rolar, o teste inteiro é decoração verde.
+      // Medido no passo 1 desta régua: 102px (os demais passos dão 82).
+      const antes = await page.evaluate((sel) => {
+        const f = document.querySelector(sel) as HTMLElement;
+        const b = f.querySelector(".viz-body") as HTMLElement;
+        f.scrollTop = 0; b.scrollTop = 0;
+        const rodar = [...f.querySelectorAll("button")].find((x) => /Rodar|Pausar/.test(x.textContent || ""))!;
+        return {
+          sobra: b.scrollHeight - b.clientHeight,
+          headTop: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - f.getBoundingClientRect().top),
+          footBottom: Math.round(f.getBoundingClientRect().bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+          rodarAbaixo: Math.round(rodar.getBoundingClientRect().bottom - window.innerHeight),
+        };
+      }, PAINEL);
+      expect(antes.sobra, "o miolo precisa ter o que rolar").toBeGreaterThan(SLACK);
+
+      // O que a camada 1 promete: sem rolar NADA, o botão que faz o algoritmo
+      // andar já está na janela. Antes da casca ele era desenhado 531px abaixo
+      // do pé dela.
+      expect(antes.rodarAbaixo, "o ▶ Rodar tem que estar dentro da janela sem rolar nada").toBeLessThanOrEqual(0);
+
+      const depois = await page.evaluate((sel) => {
+        const f = document.querySelector(sel) as HTMLElement;
+        const b = f.querySelector(".viz-body") as HTMLElement;
+        b.scrollTop = 99999;
+        f.scrollTop = 99999;
+        const rodar = [...f.querySelectorAll("button")].find((x) => /Rodar|Pausar/.test(x.textContent || ""))!;
+        return {
+          bodyScroll: b.scrollTop,
+          figScroll: f.scrollTop,
+          headTop: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - f.getBoundingClientRect().top),
+          footBottom: Math.round(f.getBoundingClientRect().bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+          rodarAbaixo: Math.round(rodar.getBoundingClientRect().bottom - window.innerHeight),
+        };
+      }, PAINEL);
+
+      expect(depois.bodyScroll, "quem rola é o miolo").toBeGreaterThan(0);
+      expect(depois.figScroll, "a figura inteira não pode ser a área rolável").toBe(0);
+      expect(depois.headTop, "o cabeçalho não anda").toBe(antes.headTop);
+      expect(depois.footBottom, "o rodapé não anda").toBe(antes.footBottom);
+      expect(depois.rodarAbaixo, "o ▶ Rodar continua na janela depois de rolar").toBeLessThanOrEqual(0);
+    });
+  });
+
+  // ------------------------------------------------------------------ camada 3
+  test.describe("camada 3, tela baixa", () => {
+    test.use({ viewport: { width: 1440, height: 600 } });
+
+    test("o botao diz Mostrar codigo e o bloco perde a ALTURA", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+      const m = await page.evaluate(LER_BLOCO, ARTIGO);
+      expect(m.codigo).toBe("off");
+      expect(m.rotulo).toBe("Mostrar código");
+      expect(m.expanded).toBe("false");
+      // Rótulo certo com altura intacta é o defeito que o `.viz-code-slot`
+      // conserta: zerar a trilha da coluna tira largura, não altura. Medido:
+      // 2px recolhido contra 459 aberto.
+      expect(m.alturaCodigo, "o bloco recolhido não pode ocupar altura").toBeLessThan(SLACK);
+      // Medido: 710px de figura contra 1123 antes da casca.
+      expect(m.figura).toBeLessThan(800);
+    });
+
+    test("a escolha do aluno vence a medicao e sobrevive a troca de preset", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+      await expect(artigo).toHaveAttribute("data-codigo", "off");
+
+      await artigo.getByRole("button", { name: "Mostrar código" }).click();
+      await expect(artigo).toHaveAttribute("data-codigo", "on");
+      expect(await alturaCodigoEstavel(page, ARTIGO), "o bloco tem que abrir de verdade").toBeGreaterThan(400);
+
+      // O preset está em `measureOn`: esta troca PEDE medição nova, e nesta
+      // janela a medição quer recolher. Sem confirmar a troca na tela, o teste
+      // aprovaria uma escolha que nada ameaçou.
+      await artigo.getByRole("button", { name: "Uma ponte cara e obrigatória", exact: true }).click();
+      await expect(artigo.locator(".tt-legenda-arvore")).toContainText("peso 20");
+
+      await expect(artigo).toHaveAttribute("data-codigo", "on");
+      const depois = await page.evaluate(LER_BLOCO, ARTIGO);
+      expect(depois.rotulo).toBe("Ocultar código");
+      expect(
+        await alturaCodigoEstavel(page, ARTIGO),
+        "a escolha do aluno não é desfeita pela medição"
+      ).toBeGreaterThan(400);
+    });
+  });
+
+  test.describe("camada 3, tela alta", () => {
+    test.use({ viewport: { width: 1512, height: 1400 } });
+
+    test("o bloco ja vem aberto quando a peca cabe", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 1400 });
+      await abrirTopico(page);
+      const m = await page.evaluate(LER_BLOCO, ARTIGO);
+      expect(m.codigo).toBe("on");
+      expect(m.rotulo).toBe("Ocultar código");
+      expect(m.expanded).toBe("true");
+      // Medido: 459px aberto, e 1133 de figura contra 1316 de orçamento.
+      expect(m.alturaCodigo).toBeGreaterThan(400);
+    });
+  });
+
+  // ------------------------------------------------------------------- teclado
+  test.describe("teclado no painel", () => {
+    test.use({ viewport: { width: 1440, height: 600 } });
+
+    test("a seta direita anda a animacao, uma tecla de cada vez", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+      await painelPronto(page);
+      const passo = painel.locator(".viz-step").last();
+      await expect(passo).toHaveText("passo 1 de 7");
+
+      // Uma tecla só, repetida: um par ArrowRight/ArrowLeft devolveria a peça ao
+      // ponto de partida e ficaria verde com o atalho quebrado.
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText("passo 2 de 7");
+      await page.keyboard.press("ArrowRight");
+      await expect(passo).toHaveText("passo 3 de 7");
+    });
+
+    test("com o slider de velocidade em foco a seta e do slider, e o passo nao anda", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+      await painelPronto(page);
+      const passo = painel.locator(".viz-step").last();
+      const slider = painel.locator(".viz-speed input");
+      await expect(passo).toHaveText("passo 1 de 7");
+      await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+
+      await slider.focus();
+      await page.keyboard.press("ArrowLeft");
+      await expect(painel.locator(".viz-speed .val")).toHaveText("1x");
+      await expect(passo, "a seta era do slider").toHaveText("passo 1 de 7");
+      await page.keyboard.press("ArrowLeft");
+      await expect(painel.locator(".viz-speed .val")).toHaveText("0.75x");
+      await expect(passo, "a seta continua sendo do slider").toHaveText("passo 1 de 7");
+    });
+  });
+
+  // ---------------------------------------------- rótulo junto do valor medido
+  test.describe("o que a tela diz", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("a peca abre em 1.5x, a marcha que ela sempre teve", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+      await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+      await expect(painel.locator(".viz-speed input")).toHaveValue("4");
+    });
+
+    test("o desenho do grafo nao esta esticado: renderizado igual ao viewBox", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      const svg = await page.evaluate((sel) => {
+        const s = document.querySelector(`${sel} svg.tt-arv`) as SVGSVGElement;
+        const r = s.getBoundingClientRect();
+        return { rend: `${Math.round(r.width)}x${Math.round(r.height)}`, box: s.getAttribute("viewBox") };
+      }, ARTIGO);
+      // Sem esticão não há vazio a devolver, e um `max-height` só encolheria a
+      // fonte dos vértices (contrato §3). Medido igual nas três réguas.
+      expect(svg.box).toBe("0 0 330 230");
+      expect(svg.rend).toBe("330x230");
+    });
+
+    for (const modo of ["Kruskal: ordena arestas", "Prim: cresce de um vértice"]) {
+      test(`no fim, o cartao arestas na MST bate com as fichas verdes e com a nota (${modo.split(":")[0]})`, async ({ page }) => {
+        expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+        await abrirTopico(page);
+        const artigo = page.locator(ARTIGO);
+        await artigo.getByRole("button", { name: modo, exact: true }).click();
+        await irAoFim(page, ARTIGO);
+
+        const cartao = await page.evaluate(CARTAO, [ARTIGO, "arestas na MST"] as [string, string]);
+        const casou = cartao.valor.match(/^(\d+) de (\d+)$/);
+        expect(casou, `o cartão devia dizer "N de M" e disse "${cartao.valor}"`).not.toBeNull();
+        const naMst = parseInt(casou![1], 10);
+
+        // Três caminhos diferentes para o mesmo número, nenhum escrito na mão:
+        // o cartão, as fichas verdes da lista de arestas e a nota do passo.
+        const verdes = await artigo.locator(".mst-item.ok").count();
+        expect(verdes, "fichas verdes na lista de arestas").toBe(naMst);
+
+        const nota = (await artigo.locator(".viz-note").textContent()) || "";
+        const naNota = nota.match(/MST completa com (\d+) arestas/);
+        expect(naNota, `a nota final não casou: "${nota}"`).not.toBeNull();
+        expect(parseInt(naNota![1], 10), "a nota diz o mesmo que o cartão").toBe(naMst);
+      });
+    }
+
+    test("Kruskal e Prim mostram o mesmo peso, e o destaque segue o modo escolhido", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+
+      const k = await page.evaluate(CARTAO, [ARTIGO, "Kruskal"] as [string, string]);
+      const p = await page.evaluate(CARTAO, [ARTIGO, "Prim"] as [string, string]);
+      // A tese da peça inteira, lida como rótulo+valor no mesmo cartão.
+      expect(k.valor, "Kruskal e Prim chegam ao mesmo peso").toBe(p.valor);
+      expect(k.valor).toMatch(/^peso \d+$/);
+
+      // Trocar os dois valores de lugar passa por qualquer guarda que compare
+      // conjuntos; quem pega é o destaque, que tem de seguir o modo ativo.
+      expect(k.destacado, "com Kruskal selecionado, o cartão Kruskal é o destacado").toBe(true);
+      expect(p.destacado).toBe(false);
+
+      await artigo.getByRole("button", { name: "Prim: cresce de um vértice", exact: true }).click();
+      const k2 = await page.evaluate(CARTAO, [ARTIGO, "Kruskal"] as [string, string]);
+      const p2 = await page.evaluate(CARTAO, [ARTIGO, "Prim"] as [string, string]);
+      expect(p2.destacado, "com Prim selecionado, o cartão Prim é o destacado").toBe(true);
+      expect(k2.destacado).toBe(false);
+
+      // E o peso do cabeçalho, no último passo, é o do cartão do modo ativo.
+      await irAoFim(page, ARTIGO);
+      const cab = (await artigo.locator(".viz-step").first().textContent()) || "";
+      const pesoCab = cab.match(/peso (\d+)/);
+      expect(pesoCab, `o cabeçalho não casou: "${cab}"`).not.toBeNull();
+      expect(`peso ${pesoCab![1]}`, "o cabeçalho fecha no peso do cartão").toBe(p2.valor);
+    });
+  });
+});

--- a/tests/viz-topological-sort.spec.ts
+++ b/tests/viz-topological-sort.spec.ts
@@ -1,0 +1,275 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no visualizador de ordenação topológica (Kahn).
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura.
+//
+// Antes da casca, quem rolava dentro do painel expandido era a FIGURA INTEIRA
+// (371, 571 e 691px de sobra, com o miolo em 0), e o que saía da tela eram os
+// controles: no passo do pico o `▶ Rodar` era desenhado 290px (1512x900),
+// 490px (1440x700) e 590px (1440x600) ABAIXO do pé da janela, e rolar até o fim
+// levava o cabeçalho para 366, 566 e 666px acima do topo. Depois, quem rola é o
+// miolo, o `▶ Rodar` fica dentro em todas as três (−156, −56 e −49px) e o
+// cabeçalho não anda um pixel.
+//
+// No fluxo do artigo a peça pedia 1132–1173px contra 816 de orçamento; com o
+// código recolhido pela medição ela pede 668–709px. Recolher devolve 474px.
+//
+// O tópico tem um visualizador só, e ele tem as três camadas: overlay, bloco de
+// código, painel de variáveis e controles. Nenhum arquivo ficou de fora.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/topological-sort/";
+
+// Notebook de 16", a régua que motivou a casca. Nela a peça passa do orçamento
+// com o código aberto (1183 contra 816) e ele entra recolhido.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para caber com o código aberto (orçamento 1516px).
+const ALTA = { width: 1512, height: 1600 };
+// Apertada de propósito: é a única régua em que o miolo do painel AINDA estoura
+// com o código já recolhido (86px), e é onde a medição mais discordaria de quem
+// abre o código na mão (581px de sobra com ele aberto).
+const APERTADA = { width: 1440, height: 600 };
+
+// Folga de subpixel, a mesma do hook.
+const SLACK = 8;
+
+// O preset do ciclo, e o passo do PICO dele: a nota final é a mais longa da peça
+// (42px contra 22 no painel), e é o passo que dá ao miolo o que rolar. Medido
+// andando a animação inteira dos três presets: o máximo é sempre o ÚLTIMO passo,
+// e o eixo da altura é a nota, não a fila nem o desenho.
+const PRESET_CICLO = "Com ciclo (impossível)";
+const PASSOS_CICLO = 10;
+
+const PRESET_CURSO = "Pré-requisitos de um curso";
+const PRESET_PARALELO = "Muita coisa independente";
+
+async function abrirPainel(page: Page, tamanho: { width: number; height: number }) {
+  await page.setViewportSize(tamanho);
+  await page.goto(URL);
+  // `newPage({ viewportSize })` é ignorado em silêncio; afirmar a janela é a
+  // única forma de saber que a medição saiu do tamanho que se pediu.
+  expect(page.viewportSize()).toEqual(tamanho);
+  await page.evaluate(() => document.fonts.ready);
+  await page.getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+  await expect(painel).toBeVisible();
+  return painel;
+}
+
+/** O cartão de variável de um nome, para ler RÓTULO e VALOR juntos. */
+function cartao(escopo: ReturnType<Page["locator"]>, nome: string) {
+  return escopo.locator(".viz-var", {
+    has: escopo.page().locator(".viz-var-name", { hasText: new RegExp(`^${nome}$`) }),
+  });
+}
+
+test.describe("ordenação topológica · casca adaptativa", () => {
+  test("o cabeçalho e os controles ficam parados quando o miolo rola", async ({ page }) => {
+    const painel = await abrirPainel(page, APERTADA);
+
+    await painel.getByRole("button", { name: PRESET_CICLO, exact: true }).click();
+    for (let i = 1; i < PASSOS_CICLO; i++) {
+      await painel.getByRole("button", { name: "Próximo ›" }).click();
+    }
+    await expect(painel.locator(".viz-step")).toHaveText(`passo ${PASSOS_CICLO} de ${PASSOS_CICLO}`);
+
+    // O `click()` do Playwright ROLA o contêiner para alcançar o alvo, então a
+    // leitura de posição começa com o miolo zerado — senão eu meço o efeito do
+    // meu próprio clique e concluo que o cabeçalho já andava.
+    await painel.locator(".viz-body").evaluate((b) => { b.scrollTop = 0; });
+
+    // PREMISSA: o miolo estoura mesmo. Sem isto, o dia em que a peça encolher o
+    // teste vira decoração verde.
+    const sobra = await painel
+      .locator(".viz-body")
+      .evaluate((b) => b.scrollHeight - b.clientHeight);
+    expect(sobra).toBeGreaterThan(SLACK);
+
+    const antes = await painel.evaluate((f) => {
+      const r = f.getBoundingClientRect();
+      return {
+        cabecaTopo: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodapePe: Math.round(r.bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+      };
+    });
+    // A camada 1 é justamente cabeçalho colado no topo e rodapé colado no pé.
+    expect(antes.cabecaTopo).toBeLessThanOrEqual(2);
+    expect(antes.rodapePe).toBeLessThanOrEqual(2);
+
+    await painel.locator(".viz-body").evaluate((b) => { b.scrollTop = b.scrollHeight; });
+    await page.waitForTimeout(120);
+
+    const depois = await painel.evaluate((f) => {
+      const r = f.getBoundingClientRect();
+      const body = f.querySelector(".viz-body") as HTMLElement;
+      return {
+        cabecaTopo: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - r.top),
+        rodapePe: Math.round(r.bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+        bodyScrollTop: Math.round(body.scrollTop),
+        figuraScrollTop: Math.round(f.scrollTop),
+        figuraSobra: f.scrollHeight - f.clientHeight,
+      };
+    });
+
+    // As três coisas juntas, porque duas delas sozinhas aprovam a quebra que
+    // devolve a rolagem para a figura inteira — que é exatamente o estado de
+    // antes desta adaptação: o miolo estourou (acima), o miolo MESMO rolou, e a
+    // figura não rola nem rolou.
+    expect(depois.bodyScrollTop).toBeGreaterThan(0);
+    expect(depois.figuraScrollTop).toBe(0);
+    expect(depois.figuraSobra).toBeLessThanOrEqual(SLACK);
+    expect(depois.cabecaTopo).toBe(antes.cabecaTopo);
+    expect(depois.rodapePe).toBe(antes.rodapePe);
+
+    // E o botão que faz o algoritmo andar continua À VISTA — não só alcançável:
+    // o `click()` rola o contêiner para chegar no alvo, então clicar nele não
+    // provaria nada.
+    const rodar = painel.getByRole("button", { name: "▶ Rodar" });
+    const caixa = (await rodar.boundingBox())!;
+    expect(caixa.y).toBeGreaterThanOrEqual(0);
+    expect(caixa.y + caixa.height).toBeLessThanOrEqual(APERTADA.height);
+  });
+
+  test("em tela baixa o código vem recolhido, e o botão diz Mostrar código", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+    // O RÓTULO, não só o estado: botão que promete uma coisa e faz outra ensina
+    // errado do mesmo jeito.
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    await expect(painel).toHaveAttribute("data-codigo", "off");
+
+    // Recolhido de verdade: o slot fechou a ALTURA, não só a largura (contrato
+    // §7). Medido: 2px recolhido contra 531 aberto.
+    const alturaCodigo = await painel
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaCodigo).toBeLessThan(SLACK);
+  });
+
+  test("em tela alta o código já vem aberto, e o botão diz Ocultar código", async ({ page }) => {
+    const painel = await abrirPainel(page, ALTA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "true");
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+
+    // E o código aberto é o do Kahn, com o nome do arquivo.
+    await expect(painel.locator(".viz-code-head")).toHaveText("kahn.py");
+    const alturaCodigo = await painel
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaCodigo).toBeGreaterThan(80);
+  });
+
+  test("a escolha do aluno sobrevive à troca de preset, que pediria medição nova", async ({ page }) => {
+    const painel = await abrirPainel(page, APERTADA);
+    const botao = painel.getByRole("button", { name: /código$/ });
+
+    // Numa janela apertada a medição recolhe de saída: é o que dá o que
+    // contrariar. Com o código aberto o miolo estoura 581px aqui, então a
+    // medição QUER recolher.
+    await expect(botao).toHaveText("Mostrar código");
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+
+    // A troca precisa mexer numa entrada REAL da medição: o preset é o único
+    // valor de `measureOn`. E a PROVA NA TELA de que ele trocou é o cartão de
+    // arestas, lido com rótulo e valor juntos.
+    await expect(cartao(painel, "arestas")).toHaveText("arestas8");
+    await painel.getByRole("button", { name: PRESET_PARALELO, exact: true }).click();
+    await expect(cartao(painel, "arestas")).toHaveText("arestas4");
+
+    // "Está aberto agora" não é "continua aberto": amostra ao longo do
+    // intervalo em que a medição rodaria.
+    for (let i = 0; i < 6; i++) {
+      await page.waitForTimeout(80);
+      await expect(painel).toHaveAttribute("data-codigo", "on");
+    }
+    await expect(botao).toHaveText("Ocultar código");
+  });
+
+  test("as setas andam a animação, e o slider de velocidade fica com a tecla", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    const passo = painel.locator(".viz-step");
+    await expect(passo).toHaveText("passo 1 de 18");
+
+    // Uma ação só, nunca um par inverso: `ArrowRight` seguido de `ArrowLeft`
+    // devolve a peça ao estado de origem e fica verde com a quebra aplicada.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 2 de 18");
+
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+    // Com o cursor no slider, a seta é DO SLIDER. Sequestrar isso deixa o
+    // controle impossível de usar, o que é pior que não ter atalho.
+    const slider = painel.locator('input[type="range"]');
+    await slider.focus();
+    const passoAntes = await passo.innerText();
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await page.keyboard.press("ArrowRight");
+    await expect(painel.locator(".viz-speed .val")).toHaveText("2x");
+    await expect(passo).toHaveText(passoAntes);
+  });
+
+  test("a peça abre na marcha 1.5x, que é a dela e não a padrão do hook", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    // A marcha inicial era `useState(4)` antes da casca. Sem `initialSpeed` a
+    // peça abriria no "1x" do hook, e nenhum outro teste notaria.
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await expect(painel.locator('input[type="range"]')).toHaveValue("4");
+  });
+
+  test("o painel de variáveis casa rótulo e valor com o que está desenhado", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    await painel.getByRole("button", { name: PRESET_CICLO, exact: true }).click();
+    await expect(painel.locator(".viz-step")).toHaveText(`passo 1 de ${PASSOS_CICLO}`);
+
+    // O grau de entrada tem uma ficha por vértice, e o "de 7" do cartão sai
+    // dessa mesma contagem: é a invariante entre dois lugares da tela, e ela
+    // vale em todo passo — melhor que um número decorado.
+    const vertices = await painel.locator(".gr-dist-item").count();
+    expect(vertices).toBe(7);
+
+    for (let i = 1; i <= PASSOS_CICLO; i++) {
+      if (i > 1) await painel.getByRole("button", { name: "Próximo ›" }).click();
+      await expect(painel.locator(".viz-step")).toHaveText(`passo ${i} de ${PASSOS_CICLO}`);
+      const naOrdem = await painel.locator(".tt-saida-item").count();
+      const naFila = await painel.locator(".tt-aux-item").count();
+      // Rótulo E valor no MESMO cartão: trocar dois valores de lugar mantém o
+      // conjunto de textos idêntico e passa pelo guarda de idioma calado.
+      await expect(cartao(painel, "na ordem")).toHaveText(`na ordem${naOrdem} de ${vertices}`);
+      await expect(cartao(painel, "na fila")).toHaveText(`na fila${naFila}`);
+    }
+
+    // E o fim do preset do ciclo é o número que o artigo cita: a fila esvazia
+    // com 4 dos 7 vértices na ordem, e o que sobra é o ciclo.
+    await expect(cartao(painel, "na ordem")).toHaveText("na ordem4 de 7");
+    await expect(painel.locator(".viz-note")).toHaveClass(/invalid/);
+  });
+
+  test("o desenho do grafo não está esticado, então não há vazio a devolver", async ({ page }) => {
+    const painel = await abrirPainel(page, BAIXA);
+    // O reflexo do contrato §7 (um `max-height` no bloco temático) só devolve
+    // VAZIO, e só há vazio quando o renderizado é maior que o natural do
+    // `viewBox`. Aqui os dois são iguais: um teto encolheria o texto dos
+    // vértices, não o respiro.
+    const svg = painel.locator("svg.tt-arv");
+    const medido = await svg.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const vb = (el.getAttribute("viewBox") ?? "").split(/\s+/).map(Number);
+      return { rendW: Math.round(r.width), rendH: Math.round(r.height), vbW: vb[2], vbH: vb[3] };
+    });
+    expect(medido.rendH).toBe(medido.vbH);
+    expect(medido.rendW).toBe(medido.vbW);
+    expect(medido.rendH).toBe(175);
+  });
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores do grupo **Grafos**:
sete tópicos, **7 visualizadores adaptados**, com um agente por tópico (janela
deslizante de 3 em paralelo) e consolidação num PR só.

## O que entrou

| tópico | visualizador | camadas |
|---|---|---|
| `grafos-intro` | `GrafoRepresentacao` | 1 e 2 — `collapsible: false` + `total: 1`, **sem rodapé nenhum** |
| `dfs-bfs` | `GrafoDfsBfs` | as três |
| `dijkstra` | `DijkstraVisualizer` | as três |
| `bellman-ford` | `BellmanFordVisualizer` | as três |
| `a-star` | `AStarVisualizer` | as três |
| `topological-sort` | `TopoSortVisualizer` | as três |
| `mst` | `MstVisualizer` | as três |

**7 de 7, nada fora do escopo.** `floyd-warshall` e `grafos-avancados` estão
`soon` e não têm visualizador. **Zero linha de CSS nova** nas sete.

## Medições

Janela **1512x900**, fontes carregadas, animação congelada, orçamento no artigo
= 816px. Cada peça medida andando a animação inteira, em todos os presets e
modos, e também em 1440x700 e 1440x600.

| peça | artigo antes | depois | o que rolava no painel |
|---|---|---|---|
| representação | 1021–1069 | **1017–1065** | a figura, 157–476px |
| DFS/BFS | 1103–1122 | **843–862** | a figura, 281–592px |
| Dijkstra | 1071–1130 | **679–739** | a figura, 294–633px |
| Bellman-Ford | 1000–1059 | **663–723** | a figura, 213–533px |
| A* | 1084–1123 | **766–805** | a figura, 323–623px |
| ordenação topológica | 1132–1173 | **668–709** | a figura, 391–691px |
| MST | 1103–1142 | **690–729** | a figura, 332–652px |

**Nas sete, quem rolava no painel era a figura inteira**, levando cabeçalho e
controles junto. O `▶ Rodar` era desenhado entre 112 e 590px **abaixo do pé da
janela**; no `grafos-intro`, que não tem reprodução, era o `✕ Fechar` — o único
botão que fecha o painel — indo até **439px acima do topo**. Depois, o cabeçalho
não anda 1px em nenhuma das três réguas e todo controle fica dentro da janela.

Quatro peças passam a caber no artigo a 1512x900 (Dijkstra, Bellman-Ford,
ordenação topológica e MST, com 77 a 93px de folga). As outras seguem acima do
orçamento com o código já recolhido — limite do §9, reportado com a altura
quebrada por bloco em cada caso.

## Testes

**60 testes novos** em sete arquivos disjuntos, **65 quebras provadas**, todas
compilando, com build visível e resumo imprimindo `failed` **e** `passed`.

**Suíte completa na branch integrada: 350 passed, 0 failed** (`--workers=2`, com
a máquina livre), confirmada em duas execuções.

## O que a consolidação pegou

**Um defeito de texto de tela.** Numa peça com linha do tempo, os `children` do
`VizHeader` e o contador de passo viram dois `.viz-step` irmãos separados só pelo
`gap`, e o separador que o componente escrevia à mão **some**. Três peças desta
rodada têm essa forma: `BellmanFordVisualizer` e `MstVisualizer` terminaram os
`children` com o `·` e preservaram a tela; o `AStarVisualizer` não, e
`0 expandidas · passo 1 de 85` perdeu o ponto médio. Nenhum teste pegou — o do
contador afirmava só o número e a palavra. Corrigido, com o teste passando a
afirmar o texto exato (9 passed → 1 failed 8 passed sem o separador → 9 passed).

**Diff do texto renderizado do build inteiro**, `origin/main` contra esta branch,
comparando o texto corrido de cada página palavra a palavra: **zero palavras
perdidas nas 53 páginas**, e nada acrescentado além das afordâncias da casca. A
página de `grafos-intro` não tem adição nenhuma — é o build confirmando o que
`collapsible: false` + `total: 1` + sem rodapé prometem.

**Varreduras de classe:** as 12 peças do repo com marcha inicial própria
mantiveram `initialSpeed` (a classe do #30); nenhum `stepBy` com aritmética (a do
#28); nenhum rodapé escrito à mão; nenhum `newPage({ viewportSize })` nos testes
novos — a única ocorrência do termo é um **comentário** avisando da armadilha.

## Contrato (`content/visualizers/README.md`)

**Uma seção nova e cinco acréscimos**, todos medidos.

### O perfil de altura de um visualizador de grafo

Sete agentes independentes mediram a mesma coisa, e isso vira atalho na §3:

| o que se mediu | resultado, em 7 de 7 |
|---|---|
| altura do desenho ao trocar preset | **constante ao pixel** (189px em 756 amostras; 366x236 em 514 estados) |
| esticão do SVG (renderizado × `viewBox`) | **0px** — nenhum teto, nenhuma linha de CSS |
| estruturas auxiliares (fila, pilha, tabela) | **34px** sempre; o `flex-wrap` nunca quebra |
| o que de fato move a peça | **a prosa** — a nota do passo e a dica do preset |

**E o critério que essa seção quase levou estava errado.** A primeira formulação
era "o layout é posicionado à mão ou gerado por código", e o A* mostra que isso
não separa nada: a grade dele é gerada por laço e tem altura tão fixa quanto sete
vértices numa constante, porque `COLS`, `ROWS` e `CELL` são constantes do arquivo
e os presets trocam *quais* células são parede, nunca *quantas* existem. A
pergunta que separa é: **existe caminho da tela até o número que gera as
linhas?**

### Os acréscimos

1. **§3, receita do pior caso — três itens novos:** ele pode estar na **ausência
   de preset** (no `GrafoRepresentacao` os oito presets empatam ao pixel e o mais
   alto é o grafo editado à mão); pode ser a **soma de dois blocos com sinais
   trocados** (no `TopoSort` o preset mais alto é o de *menos* arestas, por 2px);
   e **o que cresce ao lado de algo constante e mais alto não é altura** — numa
   linha de `.gr-split` a altura é o máximo dos dois lados, e a tabela do
   Bellman-Ford cresce 88px parando 61px antes do desenho.
2. **§3, ressalva na regra do pico:** ele muda com a largura só enquanto a coluna
   do artigo não está no `max-width`. Quando está, 1512 e 1440 são a mesma régua.
3. **§9 — a casca cria um eixo de altura próprio:** `.viz-fit .viz-head-right` é
   `flex-wrap`, e o botão novo faz a linha quebrar quando o contador ganha um
   dígito. 53 → **81px** em 19 dos 514 estados do A*, só a 1440 de largura.
4. **§9 — `children` do `VizHeader` numa peça com linha do tempo**, com o
   separador que some e a solução (terminar os `children` com ele).
5. **§9 — os −4px** que a casca devolve numa peça sem rodapé foram medidos em
   **duas peças sem parentesco** (`BinaryTreeFormatos` e `GrafoRepresentacao`),
   o que confirma o mecanismo e não só o número.

## Idioma

Identificadores traduzidos nos sete componentes. O `guarda-idioma.py` **não é
prova em nenhum deles**, e desta vez isso foi **demonstrado**: trocando `" de "`
por `" of "` em `{s.round} de {LABELS.length - 1}`, ele sai com
`SUMIRAM: nenhuma / APARECERAM: nenhuma` — o painel diria "rodada 5 **of** 4" com
o guarda verde. A prova foi comparar o texto renderizado dos estados: **1.352
estados** somados, com diff vazio no miolo, mais o diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
