### PR TITLE
feat(viz): casca adaptativa em Heaps e Busca Binária

### DIFF
--- a/content/visualizers/BinaryHeapVisualizer.tsx
+++ b/content/visualizers/BinaryHeapVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinaryHeapVisualizer, as três operações que definem o heap.
@@ -13,38 +14,42 @@ import { createPortal } from "react-dom";
 //
 // Três modos, porque o heap tem três histórias diferentes:
 //
-//   - inserir  : o valor entra no FIM e sobe (sift up). Trocar o preset de
-//                "crescente" para "decrescente" mostra o melhor caso (zero
-//                trocas) virar o pior (toda inserção sobe até a raiz).
-//   - remover  : a raiz sai, o ÚLTIMO sobe para o lugar dela e desce (sift
-//                down). Rodando até o fim, a saída sai ordenada: é heap sort.
-//   - construir: heapify a partir do último pai. O painel compara as trocas do
-//                build-heap com as de inserir um a um, que é o argumento
-//                medido de por que build-heap é O(n) e não O(n log n).
+//   - insert : o valor entra no FIM e sobe (sift up). Trocar o preset de
+//              "crescente" para "decrescente" mostra o melhor caso (zero
+//              trocas) virar o pior (toda inserção sobe até a raiz).
+//   - remove : a raiz sai, o ÚLTIMO sobe para o lugar dela e desce (sift
+//              down). Rodando até o fim, a saída sai ordenada: é heap sort.
+//   - build  : heapify a partir do último pai. O painel compara as trocas do
+//              build-heap com as de inserir um a um, que é o argumento
+//              medido de por que build-heap é O(n) e não O(n log n).
 //
 // Gerador puro: cada passo carrega o snapshot do array, então navegar para
 // trás é de graça e não existe estado escondido.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Tipo = "min" | "max";
-type Modo = "inserir" | "remover" | "construir";
+type HeapKind = "min" | "max";
+type Mode = "insert" | "remove" | "build";
 
-type Passo = {
+type Step = {
   arr: number[];
   n: number; // quantos elementos do array ainda pertencem ao heap
-  foco: number; // índice em foco
-  par: number; // com quem ele está sendo comparado (-1 = ninguém)
-  trocou: boolean; // este passo acabou de executar uma troca
-  entrando: number; // índice que acabou de entrar no fim (-1 = nenhum)
-  saida: number[]; // valores já removidos, na ordem
-  comp: number;
+  focus: number; // índice em foco
+  partner: number; // com quem ele está sendo comparado (-1 = ninguém)
+  swapped: boolean; // este passo acabou de executar uma troca
+  entering: number; // índice que acabou de entrar no fim (-1 = nenhum)
+  output: number[]; // valores já removidos, na ordem
+  comparisons: number;
   swaps: number;
-  linha: number;
-  nota: string;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO_INSERIR = [
+const CODE_INSERT = [
   "def push(heap, valor):",
   "    heap.append(valor)          # entra sempre no FIM",
   "    i = len(heap) - 1",
@@ -56,7 +61,7 @@ const CODIGO_INSERIR = [
   "        i = pai                 # subo e comparo de novo",
 ];
 
-const CODIGO_REMOVER = [
+const CODE_REMOVE = [
   "def pop(heap):",
   "    topo = heap[0]",
   "    heap[0] = heap[-1]          # o ÚLTIMO sobe para a raiz",
@@ -74,7 +79,7 @@ const CODIGO_REMOVER = [
   "        i = menor",
 ];
 
-const CODIGO_CONSTRUIR = [
+const CODE_BUILD = [
   "def build_heap(a):",
   "    # o último PAI é o único ponto de partida que faz sentido:",
   "    # folha não tem filho, então não tem para onde descer",
@@ -91,297 +96,294 @@ const CODIGO_CONSTRUIR = [
   "        i = menor",
 ];
 
-type Preset = { key: string; rotulo: string; valores: number[]; dica: string };
+type Preset = { key: string; label: string; values: number[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "chegada",
-    rotulo: "Ordem de chegada: 3 5 2 1 4 6",
-    valores: [3, 5, 2, 1, 4, 6],
-    dica: "Seis valores em ordem embaralhada. Repare que o array final NÃO fica ordenado, e mesmo assim a regra do heap vale em todos os nós.",
+    key: "arrival",
+    label: "Ordem de chegada: 3 5 2 1 4 6",
+    values: [3, 5, 2, 1, 4, 6],
+    hint: "Seis valores em ordem embaralhada. Repare que o array final NÃO fica ordenado, e mesmo assim a regra do heap vale em todos os nós.",
   },
   {
-    key: "crescente",
-    rotulo: "Chegando em ordem: 1 2 3 4 5 6 7 8 9",
-    valores: [1, 2, 3, 4, 5, 6, 7, 8, 9],
-    dica: "Nove valores em ordem crescente. Num min-heap cada um já chega maior que o pai e nada se move: 0 trocas. Troque para max-heap e as mesmas nove inserções custam 16 trocas, porque aí todo valor que chega é o novo máximo e sobe até a raiz.",
+    key: "ascending",
+    label: "Chegando em ordem: 1 2 3 4 5 6 7 8 9",
+    values: [1, 2, 3, 4, 5, 6, 7, 8, 9],
+    hint: "Nove valores em ordem crescente. Num min-heap cada um já chega maior que o pai e nada se move: 0 trocas. Troque para max-heap e as mesmas nove inserções custam 16 trocas, porque aí todo valor que chega é o novo máximo e sobe até a raiz.",
   },
   {
-    key: "decrescente",
-    rotulo: "Chegando ao contrário: 9 8 7 6 5 4 3 2 1",
-    valores: [9, 8, 7, 6, 5, 4, 3, 2, 1],
-    dica: "Os MESMOS nove valores, na ordem inversa, e os papéis se invertem: agora é o min-heap que paga as 16 trocas e o max-heap que não move nada. A ordem de chegada decide o trabalho, e o teto é sempre a altura da árvore.",
+    key: "descending",
+    label: "Chegando ao contrário: 9 8 7 6 5 4 3 2 1",
+    values: [9, 8, 7, 6, 5, 4, 3, 2, 1],
+    hint: "Os MESMOS nove valores, na ordem inversa, e os papéis se invertem: agora é o min-heap que paga as 16 trocas e o max-heap que não move nada. A ordem de chegada decide o trabalho, e o teto é sempre a altura da árvore.",
   },
   {
-    key: "repetidos",
-    rotulo: "Com repetidos: 20 15 10 40 50 100 25 15",
-    valores: [20, 15, 10, 40, 50, 100, 25, 15],
-    dica: "Valores iguais convivem sem problema: a regra é pai menor ou IGUAL ao filho, então empate não é violação.",
+    key: "duplicates",
+    label: "Com repetidos: 20 15 10 40 50 100 25 15",
+    values: [20, 15, 10, 40, 50, 100, 25, 15],
+    hint: "Valores iguais convivem sem problema: a regra é pai menor ou IGUAL ao filho, então empate não é violação.",
   },
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-// `pai` respeita a regra em relação a `filho`?
-function respeita(pai: number, filho: number, tipo: Tipo) {
-  return tipo === "min" ? pai <= filho : pai >= filho;
+// `parent` respeita a regra em relação a `child`?
+function respects(parent: number, child: number, kind: HeapKind) {
+  return kind === "min" ? parent <= child : parent >= child;
 }
-function melhorQue(a: number, b: number, tipo: Tipo) {
-  return tipo === "min" ? a < b : a > b;
+function better(a: number, b: number, kind: HeapKind) {
+  return kind === "min" ? a < b : a > b;
 }
 
-const nomeTopo = (tipo: Tipo) => (tipo === "min" ? "menor" : "maior");
+const topName = (kind: HeapKind) => (kind === "min" ? "menor" : "maior");
 
 // --- geradores puros -------------------------------------------------------
 
-function passosInserir(valores: number[], tipo: Tipo): Passo[] {
-  const out: Passo[] = [];
+function stepsInsert(values: number[], kind: HeapKind): Step[] {
+  const steps: Step[] = [];
   const h: number[] = [];
-  let comp = 0;
+  let comparisons = 0;
   let swaps = 0;
-  const base = () => ({ arr: [...h], n: h.length, saida: [], comp, swaps, trocou: false, entrando: -1, par: -1 });
+  const base = () => ({ arr: [...h], n: h.length, output: [], comparisons, swaps, swapped: false, entering: -1, partner: -1 });
 
-  for (const v of valores) {
+  for (const v of values) {
     h.push(v);
     let i = h.length - 1;
-    out.push({
-      ...base(), foco: i, entrando: i, linha: 1,
-      nota: `${v} entra no FIM do array, na posição ${i}. É a única posição que mantém a árvore completa, então nem preciso procurar onde colocar.`,
+    steps.push({
+      ...base(), focus: i, entering: i, line: 1,
+      note: `${v} entra no FIM do array, na posição ${i}. É a única posição que mantém a árvore completa, então nem preciso procurar onde colocar.`,
     });
-    let guarda = 0;
-    while (i > 0 && guarda++ < 200) {
-      const pai = (i - 1) >> 1;
-      comp++;
-      out.push({
-        ...base(), foco: i, par: pai, linha: 4,
-        nota: `Comparo com o pai: índice ${i} tem pai (${i} - 1) // 2 = ${pai}. É ${h[pai]} contra ${h[i]}.`,
+    let guard = 0;
+    while (i > 0 && guard++ < 200) {
+      const parent = (i - 1) >> 1;
+      comparisons++;
+      steps.push({
+        ...base(), focus: i, partner: parent, line: 4,
+        note: `Comparo com o pai: índice ${i} tem pai (${i} - 1) // 2 = ${parent}. É ${h[parent]} contra ${h[i]}.`,
       });
-      if (respeita(h[pai], h[i], tipo)) {
-        out.push({
-          ...base(), foco: i, par: pai, linha: 6, ok: true,
-          nota: `${h[pai]} ${h[pai] === h[i] ? "empata com" : tipo === "min" ? "é menor que" : "é maior que"} ${h[i]}: a regra já vale aqui, e como ela valia acima, vale na árvore inteira. Paro sem subir mais.`,
+      if (respects(h[parent], h[i], kind)) {
+        steps.push({
+          ...base(), focus: i, partner: parent, line: 6, ok: true,
+          note: `${h[parent]} ${h[parent] === h[i] ? "empata com" : kind === "min" ? "é menor que" : "é maior que"} ${h[i]}: a regra já vale aqui, e como ela valia acima, vale na árvore inteira. Paro sem subir mais.`,
         });
         break;
       }
-      [h[pai], h[i]] = [h[i], h[pai]];
+      [h[parent], h[i]] = [h[i], h[parent]];
       swaps++;
-      const antigoI = i;
-      i = pai;
-      out.push({
-        ...base(), foco: i, par: antigoI, trocou: true, linha: 7,
-        nota: `${h[i]} ${tipo === "min" ? "é menor" : "é maior"} que ${h[antigoI]}: violação. Troco os dois e ${h[i]} sobe para a posição ${i}. Só este caminho até a raiz é tocado, o resto da árvore nem fica sabendo.`,
+      const prevI = i;
+      i = parent;
+      steps.push({
+        ...base(), focus: i, partner: prevI, swapped: true, line: 7,
+        note: `${h[i]} ${kind === "min" ? "é menor" : "é maior"} que ${h[prevI]}: violação. Troco os dois e ${h[i]} sobe para a posição ${i}. Só este caminho até a raiz é tocado, o resto da árvore nem fica sabendo.`,
       });
     }
     if (i === 0 && h.length > 1) {
-      out.push({
-        ...base(), foco: 0, linha: 3, ok: true,
-        nota: `Cheguei na raiz: não existe pai da posição 0, então a subida acabou. ${h[0]} é o ${nomeTopo(tipo)} valor do heap.`,
+      steps.push({
+        ...base(), focus: 0, line: 3, ok: true,
+        note: `Cheguei na raiz: não existe pai da posição 0, então a subida acabou. ${h[0]} é o ${topName(kind)} valor do heap.`,
       });
     }
   }
-  const alt = altura(h.length);
-  out.push({
-    ...base(), foco: -1, linha: 8, ok: true,
-    nota: `Heap montado com ${h.length} elementos e altura ${alt}. Foram ${comp} comparações e ${swaps} trocas. Repare no array: ele NÃO está ordenado, e não precisa estar. A única promessa é que todo pai respeita a regra em relação aos filhos dele.`,
+  const treeHeight = height(h.length);
+  steps.push({
+    ...base(), focus: -1, line: 8, ok: true,
+    note: `Heap montado com ${h.length} elementos e altura ${treeHeight}. Foram ${comparisons} comparações e ${swaps} trocas. Repare no array: ele NÃO está ordenado, e não precisa estar. A única promessa é que todo pai respeita a regra em relação aos filhos dele.`,
   });
-  return out;
+  return steps;
 }
 
-function construirHeapPorInsercao(valores: number[], tipo: Tipo) {
+function buildHeapByInsertion(values: number[], kind: HeapKind) {
   const h: number[] = [];
-  let comp = 0;
+  let comparisons = 0;
   let swaps = 0;
-  for (const v of valores) {
+  for (const v of values) {
     h.push(v);
     let i = h.length - 1;
-    let guarda = 0;
-    while (i > 0 && guarda++ < 200) {
-      const pai = (i - 1) >> 1;
-      comp++;
-      if (respeita(h[pai], h[i], tipo)) break;
-      [h[pai], h[i]] = [h[i], h[pai]];
+    let guard = 0;
+    while (i > 0 && guard++ < 200) {
+      const parent = (i - 1) >> 1;
+      comparisons++;
+      if (respects(h[parent], h[i], kind)) break;
+      [h[parent], h[i]] = [h[i], h[parent]];
       swaps++;
-      i = pai;
+      i = parent;
     }
   }
-  return { heap: h, comp, swaps };
+  return { heap: h, comparisons, swaps };
 }
 
-function passosRemover(valores: number[], tipo: Tipo): Passo[] {
-  const { heap } = construirHeapPorInsercao(valores, tipo);
+function stepsRemove(values: number[], kind: HeapKind): Step[] {
+  const { heap } = buildHeapByInsertion(values, kind);
   const h = [...heap];
-  const saida: number[] = [];
-  const out: Passo[] = [];
-  let comp = 0;
+  const output: number[] = [];
+  const steps: Step[] = [];
+  let comparisons = 0;
   let swaps = 0;
-  const base = () => ({ arr: [...h], n: h.length, saida: [...saida], comp, swaps, trocou: false, entrando: -1, par: -1 });
+  const base = () => ({ arr: [...h], n: h.length, output: [...output], comparisons, swaps, swapped: false, entering: -1, partner: -1 });
 
-  out.push({
-    ...base(), foco: 0, linha: 0,
-    nota: `Heap pronto com ${h.length} elementos. O ${nomeTopo(tipo)} valor está sempre na posição 0, e olhar para ele custa O(1). O caro é REMOVER e manter a regra.`,
+  steps.push({
+    ...base(), focus: 0, line: 0,
+    note: `Heap pronto com ${h.length} elementos. O ${topName(kind)} valor está sempre na posição 0, e olhar para ele custa O(1). O caro é REMOVER e manter a regra.`,
   });
 
-  let rodada = 0;
-  while (h.length > 0 && rodada++ < 60) {
-    const topo = h[0];
-    out.push({
-      ...base(), foco: 0, linha: 1,
-      nota: `Guardo o topo (${topo}) para devolver. Agora preciso de uma raiz nova sem quebrar a forma completa da árvore.`,
+  let round = 0;
+  while (h.length > 0 && round++ < 60) {
+    const top = h[0];
+    steps.push({
+      ...base(), focus: 0, line: 1,
+      note: `Guardo o topo (${top}) para devolver. Agora preciso de uma raiz nova sem quebrar a forma completa da árvore.`,
     });
-    const ultimo = h[h.length - 1];
+    const last = h[h.length - 1];
     if (h.length > 1) {
-      h[0] = ultimo;
+      h[0] = last;
       h.pop();
-      out.push({
-        ...base(), foco: 0, trocou: true, linha: 2,
-        nota: `O ÚLTIMO elemento (${ultimo}) sobe para a raiz. Por que o último? Porque tirar ele do fim é a única remoção que mantém a árvore completa. O preço é que a regra provavelmente quebrou lá em cima.`,
+      steps.push({
+        ...base(), focus: 0, swapped: true, line: 2,
+        note: `O ÚLTIMO elemento (${last}) sobe para a raiz. Por que o último? Porque tirar ele do fim é a única remoção que mantém a árvore completa. O preço é que a regra provavelmente quebrou lá em cima.`,
       });
     } else {
       h.pop();
     }
-    saida.push(topo);
+    output.push(top);
 
     let i = 0;
-    let guarda = 0;
-    while (guarda++ < 200) {
-      const e = 2 * i + 1;
-      const d = 2 * i + 2;
-      if (e >= h.length) {
+    let guard = 0;
+    while (guard++ < 200) {
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      if (left >= h.length) {
         if (h.length > 0) {
-          out.push({
-            ...base(), foco: i, linha: 12, ok: true,
-            nota: `A posição ${i} não tem filho (2 x ${i} + 1 = ${e} já passou do fim do heap), então cheguei numa folha e a descida acabou. Saída até aqui: ${saida.join(", ")}.`,
+          steps.push({
+            ...base(), focus: i, line: 12, ok: true,
+            note: `A posição ${i} não tem filho (2 x ${i} + 1 = ${left} já passou do fim do heap), então cheguei numa folha e a descida acabou. Saída até aqui: ${output.join(", ")}.`,
           });
         }
         break;
       }
-      let alvo = i;
-      comp++;
-      if (melhorQue(h[e], h[alvo], tipo)) alvo = e;
-      let notaCmp = `Filhos da posição ${i}: esquerda em 2 x ${i} + 1 = ${e} (valor ${h[e]})`;
-      if (d < h.length) {
-        comp++;
-        notaCmp += ` e direita em 2 x ${i} + 2 = ${d} (valor ${h[d]})`;
-        if (melhorQue(h[d], h[alvo], tipo)) alvo = d;
+      let target = i;
+      comparisons++;
+      if (better(h[left], h[target], kind)) target = left;
+      let cmpNote = `Filhos da posição ${i}: esquerda em 2 x ${i} + 1 = ${left} (valor ${h[left]})`;
+      if (right < h.length) {
+        comparisons++;
+        cmpNote += ` e direita em 2 x ${i} + 2 = ${right} (valor ${h[right]})`;
+        if (better(h[right], h[target], kind)) target = right;
       } else {
-        notaCmp += ` (não existe filho à direita)`;
+        cmpNote += ` (não existe filho à direita)`;
       }
-      out.push({
-        ...base(), foco: i, par: alvo === i ? -1 : alvo, linha: d < h.length ? 11 : 10,
-        nota: `${notaCmp}. Comparo os três de uma vez: quem for o ${nomeTopo(tipo)} da tríade tem que ficar por cima.`,
+      steps.push({
+        ...base(), focus: i, partner: target === i ? -1 : target, line: right < h.length ? 11 : 10,
+        note: `${cmpNote}. Comparo os três de uma vez: quem for o ${topName(kind)} da tríade tem que ficar por cima.`,
       });
-      if (alvo === i) {
-        out.push({
-          ...base(), foco: i, linha: 12, ok: true,
-          nota: `${h[i]} já é o ${nomeTopo(tipo)} entre pai e filhos, então a regra voltou a valer daqui para baixo. Paro. Saída até aqui: ${saida.join(", ")}.`,
+      if (target === i) {
+        steps.push({
+          ...base(), focus: i, line: 12, ok: true,
+          note: `${h[i]} já é o ${topName(kind)} entre pai e filhos, então a regra voltou a valer daqui para baixo. Paro. Saída até aqui: ${output.join(", ")}.`,
         });
         break;
       }
-      const desceu = h[alvo];
-      [h[i], h[alvo]] = [h[alvo], h[i]];
+      const promoted = h[target];
+      [h[i], h[target]] = [h[target], h[i]];
       swaps++;
-      const antigo = i;
-      i = alvo;
-      out.push({
-        ...base(), foco: i, par: antigo, trocou: true, linha: 13,
-        nota: `${desceu} sobe para a posição ${antigo} e ${h[i]} desce para ${i}. Continuo a descida por ESTE ramo só: o outro filho e toda a subárvore dele ficam intocados, e é daí que vem o log.`,
+      const prev = i;
+      i = target;
+      steps.push({
+        ...base(), focus: i, partner: prev, swapped: true, line: 13,
+        note: `${promoted} sobe para a posição ${prev} e ${h[i]} desce para ${i}. Continuo a descida por ESTE ramo só: o outro filho e toda a subárvore dele ficam intocados, e é daí que vem o log.`,
       });
     }
   }
 
-  out.push({
-    ...base(), foco: -1, linha: 5, ok: true,
-    nota: `Heap vazio. A ordem de saída foi ${saida.join(", ")}: ordenada, do ${nomeTopo(tipo)} para o outro extremo. Tirar tudo de um heap é exatamente isso, e é a ideia do heap sort.`,
+  steps.push({
+    ...base(), focus: -1, line: 5, ok: true,
+    note: `Heap vazio. A ordem de saída foi ${output.join(", ")}: ordenada, do ${topName(kind)} para o outro extremo. Tirar tudo de um heap é exatamente isso, e é a ideia do heap sort.`,
   });
-  return out;
+  return steps;
 }
 
-function passosConstruir(valores: number[], tipo: Tipo): Passo[] {
-  const h = [...valores];
-  const out: Passo[] = [];
-  let comp = 0;
+function stepsBuild(values: number[], kind: HeapKind): Step[] {
+  const h = [...values];
+  const steps: Step[] = [];
+  let comparisons = 0;
   let swaps = 0;
-  const base = () => ({ arr: [...h], n: h.length, saida: [], comp, swaps, trocou: false, entrando: -1, par: -1 });
+  const base = () => ({ arr: [...h], n: h.length, output: [], comparisons, swaps, swapped: false, entering: -1, partner: -1 });
 
-  const ultimoPai = Math.floor(h.length / 2) - 1;
-  out.push({
-    ...base(), foco: -1, linha: 0,
-    nota: `Array cru, sem nenhuma garantia: ${h.join(", ")}. Vou transformá-lo em heap sem criar nada novo, mexendo só nas posições que já existem.`,
+  const lastParent = Math.floor(h.length / 2) - 1;
+  steps.push({
+    ...base(), focus: -1, line: 0,
+    note: `Array cru, sem nenhuma garantia: ${h.join(", ")}. Vou transformá-lo em heap sem criar nada novo, mexendo só nas posições que já existem.`,
   });
-  out.push({
-    ...base(), foco: ultimoPai, linha: 3,
-    nota: `Começo no índice ${ultimoPai}, que é ${h.length} // 2 - 1: o ÚLTIMO nó que tem filho. Da metade do array para a frente só existe folha, e folha não tem para onde descer. Metade do trabalho some com esta única conta.`,
+  steps.push({
+    ...base(), focus: lastParent, line: 3,
+    note: `Começo no índice ${lastParent}, que é ${h.length} // 2 - 1: o ÚLTIMO nó que tem filho. Da metade do array para a frente só existe folha, e folha não tem para onde descer. Metade do trabalho some com esta única conta.`,
   });
 
-  for (let raiz = ultimoPai; raiz >= 0; raiz--) {
-    out.push({
-      ...base(), foco: raiz, linha: 4,
-      nota: `Desço a partir da posição ${raiz} (valor ${h[raiz]}). Tudo que está ABAIXO dela já virou heap nas rodadas anteriores, então só falta acertar este nó.`,
+  for (let root = lastParent; root >= 0; root--) {
+    steps.push({
+      ...base(), focus: root, line: 4,
+      note: `Desço a partir da posição ${root} (valor ${h[root]}). Tudo que está ABAIXO dela já virou heap nas rodadas anteriores, então só falta acertar este nó.`,
     });
-    let i = raiz;
-    let guarda = 0;
-    while (guarda++ < 200) {
-      const e = 2 * i + 1;
-      const d = 2 * i + 2;
-      if (e >= h.length) break;
-      let alvo = i;
-      comp++;
-      if (melhorQue(h[e], h[alvo], tipo)) alvo = e;
-      if (d < h.length) {
-        comp++;
-        if (melhorQue(h[d], h[alvo], tipo)) alvo = d;
+    let i = root;
+    let guard = 0;
+    while (guard++ < 200) {
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      if (left >= h.length) break;
+      let target = i;
+      comparisons++;
+      if (better(h[left], h[target], kind)) target = left;
+      if (right < h.length) {
+        comparisons++;
+        if (better(h[right], h[target], kind)) target = right;
       }
-      out.push({
-        ...base(), foco: i, par: alvo === i ? -1 : alvo, linha: d < h.length ? 10 : 9,
-        nota: `Na posição ${i} tenho ${h[i]}, com filho${d < h.length ? "s" : ""} ${h[e]}${d < h.length ? ` e ${h[d]}` : ""}. O ${nomeTopo(tipo)} da tríade é ${h[alvo]}.`,
+      steps.push({
+        ...base(), focus: i, partner: target === i ? -1 : target, line: right < h.length ? 10 : 9,
+        note: `Na posição ${i} tenho ${h[i]}, com filho${right < h.length ? "s" : ""} ${h[left]}${right < h.length ? ` e ${h[right]}` : ""}. O ${topName(kind)} da tríade é ${h[target]}.`,
       });
-      if (alvo === i) {
-        out.push({
-          ...base(), foco: i, linha: 11, ok: true,
-          nota: `${h[i]} já é o ${nomeTopo(tipo)} da tríade: esta subárvore está válida e não desço mais.`,
+      if (target === i) {
+        steps.push({
+          ...base(), focus: i, line: 11, ok: true,
+          note: `${h[i]} já é o ${topName(kind)} da tríade: esta subárvore está válida e não desço mais.`,
         });
         break;
       }
-      const subiu = h[alvo];
-      [h[i], h[alvo]] = [h[alvo], h[i]];
+      const promoted = h[target];
+      [h[i], h[target]] = [h[target], h[i]];
       swaps++;
-      const antigo = i;
-      i = alvo;
-      out.push({
-        ...base(), foco: i, par: antigo, trocou: true, linha: 12,
-        nota: `Troco: ${subiu} sobe para ${antigo}, ${h[i]} desce para ${i}. Como o valor desceu, a subárvore de ${i} pode ter quebrado, então continuo a descida por ela.`,
+      const prev = i;
+      i = target;
+      steps.push({
+        ...base(), focus: i, partner: prev, swapped: true, line: 12,
+        note: `Troco: ${promoted} sobe para ${prev}, ${h[i]} desce para ${i}. Como o valor desceu, a subárvore de ${i} pode ter quebrado, então continuo a descida por ela.`,
       });
     }
   }
 
-  const porInsercao = construirHeapPorInsercao(valores, tipo);
-  out.push({
-    ...base(), foco: -1, linha: 4, ok: true,
-    nota: `Heap pronto: ${h.join(", ")}. Foram ${swaps} trocas em ${comp} comparações, contra ${porInsercao.swaps} trocas em ${porInsercao.comp} comparações para inserir os mesmos ${valores.length} valores um a um. Com n pequeno a distância é modesta; ela cresce porque metade dos nós é folha e não desce nada, um quarto desce no máximo um nível, e assim por diante. É essa soma que fecha em O(n), enquanto inserir um a um fecha em O(n log n).`,
+  const byInsertion = buildHeapByInsertion(values, kind);
+  steps.push({
+    ...base(), focus: -1, line: 4, ok: true,
+    note: `Heap pronto: ${h.join(", ")}. Foram ${swaps} trocas em ${comparisons} comparações, contra ${byInsertion.swaps} trocas em ${byInsertion.comparisons} comparações para inserir os mesmos ${values.length} valores um a um. Com n pequeno a distância é modesta; ela cresce porque metade dos nós é folha e não desce nada, um quarto desce no máximo um nível, e assim por diante. É essa soma que fecha em O(n), enquanto inserir um a um fecha em O(n log n).`,
   });
-  return out;
+  return steps;
 }
 
 // --- geometria da árvore completa -----------------------------------------
 
-function profundidade(i: number) {
-  let d = 0;
+function depth(i: number) {
+  let levels = 0;
   let x = i + 1;
   while (x > 1) {
     x >>= 1;
-    d++;
+    levels++;
   }
-  return d;
+  return levels;
 }
-function altura(n: number) {
-  return n === 0 ? 0 : profundidade(n - 1) + 1;
+function height(n: number) {
+  return n === 0 ? 0 : depth(n - 1) + 1;
 }
 
-function passosDe(modo: Modo, preset: Preset, tipo: Tipo): Passo[] {
-  if (modo === "inserir") return passosInserir(preset.valores, tipo);
-  if (modo === "remover") return passosRemover(preset.valores, tipo);
-  return passosConstruir(preset.valores, tipo);
+function stepsFor(mode: Mode, preset: Preset, kind: HeapKind): Step[] {
+  if (mode === "insert") return stepsInsert(preset.values, kind);
+  if (mode === "remove") return stepsRemove(preset.values, kind);
+  return stepsBuild(preset.values, kind);
 }
 
 // O modo inserir começa com o heap vazio, então o passo 1 é um nó solto: nada
@@ -389,158 +391,121 @@ function passosDe(modo: Modo, preset: Preset, tipo: Tipo): Passo[] {
 // passo com árvore de verdade, e volta para esse mesmo ponto sempre que a
 // animação é trocada (preset, modo ou regra). Quem quiser ver a inserção desde o
 // heap vazio tem o botão ↺, que é justamente o que ele significa.
-function primeiroInteressante(passos: Passo[]): number {
-  const i = passos.findIndex((p) => p.n >= 4);
+function firstMeaningfulStep(steps: Step[]): number {
+  const i = steps.findIndex((s) => s.n >= 4);
   return i < 0 ? 0 : i;
 }
 
-const NO_R = 16;
-const NIVEL_Y = 60;
-const TOPO_Y = 20;
+const NODE_R = 16;
+const LEVEL_Y = 60;
+const TOP_Y = 20;
 
 export function BinaryHeapVisualizer() {
-  const [presetKey, setPresetKey] = useState("chegada");
-  const [tipo, setTipo] = useState<Tipo>("min");
-  const [modo, setModo] = useState<Modo>("inserir");
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [presetKey, setPresetKey] = useState("arrival");
+  const [kind, setKind] = useState<HeapKind>("min");
+  const [mode, setMode] = useState<Mode>("insert");
 
-  useEffect(() => setMounted(true), []);
+  const preset = useMemo(() => PRESETS.find((x) => x.key === presetKey) ?? PRESETS[0], [presetKey]);
+  const steps = useMemo(() => stepsFor(mode, preset, kind), [mode, preset, kind]);
 
-  const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => passosDe(modo, preset, tipo), [modo, preset, tipo]);
+  const viz = useVisualizer({
+    title: "Visualizador · a árvore e o array do heap se movendo juntos",
+    total: steps.length,
+    // A peça já abria no "1.5x": as animações vão a 51 passos, e no 1x a
+    // reprodução inteira fica longa demais para quem só quer ver o movimento.
+    initialSpeed: 4,
+    // O que mexe na altura: o modo (o código vai de 9 a 15 linhas e o "remover"
+    // ainda acrescenta o painel de saída), o preset (6 valores dão uma árvore de
+    // 2 níveis, 8 ou 9 dão 3) e a regra (troca o texto das notas).
+    // `steps.length` é função desses três e nunca cai a 1 aqui — o menor total
+    // medido é 21 —, então não há travessia de linha do tempo a cobrir.
+    measureOn: [mode, presetKey, kind],
+  });
 
-  // `passos` não depende de `passo`, então calcular a lista antes deste useState
-  // mantém a ordem dos hooks estável.
-  const [passo, setPasso] = useState(() => primeiroInteressante(passos));
+  // Ajuste na fase de RENDER, não num `useEffect`: o hook sempre começa no passo
+  // 0, e é assim que o passo certo entra também no HTML do build estático. Com
+  // efeito, o `out/` congelaria no passo 1 e só o cliente corrigiria. Contrato §9.
+  const [placed, setPlaced] = useState(false);
+  if (!placed) {
+    setPlaced(true);
+    viz.setStep(firstMeaningfulStep(steps));
+  }
 
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const p = steps[Math.min(viz.step, steps.length - 1)];
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
-
-  // ↺ Reiniciar volta ao passo zero de verdade, que no modo inserir é o heap
-  // vazio: é para isso que o botão existe.
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
   // Trocar preset, modo ou regra é montar outra animação, e ela abre no mesmo
   // ponto em que o visualizador abriu a primeira vez. Os passos são recalculados
   // aqui porque o estado novo só chega ao `useMemo` no render seguinte.
-  const abrir = (m: Modo, pr: Preset, t: Tipo) => {
-    parar();
-    setTocando(false);
-    setPasso(primeiroInteressante(passosDe(m, pr, t)));
+  const openAt = (m: Mode, pr: Preset, k: HeapKind) => {
+    viz.reset();
+    viz.setStep(firstMeaningfulStep(stepsFor(m, pr, k)));
   };
-  const trocarPreset = (k: string) => {
-    const pr = PRESETS.find((x) => x.key === k) ?? PRESETS[0];
-    setPresetKey(k);
-    abrir(modo, pr, tipo);
+  const pickPreset = (key: string) => {
+    const pr = PRESETS.find((x) => x.key === key) ?? PRESETS[0];
+    setPresetKey(key);
+    openAt(mode, pr, kind);
   };
-  const trocarModo = (m: Modo) => {
-    setModo(m);
-    abrir(m, preset, tipo);
+  const pickMode = (m: Mode) => {
+    setMode(m);
+    openAt(m, preset, kind);
   };
-  const trocarTipo = (t: Tipo) => {
-    setTipo(t);
-    abrir(modo, preset, t);
+  const pickKind = (k: HeapKind) => {
+    setKind(k);
+    openAt(mode, preset, k);
   };
 
   // Geometria: uma árvore completa se posiciona só pelo índice, sem layout algum.
   // O tamanho vem do MAIOR heap da animação inteira, não do passo atual: assim os
   // nós ficam parados enquanto a árvore enche e esvazia, em vez de saltarem de
   // lugar a cada inserção.
-  const maxN = useMemo(() => passos.reduce((m, s) => Math.max(m, s.n), 1), [passos]);
-  const maxProf = profundidade(maxN - 1);
-  const colunas = Math.pow(2, maxProf);
-  const largura = Math.max(320, colunas * 56);
-  const W = largura + NO_R * 2;
-  const H = TOPO_Y * 2 + maxProf * NIVEL_Y + NO_R * 2;
+  const maxN = useMemo(() => steps.reduce((m, s) => Math.max(m, s.n), 1), [steps]);
+  const maxDepth = depth(maxN - 1);
+  const columns = Math.pow(2, maxDepth);
+  const spanX = Math.max(320, columns * 56);
+  const W = spanX + NODE_R * 2;
+  const H = TOP_Y * 2 + maxDepth * LEVEL_Y + NODE_R * 2;
   const cx = (i: number) => {
-    const d = profundidade(i);
+    const d = depth(i);
     const pos = i - (Math.pow(2, d) - 1);
-    return NO_R + ((pos + 0.5) * largura) / Math.pow(2, d);
+    return NODE_R + ((pos + 0.5) * spanX) / Math.pow(2, d);
   };
-  const cy = (i: number) => TOPO_Y + NO_R + profundidade(i) * NIVEL_Y;
+  const cy = (i: number) => TOP_Y + NODE_R + depth(i) * LEVEL_Y;
 
-  const alt = altura(p.n);
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const codigo = modo === "inserir" ? CODIGO_INSERIR : modo === "remover" ? CODIGO_REMOVER : CODIGO_CONSTRUIR;
-  const arquivo = modo === "inserir" ? "push.py" : modo === "remover" ? "pop.py" : "build_heap.py";
+  const treeHeight = height(p.n);
+  const code = mode === "insert" ? CODE_INSERT : mode === "remove" ? CODE_REMOVE : CODE_BUILD;
+  const file = mode === "insert" ? "push.py" : mode === "remove" ? "pop.py" : "build_heap.py";
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a árvore e o array do heap se movendo juntos</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => pickPreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="viz-inputs">
           <div className="viz-field">
             <span>Operação</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${modo === "inserir" ? " on" : ""}`} onClick={() => trocarModo("inserir")} aria-pressed={modo === "inserir"}>
+              <button className={`sub-modo-btn${mode === "insert" ? " on" : ""}`} onClick={() => pickMode("insert")} aria-pressed={mode === "insert"}>
                 inserir
               </button>
-              <button className={`sub-modo-btn${modo === "remover" ? " on" : ""}`} onClick={() => trocarModo("remover")} aria-pressed={modo === "remover"}>
+              <button className={`sub-modo-btn${mode === "remove" ? " on" : ""}`} onClick={() => pickMode("remove")} aria-pressed={mode === "remove"}>
                 remover o topo
               </button>
-              <button className={`sub-modo-btn${modo === "construir" ? " on" : ""}`} onClick={() => trocarModo("construir")} aria-pressed={modo === "construir"}>
+              <button className={`sub-modo-btn${mode === "build" ? " on" : ""}`} onClick={() => pickMode("build")} aria-pressed={mode === "build"}>
                 construir de uma vez
               </button>
             </div>
@@ -548,10 +513,10 @@ export function BinaryHeapVisualizer() {
           <div className="viz-field">
             <span>Regra</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${tipo === "min" ? " on" : ""}`} onClick={() => trocarTipo("min")} aria-pressed={tipo === "min"}>
+              <button className={`sub-modo-btn${kind === "min" ? " on" : ""}`} onClick={() => pickKind("min")} aria-pressed={kind === "min"}>
                 min-heap
               </button>
-              <button className={`sub-modo-btn${tipo === "max" ? " on" : ""}`} onClick={() => trocarTipo("max")} aria-pressed={tipo === "max"}>
+              <button className={`sub-modo-btn${kind === "max" ? " on" : ""}`} onClick={() => pickKind("max")} aria-pressed={kind === "max"}>
                 max-heap
               </button>
             </div>
@@ -565,7 +530,7 @@ export function BinaryHeapVisualizer() {
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`Heap com ${p.n} elementos e altura ${alt}. ${p.nota}`}
+            aria-label={`Heap com ${p.n} elementos e altura ${treeHeight}. ${p.note}`}
           >
             {p.arr.slice(0, p.n).map((_, i) =>
               [2 * i + 1, 2 * i + 2]
@@ -573,25 +538,25 @@ export function BinaryHeapVisualizer() {
                 .map((f) => (
                   <line
                     key={`${i}-${f}`}
-                    className={`tt-aresta${(p.foco === i && p.par === f) || (p.foco === f && p.par === i) ? " ativa" : ""}`}
+                    className={`tt-aresta${(p.focus === i && p.partner === f) || (p.focus === f && p.partner === i) ? " ativa" : ""}`}
                     x1={cx(i)}
-                    y1={cy(i) + NO_R}
+                    y1={cy(i) + NODE_R}
                     x2={cx(f)}
-                    y2={cy(f) - NO_R}
+                    y2={cy(f) - NODE_R}
                   />
                 ))
             )}
             {p.arr.slice(0, p.n).map((v, i) => {
               const cls = ["tt-no"];
-              if (i === p.foco) cls.push("on");
-              else if (i === p.par) cls.push("aux");
+              if (i === p.focus) cls.push("on");
+              else if (i === p.partner) cls.push("aux");
               return (
                 <g key={i} className={cls.join(" ")}>
-                  <circle cx={cx(i)} cy={cy(i)} r={NO_R} />
+                  <circle cx={cx(i)} cy={cy(i)} r={NODE_R} />
                   <text x={cx(i)} y={cy(i) + 4} textAnchor="middle">
                     {v}
                   </text>
-                  <text className="hp-idx" x={cx(i)} y={cy(i) - NO_R - 5} textAnchor="middle">
+                  <text className="hp-idx" x={cx(i)} y={cy(i) - NODE_R - 5} textAnchor="middle">
                     {i}
                   </text>
                 </g>
@@ -606,11 +571,13 @@ export function BinaryHeapVisualizer() {
           </div>
           <div className="hp-arr">
             {p.arr.map((v, i) => {
+              // Nomes de classe do CSS compartilhado: continuam em português de
+              // propósito, porque quem os declara é o `globals.css`.
               const cls = ["hp-cel"];
               if (i >= p.n) cls.push("fora");
-              else if (i === p.foco) cls.push("foco");
-              else if (i === p.par) cls.push("par");
-              if (i === p.entrando || (p.trocou && (i === p.foco || i === p.par))) cls.push("troca");
+              else if (i === p.focus) cls.push("foco");
+              else if (i === p.partner) cls.push("par");
+              if (i === p.entering || (p.swapped && (i === p.focus || i === p.partner))) cls.push("troca");
               return (
                 <span key={i} className={cls.join(" ")}>
                   <i>{i}</i>
@@ -622,45 +589,52 @@ export function BinaryHeapVisualizer() {
           </div>
         </div>
 
-        {modo === "remover" && (
+        {mode === "remove" && (
           <div className="hp-bloco">
             <div className="tt-painel-tit">
               Saída, na ordem em que foi removida <em>é isto que o heap sort aproveita</em>
             </div>
             <div className="tt-saida">
-              {p.saida.map((v, i) => (
-                <span key={i} className={`tt-saida-item${i === p.saida.length - 1 ? " novo" : ""}`}>
+              {p.output.map((v, i) => (
+                <span key={i} className={`tt-saida-item${i === p.output.length - 1 ? " novo" : ""}`}>
                   {v}
                 </span>
               ))}
-              {p.saida.length === 0 && <span className="tt-vazio">nada saiu ainda</span>}
+              {p.output.length === 0 && <span className="tt-vazio">nada saiu ainda</span>}
             </div>
           </div>
         )}
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{arquivo}</div>
-            <div className="viz-code-body">
-              {codigo.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura do
+              código. O `.viz-code-slot` é o grid 1fr→0fr, a única forma de
+              animar altura automática em CSS puro. O código fica no DOM mesmo
+              recolhido, que é o que permite medir o pior caso de altura. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{file}</div>
+              <div className="viz-code-body">
+                {code.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === p.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">i (foco)</span>
-              <span className="viz-var-val">{p.foco >= 0 ? p.foco : "-"}</span>
+              <span className="viz-var-val">{p.focus >= 0 ? p.focus : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">comparado com</span>
-              <span className="viz-var-val">{p.par >= 0 ? p.par : "-"}</span>
+              <span className="viz-var-val">{p.partner >= 0 ? p.partner : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">topo do heap</span>
@@ -676,65 +650,16 @@ export function BinaryHeapVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>altura</span>
-            <strong>{alt}</strong>
+            <strong>{treeHeight}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comp}</strong>
+            <strong>{p.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>trocas</span>
             <strong>{p.swaps}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -743,21 +668,12 @@ export function BinaryHeapVisualizer() {
           proteger você disso, ele promete que o estrago nunca passa da altura da árvore.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/BuscaBinariaFronteira.tsx
+++ b/content/visualizers/BuscaBinariaFronteira.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BuscaBinariaFronteira, o que fazer quando a resposta não é um único índice.
@@ -18,28 +19,33 @@ import { createPortal } from "react-dom";
 // O modo "onde entraria" também mostra de onde vem o retorno negativo do
 // `Arrays.binarySearch` do Java e do `Array.BinarySearch` do .NET, que é o
 // truque que transforma uma busca falha numa inserção pronta.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Modo = "entraria" | "primeira" | "ultima";
+type Mode = "insert" | "first" | "last";
 
-type Passo = {
-  esq: number;
-  dir: number;
-  meio: number | null;
-  anotado: number;
-  linha: number;
-  comparacoes: number;
-  fim?: boolean;
+type Step = {
+  left: number;
+  right: number;
+  mid: number | null;
+  marked: number;
+  line: number;
+  comparisons: number;
+  done?: boolean;
   // `ok` é o estado terminal BOM do passo, não "o valor existe". No modo
-  // entraria a operação sempre tem sucesso, mesmo com o alvo ausente, porque a
-  // resposta dela é a posição de inserção. Quem diz se o valor existe é o texto
-  // da nota. É o mesmo nome que os visualizadores de heap usam para este campo.
+  // "onde entraria" a operação sempre tem sucesso, mesmo com o alvo ausente,
+  // porque a resposta dela é a posição de inserção. Quem diz se o valor existe
+  // é o texto da nota. É o mesmo nome que os visualizadores de heap usam para
+  // este campo.
   ok?: boolean;
-  nota: string;
+  note: string;
 };
 
-const CODIGO: Record<Modo, string[]> = {
-  entraria: [
+const CODE: Record<Mode, string[]> = {
+  insert: [
     "def onde_entraria(nums, alvo):",
     "    esq, dir = 0, len(nums) - 1",
     "    while esq <= dir:",
@@ -50,7 +56,7 @@ const CODIGO: Record<Modo, string[]> = {
     "            dir = meio - 1",
     "    return esq        # esq para na posição de inserção",
   ],
-  primeira: [
+  first: [
     "def primeira(nums, alvo):",
     "    esq, dir, achou = 0, len(nums) - 1, -1",
     "    while esq <= dir:",
@@ -64,7 +70,7 @@ const CODIGO: Record<Modo, string[]> = {
     "            dir = meio - 1",
     "    return achou",
   ],
-  ultima: [
+  last: [
     "def ultima(nums, alvo):",
     "    esq, dir, achou = 0, len(nums) - 1, -1",
     "    while esq <= dir:",
@@ -80,270 +86,230 @@ const CODIGO: Record<Modo, string[]> = {
   ],
 };
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-const LADO: Record<Modo, string> = {
-  entraria: "onde o valor entraria",
-  primeira: "primeira ocorrência",
-  ultima: "última ocorrência",
+const FILE: Record<Mode, string> = {
+  insert: "onde_entraria.py",
+  first: "primeira.py",
+  last: "ultima.py",
 };
 
-function gerarPassos(nums: number[], alvo: number, modo: Modo): Passo[] {
-  const out: Passo[] = [];
-  let esq = 0;
-  let dir = nums.length - 1;
-  let anotado = -1;
-  let comparacoes = 0;
+const SIDE: Record<Mode, string> = {
+  insert: "onde o valor entraria",
+  first: "primeira ocorrência",
+  last: "última ocorrência",
+};
+
+function generateSteps(nums: number[], target: number, mode: Mode): Step[] {
+  const out: Step[] = [];
+  let left = 0;
+  let right = nums.length - 1;
+  let marked = -1;
+  let comparisons = 0;
 
   out.push({
-    esq, dir, meio: null, anotado, comparacoes, linha: 1,
-    nota:
-      modo === "entraria"
-        ? `Procurando a posição de ${alvo} em ${nums.length} elementos. Repare que não existe caso de acerto neste código: mesmo se o valor existir, o laço vai até o fim.`
-        : `Procurando a ${LADO[modo]} de ${alvo}. A diferença para a busca comum é uma linha só: quando eu acertar, vou anotar e continuar procurando para a ${modo === "primeira" ? "esquerda" : "direita"}.`,
+    left, right, mid: null, marked, comparisons, line: 1,
+    note:
+      mode === "insert"
+        ? `Procurando a posição de ${target} em ${nums.length} elementos. Repare que não existe caso de acerto neste código: mesmo se o valor existir, o laço vai até o fim.`
+        : `Procurando a ${SIDE[mode]} de ${target}. A diferença para a busca comum é uma linha só: quando eu acertar, vou anotar e continuar procurando para a ${mode === "first" ? "esquerda" : "direita"}.`,
   });
 
-  let guarda = 0;
-  while (esq <= dir && guarda++ < 100) {
-    const meio = esq + Math.floor((dir - esq) / 2);
-    comparacoes++;
+  let guard = 0;
+  while (left <= right && guard++ < 100) {
+    const mid = left + Math.floor((right - left) / 2);
+    comparisons++;
     out.push({
-      esq, dir, meio, anotado, comparacoes, linha: 3,
-      nota: `Meio em ${meio}, valor ${nums[meio]}. Intervalo vivo: da posição ${esq} à ${dir}.`,
+      left, right, mid, marked, comparisons, line: 3,
+      note: `Meio em ${mid}, valor ${nums[mid]}. Intervalo vivo: da posição ${left} à ${right}.`,
     });
 
-    if (modo === "entraria") {
-      if (nums[meio] < alvo) {
+    if (mode === "insert") {
+      if (nums[mid] < target) {
         out.push({
-          esq, dir, meio, anotado, comparacoes, linha: 5,
-          nota: `${nums[meio]} < ${alvo}: ${alvo} não pode entrar em ${meio} nem antes. A esquerda vai para ${meio + 1}.`,
+          left, right, mid, marked, comparisons, line: 5,
+          note: `${nums[mid]} < ${target}: ${target} não pode entrar em ${mid} nem antes. A esquerda vai para ${mid + 1}.`,
         });
-        esq = meio + 1;
+        left = mid + 1;
       } else {
         out.push({
-          esq, dir, meio, anotado, comparacoes, linha: 7,
-          nota: `${nums[meio]} ${nums[meio] === alvo ? "empata com" : ">"} ${alvo}: ${alvo} entra em ${meio} ou antes, então a direita recua para ${meio - 1}. Repare que o empate cai neste mesmo ramo: é isso que faz a resposta ser a posição do PRIMEIRO igual.`,
+          left, right, mid, marked, comparisons, line: 7,
+          note: `${nums[mid]} ${nums[mid] === target ? "empata com" : ">"} ${target}: ${target} entra em ${mid} ou antes, então a direita recua para ${mid - 1}. Repare que o empate cai neste mesmo ramo: é isso que faz a resposta ser a posição do PRIMEIRO igual.`,
         });
-        dir = meio - 1;
+        right = mid - 1;
       }
       continue;
     }
 
-    if (nums[meio] === alvo) {
-      anotado = meio;
-      if (modo === "primeira") {
+    if (nums[mid] === target) {
+      marked = mid;
+      if (mode === "first") {
         out.push({
-          esq, dir, meio, anotado, comparacoes, linha: 5,
-          nota: `Achei ${alvo} na posição ${meio}, mas pode existir outro igual mais à esquerda. Anoto ${meio} como melhor resposta até agora e continuo procurando na metade de baixo.`,
+          left, right, mid, marked, comparisons, line: 5,
+          note: `Achei ${target} na posição ${mid}, mas pode existir outro igual mais à esquerda. Anoto ${mid} como melhor resposta até agora e continuo procurando na metade de baixo.`,
         });
-        dir = meio - 1;
+        right = mid - 1;
       } else {
         out.push({
-          esq, dir, meio, anotado, comparacoes, linha: 5,
-          nota: `Achei ${alvo} na posição ${meio}, mas pode existir outro igual mais à direita. Anoto ${meio} e continuo procurando na metade de cima.`,
+          left, right, mid, marked, comparisons, line: 5,
+          note: `Achei ${target} na posição ${mid}, mas pode existir outro igual mais à direita. Anoto ${mid} e continuo procurando na metade de cima.`,
         });
-        esq = meio + 1;
+        left = mid + 1;
       }
-    } else if (nums[meio] < alvo) {
+    } else if (nums[mid] < target) {
       out.push({
-        esq, dir, meio, anotado, comparacoes, linha: 8,
-        nota: `${nums[meio]} < ${alvo}: descarto ${meio} e tudo à esquerda. A esquerda vai para ${meio + 1}.`,
+        left, right, mid, marked, comparisons, line: 8,
+        note: `${nums[mid]} < ${target}: descarto ${mid} e tudo à esquerda. A esquerda vai para ${mid + 1}.`,
       });
-      esq = meio + 1;
+      left = mid + 1;
     } else {
       out.push({
-        esq, dir, meio, anotado, comparacoes, linha: 10,
-        nota: `${nums[meio]} > ${alvo}: descarto ${meio} e tudo à direita. A direita recua para ${meio - 1}.`,
+        left, right, mid, marked, comparisons, line: 10,
+        note: `${nums[mid]} > ${target}: descarto ${mid} e tudo à direita. A direita recua para ${mid - 1}.`,
       });
-      dir = meio - 1;
+      right = mid - 1;
     }
   }
 
-  if (modo === "entraria") {
+  if (mode === "insert") {
     // `esq` pode parar em nums.length quando o alvo é maior que tudo, então o
     // limite é checado antes de indexar. Em JS isso devolveria undefined e a
     // comparação daria falso por acidente; depender disso esconde a intenção.
-    const existe = esq < nums.length && nums[esq] === alvo;
+    const exists = left < nums.length && nums[left] === target;
     out.push({
-      esq, dir, meio: null, anotado, comparacoes, linha: 8, fim: true, ok: true,
-      nota: existe
-        ? `O intervalo esvaziou e a esquerda parou em ${esq}. Como nums[${esq}] é ${alvo}, essa é a posição da PRIMEIRA ocorrência, e é um índice válido: o Arrays.binarySearch do Java devolveria um número não negativo aqui.`
-        : `O intervalo esvaziou e a esquerda parou em ${esq}. ${alvo} não está no array, e ${esq} é exatamente onde ele entraria mantendo tudo ordenado. É por isso que o Arrays.binarySearch do Java devolve -(${esq}) - 1 = ${-esq - 1} quando FALHA: o sinal diz "não achei" e o número carrega o ponto de inserção de graça. Multiplicar por -1 não serviria, porque -0 é 0 e a posição 0 ficaria indistinguível de um acerto.`,
+      left, right, mid: null, marked, comparisons, line: 8, done: true, ok: true,
+      note: exists
+        ? `O intervalo esvaziou e a esquerda parou em ${left}. Como nums[${left}] é ${target}, essa é a posição da PRIMEIRA ocorrência, e é um índice válido: o Arrays.binarySearch do Java devolveria um número não negativo aqui.`
+        : `O intervalo esvaziou e a esquerda parou em ${left}. ${target} não está no array, e ${left} é exatamente onde ele entraria mantendo tudo ordenado. É por isso que o Arrays.binarySearch do Java devolve -(${left}) - 1 = ${-left - 1} quando FALHA: o sinal diz "não achei" e o número carrega o ponto de inserção de graça. Multiplicar por -1 não serviria, porque -0 é 0 e a posição 0 ficaria indistinguível de um acerto.`,
     });
     return out;
   }
 
   out.push({
-    esq, dir, meio: null, anotado, comparacoes, linha: 11, fim: true, ok: anotado >= 0,
-    nota:
-      anotado >= 0
-        ? `Fim: a ${LADO[modo]} de ${alvo} está na posição ${anotado}, encontrada em ${comparacoes} comparações. Uma varredura linear daria a mesma resposta em até ${nums.length} passos.`
-        : `Fim: ${alvo} não existe no array, então a resposta é -1. Custou ${comparacoes} comparações provar isso.`,
+    left, right, mid: null, marked, comparisons, line: 11, done: true, ok: marked >= 0,
+    note:
+      marked >= 0
+        ? `Fim: a ${SIDE[mode]} de ${target} está na posição ${marked}, encontrada em ${comparisons} comparações. Uma varredura linear daria a mesma resposta em até ${nums.length} passos.`
+        : `Fim: ${target} não existe no array, então a resposta é -1. Custou ${comparisons} comparações provar isso.`,
   });
   return out;
 }
 
-type Preset = { key: string; rotulo: string; nums: number[]; alvo: number; dica: string };
+type Preset = { key: string; label: string; nums: number[]; target: number; hint: string };
 
-const REPETIDOS = [1, 3, 3, 3, 5, 8, 8, 11, 14];
+const REPEATED = [1, 3, 3, 3, 5, 8, 8, 11, 14];
 
 const PRESETS: Preset[] = [
   {
-    key: "bloco",
-    rotulo: "Um bloco de três iguais: procurando 3",
-    nums: REPETIDOS,
-    alvo: 3,
-    dica: "O 3 ocupa as posições 1, 2 e 3. A busca comum devolveria qualquer uma delas dependendo de onde o meio caiu. Alterne entre os três modos e veja as respostas 1 e 3 saindo do mesmo código.",
+    key: "block",
+    label: "Um bloco de três iguais: procurando 3",
+    nums: REPEATED,
+    target: 3,
+    hint: "O 3 ocupa as posições 1, 2 e 3. A busca comum devolveria qualquer uma delas dependendo de onde o meio caiu. Alterne entre os três modos e veja as respostas 1 e 3 saindo do mesmo código.",
   },
   {
-    key: "ausente",
-    rotulo: "Um valor que não existe: 7",
-    nums: REPETIDOS,
-    alvo: 7,
-    dica: "Sem ocorrência nenhuma, os modos de primeira e última devolvem -1. O modo de inserção continua útil: ele diz onde o 7 caberia.",
+    key: "absent",
+    label: "Um valor que não existe: 7",
+    nums: REPEATED,
+    target: 7,
+    hint: "Sem ocorrência nenhuma, os modos de primeira e última devolvem -1. O modo de inserção continua útil: ele diz onde o 7 caberia.",
   },
   {
-    key: "par",
-    rotulo: "Duas ocorrências no fim: procurando 8",
-    nums: REPETIDOS,
-    alvo: 8,
-    dica: "Posições 5 e 6. É o formato exato do problema Find First and Last Position of Element in Sorted Array: duas buscas binárias, uma para cada ponta.",
+    key: "pair",
+    label: "Duas ocorrências no fim: procurando 8",
+    nums: REPEATED,
+    target: 8,
+    hint: "Posições 5 e 6. É o formato exato do problema Find First and Last Position of Element in Sorted Array: duas buscas binárias, uma para cada ponta.",
   },
   {
-    key: "antes",
-    rotulo: "Menor que tudo: procurando 0",
-    nums: REPETIDOS,
-    alvo: 0,
-    dica: "A borda de baixo. A posição de inserção é 0, e nenhum passo do algoritmo precisa de tratamento especial para isso.",
+    key: "before",
+    label: "Menor que tudo: procurando 0",
+    nums: REPEATED,
+    target: 0,
+    hint: "A borda de baixo. A posição de inserção é 0, e nenhum passo do algoritmo precisa de tratamento especial para isso.",
   },
   {
-    key: "depois",
-    rotulo: "Maior que tudo: procurando 20",
-    nums: REPETIDOS,
-    alvo: 20,
-    dica: "A borda de cima, e a mais fácil de errar: a esquerda para em 9, que é o tamanho do array e não é índice de ninguém. Inserir ali continua correto (é o fim da lista), mas todo código que for LER nessa posição precisa checar o limite antes.",
+    key: "after",
+    label: "Maior que tudo: procurando 20",
+    nums: REPEATED,
+    target: 20,
+    hint: "A borda de cima, e a mais fácil de errar: a esquerda para em 9, que é o tamanho do array e não é índice de ninguém. Inserir ali continua correto (é o fim da lista), mas todo código que for LER nessa posição precisa checar o limite antes.",
   },
 ];
 
 export function BuscaBinariaFronteira() {
-  const [presetKey, setPresetKey] = useState("bloco");
-  const [modo, setModo] = useState<Modo>("primeira");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("block");
+  const [mode, setMode] = useState<Mode>("first");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.nums, preset.alvo, modo), [preset, modo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(preset.nums, preset.target, mode), [preset, mode]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · repetidos, bordas e a posição de inserção",
+    total: steps.length,
+    // O que muda a altura da peça, medido: o modo, porque o código vai de 9 a
+    // 12 linhas e o painel ganha uma variável a mais (77px no artigo); e o
+    // preset, porque cada dica tem um tamanho (até 37px). A fita de células
+    // NÃO entra: o array é fixo em 9 posições e nunca quebra linha.
+    measureOn: [mode, presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const s = steps[viz.step];
+
+  const changePreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
-  const trocarModo = (m: Modo) => {
-    reiniciar();
-    setModo(m);
+  const changeMode = (m: Mode) => {
+    viz.reset();
+    setMode(m);
   };
 
   const nums = preset.nums;
-  const resposta = modo === "entraria" ? (p.fim ? p.esq : null) : p.fim ? p.anotado : null;
+  const answer = mode === "insert" ? (s.done ? s.left : null) : s.done ? s.marked : null;
   // O retorno negativo do Arrays.binarySearch é o do caso de FALHA. Quando o
   // valor existe, a posição onde a esquerda parou é uma ocorrência de verdade e
   // a função devolveria um índice não negativo.
-  const existeNaParada = p.fim && p.esq < nums.length && nums[p.esq] === preset.alvo;
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const existsAtStop = s.done && s.left < nums.length && nums[s.left] === preset.target;
 
   const cells = nums.map((v, i) => {
     let cls = "viz-cell";
-    const dentro = i >= p.esq && i <= p.dir;
-    if (!dentro) cls += " drop";
-    if (i === p.meio) cls += " in";
-    if (i === p.anotado && modo !== "entraria") cls += " marcado";
-    if (p.fim && resposta === i) cls += " entra";
-    let marca = "";
-    if (dentro && i === p.esq) marca = "e";
-    if (dentro && i === p.dir) marca = marca ? "e d" : "d";
-    if (i === p.meio) marca = marca ? `${marca} m` : "m";
-    return { i, v, cls, marca, igual: v === preset.alvo };
+    const inside = i >= s.left && i <= s.right;
+    if (!inside) cls += " drop";
+    if (i === s.mid) cls += " in";
+    if (i === s.marked && mode !== "insert") cls += " marcado";
+    if (s.done && answer === i) cls += " entra";
+    let mark = "";
+    if (inside && i === s.left) mark = "e";
+    if (inside && i === s.right) mark = mark ? "e d" : "d";
+    if (i === s.mid) mark = mark ? `${mark} m` : "m";
+    return { i, v, cls, mark, equal: v === preset.target };
   });
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · repetidos, bordas e a posição de inserção</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => trocarPreset(pr.key)} aria-pressed={presetKey === pr.key}>
-              {pr.rotulo}
+            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => changePreset(pr.key)} aria-pressed={presetKey === pr.key}>
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="viz-inputs">
           <div className="viz-field">
             <span>O que eu quero saber</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${modo === "primeira" ? " on" : ""}`} onClick={() => trocarModo("primeira")} aria-pressed={modo === "primeira"}>
+              <button className={`sub-modo-btn${mode === "first" ? " on" : ""}`} onClick={() => changeMode("first")} aria-pressed={mode === "first"}>
                 primeira ocorrência
               </button>
-              <button className={`sub-modo-btn${modo === "ultima" ? " on" : ""}`} onClick={() => trocarModo("ultima")} aria-pressed={modo === "ultima"}>
+              <button className={`sub-modo-btn${mode === "last" ? " on" : ""}`} onClick={() => changeMode("last")} aria-pressed={mode === "last"}>
                 última ocorrência
               </button>
-              <button className={`sub-modo-btn${modo === "entraria" ? " on" : ""}`} onClick={() => trocarModo("entraria")} aria-pressed={modo === "entraria"}>
+              <button className={`sub-modo-btn${mode === "insert" ? " on" : ""}`} onClick={() => changeMode("insert")} aria-pressed={mode === "insert"}>
                 onde entraria
               </button>
             </div>
@@ -355,118 +321,76 @@ export function BuscaBinariaFronteira() {
             <div className="viz-cell-wrap" key={c.i}>
               <span className="viz-cell-idx">{c.i}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
 
-        <p className={"viz-note" + (p.fim ? (p.ok ? " ok" : " invalid") : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.done ? (s.ok ? " ok" : " invalid") : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">
-              {modo === "entraria" ? "onde_entraria.py" : modo === "primeira" ? "primeira.py" : "ultima.py"}
-            </div>
-            <div className="viz-code-body">
-              {CODIGO[modo].map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso;
+              `inert` tira ele do teclado e dos leitores de tela enquanto está
+              fora de vista, com `aria-hidden` de reserva. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{FILE[mode]}</div>
+              <div className="viz-code-body">
+                {CODE[mode].map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">esq</span>
-              <span className="viz-var-val">{p.esq}</span>
+              <span className="viz-var-val">{s.left}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">dir</span>
-              <span className="viz-var-val">{p.dir}</span>
+              <span className="viz-var-val">{s.right}</span>
             </div>
-            {modo !== "entraria" && (
+            {mode !== "insert" && (
               <div className="viz-var">
                 <span className="viz-var-name">achou (anotado)</span>
-                <span className="viz-var-val best">{p.anotado}</span>
+                <span className="viz-var-val best">{s.marked}</span>
               </div>
             )}
             <div className="viz-var">
               <span className="viz-var-name">alvo</span>
-              <span className="viz-var-val">{preset.alvo}</span>
+              <span className="viz-var-val">{preset.target}</span>
             </div>
           </div>
         </div>
 
         <div className="bigo-stats">
           <div className="bigo-stat">
-            <span>ocorrências de {preset.alvo}</span>
-            <strong>{nums.filter((v) => v === preset.alvo).length}</strong>
+            <span>ocorrências de {preset.target}</span>
+            <strong>{nums.filter((v) => v === preset.target).length}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comparacoes}</strong>
+            <strong>{s.comparisons}</strong>
           </div>
           <div className="bigo-stat">
-            <span>{LADO[modo]}</span>
-            <strong>{resposta === null ? "-" : resposta}</strong>
+            <span>{SIDE[mode]}</span>
+            <strong>{answer === null ? "-" : answer}</strong>
           </div>
           <div className="bigo-stat">
             <span>retorno do Arrays.binarySearch</span>
             <strong>
-              {p.fim && modo === "entraria" ? (existeNaParada ? `${p.esq}` : `${-p.esq - 1}`) : "-"}
+              {s.done && mode === "insert" ? (existsAtStop ? `${s.left}` : `${-s.left - 1}`) : "-"}
             </strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -476,21 +400,12 @@ export function BuscaBinariaFronteira() {
           quando o bloco de repetidos é grande.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/BuscaBinariaVisualizer.tsx
+++ b/content/visualizers/BuscaBinariaVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BuscaBinariaVisualizer, o descarte é a parte que importa.
@@ -18,21 +19,25 @@ import { createPortal } from "react-dom";
 // O meio é calculado como `esq + (dir - esq) // 2`, não `(esq + dir) // 2`. Não
 // é preciosismo: a segunda forma estoura um inteiro de 32 bits e o visualizador
 // de estouro ao lado mostra isso acontecendo.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Passo = {
-  esq: number;
-  dir: number;
-  meio: number | null;
-  comparacoes: number;
-  descartadas: number;
-  linha: number;
-  achou?: boolean;
-  fim?: boolean;
-  nota: string;
+type Step = {
+  left: number;
+  right: number;
+  mid: number | null;
+  comparisons: number;
+  discarded: number;
+  line: number;
+  found?: boolean;
+  done?: boolean;
+  note: string;
 };
 
-const CODIGO = [
+const CODE = [
   "def busca_binaria(nums, alvo):",
   "    esq, dir = 0, len(nums) - 1",
   "    while esq <= dir:",
@@ -46,240 +51,194 @@ const CODIGO = [
   "    return -1",
 ];
 
-const VELOCIDADES = [0, 1400, 950, 650, 420, 250];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
-
-function gerarPassos(nums: number[], alvo: number): Passo[] {
-  const out: Passo[] = [];
+function generateSteps(nums: number[], target: number): Step[] {
+  const out: Step[] = [];
   const n = nums.length;
-  let esq = 0;
-  let dir = n - 1;
-  let comparacoes = 0;
-  let descartadas = 0;
+  let left = 0;
+  let right = n - 1;
+  let comparisons = 0;
+  let discarded = 0;
 
   out.push({
-    esq, dir, meio: null, comparacoes, descartadas, linha: 1,
-    nota: `Começo com o espaço de busca inteiro: da posição 0 até a ${n - 1}, ${n} candidatos. Como o array está ordenado, cada olhada vai eliminar metade deles.`,
+    left, right, mid: null, comparisons, discarded, line: 1,
+    note: `Começo com o espaço de busca inteiro: da posição 0 até a ${n - 1}, ${n} candidatos. Como o array está ordenado, cada olhada vai eliminar metade deles.`,
   });
 
-  let guarda = 0;
-  while (esq <= dir && guarda++ < 100) {
-    const meio = esq + Math.floor((dir - esq) / 2);
-    const restantes = dir - esq + 1;
+  let guard = 0;
+  while (left <= right && guard++ < 100) {
+    const mid = left + Math.floor((right - left) / 2);
+    const remaining = right - left + 1;
     out.push({
-      esq, dir, meio, comparacoes, descartadas, linha: 3,
-      nota: `Sobram ${restantes} candidato${restantes === 1 ? "" : "s"} (da posição ${esq} à ${dir}). O meio é ${esq} + (${dir} - ${esq}) // 2 = ${meio}, onde está o valor ${nums[meio]}.`,
+      left, right, mid, comparisons, discarded, line: 3,
+      note: `Sobram ${remaining} candidato${remaining === 1 ? "" : "s"} (da posição ${left} à ${right}). O meio é ${left} + (${right} - ${left}) // 2 = ${mid}, onde está o valor ${nums[mid]}.`,
     });
-    comparacoes++;
-    if (nums[meio] === alvo) {
+    comparisons++;
+    if (nums[mid] === target) {
       out.push({
-        esq, dir, meio, comparacoes, descartadas, linha: 5, achou: true, fim: true,
-        nota: `${nums[meio]} é o alvo. Achei na posição ${meio} lendo ${comparacoes} posiç${comparacoes === 1 ? "ão" : "ões"} e descartando ${descartadas} sem nunca olhar para ${descartadas === 1 ? "ela" : "elas"}.`,
+        left, right, mid, comparisons, discarded, line: 5, found: true, done: true,
+        note: `${nums[mid]} é o alvo. Achei na posição ${mid} lendo ${comparisons} posiç${comparisons === 1 ? "ão" : "ões"} e descartando ${discarded} sem nunca olhar para ${discarded === 1 ? "ela" : "elas"}.`,
       });
       return out;
     }
-    if (nums[meio] < alvo) {
+    if (nums[mid] < target) {
       // A posição do meio sai do intervalo junto, mas ela foi LIDA nesta
       // iteração, então não entra na conta de "descartadas sem ler".
-      const cegas = meio - esq;
-      descartadas += cegas;
+      const blind = mid - left;
+      discarded += blind;
       out.push({
-        esq, dir, meio, comparacoes, descartadas, linha: 7,
-        nota: `${nums[meio]} < ${alvo}: se o alvo existe, ele está à DIREITA. Descarto a posição ${meio}, que acabei de ler, e ${cegas === 0 ? "não sobrou nenhuma antes dela" : `as ${cegas} que vêm antes dela sem ler nenhuma`}. A esquerda vai para ${meio + 1}.`,
+        left, right, mid, comparisons, discarded, line: 7,
+        note: `${nums[mid]} < ${target}: se o alvo existe, ele está à DIREITA. Descarto a posição ${mid}, que acabei de ler, e ${blind === 0 ? "não sobrou nenhuma antes dela" : `as ${blind} que vêm antes dela sem ler nenhuma`}. A esquerda vai para ${mid + 1}.`,
       });
-      esq = meio + 1;
+      left = mid + 1;
     } else {
-      const cegas = dir - meio;
-      descartadas += cegas;
+      const blind = right - mid;
+      discarded += blind;
       out.push({
-        esq, dir, meio, comparacoes, descartadas, linha: 9,
-        nota: `${nums[meio]} > ${alvo}: se o alvo existe, ele está à ESQUERDA. Descarto a posição ${meio}, que acabei de ler, e ${cegas === 0 ? "não sobrou nenhuma depois dela" : `as ${cegas} que vêm depois dela sem ler nenhuma`}. A direita recua para ${meio - 1}.`,
+        left, right, mid, comparisons, discarded, line: 9,
+        note: `${nums[mid]} > ${target}: se o alvo existe, ele está à ESQUERDA. Descarto a posição ${mid}, que acabei de ler, e ${blind === 0 ? "não sobrou nenhuma depois dela" : `as ${blind} que vêm depois dela sem ler nenhuma`}. A direita recua para ${mid - 1}.`,
       });
-      dir = meio - 1;
+      right = mid - 1;
     }
   }
 
   out.push({
-    esq, dir, meio: null, comparacoes, descartadas, linha: 10, fim: true,
-    nota: `A esquerda (${esq}) passou da direita (${dir}): o espaço de busca ficou vazio, então ${alvo} não está no array. Li ${comparacoes} posições e descartei ${descartadas} sem olhar, e ${comparacoes} + ${descartadas} = ${n}: cada posição foi lida ou descartada exatamente uma vez. E repare onde a esquerda parou: a posição ${esq} é exatamente onde ${alvo} entraria se fosse inserido.`,
+    left, right, mid: null, comparisons, discarded, line: 10, done: true,
+    note: `A esquerda (${left}) passou da direita (${right}): o espaço de busca ficou vazio, então ${target} não está no array. Li ${comparisons} posições e descartei ${discarded} sem olhar, e ${comparisons} + ${discarded} = ${n}: cada posição foi lida ou descartada exatamente uma vez. E repare onde a esquerda parou: a posição ${left} é exatamente onde ${target} entraria se fosse inserido.`,
   });
   return out;
 }
 
-type Preset = { key: string; rotulo: string; nums: number[]; alvo: number; dica: string };
+type Preset = { key: string; label: string; nums: number[]; target: number; hint: string };
 
 const BASE = [2, 6, 10, 15, 20, 43, 60, 70];
-const GRANDE = [3, 9, 14, 21, 28, 35, 42, 47, 55, 61, 68, 74, 80, 88, 93, 99];
+const LARGE = [3, 9, 14, 21, 28, 35, 42, 47, 55, 61, 68, 74, 80, 88, 93, 99];
 
 const PRESETS: Preset[] = [
   {
-    key: "meio",
-    rotulo: "Achando o 20 em 8 posições",
+    key: "mid",
+    label: "Achando o 20 em 8 posições",
     nums: BASE,
-    alvo: 20,
-    dica: "Oito candidatos e três olhadas. A busca linear precisaria de cinco, e a diferença só cresce a partir daqui.",
+    target: 20,
+    hint: "Oito candidatos e três olhadas. A busca linear precisaria de cinco, e a diferença só cresce a partir daqui.",
   },
   {
-    key: "grande",
-    rotulo: "16 posições, no máximo 5 olhadas",
-    nums: GRANDE,
-    alvo: 93,
-    dica: "Dobrar o array de 8 para 16 não dobrou o trabalho: acrescentou uma comparação. É literalmente o que log₂ significa.",
+    key: "large",
+    label: "16 posições, no máximo 5 olhadas",
+    nums: LARGE,
+    target: 93,
+    hint: "Dobrar o array de 8 para 16 não dobrou o trabalho: acrescentou uma comparação. É literalmente o que log₂ significa.",
   },
   {
-    key: "ausente",
-    rotulo: "Um valor que não existe: 40",
+    key: "absent",
+    label: "Um valor que não existe: 40",
     nums: BASE,
-    alvo: 40,
-    dica: "Provar que algo NÃO está lá custa o mesmo que achar. E o ponteiro da esquerda para exatamente na posição onde o 40 deveria ser inserido, o que é um brinde da mecânica do algoritmo.",
+    target: 40,
+    hint: "Provar que algo NÃO está lá custa o mesmo que achar. E o ponteiro da esquerda para exatamente na posição onde o 40 deveria ser inserido, o que é um brinde da mecânica do algoritmo.",
   },
   {
-    key: "extremo",
-    rotulo: "O pior lugar possível: o 2",
+    key: "extreme",
+    label: "O pior lugar possível: o 2",
     nums: BASE,
-    alvo: 2,
-    dica: "O primeiro elemento é justamente o que a busca binária demora mais para achar, enquanto a busca linear acerta de primeira. Nenhum algoritmo ganha em tudo.",
+    target: 2,
+    hint: "O primeiro elemento é justamente o que a busca binária demora mais para achar, enquanto a busca linear acerta de primeira. Nenhum algoritmo ganha em tudo.",
   },
 ];
 
-function ordenar(v: number[]) {
+function sortAsc(v: number[]) {
   return [...v].sort((a, b) => a - b);
 }
 
 export function BuscaBinariaVisualizer() {
   const [nums, setNums] = useState<number[]>(BASE);
-  const [entrada, setEntrada] = useState(BASE.join(", "));
-  const [alvo, setAlvo] = useState(20);
-  const [presetKey, setPresetKey] = useState("meio");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(3);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [input, setInput] = useState(BASE.join(", "));
+  const [target, setTarget] = useState(20);
+  const [presetKey, setPresetKey] = useState("mid");
 
-  useEffect(() => setMounted(true), []);
+  const steps = useMemo(() => generateSteps(nums.length ? nums : [0], target), [nums, target]);
+  const n = nums.length;
 
-  const passos = useMemo(() => gerarPassos(nums.length ? nums : [0], alvo), [nums, alvo]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · busca binária: metade some a cada olhada",
+    total: steps.length,
+    // O que muda a altura da peça, medido: o tamanho do array — a fita de
+    // células é `flex-wrap: wrap`, e ela quebra para uma segunda linha a partir
+    // de 14 células (+99px no artigo, de 8 para 16) — e o preset, porque a dica
+    // dele só existe quando há preset e cada uma tem um tamanho.
+    measureOn: [n, presetKey],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const s = steps[viz.step];
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const aoMudarEntrada = (v: string) => {
-    const arr = ordenar(
+  const onArrayChange = (v: string) => {
+    const arr = sortAsc(
       v.split(",").map((x) => parseInt(x.trim(), 10)).filter((x) => !isNaN(x)).slice(0, 16)
     );
-    reiniciar();
+    viz.reset();
     setPresetKey("");
-    setEntrada(v);
+    setInput(v);
     setNums(arr.length ? arr : [0]);
   };
-  const aoMudarAlvo = (v: string) => {
-    reiniciar();
+  const onTargetChange = (v: string) => {
+    viz.reset();
     setPresetKey("");
-    setAlvo(parseInt(v, 10) || 0);
+    setTarget(parseInt(v, 10) || 0);
   };
-  const aplicarPreset = (pr: Preset) => {
-    reiniciar();
+  const applyPreset = (pr: Preset) => {
+    viz.reset();
     setPresetKey(pr.key);
     setNums(pr.nums);
-    setEntrada(pr.nums.join(", "));
-    setAlvo(pr.alvo);
+    setInput(pr.nums.join(", "));
+    setTarget(pr.target);
   };
 
   const preset = PRESETS.find((pr) => pr.key === presetKey);
-  const n = nums.length;
-  const posLinear = nums.indexOf(alvo);
-  const passosLinear = posLinear >= 0 ? posLinear + 1 : n;
-  const teto = Math.floor(Math.log2(n)) + 1;
-  const restantes = Math.max(0, p.dir - p.esq + 1);
+  const linearPos = nums.indexOf(target);
+  const linearSteps = linearPos >= 0 ? linearPos + 1 : n;
+  const ceiling = Math.floor(Math.log2(n)) + 1;
+  const remaining = Math.max(0, s.right - s.left + 1);
 
   const cells = nums.map((v, i) => {
     let cls = "viz-cell";
-    const dentro = i >= p.esq && i <= p.dir;
-    if (!dentro) cls += " drop";
-    if (i === p.meio) cls += p.achou ? " in entra" : " in";
-    let marca = "";
-    if (dentro && i === p.esq) marca = "e";
-    if (dentro && i === p.dir) marca = marca ? "e d" : "d";
-    if (i === p.meio) marca = marca ? `${marca} m` : "m";
-    return { i, v, cls, marca };
+    const inside = i >= s.left && i <= s.right;
+    if (!inside) cls += " drop";
+    if (i === s.mid) cls += s.found ? " in entra" : " in";
+    let mark = "";
+    if (inside && i === s.left) mark = "e";
+    if (inside && i === s.right) mark = mark ? "e d" : "d";
+    if (i === s.mid) mark = mark ? `${mark} m` : "m";
+    return { i, v, cls, mark };
   });
 
-  const notaCls = "viz-note" + (p.achou ? " ok" : p.fim ? " invalid" : "");
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const noteClass = "viz-note" + (s.found ? " ok" : s.done ? " invalid" : "");
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · busca binária: metade some a cada olhada</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => aplicarPreset(pr)}
+              onClick={() => applyPreset(pr)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        {preset && <p className="tt-legenda-arvore">{preset.dica}</p>}
+        {preset && <p className="tt-legenda-arvore">{preset.hint}</p>}
 
         <div className="viz-inputs">
           <label className="viz-field grow">
             <span>Array (é ordenado sozinho, porque a busca binária exige)</span>
-            <input className="viz-input" value={entrada} onChange={(e) => aoMudarEntrada(e.target.value)} />
+            <input className="viz-input" value={input} onChange={(e) => onArrayChange(e.target.value)} />
           </label>
           <label className="viz-field">
             <span>alvo</span>
-            <input className="viz-input k" type="number" value={alvo} onChange={(e) => aoMudarAlvo(e.target.value)} />
+            <input className="viz-input k" type="number" value={target} onChange={(e) => onTargetChange(e.target.value)} />
           </label>
         </div>
 
@@ -288,49 +247,58 @@ export function BuscaBinariaVisualizer() {
             <div className="viz-cell-wrap" key={c.i}>
               <span className="viz-cell-idx">{c.i}</span>
               <div className={c.cls}>{c.v}</div>
-              <span className={`viz-mark${c.marca ? " show" : ""}`}>{c.marca || "·"}</span>
+              <span className={`viz-mark${c.mark ? " show" : ""}`}>{c.mark || "·"}</span>
             </div>
           ))}
         </div>
 
         <div className="bb-barra" aria-hidden="true">
-          <div className="bb-barra-fill" style={{ width: `${(restantes / n) * 100}%` }} />
+          <div className="bb-barra-fill" style={{ width: `${(remaining / n) * 100}%` }} />
           <span className="bb-barra-txt">
-            {restantes} de {n} candidatos ainda de pé
+            {remaining} de {n} candidatos ainda de pé
           </span>
         </div>
 
-        <p className={notaCls}>{p.nota}</p>
+        <p className={noteClass}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">busca_binaria.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código. O `.viz-code-slot` é o truque de grid 1fr→0fr, a única
+              forma de animar altura automática em CSS puro. O código fica no
+              DOM mesmo recolhido, e é isso que permite medir o pior caso;
+              `inert` tira ele do teclado e dos leitores de tela enquanto está
+              fora de vista, com `aria-hidden` de reserva. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">busca_binaria.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">esq</span>
-              <span className="viz-var-val">{p.esq}</span>
+              <span className="viz-var-val">{s.left}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">dir</span>
-              <span className="viz-var-val">{p.dir}</span>
+              <span className="viz-var-val">{s.right}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">meio</span>
-              <span className="viz-var-val">{p.meio === null ? "-" : p.meio}</span>
+              <span className="viz-var-val">{s.mid === null ? "-" : s.mid}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">alvo</span>
-              <span className="viz-var-val best">{alvo}</span>
+              <span className="viz-var-val best">{target}</span>
             </div>
           </div>
         </div>
@@ -338,69 +306,20 @@ export function BuscaBinariaVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>comparações até aqui</span>
-            <strong>{p.comparacoes}</strong>
+            <strong>{s.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>descartadas sem ler</span>
-            <strong>{p.descartadas}</strong>
+            <strong>{s.discarded}</strong>
           </div>
           <div className="bigo-stat">
             <span>busca linear gastaria</span>
-            <strong>{passosLinear}</strong>
+            <strong>{linearSteps}</strong>
           </div>
           <div className="bigo-stat">
             <span>teto: ⌊log₂({n})⌋ + 1</span>
-            <strong>{teto}</strong>
+            <strong>{ceiling}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -409,21 +328,12 @@ export function BuscaBinariaVisualizer() {
           dedução e vira um chute, e o algoritmo devolve a resposta errada com a mesma confiança.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/HeapSortVisualizer.tsx
+++ b/content/visualizers/HeapSortVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // HeapSortVisualizer, as duas fases e a fronteira que anda para trás.
@@ -21,23 +22,31 @@ import { createPortal } from "react-dom";
 // e o fim é exatamente a posição que acabou de sair do heap.
 // ---------------------------------------------------------------------------
 
-type Fase = "construir" | "ordenar" | "fim";
+type Phase = "build" | "sort" | "done";
 
-type Passo = {
+// O sufixo da classe é o que o `globals.css` compartilhado define
+// (`.hs-fase.f-ordenar` e `.hs-fase.f-fim` pintam a borda e o selo), então ele
+// continua em português mesmo com o identificador em inglês. Traduzir a classe
+// junto apagaria a cor das duas fases sem que nada reclamasse.
+const PHASE_CLASS: Record<Phase, string> = { build: "construir", sort: "ordenar", done: "fim" };
+
+type Step = {
   arr: number[];
   n: number; // tamanho do heap ativo: as posições >= n já estão ordenadas
-  foco: number;
-  par: number;
-  trocou: boolean;
-  fase: Fase;
+  focus: number;
+  pair: number;
+  swapped: boolean;
+  phase: Phase;
   comp: number;
   swaps: number;
-  linha: number;
-  nota: string;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+// Python de tela: é conteúdo didático, e os nomes daqui são os que as notas
+// explicam em português. Não traduza junto com os identificadores.
+const CODE = [
   "def heap_sort(a):",
   "    n = len(a)",
   "    # fase 1: transforma o array num max-heap, O(n)",
@@ -58,151 +67,152 @@ const CODIGO = [
   "        i = maior",
 ];
 
-type Preset = { key: string; rotulo: string; valores: number[]; dica: string };
+type Preset = { key: string; label: string; values: number[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "embaralhado",
-    rotulo: "Embaralhado: 4 10 3 5 1 8 7 2 9 6",
-    valores: [4, 10, 3, 5, 1, 8, 7, 2, 9, 6],
-    dica: "O caso comum. Acompanhe a fronteira verde crescendo da direita para a esquerda: cada rodada da fase 2 congela mais uma posição, e ela nunca mais é tocada.",
+    key: "shuffled",
+    label: "Embaralhado: 4 10 3 5 1 8 7 2 9 6",
+    values: [4, 10, 3, 5, 1, 8, 7, 2, 9, 6],
+    hint: "O caso comum. Acompanhe a fronteira verde crescendo da direita para a esquerda: cada rodada da fase 2 congela mais uma posição, e ela nunca mais é tocada.",
   },
   {
-    key: "ordenado",
-    rotulo: "Já ordenado: 1 2 3 4 5 6 7 8 9 10",
-    valores: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    dica: "A entrada já está pronta e o heap sort não liga: ele faz o trabalho inteiro assim mesmo. Compare o total de comparações com o do preset embaralhado, eles ficam na mesma faixa. Não existe atalho de melhor caso aqui.",
+    key: "sorted",
+    label: "Já ordenado: 1 2 3 4 5 6 7 8 9 10",
+    values: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+    hint: "A entrada já está pronta e o heap sort não liga: ele faz o trabalho inteiro assim mesmo. Compare o total de comparações com o do preset embaralhado, eles ficam na mesma faixa. Não existe atalho de melhor caso aqui.",
   },
   {
-    key: "invertido",
-    rotulo: "Ao contrário: 10 9 8 7 6 5 4 3 2 1",
-    valores: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
-    dica: "A entrada mais hostil que existe para quase todo algoritmo de ordenação. Para o heap sort é só mais uma: a fase 1 quase não faz nada, porque um array decrescente já é um max-heap válido.",
+    key: "reversed",
+    label: "Ao contrário: 10 9 8 7 6 5 4 3 2 1",
+    values: [10, 9, 8, 7, 6, 5, 4, 3, 2, 1],
+    hint: "A entrada mais hostil que existe para quase todo algoritmo de ordenação. Para o heap sort é só mais uma: a fase 1 quase não faz nada, porque um array decrescente já é um max-heap válido.",
   },
   {
-    key: "repetidos",
-    rotulo: "Com repetidos: 5 3 5 1 3 9 1 5",
-    valores: [5, 3, 5, 1, 3, 9, 1, 5],
-    dica: "Valores iguais não quebram nada: a regra do max-heap é maior OU IGUAL. O que se perde com eles é a estabilidade, e isso o visualizador ao lado mostra.",
+    key: "duplicates",
+    label: "Com repetidos: 5 3 5 1 3 9 1 5",
+    values: [5, 3, 5, 1, 3, 9, 1, 5],
+    hint: "Valores iguais não quebram nada: a regra do max-heap é maior OU IGUAL. O que se perde com eles é a estabilidade, e isso o visualizador ao lado mostra.",
   },
 ];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// A marcha desta peça é a dela: uma troca de array se lê rápido, e a animação
+// mais longa tem 84 passos. O padrão do hook (1400..250) arrastaria demais.
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
-function gerarPassos(valores: number[]): Passo[] {
-  const a = [...valores];
+function buildSteps(values: number[]): Step[] {
+  const a = [...values];
   const total = a.length;
-  const out: Passo[] = [];
+  const out: Step[] = [];
   let comp = 0;
   let swaps = 0;
   let n = total;
-  let fase: Fase = "construir";
-  const base = () => ({ arr: [...a], n, foco: -1, par: -1, trocou: false, fase, comp, swaps });
+  let phase: Phase = "build";
+  const base = () => ({ arr: [...a], n, focus: -1, pair: -1, swapped: false, phase, comp, swaps });
 
   // sift down com limite: tudo de `n` para a frente é resultado final e não existe
   // para o algoritmo. Empurrar os passos aqui dentro mantém o gerador puro.
-  const desce = (inicio: number, contexto: string) => {
-    let i = inicio;
-    let guarda = 0;
-    while (guarda++ < 200) {
-      const e = 2 * i + 1;
-      const d = 2 * i + 2;
-      if (e >= n) {
+  const siftDown = (start: number, context: string) => {
+    let i = start;
+    let guard = 0;
+    while (guard++ < 200) {
+      const left = 2 * i + 1;
+      const right = 2 * i + 2;
+      if (left >= n) {
         out.push({
-          ...base(), foco: i, linha: 15, ok: true,
-          nota: `A posição ${i} não tem filho dentro do heap (2 x ${i} + 1 = ${e}, e o heap só vai até ${n - 1}). Cheguei numa folha, a descida acabou.`,
+          ...base(), focus: i, line: 15, ok: true,
+          note: `A posição ${i} não tem filho dentro do heap (2 x ${i} + 1 = ${left}, e o heap só vai até ${n - 1}). Cheguei numa folha, a descida acabou.`,
         });
         return;
       }
-      let maior = i;
+      let largest = i;
       comp++;
-      if (a[e] > a[maior]) maior = e;
-      let txt = `Filhos de ${i}: esquerda em ${e} (valor ${a[e]})`;
-      if (d < n) {
+      if (a[left] > a[largest]) largest = left;
+      let text = `Filhos de ${i}: esquerda em ${left} (valor ${a[left]})`;
+      if (right < n) {
         comp++;
-        txt += `, direita em ${d} (valor ${a[d]})`;
-        if (a[d] > a[maior]) maior = d;
+        text += `, direita em ${right} (valor ${a[right]})`;
+        if (a[right] > a[largest]) largest = right;
       } else {
-        txt += `. A direita seria ${d}, que já caiu na parte ordenada, então nem olho`;
+        text += `. A direita seria ${right}, que já caiu na parte ordenada, então nem olho`;
       }
       out.push({
-        ...base(), foco: i, par: maior === i ? -1 : maior, linha: d < n ? 14 : 13,
-        nota: `${txt}. O maior da tríade é ${a[maior]}.`,
+        ...base(), focus: i, pair: largest === i ? -1 : largest, line: right < n ? 14 : 13,
+        note: `${text}. O maior da tríade é ${a[largest]}.`,
       });
-      if (maior === i) {
+      if (largest === i) {
         out.push({
-          ...base(), foco: i, linha: 15, ok: true,
-          nota: `${a[i]} já é o maior entre pai e filhos: ${contexto} está válido daqui para baixo e paro a descida.`,
+          ...base(), focus: i, line: 15, ok: true,
+          note: `${a[i]} já é o maior entre pai e filhos: ${context} está válido daqui para baixo e paro a descida.`,
         });
         return;
       }
-      const subiu = a[maior];
-      [a[i], a[maior]] = [a[maior], a[i]];
+      const raised = a[largest];
+      [a[i], a[largest]] = [a[largest], a[i]];
       swaps++;
-      const antigo = i;
-      i = maior;
+      const previous = i;
+      i = largest;
       out.push({
-        ...base(), foco: i, par: antigo, trocou: true, linha: 16,
-        nota: `${subiu} sobe para ${antigo} e ${a[i]} desce para ${i}. Sigo só por este ramo: o outro filho e a subárvore dele já estavam válidos e continuam.`,
+        ...base(), focus: i, pair: previous, swapped: true, line: 16,
+        note: `${raised} sobe para ${previous} e ${a[i]} desce para ${i}. Sigo só por este ramo: o outro filho e a subárvore dele já estavam válidos e continuam.`,
       });
     }
   };
 
   out.push({
-    ...base(), linha: 0,
-    nota: `Entrada: ${a.join(", ")}. Vou ordenar dentro deste mesmo array, sem alocar nada, em duas fases: primeiro viro tudo num max-heap, depois arranco o maior repetidas vezes.`,
+    ...base(), line: 0,
+    note: `Entrada: ${a.join(", ")}. Vou ordenar dentro deste mesmo array, sem alocar nada, em duas fases: primeiro viro tudo num max-heap, depois arranco o maior repetidas vezes.`,
   });
 
   // ---- fase 1 -------------------------------------------------------------
-  const ultimoPai = Math.floor(total / 2) - 1;
+  const lastParent = Math.floor(total / 2) - 1;
   out.push({
-    ...base(), foco: ultimoPai, linha: 3,
-    nota: `Fase 1. Começo no índice ${ultimoPai} (${total} // 2 - 1), o último nó que tem filho. As ${total - 1 - ultimoPai} posições depois dele são folhas e não têm para onde descer.`,
+    ...base(), focus: lastParent, line: 3,
+    note: `Fase 1. Começo no índice ${lastParent} (${total} // 2 - 1), o último nó que tem filho. As ${total - 1 - lastParent} posições depois dele são folhas e não têm para onde descer.`,
   });
-  for (let i = ultimoPai; i >= 0; i--) {
+  for (let i = lastParent; i >= 0; i--) {
     out.push({
-      ...base(), foco: i, linha: 4,
-      nota: `Desço a partir de ${i} (valor ${a[i]}). Tudo abaixo já foi arrumado nas rodadas anteriores, então basta acertar este nó.`,
+      ...base(), focus: i, line: 4,
+      note: `Desço a partir de ${i} (valor ${a[i]}). Tudo abaixo já foi arrumado nas rodadas anteriores, então basta acertar este nó.`,
     });
-    desce(i, "esta subárvore");
+    siftDown(i, "esta subárvore");
   }
-  const compFase1 = comp;
-  const swapsFase1 = swaps;
+  const compPhase1 = comp;
+  const swapsPhase1 = swaps;
   out.push({
-    ...base(), linha: 4, ok: true,
-    nota: `Max-heap pronto: ${a.join(", ")}. Custou ${compFase1} comparações e ${swapsFase1} trocas. O array continua embaralhado aos olhos, mas o maior valor (${a[0]}) já está na posição 0, e é só disso que a fase 2 precisa.`,
+    ...base(), line: 4, ok: true,
+    note: `Max-heap pronto: ${a.join(", ")}. Custou ${compPhase1} comparações e ${swapsPhase1} trocas. O array continua embaralhado aos olhos, mas o maior valor (${a[0]}) já está na posição 0, e é só disso que a fase 2 precisa.`,
   });
 
   // ---- fase 2 -------------------------------------------------------------
-  fase = "ordenar";
-  for (let fim = total - 1; fim > 0; fim--) {
-    const maior = a[0];
-    const trocado = a[fim];
-    [a[0], a[fim]] = [a[fim], a[0]];
+  phase = "sort";
+  for (let end = total - 1; end > 0; end--) {
+    const largest = a[0];
+    const swappedOut = a[end];
+    [a[0], a[end]] = [a[end], a[0]];
     swaps++;
-    n = fim;
+    n = end;
     out.push({
-      ...base(), foco: 0, par: fim, trocou: true, linha: 7,
-      nota: `${maior} é o maior do heap, então o lugar dele é a última posição livre, a ${fim}. Troco com ${trocado} e a posição ${fim} está resolvida para sempre.`,
+      ...base(), focus: 0, pair: end, swapped: true, line: 7,
+      note: `${largest} é o maior do heap, então o lugar dele é a última posição livre, a ${end}. Troco com ${swappedOut} e a posição ${end} está resolvida para sempre.`,
     });
     out.push({
-      ...base(), foco: 0, linha: 8,
-      nota: `Agora encolho o heap: ele passa a ter ${n} elemento${n === 1 ? "" : "s"}. Da posição ${n} em diante o resultado já está pronto, e o desce vai tratar essa parte como se não existisse. É essa mentira controlada que faz o heap sort ordenar sem memória extra.`,
+      ...base(), focus: 0, line: 8,
+      note: `Agora encolho o heap: ele passa a ter ${n} elemento${n === 1 ? "" : "s"}. Da posição ${n} em diante o resultado já está pronto, e o desce vai tratar essa parte como se não existisse. É essa mentira controlada que faz o heap sort ordenar sem memória extra.`,
     });
-    if (n > 1) desce(0, "o heap ativo");
+    if (n > 1) siftDown(0, "o heap ativo");
   }
 
-  fase = "fim";
+  phase = "done";
   n = 0;
   out.push({
-    ...base(), linha: 8, ok: true,
-    nota: `Ordenado: ${a.join(", ")}. Total de ${comp} comparações e ${swaps} trocas, sendo ${compFase1} comparações só na fase 1. Nenhum array auxiliar foi criado: as ${total} posições do começo são as mesmas do fim.`,
+    ...base(), line: 8, ok: true,
+    note: `Ordenado: ${a.join(", ")}. Total de ${comp} comparações e ${swaps} trocas, sendo ${compPhase1} comparações só na fase 1. Nenhum array auxiliar foi criado: as ${total} posições do começo são as mesmas do fim.`,
   });
   return out;
 }
 
-function profundidade(i: number) {
+function depth(i: number) {
   let d = 0;
   let x = i + 1;
   while (x > 1) {
@@ -212,61 +222,30 @@ function profundidade(i: number) {
   return d;
 }
 
-const NO_R = 16;
-const NIVEL_Y = 58;
-const TOPO_Y = 18;
+const NODE_R = 16;
+const LEVEL_Y = 58;
+const TOP_Y = 18;
 
 export function HeapSortVisualizer() {
-  const [presetKey, setPresetKey] = useState("embaralhado");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("shuffled");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.valores), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => buildSteps(preset.values), [preset]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · heap sort: duas fases no mesmo array",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O preset é a única entrada que o aluno tem, e é ele que troca a dica, as
+    // notas e o tamanho do array. O desenho não entra: a geometria sai de
+    // `arr.length`, e `depth()` devolve 3 tanto para 8 quanto para 10 elementos
+    // — medido, os quatro presets desenham a MESMA caixa de 242px em todos os
+    // passos. O que sobra de variação são 20px de nota quebrando em duas linhas.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
-    setPresetKey(k);
-  };
+  const s = steps[viz.step];
 
   // A árvore mostra só o heap ativo. Quem já foi ordenado sai dela e vive no
   // array, que é onde o aluno vê o resultado se formando.
@@ -274,59 +253,49 @@ export function HeapSortVisualizer() {
   // nó que sai do heap simplesmente some do lugar dele, e os que ficam não se
   // mexem. Se a árvore fosse redimensionada a cada rodada, pareceria que o
   // algoritmo está rearranjando tudo, que é exatamente o oposto do que acontece.
-  const maxProf = profundidade(p.arr.length - 1);
-  const colunas = Math.pow(2, maxProf);
-  const largura = Math.max(300, colunas * 54);
-  const W = largura + NO_R * 2;
-  const H = TOPO_Y * 2 + maxProf * NIVEL_Y + NO_R * 2;
+  const maxDepth = depth(s.arr.length - 1);
+  const cols = Math.pow(2, maxDepth);
+  const width = Math.max(300, cols * 54);
+  const W = width + NODE_R * 2;
+  const H = TOP_Y * 2 + maxDepth * LEVEL_Y + NODE_R * 2;
   const cx = (i: number) => {
-    const d = profundidade(i);
+    const d = depth(i);
     const pos = i - (Math.pow(2, d) - 1);
-    return NO_R + ((pos + 0.5) * largura) / Math.pow(2, d);
+    return NODE_R + ((pos + 0.5) * width) / Math.pow(2, d);
   };
-  const cy = (i: number) => TOPO_Y + NO_R + profundidade(i) * NIVEL_Y;
+  const cy = (i: number) => TOP_Y + NODE_R + depth(i) * LEVEL_Y;
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const ordenados = p.arr.length - p.n;
-  const rotuloFase = p.fase === "construir" ? "fase 1 · virando max-heap" : p.fase === "ordenar" ? "fase 2 · arrancando o maior" : "pronto";
+  const sortedCount = s.arr.length - s.n;
+  const phaseLabel =
+    s.phase === "build" ? "fase 1 · virando max-heap" : s.phase === "sort" ? "fase 2 · arrancando o maior" : "pronto";
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · heap sort: duas fases no mesmo array</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => {
+                viz.reset();
+                setPresetKey(pr.key);
+              }}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
-        <div className={`hs-fase f-${p.fase}`}>
-          <span className="hs-fase-selo">{rotuloFase}</span>
+        <div className={`hs-fase f-${PHASE_CLASS[s.phase]}`}>
+          <span className="hs-fase-selo">{phaseLabel}</span>
           <span className="hs-fase-txt">
-            heap ativo: posições 0 a {Math.max(p.n - 1, 0)} · já ordenado: {ordenados} de {p.arr.length}
+            heap ativo: posições 0 a {Math.max(s.n - 1, 0)} · já ordenado: {sortedCount} de {s.arr.length}
           </span>
         </div>
 
@@ -337,37 +306,37 @@ export function HeapSortVisualizer() {
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`Heap ativo com ${p.n} elementos. ${p.nota}`}
+            aria-label={`Heap ativo com ${s.n} elementos. ${s.note}`}
           >
-            {p.arr.slice(0, p.n).map((_, i) =>
+            {s.arr.slice(0, s.n).map((_, i) =>
               [2 * i + 1, 2 * i + 2]
-                .filter((f) => f < p.n)
+                .filter((f) => f < s.n)
                 .map((f) => (
                   <line
                     key={`${i}-${f}`}
-                    className={`tt-aresta${(p.foco === i && p.par === f) || (p.foco === f && p.par === i) ? " ativa" : ""}`}
+                    className={`tt-aresta${(s.focus === i && s.pair === f) || (s.focus === f && s.pair === i) ? " ativa" : ""}`}
                     x1={cx(i)}
-                    y1={cy(i) + NO_R}
+                    y1={cy(i) + NODE_R}
                     x2={cx(f)}
-                    y2={cy(f) - NO_R}
+                    y2={cy(f) - NODE_R}
                   />
                 ))
             )}
-            {p.arr.slice(0, p.n).map((v, i) => {
+            {s.arr.slice(0, s.n).map((v, i) => {
               const cls = ["tt-no"];
-              if (i === p.foco) cls.push("on");
-              else if (i === p.par) cls.push("aux");
+              if (i === s.focus) cls.push("on");
+              else if (i === s.pair) cls.push("aux");
               return (
                 <g key={i} className={cls.join(" ")}>
-                  <circle cx={cx(i)} cy={cy(i)} r={NO_R} />
+                  <circle cx={cx(i)} cy={cy(i)} r={NODE_R} />
                   <text x={cx(i)} y={cy(i) + 4} textAnchor="middle">
                     {v}
                   </text>
                 </g>
               );
             })}
-            {p.n === 0 && (
-              <text className="hp-idx" x={W / 2} y={TOPO_Y + NO_R} textAnchor="middle">
+            {s.n === 0 && (
+              <text className="hp-idx" x={W / 2} y={TOP_Y + NODE_R} textAnchor="middle">
                 heap vazio: tudo virou resultado
               </text>
             )}
@@ -379,12 +348,12 @@ export function HeapSortVisualizer() {
             O array, com a fronteira entre heap e resultado <em>verde = posição final, não se mexe mais</em>
           </div>
           <div className="hp-arr">
-            {p.arr.map((v, i) => {
+            {s.arr.map((v, i) => {
               const cls = ["hp-cel"];
-              if (i >= p.n) cls.push("fixo");
-              else if (i === p.foco) cls.push("foco");
-              else if (i === p.par) cls.push("par");
-              if (p.trocou && (i === p.foco || i === p.par)) cls.push("troca");
+              if (i >= s.n) cls.push("fixo");
+              else if (i === s.focus) cls.push("foco");
+              else if (i === s.pair) cls.push("par");
+              if (s.swapped && (i === s.focus || i === s.pair)) cls.push("troca");
               return (
                 <span key={i} className={cls.join(" ")}>
                   <i>{i}</i>
@@ -395,33 +364,35 @@ export function HeapSortVisualizer() {
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">heap_sort.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">heap_sort.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">n (heap ativo)</span>
-              <span className="viz-var-val best">{p.n}</span>
+              <span className="viz-var-val best">{s.n}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">i (foco)</span>
-              <span className="viz-var-val">{p.foco >= 0 ? p.foco : "-"}</span>
+              <span className="viz-var-val">{s.focus >= 0 ? s.focus : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">maior candidato</span>
-              <span className="viz-var-val">{p.par >= 0 ? p.par : "-"}</span>
+              <span className="viz-var-val">{s.pair >= 0 ? s.pair : "-"}</span>
             </div>
           </div>
         </div>
@@ -429,69 +400,20 @@ export function HeapSortVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>tamanho do array</span>
-            <strong>{p.arr.length}</strong>
+            <strong>{s.arr.length}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comp}</strong>
+            <strong>{s.comp}</strong>
           </div>
           <div className="bigo-stat">
             <span>trocas</span>
-            <strong>{p.swaps}</strong>
+            <strong>{s.swaps}</strong>
           </div>
           <div className="bigo-stat">
             <span>memória extra</span>
             <strong>O(1)</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -501,21 +423,8 @@ export function HeapSortVisualizer() {
           do heap sort: o pior caso é igual ao melhor, e nenhuma entrada consegue derrubá-lo.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -116,7 +116,15 @@ Três notas de execução, todas medidas:
 - **chave de tipo escrita como literal é código**, e qualquer ferramenta que
   protege literais a deixa para trás: em `Omit<Step, "slots" | "desloc">` o
   `"desloc"` precisava virar `"shifts"` junto com o campo. Aqui só o `tsc`
-  pegou — o guarda de idioma, por construção, nunca vai pegar.
+  pegou — o guarda de idioma, por construção, nunca vai pegar;
+- **valor de união que vira SUFIXO DE CLASSE é contrato com o CSS**, e esse
+  ninguém guarda. No `HeapSortVisualizer` a união `"construir" | "ordenar" |
+  "fim"` entra em `` `hs-fase f-${fase}` ``, e o `globals.css` compartilhado
+  define `.hs-fase.f-ordenar` e `.hs-fase.f-fim`. Traduzir a união apagaria a
+  cor de duas fases **sem nada acusar**: o `tsc` continua coerente, o guarda não
+  vê (não é texto de tela) e o teste não pega (é cor). Antes de renomear uma
+  união, **faça `grep` do valor no `globals.css`**; se ele estiver lá, use um
+  mapa (`PHASE_CLASS`) em vez de interpolar o valor cru.
 
 Depois de tudo isso, confira no navegador: contador, botões, notas, rótulos e o
 bloco de código.
@@ -328,6 +336,43 @@ pergunta certa é:
 
 Se o aluno não consegue mudar a dimensão por nenhum controle, ela não é eixo, e
 procurar pior caso ali é procurar no lugar errado.
+
+### Eixo alcançável ainda pode ser eixo com DEGRAUS
+
+A pergunta acima tem um segundo tempo, e sem ele ela leva à conclusão errada:
+**o caminho existe, mas ele chega a atravessar um degrau?**
+
+A altura de uma árvore é `⌊log₂ n⌋`, uma função **degrau**. Um controle que muda
+a contagem pode variar bastante e **não mover a altura um pixel**, porque os
+valores que ele alcança caem todos no mesmo patamar. Medido em dois tópicos
+independentes na mesma rodada:
+
+| peça | o que o controle alcança | o que a altura faz |
+|---|---|---|
+| `HeapSortVisualizer` | presets de 8 e de 10 elementos | `depth()` devolve **3 nos dois**; os quatro presets desenham **242px nos 289 estados** |
+| `BinaryHeapVisualizer` | presets de 6, 8 e 9 valores | 8 e 9 dão o **mesmo desenho ao pixel** (252px); 6 dá 192. Os 50% a mais compram um nível, o elemento seguinte compra **zero** |
+
+**Varrer os presets pode medir dois pontos achando que mediu quatro.** Antes de
+concluir "não tem pior caso", calcule em que valores o degrau muda e veja se
+algum controle chega lá. E quando o eixo satura, diga isso com o número — no
+heap binário, dos 327px entre o estado mais alto e o mais baixo, **só 60 são o
+desenho**; o resto é a operação escolhida.
+
+### A §3 se responde POR PEÇA, não por tópico
+
+Duas peças do mesmo tópico, desenhando a mesma coisa, podem ter eixos
+diferentes. Medido em `busca-binaria`, onde as duas mostram uma fita de células
+com `flex-wrap` e **sem** `overflow-x`:
+
+- **`BuscaBinariaVisualizer`** tem campo de array até 16 valores, e a fita quebra
+  linha a partir da 14ª célula: 8 → 16 posições custam **+99px**. A largura vira
+  altura, e o eixo é real;
+- **`BuscaBinariaFronteira`** usa uma constante de 9 posições, sem campo:
+  `linhasFita = 1` nos 15 estados e nas 3 réguas. Ali o eixo é o **código** (9 vs
+  12 linhas, 77px) e a prosa (37px entre dicas).
+
+Elas saíram com `measureOn` diferentes — `[n, presetKey]` e `[mode, presetKey]`.
+**Desenho igual não é eixo igual**: o que decide é o controle, não a aparência.
 
 ### O corolário que fecha a §3
 
@@ -623,6 +668,19 @@ os dois passando contra a quebra antes de serem consertados:
   "sobrevive" sem que nada a tenha ameaçado. Escolha um estado que muda mesmo a
   entrada da medição, **confirme a troca na tela** antes de concluir, e deixe a
   janela apertada o bastante para a medição querer recolher.
+- **`toBeInViewport()` sozinho não prova a camada 1.** Com o rodapé de volta
+  dentro do miolo — que é a quebra canônica desta camada — ele passa nas **duas**
+  pontas da rolagem: no fim porque é lá que o rodapé foi parar, e no começo
+  porque o botão ainda cruza a área visível, e a asserção aceita **qualquer**
+  interseção. Medido: uma quebra assim saiu `0 failed / 2 passed` com a quebra
+  confirmada no HTML do build.
+
+  A asserção que carrega o sentido é **a posição comparada com ela mesma** — o
+  `boundingBox().y` do controle antes e depois de o miolo rolar — e o
+  `toBeInViewport({ ratio: 1 })` entra como complemento, não como prova. É o que
+  os testes bons deste repo já fazem: `headMoveu === 0`, `footMoveu === 0`,
+  `sobraFigura <= 8`. Se o seu teste de camada 1 não tem um desses, ele está
+  aprovando a quebra.
 
 ---
 

--- a/tests/viz-binary-heap.spec.ts
+++ b/tests/viz-binary-heap.spec.ts
@@ -1,0 +1,435 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no visualizador do heap binário.
+//
+// Estes testes medem COMPORTAMENTO e leem RÓTULO. Contar elemento não prova
+// nada: já passaram por suíte verde um visualizador sem botão nenhum e um
+// painel com 0px de largura.
+//
+// Antes da casca, a peça rolava INTEIRA dentro do painel expandido e o
+// `.viz-foot` nem existia — os controles moravam no miolo rolável. Medido, nos
+// 24 estados (4 presets x 3 operações x 2 regras) e nas três janelas: ao rolar
+// até o fim o cabeçalho subia até 660px (1512x900), 860px (1440x700) e 960px
+// (1440x600), e o `▶ Rodar` era desenhado até 559, 759 e 859px ABAIXO do pé
+// visível. Depois: cabeçalho parado em 0px nos 72 estados, e o `▶ Rodar` de 49
+// a 57px DENTRO da janela.
+//
+// No artigo a peça ia de 1190 a 1517px contra um orçamento de 816 (1512x900).
+// Com o código recolhido pela medição ela vai de 956 a 1129 — 234 a 388px a
+// menos. Continua passando do orçamento por 140 a 313px, e isso é esperado: a
+// camada 2 não alcança o fluxo do artigo (contrato §9), e o que sobra é
+// conteúdo (a árvore, o array, a saída, a nota e as fichas), não respiro.
+//
+// O tópico tem três visualizadores; só este tem overlay, e ele leva as três
+// camadas. `HeapEstruturas` e `HeapIndicesVisualizer` não têm botão Expandir,
+// então não há painel para arrumar neles.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/binary-heap/";
+
+// Janela de notebook de 16", o caso que motivou a casca. Nela a peça pede
+// 1200px com o código à mostra contra 816 de orçamento.
+const BAIXA = { width: 1512, height: 900 };
+// Alta o bastante para o código caber aberto: a decisão vira entre 1200 e 1300
+// de janela (orçamento 1116 x 1216 contra os 1200px da peça aberta).
+const ALTA = { width: 1512, height: 1400 };
+// Apertada de propósito: garante que o miolo do painel tem o que rolar (199 a
+// 219px medidos ao longo da animação) e que a medição REALMENTE discordaria de
+// quem abre o código na mão.
+const APERTADA = { width: 1512, height: 700 };
+
+const PRESET_SEIS = "Ordem de chegada: 3 5 2 1 4 6";
+const PRESET_NOVE = "Chegando em ordem: 1 2 3 4 5 6 7 8 9";
+const PRESET_OITO = "Com repetidos: 20 15 10 40 50 100 25 15";
+
+/**
+ * A peça NÃO abre no passo 0: `firstMeaningfulStep` pula até a primeira árvore
+ * com quatro nós, que no preset padrão é o passo 9 de 21.
+ */
+const PASSO_DE_ABERTURA = "passo 9 de 21";
+const TOTAL_PADRAO = 21;
+
+// A página tem OUTRO `figure.viz` (o HeapIndicesVisualizer) com o seu próprio
+// `.viz-step`, `.bigo-stat` e `input[type=range]`. Medido: `.viz-step` casa 2 na
+// página e 1 dentro da peça. Todo seletor daqui é escopado por isso — um
+// seletor ambíguo não dá erro, devolve o PRIMEIRO elemento.
+function noArtigo(page: Page): Locator {
+  return page.locator("article figure.viz-fit");
+}
+
+/** A peça depois de expandida: ela é portada para fora do artigo. */
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz-fit");
+}
+
+async function abrir(page: Page, viewport: { width: number; height: number }) {
+  await page.setViewportSize(viewport);
+  await page.goto(URL);
+  // As fontes chegam com `display: swap`: medir antes é medir o fallback, e a
+  // casca só decide depois delas.
+  await page.evaluate(() => document.fonts.ready);
+  await expect(noArtigo(page)).toBeVisible();
+  // A janela pedida é a janela real. `viewportSize` como OPÇÃO é ignorada em
+  // silêncio noutro caminho da API, e três janelas viram uma sem ninguém avisar.
+  expect(page.viewportSize()).toEqual(viewport);
+  // `data-anim` volta para "on" quando a casca terminou de medir e decidir. É o
+  // sinal que ela já publica; esperar por ele custa menos que um sono fixo e
+  // não vira flake com a máquina cheia.
+  await expect(noArtigo(page)).toHaveAttribute("data-anim", "on");
+}
+
+async function expandir(page: Page): Promise<Locator> {
+  await noArtigo(page).getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = noPainel(page);
+  await expect(painel).toBeVisible();
+  // `toBeVisible()` NÃO quer dizer "pronto para o teclado": o listener de
+  // `keydown` nasce num efeito passivo, e a tecla enviada antes some sem erro
+  // nenhum — o que imita flake perfeitamente. O foco entrando na figura é o
+  // efeito irmão desse, e esperar por ele é a pré-condição que falta.
+  await expect(painel).toBeFocused();
+  return painel;
+}
+
+async function altura(loc: Locator): Promise<number> {
+  return loc.evaluate((el) => Math.round(el.getBoundingClientRect().height));
+}
+
+/**
+ * A altura depois que ela PARA de mudar.
+ *
+ * A transição da casca dura 0,32s — curta o bastante para o Playwright
+ * atravessar sem perceber, longa o bastante para mudar a conta. Um
+ * `expect.poll(...).toBeGreaterThan(orc)` fica verde no primeiro quadro em que
+ * a peça passa do orçamento e a leitura seguinte pega o meio do percurso. E
+ * duas leituras iguais não bastam: uma transição passa por patamares, e dois
+ * quadros vizinhos arredondam para o mesmo inteiro no meio do caminho. São
+ * precisas TRÊS iguais seguidas.
+ */
+async function alturaEstavel(loc: Locator): Promise<number> {
+  let anterior = -1;
+  let iguais = 0;
+  for (let k = 0; k < 60; k++) {
+    const agora = await altura(loc);
+    iguais = agora === anterior ? iguais + 1 : 0;
+    if (iguais >= 3) return agora;
+    anterior = agora;
+    await loc.page().waitForTimeout(50);
+  }
+  return anterior;
+}
+
+/** O orçamento do artigo: a janela menos o cabeçalho fixo e um respiro. */
+async function orcamento(page: Page): Promise<number> {
+  return page.evaluate(() => {
+    const h =
+      parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+    return window.innerHeight - h - 24;
+  });
+}
+
+/**
+ * Lê uma ficha de estatística pelo ÍNDICE e confere o rótulo junto do valor.
+ *
+ * Ler os dois no mesmo cartão é o que pega a troca de posição: o guarda de
+ * idioma compara o CONJUNTO de textos, não onde cada um aparece, então dois
+ * campos invertidos passam verde por lá e mentem na tela.
+ */
+async function ficha(fig: Locator, i: number, rotulo: string, valor: string) {
+  const cartao = fig.locator(".bigo-stat").nth(i);
+  await expect(cartao.locator("span")).toHaveText(rotulo);
+  await expect(cartao.locator("strong")).toHaveText(valor);
+}
+
+/**
+ * Amostra o estado do bloco recolhível N vezes ao longo de `ms` e devolve as
+ * amostras que falharam.
+ *
+ * Quando a promessa é PERMANÊNCIA ("a escolha do aluno sobrevive"), uma espera
+ * fixa seguida de uma leitura olha um instante só. Amostrar responde a pergunta
+ * certa: nenhum instante da janela pode ter falhado.
+ */
+async function amostrarAberto(page: Page, fig: Locator, ms = 900, n = 9): Promise<string[]> {
+  const falhas: string[] = [];
+  for (let k = 0; k < n; k++) {
+    const alturaSlot = await altura(fig.locator(".viz-code-slot"));
+    const rotulo = (await fig.locator("button.viz-toggle-codigo").textContent()) ?? "";
+    if (alturaSlot <= 60 || rotulo !== "Ocultar código") {
+      falhas.push(`aos ${Math.round((k * ms) / n)}ms: slot=${alturaSlot}px, rótulo=${JSON.stringify(rotulo)}`);
+    }
+    await page.waitForTimeout(ms / n);
+  }
+  return falhas;
+}
+
+test.describe("binary-heap · a árvore e o array se movendo juntos", () => {
+  // §8.1: no expandido o cabeçalho e o rodapé ficam parados, e o botão que faz
+  // o algoritmo andar nunca sai da tela.
+  //
+  // As três asserções de rolagem não são cerimônia: um teste que rola o
+  // `.viz-body` sem provar que é ELE quem rola aprova justamente a quebra que
+  // devolve a rolagem para a figura inteira — ali o `scrollTop` do miolo fica
+  // em zero, o cabeçalho não se mexe, e o teste passa feliz.
+  //
+  // E o passo importa. A sobra do miolo é maior no ÚLTIMO passo desta animação
+  // (219px contra 199 no menor), então o teste anda até lá antes de medir.
+  test("expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim", async ({ page }) => {
+    await abrir(page, APERTADA);
+    const painel = await expandir(page);
+    const passo = painel.locator(".viz-step");
+    await expect(passo).toHaveText(PASSO_DE_ABERTURA);
+
+    // Até o último passo, pela TECLA: o `click()` do Playwright ROLA o
+    // contêiner para alcançar o alvo, e isso mudaria justamente o que vou medir.
+    for (let k = 9; k < TOTAL_PADRAO; k++) await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo ${TOTAL_PADRAO} de ${TOTAL_PADRAO}`);
+
+    const miolo = painel.locator(".viz-body");
+    const cabeca = painel.locator(".viz-head");
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+
+    // 1. o miolo é o que estoura...
+    await expect
+      .poll(() => miolo.evaluate((el) => el.scrollHeight - el.clientHeight))
+      .toBeGreaterThan(8);
+    // ...e a leitura do cabeçalho parte do topo: o `click()` de um passo
+    // anterior teria rolado o contêiner sozinho, e o cabeçalho "andaria" por
+    // causa do meu próprio teste.
+    expect(await miolo.evaluate((el) => Math.round(el.scrollTop))).toBe(0);
+
+    const topoAntes = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+    // O rótulo importa tanto quanto a posição: um botão no lugar certo dizendo
+    // a coisa errada ensina errado do mesmo jeito.
+    await expect(rodar).toHaveText("▶ Rodar");
+    await expect(rodar).toBeInViewport();
+
+    // 2. ...e é ele que rola, não a figura inteira.
+    await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    await expect.poll(() => miolo.evaluate((el) => Math.round(el.scrollTop))).toBeGreaterThan(8);
+    expect(await painel.evaluate((f) => Math.round(f.scrollTop))).toBe(0);
+
+    // 3. e o cabeçalho não saiu do lugar. (Antes da casca ele subia 428px nesta
+    // mesma janela de 700 de altura, e 660px na de 900.)
+    const topoDepois = await cabeca.evaluate((el) => Math.round(el.getBoundingClientRect().top));
+    expect(Math.abs(topoDepois - topoAntes)).toBeLessThanOrEqual(1);
+    await expect(rodar).toBeInViewport();
+    await expect(rodar).toHaveText("▶ Rodar");
+
+    // E o rodapé está colado no pé da figura, não empurrado para fora dela.
+    const folga = await painel.evaluate((f) => {
+      const foot = f.querySelector(".viz-foot") as HTMLElement;
+      return Math.round(f.getBoundingClientRect().bottom - foot.getBoundingClientRect().bottom);
+    });
+    expect(folga).toBeLessThanOrEqual(2);
+  });
+
+  // §8.2: em tela baixa a peça não cabe com o código à mostra, então ele
+  // recolhe — e o botão passa a dizer o que faria aparecer.
+  test("tela baixa: o botão diz 'Mostrar código' e o bloco está recolhido", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    const botao = fig.locator("button.viz-toggle-codigo");
+
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    // Recolhido de verdade: o slot perde a ALTURA, não só a largura. Zerar a
+    // trilha da coluna deixava a linha do grid com a altura do código.
+    await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeLessThanOrEqual(4);
+
+    const recolhida = await alturaEstavel(fig);
+    const orc = await orcamento(page);
+
+    // A premissa medida DENTRO do teste, e DEPOIS da asserção: com o código à
+    // mostra a peça não cabe. Sem ela, no dia em que a peça encolher isto vira
+    // decoração verde.
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    const aberta = await alturaEstavel(fig);
+    expect(aberta).toBeGreaterThan(orc);
+    // Recolher vale 244px medidos (1200 → 956). O teto aqui é regressão.
+    expect(aberta - recolhida).toBeGreaterThan(200);
+    // E mesmo recolhida a peça ainda passa do orçamento (956 contra 816): a
+    // camada 2 não alcança o fluxo do artigo (contrato §9), e o que sobra é
+    // conteúdo. Dizer isso com número é melhor que arredondar para "coube".
+    expect(recolhida).toBeGreaterThan(orc);
+    expect(recolhida).toBeLessThan(1000);
+  });
+
+  // §8.3: onde cabe, o código já vem à mostra — a medição decide, não um
+  // breakpoint de largura. A janela aqui é MAIS ALTA, não mais larga.
+  test("tela alta: o código já vem aberto e o botão diz 'Ocultar código'", async ({ page }) => {
+    await abrir(page, ALTA);
+    const fig = noArtigo(page);
+    const botao = fig.locator("button.viz-toggle-codigo");
+
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "true");
+    await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+    // O bloco é mesmo o código DESTE visualizador, no modo em que ele abre.
+    await expect(fig.locator(".viz-code-head")).toHaveText("push.py");
+  });
+
+  // §8.4: a escolha explícita do aluno vence a medição e não é desfeita por
+  // uma troca de estado que pediria medição nova.
+  test("a escolha do aluno sobrevive a uma troca de estado que pede medição nova", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    const botao = fig.locator("button.viz-toggle-codigo");
+
+    await expect(botao).toHaveText("Mostrar código");
+    await botao.click();
+    await expect(botao).toHaveText("Ocultar código");
+    await expect.poll(() => altura(fig.locator(".viz-code-slot"))).toBeGreaterThan(60);
+
+    // Trocar a operação mexe no `mode`, que está em `measureOn`: o código vai
+    // de 9 para 15 linhas, entra um painel de saída inteiro, e a peça recolhida
+    // sobe de 956 para 1051px contra 816 de orçamento. É uma troca com que a
+    // medição discordaria mesmo.
+    await fig.getByRole("button", { name: "remover o topo", exact: true }).click();
+
+    // A entrada da medição mudou MESMO, e a leitura é do rótulo junto do valor:
+    // o modo remover abre com o heap já montado, seis elementos.
+    await ficha(fig, 0, "elementos", "6");
+    await expect(fig.locator(".viz-code-head")).toHaveText("pop.py");
+
+    // A janela amostrada cobre a medição E a transição de 0,32s que viria
+    // depois dela. Exigir que NENHUMA amostra tenha falhado é o que separa
+    // "está aberto" de "continua aberto".
+    expect(await amostrarAberto(page, fig)).toEqual([]);
+  });
+
+  // §8.5: as teclas dirigem a animação dentro do painel.
+  test("expandido: as setas andam o passo e o espaço roda", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page);
+    const passo = painel.locator(".viz-step");
+
+    await expect(passo).toHaveText(PASSO_DE_ABERTURA);
+
+    // Uma asserção DEPOIS DE CADA TECLA: `→` seguido de `←` se cancelam, e um
+    // teste que só olha o fim aprova a quebra que ignora as duas.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo 10 de ${TOTAL_PADRAO}`);
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText(`passo 11 de ${TOTAL_PADRAO}`);
+    await page.keyboard.press("ArrowLeft");
+    await expect(passo).toHaveText(`passo 10 de ${TOTAL_PADRAO}`);
+
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("❚❚ Pausar");
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+
+  // A regra mais importante dos atalhos é o inverso deles: campo em edição
+  // manda. Esta peça não tem campo de texto — o único campo dela é o slider de
+  // velocidade, e ali a seta é do slider.
+  //
+  // E a MARCHA DE ABERTURA é da peça, não do hook: ela abre no "1.5x"
+  // (`initialSpeed: 4`), porque as animações chegam a 51 passos e no 1x a
+  // reprodução inteira fica longa demais. Perder o `initialSpeed` na migração
+  // compila e não muda teste nenhum — por isso ele é afirmado aqui, pelo
+  // rótulo que o aluno lê.
+  //
+  // A seta é apertada DUAS VEZES na mesma direção, nunca ida e volta: um par de
+  // ações inversas devolve a peça ao estado de origem e fica verde com a quebra.
+  test("a marcha de abertura é 1.5x e a seta no slider é do slider", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const painel = await expandir(page);
+    const slider = painel.locator('input[type="range"]');
+    const passo = painel.locator(".viz-step");
+    const marcha = painel.locator(".viz-speed .val");
+
+    await expect(marcha).toHaveText("1.5x");
+    await expect(passo).toHaveText(PASSO_DE_ABERTURA);
+
+    await slider.focus();
+    await page.keyboard.press("ArrowLeft");
+    await expect(marcha).toHaveText("1x");
+    await expect(passo).toHaveText(PASSO_DE_ABERTURA);
+    await page.keyboard.press("ArrowLeft");
+    await expect(marcha).toHaveText("0.75x");
+    await expect(passo).toHaveText(PASSO_DE_ABERTURA);
+
+    // E o espaço com um botão em foco é do botão: ele anda UM passo (ativação
+    // do `Próximo ›`) em vez de começar a reprodução.
+    const rodar = painel.getByRole("button", { name: /Rodar|Pausar/ });
+    await painel.getByRole("button", { name: "Próximo ›" }).focus();
+    await page.keyboard.press("Space");
+    await expect(passo).toHaveText(`passo 10 de ${TOTAL_PADRAO}`);
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+
+  // O que a MEDIÇÃO contrariou, virado teste.
+  //
+  // O palpite óbvio para o pior caso de altura de uma árvore é "mais nós". Aqui
+  // é falso duas vezes. O eixo do desenho é a PROFUNDIDADE: 6 valores dão dois
+  // níveis (192px) e 9 dão três (252px), então 50% mais elementos custam UM
+  // nível — os 60px de `LEVEL_Y`. E de 8 para 9 valores a altura não muda NADA,
+  // porque os dois cabem em três níveis: o desenho é idêntico ao pixel.
+  //
+  // É por isso que `measureOn` leva o preset, e não uma contagem de nós.
+  test("o desenho cresce por NÍVEL, não por elemento: 8 e 9 valores dão a mesma altura", async ({ page }) => {
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    const desenho = fig.locator("svg.tt-arv");
+
+    // O modo "construir" abre com o array cru inteiro, então a ficha
+    // "elementos" mostra o tamanho do preset — que é o que quero comparar.
+    await fig.getByRole("button", { name: "construir de uma vez", exact: true }).click();
+
+    await fig.getByRole("button", { name: PRESET_SEIS, exact: true }).click();
+    await ficha(fig, 0, "elementos", "6");
+    await ficha(fig, 1, "altura", "3");
+    const seis = await altura(desenho);
+
+    await fig.getByRole("button", { name: PRESET_OITO, exact: true }).click();
+    await ficha(fig, 0, "elementos", "8");
+    await ficha(fig, 1, "altura", "4");
+    const oito = await altura(desenho);
+
+    await fig.getByRole("button", { name: PRESET_NOVE, exact: true }).click();
+    await ficha(fig, 0, "elementos", "9");
+    await ficha(fig, 1, "altura", "4");
+    const nove = await altura(desenho);
+
+    // Um nível a mais custa exatamente `LEVEL_Y`...
+    expect(nove - seis).toBe(60);
+    // ...e o elemento a mais que NÃO abre nível não custa nada.
+    expect(nove - oito).toBe(0);
+
+    // E o desenho está no tamanho NATURAL, não esticado: por isso um teto de
+    // altura aqui destruiria conteúdo em vez de devolver vazio (contrato §3).
+    // Medido em 72 estados: esticão de 0px em todos. Se algum dia o `.tt-arv`
+    // ganhar `width: 100%`, esta asserção avisa.
+    const esticao = await desenho.evaluate((el) => {
+      const r = el.getBoundingClientRect();
+      const vb = (el as unknown as SVGSVGElement).viewBox.baseVal;
+      return { rend: Math.round(r.height), natural: vb.height };
+    });
+    expect(esticao.rend).toBe(esticao.natural);
+  });
+
+  // A peça não abre no passo 0: no modo inserir o passo 0 é o heap VAZIO, e
+  // abrir um visualizador de heap sem heap na tela não ensina nada. O ajuste é
+  // na fase de render, não num efeito — é isso que faz o HTML do build estático
+  // já sair no passo certo (contrato §9). Perder isso compila e não quebra mais
+  // nada, então a prova é ler o `out/` cru, sem JavaScript.
+  test("abre no primeiro passo com árvore de verdade, inclusive no HTML do build", async ({ page, request }) => {
+    const html = await (await request.get(URL)).text();
+    // Duas peças da página têm `.viz-step`; a do heap é a que conta passos.
+    expect(html).toContain("passo <!-- -->9<!-- --> de <!-- -->21");
+
+    await abrir(page, BAIXA);
+    const fig = noArtigo(page);
+    await expect(fig.locator(".viz-step")).toHaveText(PASSO_DE_ABERTURA);
+    // Quatro nós na tela, lidos no rótulo junto do valor.
+    await ficha(fig, 0, "elementos", "4");
+
+    // E o ↺ continua sendo o caminho para ver a inserção desde o heap vazio.
+    await fig.getByRole("button", { name: "↺" }).click();
+    await expect(fig.locator(".viz-step")).toHaveText(`passo 1 de ${TOTAL_PADRAO}`);
+    await ficha(fig, 0, "elementos", "1");
+  });
+});

--- a/tests/viz-busca-binaria.spec.ts
+++ b/tests/viz-busca-binaria.spec.ts
@@ -1,0 +1,374 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// A casca adaptativa nos dois visualizadores com linha do tempo do tópico
+// busca-binaria. Contrato em `content/visualizers/README.md`, §8.
+//
+// A página tem TRÊS `figure.viz`: a busca (0), o estouro de 32 bits (1, que não
+// tem overlay e está fora deste arquivo) e as fronteiras (2). Todo seletor sai
+// da figura, nunca da página — a casca acrescenta elementos e um seletor de
+// página passa a casar com mais de um sem reclamar.
+//
+// Duas medições deste arquivo têm número medido por trás:
+//   · a 1440x600 o miolo do painel sobra 34px no mínimo, em todos os passos de
+//     todos os estados das duas peças, então o teste da camada 1 pode rodar em
+//     qualquer passo (o pico é o último);
+//   · a 1512x900 as duas peças recolhem o código sempre (752..851px de peça
+//     contra 816 de orçamento COM o código aberto passando de 1038), e só a
+//     partir de ~1130px de janela é que ele abre sozinho.
+
+const URL = "/topico/busca-binaria/";
+
+type Peca = {
+  nome: string;
+  idx: number;
+  titulo: string;
+  /** Troca um estado que ESTÁ no `measureOn`, e devolve o que confere na tela. */
+  trocaMedida: {
+    aplicar: (fig: Locator) => Promise<void>;
+    marcador: (fig: Locator) => Locator;
+    antes: string;
+    depois: string;
+  };
+};
+
+const PECAS: Peca[] = [
+  {
+    nome: "busca binária",
+    idx: 0,
+    titulo: "Visualizador · busca binária: metade some a cada olhada",
+    // 8 → 16 células: muda `n`, que é o eixo de altura desta peça (a fita
+    // quebra para uma segunda linha), e muda o preset junto.
+    trocaMedida: {
+      aplicar: async (fig) => {
+        await fig.getByRole("button", { name: "16 posições, no máximo 5 olhadas" }).click();
+      },
+      marcador: (fig) => fig.locator(".bb-barra-txt"),
+      antes: "8 de 8 candidatos ainda de pé",
+      depois: "16 de 16 candidatos ainda de pé",
+    },
+  },
+  {
+    nome: "fronteiras",
+    idx: 2,
+    titulo: "Visualizador · repetidos, bordas e a posição de inserção",
+    // "primeira" → "onde entraria": o código vai de 12 para 9 linhas e o painel
+    // perde uma variável. É o eixo de altura desta peça — a fita dela é fixa.
+    trocaMedida: {
+      aplicar: async (fig) => {
+        await fig.getByRole("button", { name: "onde entraria", exact: true }).click();
+      },
+      marcador: (fig) => fig.locator(".viz-code-head"),
+      antes: "primeira.py",
+      depois: "onde_entraria.py",
+    },
+  },
+];
+
+/** Uma ordem só de aplicar controles, usada por todos os testes. */
+async function abrir(page: Page, peca: Peca): Promise<Locator> {
+  await page.goto(URL);
+  await page.evaluate(() => document.fonts.ready);
+  const fig = page.locator("article figure.viz").nth(peca.idx);
+  await expect(fig).toHaveClass(/viz-fit/);
+  // A medição da casca acontece com `data-anim="off"`; esperar o atributo
+  // virar "on" é esperar a decisão, e é mais barato que um timeout fixo.
+  await expect(fig).toHaveAttribute("data-anim", "on");
+  return fig;
+}
+
+async function expandir(page: Page, peca: Peca, fig: Locator): Promise<Locator> {
+  await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+  // O diálogo é rotulado pelo título DESTA peça, não por um genérico: com três
+  // figuras na mesma página, um `aria-label` copiado deixaria o leitor de tela
+  // sem saber qual das três abriu.
+  const dialogo = page.getByRole("dialog", { name: peca.titulo });
+  await expect(dialogo).toHaveCount(1);
+  const painel = dialogo.locator("figure.viz-fit");
+  await expect(painel).toHaveAttribute("data-anim", "on");
+  return painel;
+}
+
+/**
+ * Altura estável. Não basta "duas leituras iguais" nem `expect.poll`: o
+ * `.viz-split` é `align-items: start`, então enquanto o bloco cresce por baixo
+ * da coluna vizinha a FIGURA não anda um pixel — um patamar estrutural de
+ * centenas de milissegundos dentro da transição de 0,32s.
+ */
+async function alturaEstavel(loc: Locator): Promise<number> {
+  await loc.page().waitForTimeout(450);
+  let iguais = 0;
+  let ultima = -1;
+  for (let i = 0; i < 40; i++) {
+    const h = Math.round((await loc.boundingBox())?.height ?? -1);
+    iguais = h === ultima ? iguais + 1 : 0;
+    ultima = h;
+    if (iguais >= 3) return h;
+    await loc.page().waitForTimeout(50);
+  }
+  return ultima;
+}
+
+for (const peca of PECAS) {
+  test.describe(`viz busca-binaria · ${peca.nome}`, () => {
+    // ---------------------------------------------------------------- camada 1
+    test.describe("painel expandido em tela baixa", () => {
+      test.use({ viewport: { width: 1440, height: 600 } });
+
+      test(`cabeçalho e rodapé ficam parados quando o miolo rola · ${peca.nome}`, async ({
+        page,
+      }) => {
+        const painel = await expandir(page, peca, await abrir(page, peca));
+        const miolo = painel.locator(".viz-body");
+        const cabeca = painel.locator(".viz-head");
+        const rodar = painel.getByRole("button", { name: "▶ Rodar" });
+
+        // Premissa: existe sobra para rolar. Sem isto o teste é decoração
+        // verde no dia em que a peça encolher. (Medido: 34px é o mínimo em
+        // todos os passos de todos os estados nesta janela.)
+        const sobra = await miolo.evaluate((b) => b.scrollHeight - b.clientHeight);
+        expect(sobra).toBeGreaterThan(20);
+
+        // A promessa é PARADO, e é ela que a asserção tem de medir: onde o
+        // `▶ Rodar` está desenhado antes e depois de o miolo rolar.
+        //
+        // Medido, e é a razão de este teste não ser o óbvio: com o rodapé de
+        // volta dentro do miolo, `toBeInViewport()` passa nas duas pontas. No
+        // fim da rolagem ele passa porque é lá que o rodapé está desenhado; no
+        // começo passa porque o botão fica 33px para dentro da área visível e a
+        // asserção padrão aceita QUALQUER interseção. Só a posição comparada
+        // com ela mesma separa os dois casos — com a quebra ela anda o tanto
+        // que o miolo rolou.
+        expect(await miolo.evaluate((b) => b.scrollTop)).toBe(0);
+        await expect(rodar).toBeInViewport({ ratio: 1 });
+        const rodarAntes = await rodar.evaluate((b) =>
+          Math.round(b.getBoundingClientRect().top)
+        );
+
+        await miolo.evaluate((b) => b.scrollTo(0, b.scrollHeight));
+        await page.waitForTimeout(120);
+
+        const rodarDepois = await rodar.evaluate((b) =>
+          Math.round(b.getBoundingClientRect().top)
+        );
+        expect(Math.abs(rodarDepois - rodarAntes)).toBeLessThanOrEqual(2);
+
+        // É o MIOLO que rola, e a figura NÃO. Sem as duas asserções, a quebra
+        // que devolve a rolagem para a figura inteira passa: lá o `scrollTop`
+        // do miolo fica em zero e o cabeçalho também não se mexe.
+        expect(await miolo.evaluate((b) => b.scrollTop)).toBeGreaterThan(0);
+        expect(await painel.evaluate((f) => f.scrollTop)).toBe(0);
+        expect(
+          await painel.evaluate((f) => f.scrollHeight - f.clientHeight)
+        ).toBeLessThanOrEqual(2);
+
+        // O cabeçalho continua colado no topo da figura.
+        const desvio = await painel.evaluate((f) => {
+          const h = f.querySelector(".viz-head") as HTMLElement;
+          return Math.round(h.getBoundingClientRect().top - f.getBoundingClientRect().top);
+        });
+        expect(desvio).toBeLessThanOrEqual(2);
+        await expect(cabeca).toBeInViewport();
+
+        // E continua inteiro à vista com o miolo rolado até o fim, sem clicar
+        // nele (o `click()` rola o contêiner para alcançar o alvo, então clicar
+        // nunca prova que ele estava visível).
+        await expect(rodar).toBeInViewport({ ratio: 1 });
+        const forade = await rodar.evaluate(
+          (b) => Math.round(b.getBoundingClientRect().bottom - window.innerHeight)
+        );
+        expect(forade).toBeLessThanOrEqual(0);
+      });
+    });
+
+    // ---------------------------------------------------------------- camada 3
+    test.describe("tela baixa", () => {
+      test.use({ viewport: { width: 1512, height: 900 } });
+
+      test(`o bloco vem recolhido e o botão diz "Mostrar código" · ${peca.nome}`, async ({
+        page,
+      }) => {
+        const fig = await abrir(page, peca);
+        await expect(fig).toHaveAttribute("data-codigo", "off");
+
+        const botao = fig.getByRole("button", { name: /código$/ });
+        await expect(botao).toHaveCount(1);
+        await expect(botao).toHaveText("Mostrar código");
+        await expect(botao).toHaveAttribute("aria-expanded", "false");
+
+        // Rótulo certo não basta: a altura tem que ter sumido de verdade.
+        // Sem esta linha, tirar o `.viz-code-slot` passa despercebido — o
+        // atributo, o rótulo e o `aria-hidden` continuam todos corretos e a
+        // peça continua 286px mais alta.
+        const slot = fig.locator(".viz-code-slot");
+        await expect(slot).toHaveCount(1);
+        expect(await alturaEstavel(slot)).toBeLessThan(8);
+
+        // O código sai do teclado e dos leitores enquanto está fora de vista.
+        await expect(fig.locator(".viz-code")).toHaveAttribute("aria-hidden", "true");
+
+        await botao.click();
+        await expect(fig).toHaveAttribute("data-codigo", "on");
+        await expect(botao).toHaveText("Ocultar código");
+        expect(await alturaEstavel(slot)).toBeGreaterThan(100);
+      });
+    });
+
+    test.describe("tela alta", () => {
+      test.use({ viewport: { width: 1512, height: 1300 } });
+
+      test(`o bloco já vem aberto quando cabe · ${peca.nome}`, async ({ page }) => {
+        const fig = await abrir(page, peca);
+        await expect(fig).toHaveAttribute("data-codigo", "on");
+        await expect(fig.getByRole("button", { name: /código$/ })).toHaveText("Ocultar código");
+        expect(await alturaEstavel(fig.locator(".viz-code-slot"))).toBeGreaterThan(100);
+        await expect(fig.locator(".viz-code")).not.toHaveAttribute("aria-hidden", "true");
+      });
+    });
+
+    // ------------------------------------------------- escolha manual x medição
+    test.describe("escolha do aluno", () => {
+      test.use({ viewport: { width: 1512, height: 900 } });
+
+      test(`mostrar o código vence a medição seguinte · ${peca.nome}`, async ({ page }) => {
+        const fig = await abrir(page, peca);
+        const marcador = peca.trocaMedida.marcador(fig);
+        await expect(marcador).toHaveText(peca.trocaMedida.antes);
+
+        // O aluno abre o que a medição tinha fechado.
+        await expect(fig).toHaveAttribute("data-codigo", "off");
+        await fig.getByRole("button", { name: "Mostrar código" }).click();
+        await expect(fig).toHaveAttribute("data-codigo", "on");
+
+        // Uma troca que MUDA a entrada da medição — conferida na tela, senão a
+        // escolha "sobrevive" sem que nada a tenha ameaçado.
+        await peca.trocaMedida.aplicar(fig);
+        await expect(marcador).toHaveText(peca.trocaMedida.depois);
+
+        // Permanência se prova amostrando, não com uma leitura depois de uma
+        // espera: 9 leituras ao longo de 900ms, nenhuma pode falhar.
+        for (let i = 0; i < 9; i++) {
+          await expect(fig).toHaveAttribute("data-codigo", "on");
+          await page.waitForTimeout(100);
+        }
+
+        // Premissa DEPOIS da asserção, de propósito: com a quebra aplicada o
+        // código recolhe, a peça encolhe, e uma premissa escrita antes
+        // reprovaria antes de a asserção rodar — apontando para o lugar errado.
+        const alturaAberta = await alturaEstavel(fig);
+        const orcamento = await page.evaluate(() => window.innerHeight - 60 - 24);
+        expect(alturaAberta).toBeGreaterThan(orcamento);
+      });
+    });
+
+    // ----------------------------------------------------------------- teclado
+    test.describe("teclado no painel", () => {
+      test.use({ viewport: { width: 1440, height: 700 } });
+
+      test(`as setas andam o passo e não roubam a tecla de quem edita · ${peca.nome}`, async ({
+        page,
+      }) => {
+        const painel = await expandir(page, peca, await abrir(page, peca));
+        const passo = painel.locator(".viz-step");
+        // Só um contador: esta peça não passa `children` ao `VizHeader`.
+        await expect(passo).toHaveCount(1);
+        await expect(passo).toHaveText(/^passo 1 de \d+$/);
+
+        // `toBeVisible()` no painel NÃO é "pronto para o teclado": o listener
+        // nasce num efeito passivo, e a tecla enviada antes some sem erro
+        // nenhum. O que prova é o foco já estar dentro do painel.
+        await expect
+          .poll(() =>
+            page.evaluate(() => !!document.activeElement?.closest(".viz-overlay-fit"))
+          )
+          .toBe(true);
+
+        // A MESMA tecla duas vezes, nunca um par inverso: `→` seguido de `←`
+        // devolve a peça ao estado de origem e fica verde mesmo com as duas
+        // teclas roubadas. E uma asserção depois de cada tecla.
+        await page.keyboard.press("ArrowRight");
+        await expect(passo).toHaveText(/^passo 2 de \d+$/);
+        await page.keyboard.press("ArrowRight");
+        await expect(passo).toHaveText(/^passo 3 de \d+$/);
+
+        // Com o cursor no controle de velocidade, a seta é do slider: o passo
+        // não anda E a marcha muda. Sem a segunda metade, a asserção do passo
+        // sozinha não prova nada — no passo 1 a seta para trás já está no piso.
+        const marcha = painel.locator(".viz-speed .val");
+        const range = painel.locator('input[type="range"]');
+        await expect(range).toHaveCount(1);
+        await expect(marcha).toHaveText("1x");
+        await range.focus();
+        await page.keyboard.press("ArrowRight");
+        await expect(marcha).toHaveText("1.5x");
+        await expect(passo).toHaveText(/^passo 3 de \d+$/);
+
+        // Espaço com um botão em foco é o botão, não o roda/pausa.
+        const proximo = painel.getByRole("button", { name: "Próximo ›" });
+        await proximo.focus();
+        await page.keyboard.press(" ");
+        await expect(passo).toHaveText(/^passo 4 de \d+$/);
+        await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+      });
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// As invariantes de cada peça: números que a tela tem de concordar entre si.
+// Nenhum valor escrito de cabeça — cada asserção compara dois ou três lugares
+// da tela que chegam ao número por caminhos diferentes.
+// ---------------------------------------------------------------------------
+
+test.describe("as contas que a tela promete", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("busca binária · lidas + descartadas sem ler = o array inteiro", async ({ page }) => {
+    const fig = await abrir(page, PECAS[0]);
+    await fig.getByRole("button", { name: "Um valor que não existe: 40" }).click();
+
+    const proximo = fig.getByRole("button", { name: "Próximo ›" });
+    for (let i = 0; i < 40 && !(await proximo.isDisabled()); i++) await proximo.click();
+    await expect(proximo).toBeDisabled();
+
+    const doCartao = async (rotulo: string) => {
+      const cartao = fig.locator(".bigo-stat").filter({ hasText: rotulo });
+      await expect(cartao).toHaveCount(1);
+      return parseInt(await cartao.locator("strong").innerText(), 10);
+    };
+    const lidas = await doCartao("comparações até aqui");
+    const descartadas = await doCartao("descartadas sem ler");
+    const total = (await fig.locator(".viz-cells .viz-cell").count());
+
+    // O cartão diz "descartadas SEM LER": a posição do meio foi lida nesta
+    // iteração e não pode entrar nesta conta. Se ela entrasse, a soma passaria
+    // do tamanho do array — que é exatamente o rótulo mentindo.
+    expect(lidas + descartadas).toBe(total);
+    await expect(fig.locator(".viz-note")).toContainText(
+      `${lidas} + ${descartadas} = ${total}`
+    );
+  });
+
+  test("fronteiras · o retorno negativo é -(esq) - 1, com esq lido do painel", async ({
+    page,
+  }) => {
+    const fig = await abrir(page, PECAS[1]);
+    await fig.getByRole("button", { name: "Um valor que não existe: 7" }).click();
+    await fig.getByRole("button", { name: "onde entraria", exact: true }).click();
+
+    const proximo = fig.getByRole("button", { name: "Próximo ›" });
+    for (let i = 0; i < 40 && !(await proximo.isDisabled()); i++) await proximo.click();
+    await expect(proximo).toBeDisabled();
+
+    // `esq` sai do painel de variáveis, pelo nome — não pela posição na lista.
+    const linhaEsq = fig.locator(".viz-var").filter({ hasText: "esq" });
+    await expect(linhaEsq).toHaveCount(1);
+    const esq = parseInt(await linhaEsq.locator(".viz-var-val").innerText(), 10);
+
+    const cartao = fig.locator(".bigo-stat").filter({ hasText: "retorno do Arrays.binarySearch" });
+    await expect(cartao).toHaveCount(1);
+    const retorno = parseInt(await cartao.locator("strong").innerText(), 10);
+
+    expect(retorno).toBe(-esq - 1);
+    await expect(fig.locator(".viz-note")).toContainText(`-(${esq}) - 1 = ${retorno}`);
+  });
+});

--- a/tests/viz-heap-sort.spec.ts
+++ b/tests/viz-heap-sort.spec.ts
@@ -1,0 +1,370 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// A casca adaptativa do HeapSortVisualizer.
+//
+// Todo número aqui foi MEDIDO no build antes de virar asserção, e o que dá para
+// escrever como invariante entre dois lugares da tela está escrito assim.
+//
+// Um aviso de seletor, porque a página tem TRÊS visualizadores: `.viz-step`,
+// `.viz-note`, `.tt-legenda-arvore` e `.hp-cel` também existem no
+// HeapSortEstabilidade (28 `.hp-cel` na página, 10 são desta peça). Tudo aqui
+// desce a partir da figura, nunca da página.
+
+const ARTIGO = "article figure.viz-fit";
+const PAINEL = ".viz-overlay-fit figure.viz-fit";
+
+/** Folga de subpixel, o mesmo valor que o hook usa para decidir. */
+const SLACK = 8;
+
+async function abrirTopico(page: Page) {
+  await page.goto("/topico/heap-sort/");
+  await page.evaluate(() => document.fonts.ready);
+  await page.locator(ARTIGO).scrollIntoViewIfNeeded();
+  // A decisão da casca roda em dois passes de layout depois das fontes; sem
+  // esperar por ela, `data-codigo` ainda é o "on" do primeiro render.
+  await expect(page.locator(ARTIGO)).toHaveAttribute("data-anim", "on");
+}
+
+/** Altura da figura, o orçamento da janela e o estado do bloco recolhível. */
+const LER = (sel: string) => {
+  const f = document.querySelector(sel) as HTMLElement;
+  const code = f.querySelector(".viz-code") as HTMLElement;
+  const hh = parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) || 60;
+  return {
+    figura: Math.round(f.getBoundingClientRect().height),
+    orcamento: Math.round(window.innerHeight - hh - 24),
+    codigo: f.getAttribute("data-codigo"),
+    alturaCodigo: Math.round(code.getBoundingClientRect().height),
+  };
+};
+
+const passoAtual = (raiz: string) => {
+  const f = document.querySelector(raiz) as HTMLElement;
+  const txt = [...f.querySelectorAll(".viz-step")].map((e) => e.textContent).join(" ");
+  const m = txt.match(/passo (\d+) de (\d+)/);
+  if (!m) throw new Error(`o contador de passo nao casou: "${txt}"`);
+  return { passo: parseInt(m[1], 10), total: parseInt(m[2], 10) };
+};
+
+test.describe("heap-sort", () => {
+  // ---------------------------------------------------------------- camada 1
+  test.describe("camada 1", () => {
+    test.use({ viewport: { width: 1440, height: 600 } });
+
+    test("cabecalho e rodape ficam parados quando o miolo rola ate o fim", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+      await abrirTopico(page);
+
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+
+      // A casca acrescenta elementos, e um seletor que casava com um passa a
+      // casar com dois — aí ele devolve o primeiro em vez de erro. Dentro da
+      // figura o contador é UM.
+      await expect(painel.locator(".viz-step")).toHaveCount(1);
+
+      // Esta peça NÃO cresce com a animação: a geometria da árvore sai de
+      // `arr.length`, não do heap ativo, e a caixa mede 242px em todos os
+      // passos. Medido: 958..978px nos 78 passos, com o passo 1 já no patamar
+      // máximo — por isso o teste de rolagem pode morar aqui. A pré-condição
+      // abaixo é quem garante isso, e não este comentário.
+      const antes = await page.evaluate((sel) => {
+        const f = document.querySelector(sel) as HTMLElement;
+        const b = f.querySelector(".viz-body") as HTMLElement;
+        b.scrollTop = 0;
+        return {
+          sobra: b.scrollHeight - b.clientHeight,
+          headTop: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - f.getBoundingClientRect().top),
+          footBottom: Math.round(f.getBoundingClientRect().bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+        };
+      }, PAINEL);
+      // PRÉ-CONDIÇÃO: sem sobra para rolar, o teste inteiro é decoração verde.
+      expect(antes.sobra, "o miolo precisa ter o que rolar").toBeGreaterThan(SLACK);
+
+      const depois = await page.evaluate((sel) => {
+        const f = document.querySelector(sel) as HTMLElement;
+        const b = f.querySelector(".viz-body") as HTMLElement;
+        b.scrollTop = b.scrollHeight;
+        const play = f.querySelector(".viz-play") as HTMLElement;
+        return {
+          bodyScrollTop: Math.round(b.scrollTop),
+          figScrollTop: Math.round(f.scrollTop),
+          headTop: Math.round(f.querySelector(".viz-head")!.getBoundingClientRect().top - f.getBoundingClientRect().top),
+          footBottom: Math.round(f.getBoundingClientRect().bottom - f.querySelector(".viz-foot")!.getBoundingClientRect().bottom),
+          playAbaixoDaJanela: Math.round(play.getBoundingClientRect().bottom - window.innerHeight),
+        };
+      }, PAINEL);
+
+      // Quem rolou foi o MIOLO, e não a figura: sem esta dupla o teste aprova a
+      // quebra que devolve a rolagem para a figura inteira, que é o defeito de
+      // origem (medido no código antigo: o cabeçalho subia 908px e o ▶ Rodar
+      // ficava 831px abaixo do pé visível da peça).
+      expect(depois.bodyScrollTop, "o miolo tem que ser quem rola").toBeGreaterThan(0);
+      expect(depois.figScrollTop, "a figura nao pode rolar").toBe(0);
+      expect(depois.headTop, "o cabecalho andou junto com o miolo").toBe(antes.headTop);
+      expect(depois.footBottom, "o rodape andou junto com o miolo").toBe(antes.footBottom);
+      expect(depois.playAbaixoDaJanela, "o ▶ Rodar caiu para fora da janela").toBeLessThanOrEqual(0);
+
+      // E o botão continua dizendo o que faz, com a animação parada.
+      await expect(painel.locator(".viz-play")).toHaveText("▶ Rodar");
+    });
+  });
+
+  // ------------------------------------------------- camada 3: tela baixa
+  test.describe("tela baixa", () => {
+    test.use({ viewport: { width: 1440, height: 700 } });
+
+    test("o codigo vem recolhido e o botao diz o que some", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 700 });
+      await abrirTopico(page);
+
+      const m = await page.evaluate(LER, ARTIGO);
+      expect(m.codigo, "a medicao devia ter recolhido o codigo").toBe("off");
+      // Recolher a COLUNA tira largura, não altura: é o `.viz-code-slot` que
+      // fecha a linha do grid. Medido: 2px fechado contra 510px aberto.
+      expect(m.alturaCodigo, "o bloco continua ocupando altura").toBeLessThan(SLACK);
+
+      await expect(page.locator(`${ARTIGO} .viz-toggle-codigo`)).toHaveText("Mostrar código");
+      await expect(page.locator(`${ARTIGO} .viz-code`)).toHaveAttribute("aria-hidden", "true");
+    });
+
+    test("a escolha do aluno vence a medicao na troca de preset", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1440, height: 700 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Mostrar código");
+      await artigo.locator(".viz-toggle-codigo").click();
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+      await expect(artigo.locator(".viz-code")).not.toHaveAttribute("aria-hidden", "true");
+
+      // O preset É a entrada da medição (`measureOn: [presetKey]`) e é a única
+      // entrada que esta peça tem. Sem trocar um estado que a medição enxerga, a
+      // escolha "sobrevive" sem que nada a tenha ameaçado.
+      const dicaAntes = await artigo.locator(".tt-legenda-arvore").textContent();
+      await artigo.getByRole("button", { name: /^Ao contrário/ }).click();
+      await expect(artigo.locator(".tt-legenda-arvore")).not.toHaveText(dicaAntes!);
+
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+      const m = await page.evaluate(LER, ARTIGO);
+      expect(m.codigo, "a medicao desfez a escolha do aluno").toBe("on");
+      // E a medição discordava mesmo: com o código aberto a peça pede 1.452px
+      // contra 616 de orçamento nesta janela. É por isso que o miolo rola no
+      // expandido.
+      expect(m.figura, "a medicao nem queria recolher aqui").toBeGreaterThan(m.orcamento);
+    });
+  });
+
+  // -------------------------------------------------- camada 3: tela alta
+  test.describe("tela alta", () => {
+    test.use({ viewport: { width: 1512, height: 1600 } });
+
+    test("o codigo ja vem aberto quando cabe", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 1600 });
+      await abrirTopico(page);
+
+      const m = await page.evaluate(LER, ARTIGO);
+      expect(m.codigo, "a medicao recolheu o codigo numa janela onde ele cabe").toBe("on");
+      expect(m.alturaCodigo, "o bloco esta aberto mas sem altura").toBeGreaterThan(400);
+      expect(m.figura, "a peca aberta nao cabia no orcamento desta janela").toBeLessThanOrEqual(m.orcamento);
+      await expect(page.locator(`${ARTIGO} .viz-toggle-codigo`)).toHaveText("Ocultar código");
+    });
+  });
+
+  // ----------------------------------------- camada 3: o que ela devolve
+  test.describe("orcamento", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("o bloco devolve altura, e ainda assim a peca so cabe no expandido", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+
+      const fechado = await page.evaluate(LER, ARTIGO);
+      expect(fechado.codigo).toBe("off");
+      // Esta peça é a exceção da série: mesmo recolhida ela passa do orçamento
+      // do artigo (medido: 978px contra 816). A camada 2 não alcança o fluxo do
+      // artigo, então o que sobra é o expandido — e é lá que o miolo rola com o
+      // cabeçalho parado. O teste registra o fato em vez de fingir que sumiu.
+      expect(fechado.figura, "a peca passou a caber no artigo: reveja este teste").toBeGreaterThan(
+        fechado.orcamento
+      );
+
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Mostrar código");
+      await artigo.locator(".viz-toggle-codigo").click();
+      await expect(artigo.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+      // A transição da casca dura 0,32s: sem esperar o valor ESTABILIZAR, a
+      // leitura pega a altura do meio do caminho.
+      await expect.poll(async () => (await page.evaluate(LER, ARTIGO)).alturaCodigo).toBeGreaterThan(400);
+
+      const aberto = await page.evaluate(LER, ARTIGO);
+      // Medido: 1.452 aberto contra 978 recolhido, 474px de volta.
+      expect(aberto.figura - fechado.figura, "o bloco recolhivel devolve pouca altura").toBeGreaterThan(400);
+    });
+  });
+
+  // ------------------------------------------------------- teclado e marcha
+  test.describe("teclado", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("as setas andam o passo e o slider de velocidade nao perde a seta", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      await page.locator(ARTIGO).getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.locator(PAINEL);
+      await expect(painel).toBeVisible();
+
+      // PRÉ-CONDIÇÃO: `toBeVisible()` não é "pronto para o teclado". O listener
+      // de `keydown` nasce num efeito passivo, junto com o que traz o foco para
+      // o painel; esperar o foco chegar prova que aquele commit já rodou. Sem
+      // isso, a tecla enviada antes some SEM ERRO NENHUM e imita flake.
+      await expect
+        .poll(async () =>
+          page.evaluate((sel) => !!document.querySelector(sel)?.contains(document.activeElement), PAINEL)
+        )
+        .toBe(true);
+
+      // A marcha desta peça é a dela (`initialSpeed: 4` sobre os SPEEDS
+      // próprios). Já se perdeu num rename sem nenhum teste pegar.
+      await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+
+      // UMA ação por asserção: um par de ações inversas volta ao estado de
+      // origem e fica verde mesmo com a tecla sendo roubada.
+      const inicio = await page.evaluate(passoAtual, PAINEL);
+      await painel.locator(".viz-speed input[type=range]").focus();
+      await page.keyboard.press("ArrowRight");
+      await expect(painel.locator(".viz-speed .val"), "a seta nao chegou ao slider").toHaveText("2x");
+      expect((await page.evaluate(passoAtual, PAINEL)).passo, "a casca roubou a seta de quem edita").toBe(
+        inicio.passo
+      );
+
+      // Fora do campo, a mesma tecla é da animação.
+      await painel.locator(".viz-head-title").click();
+      await page.keyboard.press("ArrowRight");
+      await expect(painel.locator(".viz-step")).toHaveText(`passo ${inicio.passo + 1} de ${inicio.total}`);
+
+      // Espaço roda e pausa, e o rótulo do botão diz qual dos dois.
+      await page.keyboard.press(" ");
+      await expect(painel.locator(".viz-play")).toHaveText("❚❚ Pausar");
+      await page.keyboard.press(" ");
+      await expect(painel.locator(".viz-play")).toHaveText("▶ Rodar");
+    });
+  });
+
+  // ------------------------------------------------- o que a peca ENSINA
+  test.describe("fronteira", () => {
+    test.use({ viewport: { width: 1512, height: 900 } });
+
+    test("o cartao da fase, o painel e o array contam a MESMA fronteira", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+
+      // Anda a animação inteira lendo três lugares da tela e cruzando os três.
+      // Nenhum número escrito na mão: o que se afirma é que eles concordam.
+      const leitura = await page.evaluate(
+        (sel) =>
+          new Promise<{
+            passos: number;
+            erros: string[];
+            comparacoes: number[];
+            ultimoArr: number[];
+            ultimoOrdenado: string;
+          }>((resolve) => {
+            const f = document.querySelector(sel) as HTMLElement;
+            const prox = [...f.querySelectorAll("button")].find((b) =>
+              b.textContent?.includes("Próximo")
+            ) as HTMLButtonElement;
+            const erros: string[] = [];
+            const comparacoes: number[] = [];
+            let ultimoArr: number[] = [];
+            let ultimoOrdenado = "";
+
+            const contador = () => {
+              const t = [...f.querySelectorAll(".viz-step")].map((e) => e.textContent).join(" ");
+              const m = t.match(/passo (\d+) de (\d+)/);
+              if (!m) throw new Error(`o contador de passo nao casou: "${t}"`);
+              return { i: parseInt(m[1], 10), n: parseInt(m[2], 10) };
+            };
+            // Rótulo E valor do MESMO cartão: um par trocado de lugar mantém o
+            // conjunto de textos da página e só é pego lendo os dois juntos.
+            const varDe = (nome: string) => {
+              const c = [...f.querySelectorAll(".viz-var")].find(
+                (e) => e.querySelector(".viz-var-name")!.textContent!.trim() === nome
+              );
+              if (!c) throw new Error(`nao achei a variavel "${nome}"`);
+              return c.querySelector(".viz-var-val")!.textContent!.trim();
+            };
+            const statDe = (nome: string) => {
+              const c = [...f.querySelectorAll(".bigo-stat")].find(
+                (e) => e.querySelector("span")!.textContent!.trim() === nome
+              );
+              if (!c) throw new Error(`nao achei o cartao "${nome}"`);
+              return c.querySelector("strong")!.textContent!.trim();
+            };
+
+            const ler = () => {
+              const { i } = contador();
+              const txt = f.querySelector(".hs-fase-txt")!.textContent!.replace(/\s+/g, " ").trim();
+              const m = txt.match(/heap ativo: posições 0 a (\d+) · já ordenado: (\d+) de (\d+)/);
+              if (!m) {
+                erros.push(`passo ${i}: o cartao da fase nao casou: "${txt}"`);
+                return;
+              }
+              const ultimo = parseInt(m[1], 10);
+              const ordenados = parseInt(m[2], 10);
+              const tamanho = parseInt(m[3], 10);
+
+              const n = parseInt(varDe("n (heap ativo)"), 10);
+              const celulas = [...f.querySelectorAll(".hp-cel")];
+              const verdes = celulas.filter((c) => c.classList.contains("fixo")).length;
+
+              if (ultimo !== Math.max(n - 1, 0))
+                erros.push(`passo ${i}: cartao diz ate ${ultimo}, painel diz n=${n}`);
+              if (ordenados !== tamanho - n)
+                erros.push(`passo ${i}: cartao diz ${ordenados} ordenados, n=${n} de ${tamanho}`);
+              if (verdes !== ordenados)
+                erros.push(`passo ${i}: ${verdes} celulas verdes contra ${ordenados} no cartao`);
+              if (celulas.length !== tamanho)
+                erros.push(`passo ${i}: ${celulas.length} celulas contra ${tamanho} no cartao`);
+              if (statDe("tamanho do array") !== String(tamanho))
+                erros.push(`passo ${i}: o cartao de tamanho diz ${statDe("tamanho do array")}`);
+
+              comparacoes.push(parseInt(statDe("comparações"), 10));
+              ultimoArr = celulas.map((c) => parseInt(c.textContent!.replace(/^\d+/, ""), 10));
+              ultimoOrdenado = `${ordenados} de ${tamanho}`;
+            };
+
+            const total = contador().n;
+            let k = 0;
+            const tick = () => {
+              ler();
+              k++;
+              if (k >= total) {
+                resolve({ passos: total, erros, comparacoes, ultimoArr, ultimoOrdenado });
+                return;
+              }
+              prox.click();
+              requestAnimationFrame(() => requestAnimationFrame(tick));
+            };
+            tick();
+          }),
+        ARTIGO
+      );
+
+      expect(leitura.passos, "a animacao encurtou demais para o teste significar algo").toBeGreaterThan(50);
+      expect(leitura.erros, "os tres lugares da tela discordam da fronteira").toEqual([]);
+      expect(leitura.comparacoes.length).toBe(leitura.passos);
+
+      // O contador de comparações nunca anda para trás.
+      const recuos = leitura.comparacoes.filter((c, i) => i > 0 && c < leitura.comparacoes[i - 1]);
+      expect(recuos, "o contador de comparacoes andou para tras").toEqual([]);
+
+      // E no fim o array está ordenado, com a fronteira cobrindo tudo.
+      expect(leitura.ultimoOrdenado).toBe(`${leitura.ultimoArr.length} de ${leitura.ultimoArr.length}`);
+      expect(leitura.ultimoArr, "o heap sort terminou com o array fora de ordem").toEqual(
+        [...leitura.ultimoArr].sort((a, b) => a - b)
+      );
+    });
+  });
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores dos grupos **Heaps** e
**Busca Binária**: três tópicos, **4 visualizadores adaptados**, com um agente
por tópico em paralelo e consolidação num PR só.

## O que entrou, e o que ficou de fora

| tópico | adaptados | fora do escopo |
|---|---|---|
| `binary-heap` | `BinaryHeapVisualizer` | `HeapEstruturas` (cartaz `bigo-fam`), `HeapIndicesVisualizer` (sem botão Expandir) |
| `heap-sort` | `HeapSortVisualizer` | `HeapSortComparativo` (`bigo-fam`), `HeapSortEstabilidade` (sem Expandir) |
| `busca-binaria` | `BuscaBinariaVisualizer`, `BuscaBinariaFronteira` | `BuscaBinariaOverflow` (sem overlay) |

**4 de 9.** É a maior proporção de descarte das rodadas até aqui, e todos pelo
mesmo motivo: sem painel expandido não há o que arrumar. Os cinco foram
conferidos lendo o arquivo, não só pela coluna do inventário.
`busca-binaria-avancada` está `soon`. **Zero linha de CSS nova.**

## Medições

Janela **1512x900**, fontes carregadas, animação congelada, orçamento no artigo
= 816px. Cada peça medida andando a animação inteira, em todos os presets, e
também em 1440x700 e 1440x600.

| peça | artigo antes | depois | `▶ Rodar` abaixo do pé, no painel |
|---|---|---|---|
| heap binário | 1190–1517 | **956–1129** | até 859px → **dentro** |
| heap sort | 1422–1442 | **958–978** | até 831px → **dentro** |
| busca binária | 1038–1137 | **752–851** | até 205px → **dentro** |
| fronteiras | 984–1079 | **731–810** | até 147px → **dentro** |

**Nas quatro, quem rolava no painel era a figura inteira**, levando cabeçalho e
controles junto — até 960px no heap binário. Agora o cabeçalho não anda 1px em
nenhuma das três réguas, e todo controle fica dentro da janela.

Três peças seguem acima do orçamento no artigo com o código já recolhido (heap
binário por 140–313px, heap sort por 162px, busca binária por 28–35px em dois
estados de 16 posições) — limite do §9, reportado com número em vez de omitido.

## Testes

**27 testes novos** em três arquivos disjuntos, **25 quebras provadas**, todas
compilando, com build visível e resumo imprimindo `failed` **e** `passed`.

**Suíte completa na branch integrada: 390 passed, 0 failed** (`--workers=2`, com
a máquina livre).

## Verificação da consolidação

- **Diff do texto renderizado do build inteiro**, `origin/main` contra esta
  branch, comparando o texto corrido de cada página palavra a palavra: **zero
  palavras perdidas**, e nada acrescentado além das afordâncias da casca.
- **Chaves de preset:** todas em inglês nas quatro peças, sem divergência. Na
  rodada anterior três de sete agentes deixaram em português e a revisão pegou;
  desta vez a instrução foi de partida e o resultado foi uniforme.
- **Varreduras de classe:** nenhuma marcha inicial perdida (a do #30), nenhum
  `stepBy` com aritmética (a do #28), nenhum rodapé escrito à mão, nenhum
  `newPage({ viewportSize })`.

## Contrato (`content/visualizers/README.md`)

### Eixo alcançável ainda pode ser eixo com DEGRAUS

A §3 pergunta se existe caminho da tela até o número que gera as linhas. **Falta
o segundo tempo:** o caminho chega a atravessar um degrau? A altura de uma
árvore é `⌊log₂ n⌋`, e dois tópicos independentes mediram a saturação na mesma
rodada:

| peça | o que o controle alcança | o que a altura faz |
|---|---|---|
| `HeapSortVisualizer` | presets de 8 e 10 elementos | `depth()` = **3 nos dois**; 242px nos 289 estados |
| `BinaryHeapVisualizer` | presets de 6, 8 e 9 valores | 8 e 9 dão o **mesmo desenho ao pixel**; só o 6 desce um nível |

Varrer quatro presets pode medir dois pontos. E quando o eixo satura, o número
diz o resto: no heap binário, dos 327px entre o estado mais alto e o mais baixo,
**só 60 são o desenho**.

### A §3 se responde por PEÇA, não por tópico

As duas peças de `busca-binaria` desenham a mesma fita de células (`flex-wrap`,
sem `overflow-x`) e têm eixos diferentes: uma tem campo até 16 valores e quebra
linha na 14ª célula (**+99px**), a outra usa uma constante de 9 posições e fica
em uma linha nos 15 estados. Saíram com `measureOn` diferentes. **Desenho igual
não é eixo igual.**

### §8 — `toBeInViewport()` sozinho não prova a camada 1

Com o rodapé de volta dentro do miolo — a quebra canônica desta camada — ele
passa nas **duas** pontas da rolagem: no fim porque é lá que o rodapé foi parar,
no começo porque o botão ainda cruza a área visível e a asserção aceita qualquer
interseção. Medido: uma quebra assim saiu **`0 failed / 2 passed`** com a quebra
confirmada no HTML do build. O que carrega o sentido é a posição comparada com
ela mesma, que é o que os testes bons deste repo já fazem.

### §0 — valor de união que vira sufixo de classe é contrato com o CSS

No `HeapSortVisualizer` a união `"construir" | "ordenar" | "fim"` entra em
`` `hs-fase f-${fase}` ``, e o `globals.css` compartilhado define
`.hs-fase.f-ordenar` e `.hs-fase.f-fim`. Traduzir a união apagaria a cor de duas
fases **sem nada acusar** — o `tsc` continua coerente, o guarda não vê (não é
texto de tela), o teste não pega (é cor). Resolvido com um mapa.

## Idioma

Identificadores traduzidos nas quatro peças, incluindo as `key` dos presets e os
valores das uniões. O `guarda-idioma.py` **não é prova** (os buracos do §0), e a
prova foi comparar o texto renderizado dos estados: **1.118 estados** somados
(657 + 289 + 172), com diff vazio no miolo, mais o diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
