### PR TITLE
feat(viz): casca adaptativa no grupo Ordenação

### DIFF
--- a/content/visualizers/MergeSortNiveis.tsx
+++ b/content/visualizers/MergeSortNiveis.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { segmentos } from "./MergeSortVisualizer";
+import { segments } from "./MergeSortVisualizer";
 
 // ---------------------------------------------------------------------------
 // MergeSortNiveis, de onde sai o n log n.
@@ -40,7 +40,7 @@ const ESCALAS = [1_000, 1_000_000, 1_000_000_000];
 
 export function MergeSortNiveis() {
   const [n, setN] = useState(16);
-  const niveis = useMemo(() => segmentos(n), [n]);
+  const niveis = useMemo(() => segments(n), [n]);
   const rodadas = Math.log2(n); // n é sempre potência de 2 aqui
   const movimentos = n * rodadas;
   const quadratico = (n * (n - 1)) / 2;

--- a/content/visualizers/MergeSortVisualizer.tsx
+++ b/content/visualizers/MergeSortVisualizer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // MergeSortVisualizer, a descida que não faz nada e a subida que faz tudo.
@@ -26,23 +26,23 @@ import { createPortal } from "react-dom";
 // justamente a ligação que precisa ficar óbvia aqui.
 // ---------------------------------------------------------------------------
 
-type Merge = { esq: number[]; dir: number[]; i: number; j: number; saida: number[]; lo: number; escolhido: "esq" | "dir" | null };
+type Merge = { left: number[]; right: number[]; i: number; j: number; output: number[]; lo: number; picked: "left" | "right" | null };
 
-type Passo = {
+type Step = {
   arr: number[];
   lo: number;
   hi: number;
   mid: number;
-  prontos: string[];
+  done: string[];
   merge: Merge | null;
-  comp: number;
-  copias: number;
-  linha: number;
-  nota: string;
+  comparisons: number;
+  copies: number;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "def merge_sort(a, lo, hi):",
   "    if lo >= hi: return      # 1 elemento já está ordenado",
   "    mid = lo + (hi - lo) // 2",
@@ -60,289 +60,247 @@ const CODIGO = [
   "            a[k] = dir[j]; j += 1",
 ];
 
-type Preset = { key: string; rotulo: string; valores: number[]; dica: string };
+type Preset = { key: string; label: string; values: number[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "sete",
-    rotulo: "Sete valores: 38 27 43 3 9 82 10",
-    valores: [38, 27, 43, 3, 9, 82, 10],
-    dica: "Sete elementos, ou seja, divisão ímpar. Repare nas faixas de nível: o lado esquerdo fica com quatro posições e o direito com três, e a diferença entre os dois lados nunca passa de um elemento, por mais fundo que a recursão vá.",
+    key: "seven",
+    label: "Sete valores: 38 27 43 3 9 82 10",
+    values: [38, 27, 43, 3, 9, 82, 10],
+    hint: "Sete elementos, ou seja, divisão ímpar. Repare nas faixas de nível: o lado esquerdo fica com quatro posições e o direito com três, e a diferença entre os dois lados nunca passa de um elemento, por mais fundo que a recursão vá.",
   },
   {
-    key: "ordenado",
-    rotulo: "Já ordenado: 1 2 3 4 5 6 7 8",
-    valores: [1, 2, 3, 4, 5, 6, 7, 8],
-    dica: "A entrada já pronta. O merge sort desce e sobe a árvore inteira do mesmo jeito, e o único desconto aparece nas comparações: cada intercalação esvazia o lado esquerdo primeiro e copia o direito em bloco.",
+    key: "sorted",
+    label: "Já ordenado: 1 2 3 4 5 6 7 8",
+    values: [1, 2, 3, 4, 5, 6, 7, 8],
+    hint: "A entrada já pronta. O merge sort desce e sobe a árvore inteira do mesmo jeito, e o único desconto aparece nas comparações: cada intercalação esvazia o lado esquerdo primeiro e copia o direito em bloco.",
   },
   {
-    key: "pior",
-    rotulo: "Pior caso: 1 3 2 7 4 6 5 8",
-    valores: [1, 3, 2, 7, 4, 6, 5, 8],
-    dica: "A entrada mais cara que existe para o merge sort com oito elementos, achada testando as 40.320 permutações possíveis. Ela custa 17 comparações. O melhor caso custa 12. Cinco comparações separam o melhor do pior, e é isso que quer dizer ter garantia.",
+    key: "worst",
+    label: "Pior caso: 1 3 2 7 4 6 5 8",
+    values: [1, 3, 2, 7, 4, 6, 5, 8],
+    hint: "A entrada mais cara que existe para o merge sort com oito elementos, achada testando as 40.320 permutações possíveis. Ela custa 17 comparações. O melhor caso custa 12. Cinco comparações separam o melhor do pior, e é isso que quer dizer ter garantia.",
   },
   {
-    key: "invertido",
-    rotulo: "Ao contrário: 8 7 6 5 4 3 2 1",
-    valores: [8, 7, 6, 5, 4, 3, 2, 1],
-    dica: "A entrada mais hostil para quase todo algoritmo, e para o merge sort é só mais uma: custa as mesmas 12 comparações do array já ordenado. A estrutura da recursão não depende dos dados, então não existe entrada capaz de derrubá-lo.",
+    key: "reversed",
+    label: "Ao contrário: 8 7 6 5 4 3 2 1",
+    values: [8, 7, 6, 5, 4, 3, 2, 1],
+    hint: "A entrada mais hostil para quase todo algoritmo, e para o merge sort é só mais uma: custa as mesmas 12 comparações do array já ordenado. A estrutura da recursão não depende dos dados, então não existe entrada capaz de derrubá-lo.",
   },
 ];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// Ritmo próprio: uma intercalação tem passos curtos e muitos, então cada marcha
+// é mais rápida que a do hook. Não é o DEFAULT_SPEEDS.
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
-type Seg = { lo: number; hi: number; prof: number };
+type Seg = { lo: number; hi: number; depth: number };
 
 // O mapa da recursão é determinístico: depende só de n. Calcular fora do
 // gerador deixa as faixas fixas, e é o que permite acompanhar uma posição.
-export function segmentos(n: number): Seg[][] {
-  const niveis: Seg[][] = [];
-  const visitar = (lo: number, hi: number, prof: number) => {
-    (niveis[prof] ??= []).push({ lo, hi, prof });
+export function segments(n: number): Seg[][] {
+  const levels: Seg[][] = [];
+  const visit = (lo: number, hi: number, depth: number) => {
+    (levels[depth] ??= []).push({ lo, hi, depth });
     if (lo >= hi) return;
     const mid = lo + ((hi - lo) >> 1);
-    visitar(lo, mid, prof + 1);
-    visitar(mid + 1, hi, prof + 1);
+    visit(lo, mid, depth + 1);
+    visit(mid + 1, hi, depth + 1);
   };
-  visitar(0, n - 1, 0);
-  return niveis;
+  visit(0, n - 1, 0);
+  return levels;
 }
 
-const chave = (lo: number, hi: number) => `${lo}-${hi}`;
+const segKey = (lo: number, hi: number) => `${lo}-${hi}`;
 
-export function gerarPassos(valores: number[]): Passo[] {
-  const a = [...valores];
-  const out: Passo[] = [];
-  let comp = 0;
-  let copias = 0;
-  const prontos = new Set<string>();
-  const base = () => ({ arr: [...a], mid: -1, prontos: [...prontos], merge: null as Merge | null, comp, copias });
+export function generateSteps(values: number[]): Step[] {
+  const a = [...values];
+  const steps: Step[] = [];
+  let comparisons = 0;
+  let copies = 0;
+  const done = new Set<string>();
+  const base = () => ({ arr: [...a], mid: -1, done: [...done], merge: null as Merge | null, comparisons, copies });
 
-  out.push({
+  steps.push({
     ...base(),
     lo: 0,
     hi: a.length - 1,
-    linha: 0,
-    nota: `Entrada: ${a.join(", ")}. O merge sort vai quebrar isto pela metade até sobrar um elemento por trecho, e só então começar a ordenar de verdade, na volta.`,
+    line: 0,
+    note: `Entrada: ${a.join(", ")}. O merge sort vai quebrar isto pela metade até sobrar um elemento por trecho, e só então começar a ordenar de verdade, na volta.`,
   });
 
-  const ordenar = (lo: number, hi: number) => {
+  const sortRange = (lo: number, hi: number) => {
     if (lo >= hi) {
-      prontos.add(chave(lo, hi));
-      out.push({
+      done.add(segKey(lo, hi));
+      steps.push({
         ...base(),
         lo,
         hi,
-        linha: 1,
+        line: 1,
         ok: true,
-        nota: `Trecho ${lo}..${lo} tem um elemento só (${a[lo]}). Um array de um elemento já está ordenado por definição, então este é o caso base e a descida para aqui.`,
+        note: `Trecho ${lo}..${lo} tem um elemento só (${a[lo]}). Um array de um elemento já está ordenado por definição, então este é o caso base e a descida para aqui.`,
       });
       return;
     }
     const mid = lo + ((hi - lo) >> 1);
-    out.push({
+    steps.push({
       ...base(),
       lo,
       hi,
       mid,
-      linha: 2,
-      nota: `Divido o trecho ${lo}..${hi} (${a.slice(lo, hi + 1).join(", ")}) no meio: ${lo}..${mid} com ${mid - lo + 1} posições e ${mid + 1}..${hi} com ${hi - mid}. Nenhuma comparação acontece aqui: dividir é só aritmética de índice.`,
+      line: 2,
+      note: `Divido o trecho ${lo}..${hi} (${a.slice(lo, hi + 1).join(", ")}) no meio: ${lo}..${mid} com ${mid - lo + 1} posições e ${mid + 1}..${hi} com ${hi - mid}. Nenhuma comparação acontece aqui: dividir é só aritmética de índice.`,
     });
-    out.push({ ...base(), lo, hi, mid, linha: 3, nota: `Desço primeiro pela esquerda, ${lo}..${mid}. Só volto daqui com esse trecho ordenado.` });
-    ordenar(lo, mid);
-    out.push({ ...base(), lo, hi, mid, linha: 4, nota: `A esquerda voltou ordenada (${a.slice(lo, mid + 1).join(", ")}). Agora desço pela direita, ${mid + 1}..${hi}.` });
-    ordenar(mid + 1, hi);
+    steps.push({ ...base(), lo, hi, mid, line: 3, note: `Desço primeiro pela esquerda, ${lo}..${mid}. Só volto daqui com esse trecho ordenado.` });
+    sortRange(lo, mid);
+    steps.push({ ...base(), lo, hi, mid, line: 4, note: `A esquerda voltou ordenada (${a.slice(lo, mid + 1).join(", ")}). Agora desço pela direita, ${mid + 1}..${hi}.` });
+    sortRange(mid + 1, hi);
 
     // ---- intercalação: é aqui, e só aqui, que a ordenação acontece ---------
-    const esq = a.slice(lo, mid + 1);
-    const dir = a.slice(mid + 1, hi + 1);
-    const saida: number[] = [];
+    const left = a.slice(lo, mid + 1);
+    const right = a.slice(mid + 1, hi + 1);
+    const output: number[] = [];
     let i = 0;
     let j = 0;
-    const m = (escolhido: "esq" | "dir" | null): Merge => ({ esq, dir, i, j, saida: [...saida], lo, escolhido });
-    out.push({
+    const m = (picked: "left" | "right" | null): Merge => ({ left, right, i, j, output: [...output], lo, picked });
+    steps.push({
       ...base(),
       lo,
       hi,
       mid,
       merge: m(null),
-      linha: 8,
-      nota: `Os dois lados voltaram ordenados: ${esq.join(", ")} e ${dir.join(", ")}. Agora intercalo os dois num buffer, e é esta operação que ordena. Todo o resto do algoritmo só existe para chegar aqui com os dois lados prontos.`,
+      line: 8,
+      note: `Os dois lados voltaram ordenados: ${left.join(", ")} e ${right.join(", ")}. Agora intercalo os dois num buffer, e é esta operação que ordena. Todo o resto do algoritmo só existe para chegar aqui com os dois lados prontos.`,
     });
     for (let k = lo; k <= hi; k++) {
-      const pegaEsq = j >= dir.length || (i < esq.length && esq[i] <= dir[j]);
-      if (i < esq.length && j < dir.length) {
-        comp++;
-        out.push({
+      const takeLeft = j >= right.length || (i < left.length && left[i] <= right[j]);
+      if (i < left.length && j < right.length) {
+        comparisons++;
+        steps.push({
           ...base(),
           lo,
           hi,
           mid,
           merge: m(null),
-          linha: 11,
-          nota: `Comparo o topo dos dois lados: ${esq[i]} da esquerda contra ${dir[j]} da direita. ${
-            esq[i] === dir[j]
+          line: 11,
+          note: `Comparo o topo dos dois lados: ${left[i]} da esquerda contra ${right[j]} da direita. ${
+            left[i] === right[j]
               ? `Empate. O sinal é <=, então o da esquerda vai primeiro, e é essa escolha que torna o merge sort estável.`
-              : `Vai o menor, ${Math.min(esq[i], dir[j])}, da ${pegaEsq ? "esquerda" : "direita"}.`
+              : `Vai o menor, ${Math.min(left[i], right[j])}, da ${takeLeft ? "esquerda" : "direita"}.`
           }`,
         });
       } else {
-        out.push({
+        steps.push({
           ...base(),
           lo,
           hi,
           mid,
           merge: m(null),
-          linha: 11,
-          nota: `A ${j >= dir.length ? "direita" : "esquerda"} acabou. Tudo que resta do outro lado já está ordenado e é maior que tudo que já saiu, então entra em bloco, sem nenhuma comparação.`,
+          line: 11,
+          note: `A ${j >= right.length ? "direita" : "esquerda"} acabou. Tudo que resta do outro lado já está ordenado e é maior que tudo que já saiu, então entra em bloco, sem nenhuma comparação.`,
           ok: true,
         });
       }
-      const v = pegaEsq ? esq[i++] : dir[j++];
-      saida.push(v);
-      copias++;
-      out.push({
+      const v = takeLeft ? left[i++] : right[j++];
+      output.push(v);
+      copies++;
+      steps.push({
         ...base(),
         lo,
         hi,
         mid,
-        merge: m(pegaEsq ? "esq" : "dir"),
-        linha: pegaEsq ? 12 : 14,
-        nota: `${v} sai da ${pegaEsq ? "esquerda" : "direita"} e ocupa a posição ${k} do buffer. O ponteiro daquele lado anda uma casa; o outro fica parado.`,
+        merge: m(takeLeft ? "left" : "right"),
+        line: takeLeft ? 12 : 14,
+        note: `${v} sai da ${takeLeft ? "esquerda" : "direita"} e ocupa a posição ${k} do buffer. O ponteiro daquele lado anda uma casa; o outro fica parado.`,
       });
     }
-    for (let k = 0; k < saida.length; k++) a[lo + k] = saida[k];
-    prontos.add(chave(lo, hi));
-    out.push({
+    for (let k = 0; k < output.length; k++) a[lo + k] = output[k];
+    done.add(segKey(lo, hi));
+    steps.push({
       ...base(),
       lo,
       hi,
       mid,
-      linha: 5,
+      line: 5,
       ok: true,
-      nota: `Trecho ${lo}..${hi} ordenado: ${saida.join(", ")}. Ele volta pronto para quem chamou, e quem chamou vai usá-lo como um dos lados da próxima intercalação.`,
+      note: `Trecho ${lo}..${hi} ordenado: ${output.join(", ")}. Ele volta pronto para quem chamou, e quem chamou vai usá-lo como um dos lados da próxima intercalação.`,
     });
   };
 
-  ordenar(0, a.length - 1);
-  out.push({
+  sortRange(0, a.length - 1);
+  steps.push({
     ...base(),
     lo: 0,
     hi: a.length - 1,
-    linha: 5,
+    line: 5,
     ok: true,
-    nota: `Ordenado: ${a.join(", ")}. Foram ${comp} comparações e ${copias} cópias, com um buffer auxiliar do tamanho do trecho sendo intercalado. Esse buffer é o preço do merge sort, e é o que ele compra com uma garantia que nenhuma entrada quebra.`,
+    note: `Ordenado: ${a.join(", ")}. Foram ${comparisons} comparações e ${copies} cópias, com um buffer auxiliar do tamanho do trecho sendo intercalado. Esse buffer é o preço do merge sort, e é o que ele compra com uma garantia que nenhuma entrada quebra.`,
   });
-  return out;
+  return steps;
 }
 
 export function MergeSortVisualizer() {
-  const [presetKey, setPresetKey] = useState("sete");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("seven");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.valores), [preset]);
-  const niveis = useMemo(() => segmentos(preset.valores.length), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const n = preset.valores.length;
+  const steps = useMemo(() => generateSteps(preset.values), [preset]);
+  const levels = useMemo(() => segments(preset.values.length), [preset]);
+  const n = preset.values.length;
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · merge sort: a descida divide, a subida ordena",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O preset é o único controle da peça: ele troca o array (e com ele as
+    // faixas e o número de passos) e a dica, que é o bloco de texto que mais
+    // muda de altura entre eles.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const s = steps[viz.step];
+  const ready = new Set(s.done);
+
+  const changePreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const prontos = new Set(p.prontos);
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · merge sort: a descida divide, a subida ordena</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
-
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => changePreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
             O mapa da recursão <em>azul = trecho ativo, verde = já voltou ordenado</em>
           </div>
           <div className="ms-niveis">
-            {niveis.map((segs, prof) => (
-              <div className="ms-nivel" key={prof}>
-                <span className="ms-nivel-rot">nível {prof}</span>
+            {levels.map((segs, depth) => (
+              <div className="ms-nivel" key={depth}>
+                <span className="ms-nivel-rot">nível {depth}</span>
                 <div className="ms-nivel-faixa" style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}>
-                  {segs.map((s) => {
+                  {segs.map((sg) => {
                     const cls = ["ms-seg"];
-                    if (prontos.has(chave(s.lo, s.hi))) cls.push("pronto");
-                    if (s.lo === p.lo && s.hi === p.hi) cls.push("ativo");
+                    if (ready.has(segKey(sg.lo, sg.hi))) cls.push("pronto");
+                    if (sg.lo === s.lo && sg.hi === s.hi) cls.push("ativo");
                     return (
-                      <span key={`${s.lo}-${s.hi}`} className={cls.join(" ")} style={{ gridColumn: `${s.lo + 1} / ${s.hi + 2}` }}>
-                        {s.lo === s.hi ? s.lo : `${s.lo}..${s.hi}`}
+                      <span key={`${sg.lo}-${sg.hi}`} className={cls.join(" ")} style={{ gridColumn: `${sg.lo + 1} / ${sg.hi + 2}` }}>
+                        {sg.lo === sg.hi ? sg.lo : `${sg.lo}..${sg.hi}`}
                       </span>
                     );
                   })}
@@ -357,10 +315,10 @@ export function MergeSortVisualizer() {
             O array <em>as posições fora do trecho ativo ficam apagadas</em>
           </div>
           <div className="hp-arr">
-            {p.arr.map((v, i) => {
+            {s.arr.map((v, i) => {
               const cls = ["hp-cel"];
-              if (i < p.lo || i > p.hi) cls.push("fantasma");
-              else if (p.mid >= 0 && i <= p.mid) cls.push("foco");
+              if (i < s.lo || i > s.hi) cls.push("fantasma");
+              else if (s.mid >= 0 && i <= s.mid) cls.push("foco");
               else cls.push("par");
               return (
                 <span key={i} className={cls.join(" ")}>
@@ -372,7 +330,7 @@ export function MergeSortVisualizer() {
           </div>
         </div>
 
-        {p.merge ? (
+        {s.merge ? (
           <div className="hp-bloco">
             <div className="tt-painel-tit">
               A intercalação <em>o algoritmo inteiro existe para chegar aqui</em>
@@ -381,9 +339,9 @@ export function MergeSortVisualizer() {
               <div className="ms-lado">
                 <span className="ms-lado-rot">esquerda</span>
                 <div className="hp-arr">
-                  {p.merge.esq.map((v, k) => (
-                    <span key={k} className={`hp-cel${k < p.merge!.i ? " fantasma" : k === p.merge!.i ? " foco" : ""}`}>
-                      <i>{p.merge!.lo + k}</i>
+                  {s.merge.left.map((v, k) => (
+                    <span key={k} className={`hp-cel${k < s.merge!.i ? " fantasma" : k === s.merge!.i ? " foco" : ""}`}>
+                      <i>{s.merge!.lo + k}</i>
                       {v}
                     </span>
                   ))}
@@ -392,9 +350,9 @@ export function MergeSortVisualizer() {
               <div className="ms-lado">
                 <span className="ms-lado-rot">direita</span>
                 <div className="hp-arr">
-                  {p.merge.dir.map((v, k) => (
-                    <span key={k} className={`hp-cel${k < p.merge!.j ? " fantasma" : k === p.merge!.j ? " par" : ""}`}>
-                      <i>{p.merge!.lo + p.merge!.esq.length + k}</i>
+                  {s.merge.right.map((v, k) => (
+                    <span key={k} className={`hp-cel${k < s.merge!.j ? " fantasma" : k === s.merge!.j ? " par" : ""}`}>
+                      <i>{s.merge!.lo + s.merge!.left.length + k}</i>
                       {v}
                     </span>
                   ))}
@@ -403,48 +361,50 @@ export function MergeSortVisualizer() {
               <div className="ms-lado saida">
                 <span className="ms-lado-rot">buffer de saída</span>
                 <div className="hp-arr">
-                  {p.merge.saida.map((v, k) => (
-                    <span key={k} className={`hp-cel fixo${k === p.merge!.saida.length - 1 && p.merge!.escolhido ? " troca" : ""}`}>
-                      <i>{p.merge!.lo + k}</i>
+                  {s.merge.output.map((v, k) => (
+                    <span key={k} className={`hp-cel fixo${k === s.merge!.output.length - 1 && s.merge!.picked ? " troca" : ""}`}>
+                      <i>{s.merge!.lo + k}</i>
                       {v}
                     </span>
                   ))}
-                  {p.merge.saida.length === 0 ? <span className="bb-array-nota">vazio</span> : null}
+                  {s.merge.output.length === 0 ? <span className="bb-array-nota">vazio</span> : null}
                 </div>
               </div>
             </div>
           </div>
         ) : null}
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">merge_sort.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">merge_sort.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">trecho ativo</span>
               <span className="viz-var-val best">
-                {p.lo}..{p.hi}
+                {s.lo}..{s.hi}
               </span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">mid</span>
-              <span className="viz-var-val">{p.mid >= 0 ? p.mid : "-"}</span>
+              <span className="viz-var-val">{s.mid >= 0 ? s.mid : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">i, j (topo de cada lado)</span>
-              <span className="viz-var-val">{p.merge ? `${p.merge.i}, ${p.merge.j}` : "-"}</span>
+              <span className="viz-var-val">{s.merge ? `${s.merge.i}, ${s.merge.j}` : "-"}</span>
             </div>
           </div>
         </div>
@@ -456,65 +416,16 @@ export function MergeSortVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comp}</strong>
+            <strong>{s.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>cópias para o buffer</span>
-            <strong>{p.copias}</strong>
+            <strong>{s.copies}</strong>
           </div>
           <div className="bigo-stat">
             <span>níveis de recursão</span>
-            <strong>{niveis.length}</strong>
+            <strong>{levels.length}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -524,21 +435,8 @@ export function MergeSortVisualizer() {
           efeito de comparação, o insertion sort vai de 7 a 28 comparações no mesmo tamanho de array.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/OrdenacaoBasicaCorrida.tsx
+++ b/content/visualizers/OrdenacaoBasicaCorrida.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { ALGOS, NOMES, PRESETS, custo, inversoes, type Algo } from "./OrdenacaoBasicaVisualizer";
+import { ALGOS, NAMES, PRESETS, cost, inversions, type Algorithm } from "./OrdenacaoBasicaVisualizer";
 
 // ---------------------------------------------------------------------------
 // OrdenacaoBasicaCorrida, o custo total dos três lado a lado.
@@ -14,7 +14,7 @@ import { ALGOS, NOMES, PRESETS, custo, inversoes, type Algo } from "./OrdenacaoB
 // Interativo sem linha do tempo: não há passo, não há play, não há intervalo.
 // A variável que o aluno mexe é a ENTRADA, e as seis barras respondem juntas.
 //
-// Os números vêm de `custo()`, que roda o mesmo gerador de passos da animação.
+// Os números vêm de `cost()`, que roda o mesmo gerador de passos da animação.
 // Nada aqui é tabela fixa: mudar o gerador muda as barras no mesmo commit, e é
 // isso que impede a corrida de mentir sobre o que o visualizador ao lado mostra.
 //
@@ -24,34 +24,34 @@ import { ALGOS, NOMES, PRESETS, custo, inversoes, type Algo } from "./OrdenacaoB
 // barras seriam só três números bonitos sem explicação.
 // ---------------------------------------------------------------------------
 
-type Linha = { algo: Algo; comp: number; escritas: number };
+type Row = { algo: Algorithm; comps: number; writes: number };
 
-function leiDe(algo: Algo, inv: number, n: number): string {
+function lawFor(algo: Algorithm, inv: number, n: number): string {
   if (algo === "bubble") return `2 x ${inv} inversões = ${2 * inv}`;
   if (algo === "insertion") return `${inv} inversões + ${n - 1} colocações = ${inv + n - 1}`;
   return "2 por rodada que precisou trocar";
 }
 
 export function OrdenacaoBasicaCorrida() {
-  const [presetKey, setPresetKey] = useState("embaralhado");
+  const [presetKey, setPresetKey] = useState("shuffled");
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const n = preset.valores.length;
-  const inv = useMemo(() => inversoes(preset.valores), [preset]);
+  const n = preset.values.length;
+  const inv = useMemo(() => inversions(preset.values), [preset]);
 
-  const linhas: Linha[] = useMemo(
-    () => ALGOS.map((algo) => ({ algo, ...custo(algo, preset.valores) })),
+  const rows: Row[] = useMemo(
+    () => ALGOS.map((algo) => ({ algo, ...cost(algo, preset.values) })),
     [preset]
   );
 
-  const maxComp = Math.max(...linhas.map((l) => l.comp), 1);
-  const maxEsc = Math.max(...linhas.map((l) => l.escritas), 1);
-  const melhorComp = Math.min(...linhas.map((l) => l.comp));
-  const melhorEsc = Math.min(...linhas.map((l) => l.escritas));
+  const maxComps = Math.max(...rows.map((l) => l.comps), 1);
+  const maxWrites = Math.max(...rows.map((l) => l.writes), 1);
+  const bestComps = Math.min(...rows.map((l) => l.comps));
+  const bestWrites = Math.min(...rows.map((l) => l.writes));
 
   // O piso teórico de comparações de qualquer ordenação por comparação em cima
   // deste array: n - 1 (é preciso ao menos olhar cada vizinho uma vez).
-  const piso = n - 1;
-  const teto = (n * (n - 1)) / 2;
+  const floor = n - 1;
+  const ceiling = (n * (n - 1)) / 2;
 
   return (
     <figure className="viz" style={{ margin: 0 }}>
@@ -62,7 +62,7 @@ export function OrdenacaoBasicaCorrida() {
         </div>
         <div className="viz-head-right">
           <span className="viz-step">
-            {inv} inversões na entrada · piso {piso}, teto {teto} comparações
+            {inv} inversões na entrada · piso {floor}, teto {ceiling} comparações
           </span>
         </div>
       </div>
@@ -76,32 +76,32 @@ export function OrdenacaoBasicaCorrida() {
               onClick={() => setPresetKey(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="ord-corrida">
-          {linhas.map((l) => (
+          {rows.map((l) => (
             <div className="ord-linha" key={l.algo}>
-              <div className="ord-linha-nome">{NOMES[l.algo]}</div>
+              <div className="ord-linha-nome">{NAMES[l.algo]}</div>
               <div className="ord-medidas">
-                <div className={`ord-medida${l.comp === melhorComp ? " melhor" : ""}`}>
+                <div className={`ord-medida${l.comps === bestComps ? " melhor" : ""}`}>
                   <span className="ord-medida-rot">comparações</span>
                   <div className="bb-barra">
-                    <div className="bb-barra-fill" style={{ width: `${(l.comp / maxComp) * 100}%` }} />
-                    <span className="bb-barra-txt">{l.comp}</span>
+                    <div className="bb-barra-fill" style={{ width: `${(l.comps / maxComps) * 100}%` }} />
+                    <span className="bb-barra-txt">{l.comps}</span>
                   </div>
                 </div>
-                <div className={`ord-medida${l.escritas === melhorEsc ? " melhor" : ""}`}>
+                <div className={`ord-medida${l.writes === bestWrites ? " melhor" : ""}`}>
                   <span className="ord-medida-rot">escritas no array</span>
                   <div className="bb-barra">
-                    <div className="bb-barra-fill esc" style={{ width: `${(l.escritas / maxEsc) * 100}%` }} />
-                    <span className="bb-barra-txt">{l.escritas}</span>
+                    <div className="bb-barra-fill esc" style={{ width: `${(l.writes / maxWrites) * 100}%` }} />
+                    <span className="bb-barra-txt">{l.writes}</span>
                   </div>
-                  <span className="ord-lei">{leiDe(l.algo, inv, n)}</span>
+                  <span className="ord-lei">{lawFor(l.algo, inv, n)}</span>
                 </div>
               </div>
             </div>
@@ -119,8 +119,8 @@ export function OrdenacaoBasicaCorrida() {
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           Troque a entrada e olhe quem ganha cada barra. O selection sort tem sempre as mesmas{" "}
-          {teto} comparações, nos quatro presets, porque a varredura dele não depende dos dados. O insertion
-          sort vai de {teto} comparações no invertido a {piso} no já ordenado. Os três são O(n²) e mesmo assim
+          {ceiling} comparações, nos quatro presets, porque a varredura dele não depende dos dados. O insertion
+          sort vai de {ceiling} comparações no invertido a {floor} no já ordenado. Os três são O(n²) e mesmo assim
           não são intercambiáveis: O(n²) é o teto, não a conta.
         </p>
       </div>

--- a/content/visualizers/OrdenacaoBasicaVisualizer.tsx
+++ b/content/visualizers/OrdenacaoBasicaVisualizer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // OrdenacaoBasicaVisualizer, os três O(n²) sobre exatamente o mesmo array.
@@ -24,26 +24,34 @@ import { createPortal } from "react-dom";
 // justamente o que a explicação de estabilidade e de custo exige.
 // ---------------------------------------------------------------------------
 
-export type Algo = "bubble" | "selection" | "insertion";
+export type Algorithm = "bubble" | "selection" | "insertion";
 
-type Regiao = { de: number; ate: number; tipo: "final" | "ordenada" };
+// `kind` é dado, e os sufixos de classe abaixo são contrato com o CSS: o
+// `globals.css` define `.hs-fase.f-fim`, `.hs-fase.f-ordenar`, `.hp-cel.fixo` e
+// `.hp-cel.quase`. Por isso o valor da união NÃO é interpolado na className —
+// ele passa por estes mapas, e traduzir a união não apaga cor nenhuma.
+type RegionKind = "final" | "sorted";
+const PHASE_CLASS: Record<RegionKind, string> = { final: "f-fim", sorted: "f-ordenar" };
+const CELL_CLASS: Record<RegionKind, string> = { final: "fixo", sorted: "quase" };
 
-type Passo = {
+type Region = { from: number; to: number; kind: RegionKind };
+
+type Step = {
   arr: number[];
-  foco: number; // o elemento em foco (o que está sendo colocado)
-  par: number; // o elemento com quem se compara
-  marca: number; // auxiliar: o menor encontrado até agora (selection)
-  naMao: number; // o valor guardado na variável temporária (insertion), ou -1
-  regiao: Regiao | null;
-  escreveu: boolean;
-  comp: number;
-  escritas: number;
-  linha: number;
-  nota: string;
+  focus: number; // o elemento em foco (o que está sendo colocado)
+  pair: number; // o elemento com quem se compara
+  mark: number; // auxiliar: o menor encontrado até agora (selection)
+  inHand: number; // o valor guardado na variável temporária (insertion), ou -1
+  region: Region | null;
+  wrote: boolean;
+  comps: number;
+  writes: number;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO: Record<Algo, string[]> = {
+const CODE: Record<Algorithm, string[]> = {
   bubble: [
     "def bubble_sort(a):",
     "    n = len(a)",
@@ -79,351 +87,310 @@ const CODIGO: Record<Algo, string[]> = {
   ],
 };
 
-export const NOMES: Record<Algo, string> = {
+export const NAMES: Record<Algorithm, string> = {
   bubble: "Bubble sort",
   selection: "Selection sort",
   insertion: "Insertion sort",
 };
 
-type Preset = { key: string; rotulo: string; valores: number[]; dica: string };
+type Preset = { key: string; label: string; values: number[]; hint: string };
 
 export const PRESETS: Preset[] = [
   {
-    key: "embaralhado",
-    rotulo: "Embaralhado: 5 3 21 13 1 7 6 15",
-    valores: [5, 3, 21, 13, 1, 7, 6, 15],
-    dica: "O caso comum. Rode os três e compare o card de escritas no array: os oito valores são os mesmos, o resultado é o mesmo, e o trabalho para chegar lá não é nem parecido.",
+    key: "shuffled",
+    label: "Embaralhado: 5 3 21 13 1 7 6 15",
+    values: [5, 3, 21, 13, 1, 7, 6, 15],
+    hint: "O caso comum. Rode os três e compare o card de escritas no array: os oito valores são os mesmos, o resultado é o mesmo, e o trabalho para chegar lá não é nem parecido.",
   },
   {
-    key: "ordenado",
-    rotulo: "Já ordenado: 1 3 5 6 7 13 15 21",
-    valores: [1, 3, 5, 6, 7, 13, 15, 21],
-    dica: "A entrada de sonho. Bubble e insertion percebem e saem em 7 comparações; o selection varre as 28 assim mesmo, porque ele não tem como saber que já está pronto sem olhar tudo.",
+    key: "sorted",
+    label: "Já ordenado: 1 3 5 6 7 13 15 21",
+    values: [1, 3, 5, 6, 7, 13, 15, 21],
+    hint: "A entrada de sonho. Bubble e insertion percebem e saem em 7 comparações; o selection varre as 28 assim mesmo, porque ele não tem como saber que já está pronto sem olhar tudo.",
   },
   {
-    key: "invertido",
-    rotulo: "Ao contrário: 21 15 13 7 6 5 3 1",
-    valores: [21, 15, 13, 7, 6, 5, 3, 1],
-    dica: "A entrada mais hostil possível: as 28 inversões estão todas lá. Aqui os três fazem 28 comparações, e a diferença aparece toda no número de escritas.",
+    key: "reversed",
+    label: "Ao contrário: 21 15 13 7 6 5 3 1",
+    values: [21, 15, 13, 7, 6, 5, 3, 1],
+    hint: "A entrada mais hostil possível: as 28 inversões estão todas lá. Aqui os três fazem 28 comparações, e a diferença aparece toda no número de escritas.",
   },
   {
-    key: "quase",
-    rotulo: "Quase ordenado: 1 3 5 7 6 13 15 21",
-    valores: [1, 3, 5, 7, 6, 13, 15, 21],
-    dica: "Uma única inversão no meio de tudo. É o cenário em que o insertion sort humilha os outros dois, e é por isso que ele sobrevive dentro das bibliotecas modernas.",
+    key: "nearly",
+    label: "Quase ordenado: 1 3 5 7 6 13 15 21",
+    values: [1, 3, 5, 7, 6, 13, 15, 21],
+    hint: "Uma única inversão no meio de tudo. É o cenário em que o insertion sort humilha os outros dois, e é por isso que ele sobrevive dentro das bibliotecas modernas.",
   },
 ];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// O ritmo é desta peça: uma troca de array pede mais tempo de leitura que um
+// passo de sudoku. A marcha de abertura é a 4 (1.5x), não a 3 do padrão.
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
 // Inversões: pares (i < j) com a[i] > a[j]. É a lei de conservação da tela.
 // Bubble e insertion pagam exatamente uma operação por inversão; selection não.
-export function inversoes(v: number[]): number {
+export function inversions(v: number[]): number {
   let n = 0;
   for (let i = 0; i < v.length; i++) for (let j = i + 1; j < v.length; j++) if (v[i] > v[j]) n++;
   return n;
 }
 
-function gerarPassos(algo: Algo, valores: number[]): Passo[] {
-  const a = [...valores];
+function generateSteps(algo: Algorithm, values: number[]): Step[] {
+  const a = [...values];
   const n = a.length;
-  const out: Passo[] = [];
-  let comp = 0;
-  let escritas = 0;
-  let regiao: Regiao | null = null;
-  const base = () => ({ arr: [...a], foco: -1, par: -1, marca: -1, naMao: -1, regiao, escreveu: false, comp, escritas });
+  const out: Step[] = [];
+  let comps = 0;
+  let writes = 0;
+  let region: Region | null = null;
+  const base = () => ({ arr: [...a], focus: -1, pair: -1, mark: -1, inHand: -1, region, wrote: false, comps, writes });
 
   out.push({
     ...base(),
-    linha: 0,
-    nota: `Entrada: ${a.join(", ")}. ${NOMES[algo]} vai ordenar dentro deste mesmo array, sem alocar nada. Acompanhe os dois contadores: comparações e escritas no array.`,
+    line: 0,
+    note: `Entrada: ${a.join(", ")}. ${NAMES[algo]} vai ordenar dentro deste mesmo array, sem alocar nada. Acompanhe os dois contadores: comparações e escritas no array.`,
   });
 
   if (algo === "bubble") {
-    let saiuCedo = false;
-    for (let fim = n - 1; fim > 0; fim--) {
-      let trocou = false;
+    let exitedEarly = false;
+    for (let end = n - 1; end > 0; end--) {
+      let swapped = false;
       out.push({
         ...base(),
-        linha: 2,
-        nota:
-          fim === n - 1
+        line: 2,
+        note:
+          end === n - 1
             ? `Primeira passada, indo até a última posição. Ainda não sei nada sobre o array, então preciso comparar todos os vizinhos.`
-            : `Passada nova, indo só até a posição ${fim}. As ${n - 1 - fim} posições depois dela já estão resolvidas para sempre, então nem olho para elas.`,
+            : `Passada nova, indo só até a posição ${end}. As ${n - 1 - end} posições depois dela já estão resolvidas para sempre, então nem olho para elas.`,
       });
-      for (let j = 0; j < fim; j++) {
-        comp++;
-        const troca = a[j] > a[j + 1];
+      for (let j = 0; j < end; j++) {
+        comps++;
+        const swap = a[j] > a[j + 1];
         out.push({
           ...base(),
-          foco: j,
-          par: j + 1,
-          linha: 5,
-          nota: troca
+          focus: j,
+          pair: j + 1,
+          line: 5,
+          note: swap
             ? `${a[j]} > ${a[j + 1]}: os dois estão fora de ordem entre si, então troco.`
             : `${a[j]} não é maior que ${a[j + 1]}: este par já está em ordem, sigo em frente sem tocar em nada.`,
         });
-        if (troca) {
+        if (swap) {
           const [x, y] = [a[j], a[j + 1]];
           [a[j], a[j + 1]] = [a[j + 1], a[j]];
-          escritas += 2;
-          trocou = true;
+          writes += 2;
+          swapped = true;
           out.push({
             ...base(),
-            foco: j + 1,
-            par: j,
-            escreveu: true,
-            linha: 6,
-            nota: `${x} andou uma casa para a direita e ${y} uma para a esquerda. Foi uma troca entre vizinhos: ninguém pulou por cima de ninguém, e é isso que torna o bubble sort estável.`,
+            focus: j + 1,
+            pair: j,
+            wrote: true,
+            line: 6,
+            note: `${x} andou uma casa para a direita e ${y} uma para a esquerda. Foi uma troca entre vizinhos: ninguém pulou por cima de ninguém, e é isso que torna o bubble sort estável.`,
           });
         }
       }
-      regiao = { de: fim, ate: n - 1, tipo: "final" };
+      region = { from: end, to: n - 1, kind: "final" };
       out.push({
         ...base(),
-        linha: 8,
-        ok: !trocou,
-        nota: trocou
-          ? `Fim da passada: o maior valor desta faixa (${a[fim]}) chegou à posição ${fim} e não sai mais de lá. Encolho o limite e recomeço.`
-          : `Esta passada inteira não trocou nada. Isso só acontece quando cada vizinho já é maior que o anterior, ou seja, o array está ordenado. Paro aqui, sem fazer as ${(fim * (fim - 1)) / 2} comparações que ainda faltariam.`,
+        line: 8,
+        ok: !swapped,
+        note: swapped
+          ? `Fim da passada: o maior valor desta faixa (${a[end]}) chegou à posição ${end} e não sai mais de lá. Encolho o limite e recomeço.`
+          : `Esta passada inteira não trocou nada. Isso só acontece quando cada vizinho já é maior que o anterior, ou seja, o array está ordenado. Paro aqui, sem fazer as ${(end * (end - 1)) / 2} comparações que ainda faltariam.`,
       });
-      if (!trocou) {
-        saiuCedo = true;
+      if (!swapped) {
+        exitedEarly = true;
         break;
       }
     }
-    if (!saiuCedo) regiao = { de: 0, ate: n - 1, tipo: "final" };
+    if (!exitedEarly) region = { from: 0, to: n - 1, kind: "final" };
   }
 
   if (algo === "selection") {
     for (let i = 0; i < n - 1; i++) {
-      let menor = i;
+      let smallest = i;
       out.push({
         ...base(),
-        foco: i,
-        marca: menor,
-        linha: 3,
-        nota: `Vou preencher a posição ${i}. Por enquanto o candidato a menor é o próprio ${a[i]}, e eu ainda não sei nada sobre o resto.`,
+        focus: i,
+        mark: smallest,
+        line: 3,
+        note: `Vou preencher a posição ${i}. Por enquanto o candidato a menor é o próprio ${a[i]}, e eu ainda não sei nada sobre o resto.`,
       });
       for (let j = i + 1; j < n; j++) {
-        comp++;
-        const anterior = menor; // o candidato ANTES desta comparação
-        const melhor = a[j] < a[menor];
-        if (melhor) menor = j;
+        comps++;
+        const previous = smallest; // o candidato ANTES desta comparação
+        const better = a[j] < a[smallest];
+        if (better) smallest = j;
         out.push({
           ...base(),
-          foco: i,
-          par: j,
-          marca: menor,
-          linha: 5,
-          nota: melhor
-            ? `${a[j]} é menor que ${a[anterior]} (posição ${anterior}): achei um candidato melhor, o menor passa a ser o da posição ${j}.`
-            : `${a[j]} não é menor que ${a[anterior]}: o candidato continua sendo o da posição ${anterior}. Mesmo assim tive que olhar, e é por isso que este algoritmo não tem melhor caso.`,
+          focus: i,
+          pair: j,
+          mark: smallest,
+          line: 5,
+          note: better
+            ? `${a[j]} é menor que ${a[previous]} (posição ${previous}): achei um candidato melhor, o menor passa a ser o da posição ${j}.`
+            : `${a[j]} não é menor que ${a[previous]}: o candidato continua sendo o da posição ${previous}. Mesmo assim tive que olhar, e é por isso que este algoritmo não tem melhor caso.`,
         });
       }
-      if (menor !== i) {
-        const [x, y] = [a[i], a[menor]];
-        const distancia = menor - i;
-        [a[i], a[menor]] = [a[menor], a[i]];
-        escritas += 2;
+      if (smallest !== i) {
+        const [x, y] = [a[i], a[smallest]];
+        const distance = smallest - i;
+        [a[i], a[smallest]] = [a[smallest], a[i]];
+        writes += 2;
         out.push({
           ...base(),
-          foco: i,
-          par: menor,
-          marca: -1,
-          escreveu: true,
-          linha: 8,
-          nota: `${y} vem da posição ${menor} direto para a ${i}, um salto de ${distancia} casa${distancia === 1 ? "" : "s"}, e ${x} vai no lugar dele. Salto longo assim pode passar por cima de um valor igual, e é exatamente daí que vem a instabilidade do selection sort.`,
+          focus: i,
+          pair: smallest,
+          mark: -1,
+          wrote: true,
+          line: 8,
+          note: `${y} vem da posição ${smallest} direto para a ${i}, um salto de ${distance} casa${distance === 1 ? "" : "s"}, e ${x} vai no lugar dele. Salto longo assim pode passar por cima de um valor igual, e é exatamente daí que vem a instabilidade do selection sort.`,
         });
       } else {
         out.push({
           ...base(),
-          foco: i,
-          marca: -1,
-          linha: 7,
-          nota: `O menor já era o próprio ${a[i]}: nenhuma escrita nesta rodada. As ${n - 1 - i} comparações, porém, foram feitas do mesmo jeito.`,
+          focus: i,
+          mark: -1,
+          line: 7,
+          note: `O menor já era o próprio ${a[i]}: nenhuma escrita nesta rodada. As ${n - 1 - i} comparações, porém, foram feitas do mesmo jeito.`,
         });
       }
-      regiao = { de: 0, ate: i, tipo: "final" };
+      region = { from: 0, to: i, kind: "final" };
       out.push({
         ...base(),
-        linha: 2,
-        nota: `Posição ${i} fechada com ${a[i]}. As posições 0 a ${i} estão definitivas e nunca mais serão tocadas.`,
+        line: 2,
+        note: `Posição ${i} fechada com ${a[i]}. As posições 0 a ${i} estão definitivas e nunca mais serão tocadas.`,
       });
     }
-    regiao = { de: 0, ate: n - 1, tipo: "final" };
+    region = { from: 0, to: n - 1, kind: "final" };
   }
 
   if (algo === "insertion") {
-    regiao = { de: 0, ate: 0, tipo: "ordenada" };
+    region = { from: 0, to: 0, kind: "sorted" };
     for (let i = 1; i < n; i++) {
-      const atual = a[i];
+      const current = a[i];
       out.push({
         ...base(),
-        naMao: atual,
-        foco: i,
-        linha: 2,
-        nota: `Pego ${atual} na mão. Tudo da posição 0 até a ${i - 1} já está em ordem entre si, então basta achar onde ${atual} se encaixa nesse trecho.`,
+        inHand: current,
+        focus: i,
+        line: 2,
+        note: `Pego ${current} na mão. Tudo da posição 0 até a ${i - 1} já está em ordem entre si, então basta achar onde ${current} se encaixa nesse trecho.`,
       });
       let j = i - 1;
-      let deslocou = 0;
+      let shifted = 0;
       while (j >= 0) {
-        comp++;
-        if (!(a[j] > atual)) {
+        comps++;
+        if (!(a[j] > current)) {
           out.push({
             ...base(),
-            naMao: atual,
-            foco: j,
-            par: i,
-            linha: 4,
-            nota: `${a[j]} não é maior que ${atual}: parei. Achei o lugar, logo depois da posição ${j}. Empate também para aqui, e é isso que preserva a ordem original entre iguais.`,
+            inHand: current,
+            focus: j,
+            pair: i,
+            line: 4,
+            note: `${a[j]} não é maior que ${current}: parei. Achei o lugar, logo depois da posição ${j}. Empate também para aqui, e é isso que preserva a ordem original entre iguais.`,
           });
           break;
         }
         a[j + 1] = a[j];
-        escritas++;
-        deslocou++;
+        writes++;
+        shifted++;
         out.push({
           ...base(),
-          naMao: atual,
-          foco: j + 1,
-          par: j,
-          escreveu: true,
-          linha: 5,
-          nota: `${a[j + 1]} é maior que ${atual}, então empurro ele uma casa para a direita para abrir espaço. Cada empurrão desses corresponde a exatamente uma inversão da entrada.`,
+          inHand: current,
+          focus: j + 1,
+          pair: j,
+          wrote: true,
+          line: 5,
+          note: `${a[j + 1]} é maior que ${current}, então empurro ele uma casa para a direita para abrir espaço. Cada empurrão desses corresponde a exatamente uma inversão da entrada.`,
         });
         j--;
       }
-      a[j + 1] = atual;
-      escritas++;
-      regiao = { de: 0, ate: i, tipo: "ordenada" };
+      a[j + 1] = current;
+      writes++;
+      region = { from: 0, to: i, kind: "sorted" };
       out.push({
         ...base(),
-        naMao: atual,
-        foco: j + 1,
-        escreveu: true,
-        linha: 7,
-        nota: `${atual} entra na posição ${j + 1} depois de ${deslocou} deslocamento${deslocou === 1 ? "" : "s"}. Atenção: o trecho 0 a ${i} está ordenado entre si, mas nenhuma dessas posições é definitiva, porque um valor pequeno lá na frente ainda vai entrar no meio delas.`,
-        ok: deslocou === 0,
+        inHand: current,
+        focus: j + 1,
+        wrote: true,
+        line: 7,
+        note: `${current} entra na posição ${j + 1} depois de ${shifted} deslocamento${shifted === 1 ? "" : "s"}. Atenção: o trecho 0 a ${i} está ordenado entre si, mas nenhuma dessas posições é definitiva, porque um valor pequeno lá na frente ainda vai entrar no meio delas.`,
+        ok: shifted === 0,
       });
     }
-    regiao = { de: 0, ate: n - 1, tipo: "final" };
+    region = { from: 0, to: n - 1, kind: "final" };
   }
 
   out.push({
     ...base(),
-    linha: CODIGO[algo].length - 1,
+    line: CODE[algo].length - 1,
     ok: true,
-    nota: `Ordenado: ${a.join(", ")}. ${comp} comparações e ${escritas} escritas no array, sem nenhuma memória extra além de uma variável de apoio.`,
+    note: `Ordenado: ${a.join(", ")}. ${comps} comparações e ${writes} escritas no array, sem nenhuma memória extra além de uma variável de apoio.`,
   });
   return out;
 }
 
-export const ALGOS: Algo[] = ["bubble", "selection", "insertion"];
+export const ALGOS: Algorithm[] = ["bubble", "selection", "insertion"];
 
 // O custo total sai do MESMO gerador que a animação, de propósito: assim a
 // corrida ao lado não tem como divergir do que o passo a passo mostra na tela.
-export function custo(algo: Algo, valores: number[]): { comp: number; escritas: number } {
-  const ps = gerarPassos(algo, valores);
+export function cost(algo: Algorithm, values: number[]): { comps: number; writes: number } {
+  const ps = generateSteps(algo, values);
   const f = ps[ps.length - 1];
-  return { comp: f.comp, escritas: f.escritas };
+  return { comps: f.comps, writes: f.writes };
 }
 
 export function OrdenacaoBasicaVisualizer() {
-  const [algo, setAlgo] = useState<Algo>("bubble");
-  const [presetKey, setPresetKey] = useState("embaralhado");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [algo, setAlgo] = useState<Algorithm>("bubble");
+  const [presetKey, setPresetKey] = useState("shuffled");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(algo, preset.valores), [algo, preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const inv = useMemo(() => inversoes(preset.valores), [preset]);
+  const steps = useMemo(() => generateSteps(algo, preset.values), [algo, preset]);
+  const inv = useMemo(() => inversions(preset.values), [preset]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · os três O(n²) sobre o mesmo array",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O que move a altura desta peça é o ALGORITMO: o bloco de código vai de 8
+    // linhas (insertion) a 10 (bubble), 51px medidos. O preset entra porque é a
+    // entrada inteira — ele troca o array e todas as notas da animação.
+    measureOn: [algo, presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarAlgo = (k: Algo) => {
-    reiniciar();
+  const s = steps[viz.step];
+
+  const changeAlgo = (k: Algorithm) => {
+    viz.reset();
     setAlgo(k);
   };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const changePreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const naRegiao = (i: number) => p.regiao !== null && i >= p.regiao.de && i <= p.regiao.ate;
-  const rotuloRegiao =
-    p.regiao === null
+  const inRegion = (i: number) => s.region !== null && i >= s.region.from && i <= s.region.to;
+  const regionLabel =
+    s.region === null
       ? "nada resolvido ainda"
-      : p.regiao.tipo === "final"
-        ? `posições ${p.regiao.de} a ${p.regiao.ate} definitivas: não são mais tocadas`
-        : `posições ${p.regiao.de} a ${p.regiao.ate} ordenadas entre si, mas ainda podem receber elementos no meio`;
+      : s.region.kind === "final"
+        ? `posições ${s.region.from} a ${s.region.to} definitivas: não são mais tocadas`
+        : `posições ${s.region.from} a ${s.region.to} ordenadas entre si, mas ainda podem receber elementos no meio`;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · os três O(n²) sobre o mesmo array</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {ALGOS.map((k) => (
             <button
               key={k}
               className={`bigo-chip${algo === k ? " on" : ""}`}
-              onClick={() => trocarAlgo(k)}
+              onClick={() => changeAlgo(k)}
               aria-pressed={algo === k}
             >
-              {NOMES[k]}
+              {NAMES[k]}
             </button>
           ))}
         </div>
@@ -432,33 +399,33 @@ export function OrdenacaoBasicaVisualizer() {
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => changePreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
-        <div className={`hs-fase ${p.regiao === null ? "" : p.regiao.tipo === "final" ? "f-fim" : "f-ordenar"}`}>
-          <span className="hs-fase-selo">{NOMES[algo]}</span>
-          <span className="hs-fase-txt">{rotuloRegiao}</span>
+        <div className={`hs-fase ${s.region === null ? "" : PHASE_CLASS[s.region.kind]}`}>
+          <span className="hs-fase-selo">{NAMES[algo]}</span>
+          <span className="hs-fase-txt">{regionLabel}</span>
         </div>
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
-            O array <em>{p.regiao?.tipo === "ordenada" ? "verde = ordenado entre si, ainda não definitivo" : "verde = posição final"}</em>
+            O array <em>{s.region?.kind === "sorted" ? "verde = ordenado entre si, ainda não definitivo" : "verde = posição final"}</em>
           </div>
           <div className="hp-arr">
-            {p.arr.map((v, i) => {
+            {s.arr.map((v, i) => {
               const cls = ["hp-cel"];
-              if (naRegiao(i)) cls.push(p.regiao?.tipo === "final" ? "fixo" : "quase");
-              if (i === p.foco) cls.push("foco");
-              else if (i === p.par) cls.push("par");
-              else if (i === p.marca) cls.push("alvo");
-              if (p.escreveu && (i === p.foco || i === p.par)) cls.push("troca");
+              if (inRegion(i) && s.region) cls.push(CELL_CLASS[s.region.kind]);
+              if (i === s.focus) cls.push("foco");
+              else if (i === s.pair) cls.push("par");
+              else if (i === s.mark) cls.push("alvo");
+              if (s.wrote && (i === s.focus || i === s.pair)) cls.push("troca");
               return (
                 <span key={i} className={cls.join(" ")}>
                   <i>{i}</i>
@@ -469,42 +436,44 @@ export function OrdenacaoBasicaVisualizer() {
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">{algo}_sort.py</div>
-            <div className="viz-code-body">
-              {CODIGO[algo].map((txt, i) => (
-                <div key={i} className={`viz-line${i === p.linha ? " on" : ""}`}>
-                  <span className="ln">{i + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">{algo}_sort.py</div>
+              <div className="viz-code-body">
+                {CODE[algo].map((txt, i) => (
+                  <div key={i} className={`viz-line${i === s.line ? " on" : ""}`}>
+                    <span className="ln">{i + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">
                 {algo === "insertion" ? "atual (valor na mão)" : algo === "selection" ? "a[i] (posição a preencher)" : "a[j] (esquerda do par)"}
               </span>
               <span className="viz-var-val best">
-                {algo === "insertion" ? (p.naMao >= 0 ? p.naMao : "-") : p.foco >= 0 ? p.arr[p.foco] : "-"}
+                {algo === "insertion" ? (s.inHand >= 0 ? s.inHand : "-") : s.focus >= 0 ? s.arr[s.focus] : "-"}
               </span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">
                 {algo === "selection" ? "a[j] (candidato da varredura)" : algo === "insertion" ? "a[j] (comparado)" : "a[j+1] (direita do par)"}
               </span>
-              <span className="viz-var-val">{p.par >= 0 ? p.arr[p.par] : "-"}</span>
+              <span className="viz-var-val">{s.pair >= 0 ? s.arr[s.pair] : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">
                 {algo === "selection" ? "menor (índice)" : algo === "bubble" ? "posições finais" : "trecho ordenado entre si"}
               </span>
               <span className="viz-var-val">
-                {algo === "selection" ? (p.marca >= 0 ? p.marca : "-") : p.regiao === null ? 0 : p.regiao.ate - p.regiao.de + 1}
+                {algo === "selection" ? (s.mark >= 0 ? s.mark : "-") : s.region === null ? 0 : s.region.to - s.region.from + 1}
               </span>
             </div>
           </div>
@@ -513,69 +482,20 @@ export function OrdenacaoBasicaVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>tamanho do array</span>
-            <strong>{p.arr.length}</strong>
+            <strong>{s.arr.length}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comp}</strong>
+            <strong>{s.comps}</strong>
           </div>
           <div className="bigo-stat">
             <span>escritas no array</span>
-            <strong>{p.escritas}</strong>
+            <strong>{s.writes}</strong>
           </div>
           <div className="bigo-stat">
             <span>inversões da entrada</span>
             <strong>{inv}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -585,21 +505,8 @@ export function OrdenacaoBasicaVisualizer() {
           tira dele qualquer melhor caso.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/QuickSortVisualizer.tsx
+++ b/content/visualizers/QuickSortVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // QuickSortVisualizer, a invariante da partição e o pivô que fica pronto.
@@ -24,35 +25,39 @@ import { createPortal } from "react-dom";
 // motivo diferente: já ordenado, invertido e todos iguais. O quadrático do
 // quick sort não é uma curiosidade teórica, ele mora nas entradas mais comuns
 // que existem, e um preset "aleatório bonitinho" esconderia isso.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   arr: number[];
   lo: number;
   hi: number;
   i: number; // fronteira dos menores ou iguais
   j: number; // varredura
-  pivoIdx: number;
+  pivotIdx: number;
   // As faixas da invariante saem do GERADOR, não de uma reconstrução na
   // renderização: só aqui dentro se sabe se a posição j já foi classificada ou
   // se ela ainda está em exame, e reconstruir isso a partir de i e j fazia a
   // faixa contradizer a nota no passo da comparação.
-  particionando: boolean;
-  menorAte: number; // último índice comprovadamente <= pivô
-  maiorAte: number; // último índice comprovadamente > pivô
-  exame: number; // índice sendo examinado agora, ou -1
-  fixos: number[];
-  pilha: string[];
-  comp: number;
-  trocas: number;
-  semEfeito: number;
-  prof: number;
-  linha: number;
-  nota: string;
+  partitioning: boolean;
+  lessUpTo: number; // último índice comprovadamente <= pivô
+  greaterUpTo: number; // último índice comprovadamente > pivô
+  probing: number; // índice sendo examinado agora, ou -1
+  fixed: number[];
+  stack: string[];
+  comparisons: number;
+  swaps: number;
+  noOpSwaps: number;
+  depth: number;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "def quick_sort(a, lo, hi):",
   "    if lo >= hi: return           # 0 ou 1 elemento",
   "    p = particiona(a, lo, hi)",
@@ -70,343 +75,306 @@ const CODIGO = [
   "    return i",
 ];
 
-type Preset = { key: string; rotulo: string; valores: number[]; dica: string };
+type Preset = { key: string; label: string; values: number[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "embaralhado",
-    rotulo: "Embaralhado: 5 3 13 1 7 6 21 3",
-    valores: [5, 3, 13, 1, 7, 6, 21, 3],
-    dica: "O caso comum, e o único bom deste conjunto. Acompanhe a faixa de regiões: a região cinza (não vistos) só encolhe, nunca cresce, e quando ela zera o pivô entra no lugar definitivo dele.",
+    key: "shuffled",
+    label: "Embaralhado: 5 3 13 1 7 6 21 3",
+    values: [5, 3, 13, 1, 7, 6, 21, 3],
+    hint: "O caso comum, e o único bom deste conjunto. Acompanhe a faixa de regiões: a região cinza (não vistos) só encolhe, nunca cresce, e quando ela zera o pivô entra no lugar definitivo dele.",
   },
   {
-    key: "ordenado",
-    rotulo: "Já ordenado: 1 2 3 4 5 6 7 8",
-    valores: [1, 2, 3, 4, 5, 6, 7, 8],
-    dica: "O desastre mais famoso do quick sort. Com o pivô fixo no último elemento, o maior valor é sempre o pivô, tudo cai à esquerda dele e a partição direita nasce vazia. Compare a profundidade da recursão com a do preset embaralhado.",
+    key: "sorted",
+    label: "Já ordenado: 1 2 3 4 5 6 7 8",
+    values: [1, 2, 3, 4, 5, 6, 7, 8],
+    hint: "O desastre mais famoso do quick sort. Com o pivô fixo no último elemento, o maior valor é sempre o pivô, tudo cai à esquerda dele e a partição direita nasce vazia. Compare a profundidade da recursão com a do preset embaralhado.",
   },
   {
-    key: "invertido",
-    rotulo: "Ao contrário: 8 7 6 5 4 3 2 1",
-    valores: [8, 7, 6, 5, 4, 3, 2, 1],
-    dica: "O mesmo desastre pelo motivo oposto: o pivô é sempre o menor valor, nada cai à esquerda e a partição esquerda nasce vazia. As duas entradas mais previsíveis do mundo são as duas piores para este pivô.",
+    key: "reversed",
+    label: "Ao contrário: 8 7 6 5 4 3 2 1",
+    values: [8, 7, 6, 5, 4, 3, 2, 1],
+    hint: "O mesmo desastre pelo motivo oposto: o pivô é sempre o menor valor, nada cai à esquerda e a partição esquerda nasce vazia. As duas entradas mais previsíveis do mundo são as duas piores para este pivô.",
   },
   {
-    key: "iguais",
-    rotulo: "Todos iguais: 4 4 4 4 4 4 4 4",
-    valores: [4, 4, 4, 4, 4, 4, 4, 4],
-    dica: "O caso que mais surpreende. Não há nada para ordenar e mesmo assim o algoritmo faz o trabalho quadrático inteiro: como toda comparação passa no <=, a fronteira avança sempre e o pivô termina na última posição. Trocar o <= por < só inverte o lado do desastre.",
+    key: "equal",
+    label: "Todos iguais: 4 4 4 4 4 4 4 4",
+    values: [4, 4, 4, 4, 4, 4, 4, 4],
+    hint: "O caso que mais surpreende. Não há nada para ordenar e mesmo assim o algoritmo faz o trabalho quadrático inteiro: como toda comparação passa no <=, a fronteira avança sempre e o pivô termina na última posição. Trocar o <= por < só inverte o lado do desastre.",
   },
 ];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// Este visualizador anda mais rápido que o padrão do hook: cada passo é uma
+// comparação ou uma troca, e são até 115 deles num preset só.
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
-export function gerarPassos(valores: number[]): Passo[] {
-  const a = [...valores];
-  const out: Passo[] = [];
-  let comp = 0;
-  let trocas = 0;
-  let semEfeito = 0;
-  let profMax = 0;
-  const fixos = new Set<number>();
-  const pilha: string[] = [];
+export function generateSteps(values: number[]): Step[] {
+  const a = [...values];
+  const steps: Step[] = [];
+  let comparisons = 0;
+  let swaps = 0;
+  let noOpSwaps = 0;
+  let maxDepth = 0;
+  const fixed = new Set<number>();
+  const stack: string[] = [];
   const base = () => ({
     arr: [...a],
     i: -1,
     j: -1,
-    pivoIdx: -1,
-    particionando: false,
-    menorAte: -1,
-    maiorAte: -1,
-    exame: -1,
-    fixos: [...fixos],
-    pilha: [...pilha],
-    comp,
-    trocas,
-    semEfeito,
-    prof: profMax,
+    pivotIdx: -1,
+    partitioning: false,
+    lessUpTo: -1,
+    greaterUpTo: -1,
+    probing: -1,
+    fixed: [...fixed],
+    stack: [...stack],
+    comparisons,
+    swaps,
+    noOpSwaps,
+    depth: maxDepth,
   });
-  const trocar = (x: number, y: number) => {
-    trocas++;
-    if (x === y) semEfeito++;
+  const swap = (x: number, y: number) => {
+    swaps++;
+    if (x === y) noOpSwaps++;
     else [a[x], a[y]] = [a[y], a[x]];
   };
 
-  out.push({
+  steps.push({
     ...base(),
     lo: 0,
     hi: a.length - 1,
-    linha: 0,
-    nota: `Entrada: ${a.join(", ")}. O quick sort escolhe um pivô, joga os menores para a esquerda dele e os maiores para a direita, e com isso o pivô já fica na posição final. Depois repete nos dois lados.`,
+    line: 0,
+    note: `Entrada: ${a.join(", ")}. O quick sort escolhe um pivô, joga os menores para a esquerda dele e os maiores para a direita, e com isso o pivô já fica na posição final. Depois repete nos dois lados.`,
   });
 
-  const quick = (lo: number, hi: number, prof: number) => {
+  const quick = (lo: number, hi: number, depth: number) => {
     if (lo > hi) return; // intervalo vazio: nem chega a virar quadro de pilha
-    profMax = Math.max(profMax, prof);
+    maxDepth = Math.max(maxDepth, depth);
     if (lo === hi) {
-      fixos.add(lo);
-      out.push({
+      fixed.add(lo);
+      steps.push({
         ...base(),
         lo,
         hi,
-        linha: 1,
+        line: 1,
         ok: true,
-        nota: `Trecho ${lo}..${lo} tem um elemento só (${a[lo]}). Um elemento sozinho já está ordenado, então esta chamada volta sem fazer nada.`,
+        note: `Trecho ${lo}..${lo} tem um elemento só (${a[lo]}). Um elemento sozinho já está ordenado, então esta chamada volta sem fazer nada.`,
       });
       return;
     }
 
-    const pivo = a[hi];
-    out.push({
+    const pivot = a[hi];
+    steps.push({
       ...base(),
       lo,
       hi,
-      pivoIdx: hi,
-      linha: 7,
-      nota: `Chamada no trecho ${lo}..${hi}. Escolho o último elemento como pivô: ${pivo}. Ele é só a referência de comparação por enquanto, e a posição final dele ainda vai ser descoberta.`,
+      pivotIdx: hi,
+      line: 7,
+      note: `Chamada no trecho ${lo}..${hi}. Escolho o último elemento como pivô: ${pivot}. Ele é só a referência de comparação por enquanto, e a posição final dele ainda vai ser descoberta.`,
     });
 
     let i = lo;
-    out.push({
+    steps.push({
       ...base(),
       lo,
       hi,
       i,
-      pivoIdx: hi,
-      particionando: true,
-      menorAte: lo - 1,
-      maiorAte: lo - 1,
-      linha: 8,
-      nota: `A fronteira i começa em ${lo}. A promessa dela é: tudo antes de i já foi visto e é menor ou igual ao pivô. Agora ela está vazia, e a promessa vale de graça.`,
+      pivotIdx: hi,
+      partitioning: true,
+      lessUpTo: lo - 1,
+      greaterUpTo: lo - 1,
+      line: 8,
+      note: `A fronteira i começa em ${lo}. A promessa dela é: tudo antes de i já foi visto e é menor ou igual ao pivô. Agora ela está vazia, e a promessa vale de graça.`,
     });
 
     for (let j = lo; j < hi; j++) {
-      comp++;
-      const cabe = a[j] <= pivo;
-      out.push({
+      comparisons++;
+      const fits = a[j] <= pivot;
+      steps.push({
         ...base(),
         lo,
         hi,
         i,
         j,
-        pivoIdx: hi,
-        particionando: true,
-        menorAte: i - 1,
-        maiorAte: j - 1,
-        exame: j,
-        linha: 10,
-        nota: cabe
-          ? `${a[j]} <= ${pivo}: este elemento pertence ao lado dos menores. Vou trocá-lo com quem está na fronteira e empurrar a fronteira uma casa.`
-          : `${a[j]} > ${pivo}: este elemento fica onde está, do lado dos maiores. A fronteira não anda, e nenhuma escrita acontece.`,
+        pivotIdx: hi,
+        partitioning: true,
+        lessUpTo: i - 1,
+        greaterUpTo: j - 1,
+        probing: j,
+        line: 10,
+        note: fits
+          ? `${a[j]} <= ${pivot}: este elemento pertence ao lado dos menores. Vou trocá-lo com quem está na fronteira e empurrar a fronteira uma casa.`
+          : `${a[j]} > ${pivot}: este elemento fica onde está, do lado dos maiores. A fronteira não anda, e nenhuma escrita acontece.`,
       });
-      if (cabe) {
-        const igual = i === j;
-        const [naFronteira, varrido] = [a[i], a[j]]; // valores ANTES da troca
-        trocar(i, j);
-        out.push({
+      if (fits) {
+        const same = i === j;
+        const [atBoundary, scanned] = [a[i], a[j]]; // valores ANTES da troca
+        swap(i, j);
+        steps.push({
           ...base(),
           lo,
           hi,
           i,
           j,
-          pivoIdx: hi,
-          particionando: true,
-          menorAte: i,
-          maiorAte: j,
-          linha: 11,
-          nota: igual
+          pivotIdx: hi,
+          partitioning: true,
+          lessUpTo: i,
+          greaterUpTo: j,
+          line: 11,
+          note: same
             ? `Troca da posição ${i} com ela mesma: quando nenhum elemento maior apareceu ainda, i e j andam colados. O esquema de Lomuto faz muito disso, e é um dos motivos de ele perder em número de escritas para outros esquemas de partição.`
-            : `${varrido} sai da posição ${j} e vai para a fronteira, em ${i}; ${naFronteira} faz o caminho inverso. Repare que ${naFronteira} era maior que o pivô: ele só mudou de casa dentro da região dos maiores, e continua do lado certo.`,
+            : `${scanned} sai da posição ${j} e vai para a fronteira, em ${i}; ${atBoundary} faz o caminho inverso. Repare que ${atBoundary} era maior que o pivô: ele só mudou de casa dentro da região dos maiores, e continua do lado certo.`,
         });
         i++;
-        out.push({
+        steps.push({
           ...base(),
           lo,
           hi,
           i,
           j,
-          pivoIdx: hi,
-          particionando: true,
-          menorAte: i - 1,
-          maiorAte: j,
-          linha: 12,
-          nota: `A fronteira avança para ${i}. Agora as posições ${lo} a ${i - 1} são, todas, menores ou iguais a ${pivo}.`,
+          pivotIdx: hi,
+          partitioning: true,
+          lessUpTo: i - 1,
+          greaterUpTo: j,
+          line: 12,
+          note: `A fronteira avança para ${i}. Agora as posições ${lo} a ${i - 1} são, todas, menores ou iguais a ${pivot}.`,
         });
       }
     }
 
-    const igualFinal = i === hi;
-    trocar(i, hi);
-    fixos.add(i);
+    const sameFinal = i === hi;
+    swap(i, hi);
+    fixed.add(i);
     const p = i;
-    out.push({
+    steps.push({
       ...base(),
       lo,
       hi,
       i,
-      pivoIdx: p,
-      linha: 13,
+      pivotIdx: p,
+      line: 13,
       ok: true,
-      nota: `A varredura acabou e o pivô vai para a fronteira: troco a posição ${i} com a ${hi}. ${
-        igualFinal ? "As duas são a mesma, então nada se move, e mesmo assim " : ""
+      note: `A varredura acabou e o pivô vai para a fronteira: troco a posição ${i} com a ${hi}. ${
+        sameFinal ? "As duas são a mesma, então nada se move, e mesmo assim " : ""
       }A posição ${p} está definitiva: ${a[p]} tem ${p - lo} valores menores ou iguais à esquerda e ${hi - p} maiores à direita, que é exatamente o lugar dele no array ordenado. Ele nunca mais será tocado.`,
     });
 
     // Só entra na pilha o que é de fato chamada pendente: com o pivô na última
     // posição o lado direito nasce vazio, e mostrar "8..7" como algo a resolver
     // faria o painel de chamadas mentir.
-    const temDireita = p < hi;
-    if (temDireita) pilha.push(`${p + 1}..${hi}`);
-    out.push({
+    const hasRight = p < hi;
+    if (hasRight) stack.push(`${p + 1}..${hi}`);
+    steps.push({
       ...base(),
       lo,
       hi,
-      pivoIdx: p,
-      linha: 3,
-      nota: temDireita
+      pivotIdx: p,
+      line: 3,
+      note: hasRight
         ? `Guardo o lado direito (${p + 1}..${hi}, ${hi - p} elemento${hi - p === 1 ? "" : "s"}) para depois e desço no lado esquerdo, ${lo}..${p - 1}, com ${p - lo} elemento${p - lo === 1 ? "" : "s"}.`
         : `O pivô ficou na última posição, então o lado direito nasce vazio: não há nada para guardar. Desço direto no lado esquerdo, ${lo}..${p - 1}, com ${p - lo} elemento${p - lo === 1 ? "" : "s"}. Partição assim, ${p - lo} contra 0, é a definição do pior caso.`,
     });
-    quick(lo, p - 1, prof + 1);
-    if (temDireita) pilha.pop();
-    if (temDireita) {
-      out.push({
+    quick(lo, p - 1, depth + 1);
+    if (hasRight) stack.pop();
+    if (hasRight) {
+      steps.push({
         ...base(),
         lo,
         hi,
-        pivoIdx: p,
-        linha: 4,
-        nota: `Esquerda resolvida. Agora o lado direito, ${p + 1}..${hi}.`,
+        pivotIdx: p,
+        line: 4,
+        note: `Esquerda resolvida. Agora o lado direito, ${p + 1}..${hi}.`,
       });
-      quick(p + 1, hi, prof + 1);
+      quick(p + 1, hi, depth + 1);
     }
   };
 
   quick(0, a.length - 1, 1);
-  for (let k = 0; k < a.length; k++) fixos.add(k);
-  out.push({
+  for (let k = 0; k < a.length; k++) fixed.add(k);
+  steps.push({
     ...base(),
     lo: 0,
     hi: a.length - 1,
-    linha: 1,
+    line: 1,
     ok: true,
-    nota: `Ordenado: ${a.join(", ")}. Foram ${comp} comparações e ${trocas} trocas (${semEfeito} delas de um elemento com ele mesmo), com profundidade máxima de recursão ${profMax}. Nenhum array auxiliar foi criado: o único custo de memória é a pilha de chamadas.`,
+    note: `Ordenado: ${a.join(", ")}. Foram ${comparisons} comparações e ${swaps} trocas (${noOpSwaps} delas de um elemento com ele mesmo), com profundidade máxima de recursão ${maxDepth}. Nenhum array auxiliar foi criado: o único custo de memória é a pilha de chamadas.`,
   });
-  return out;
+  return steps;
 }
 
 export function QuickSortVisualizer() {
-  const [presetKey, setPresetKey] = useState("embaralhado");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("shuffled");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.valores), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const n = preset.valores.length;
+  const steps = useMemo(() => generateSteps(preset.values), [preset]);
+  const n = preset.values.length;
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · quick sort: a partição e o pivô que fica pronto",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O preset é a entrada inteira: ele troca a dica (a prosa mais longa da
+    // peça) e o número de passos. O tamanho do array NÃO entra: os quatro
+    // presets têm oito valores e não há campo para o aluno mudar isso.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const s = steps[viz.step];
+
+  const pickPreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const fixos = new Set(p.fixos);
+  const fixed = new Set(s.fixed);
 
   // As cinco faixas da invariante, todas vindas do passo. A de "em exame" tem
   // uma posição só e existe porque, no instante da comparação, aquele elemento
   // ainda não pertence a nenhum dos dois lados.
-  const regioes: { de: number; ate: number; cls: string; txt: string }[] = [];
-  if (p.particionando) {
-    const primeiroNaoVisto = (p.exame >= 0 ? p.exame : p.maiorAte) + 1;
-    if (p.menorAte >= p.lo) regioes.push({ de: p.lo, ate: p.menorAte, cls: "menor", txt: "<= pivô" });
-    if (p.maiorAte > p.menorAte) regioes.push({ de: p.menorAte + 1, ate: p.maiorAte, cls: "maior", txt: "> pivô" });
-    if (p.exame >= 0) regioes.push({ de: p.exame, ate: p.exame, cls: "exame", txt: "em exame" });
-    if (p.hi - 1 >= primeiroNaoVisto) regioes.push({ de: primeiroNaoVisto, ate: p.hi - 1, cls: "naovisto", txt: "não vistos" });
-    regioes.push({ de: p.hi, ate: p.hi, cls: "pivo", txt: "pivô" });
+  //
+  // `cls` é nome de classe do CSS compartilhado (`.ms-seg.menor`,
+  // `.ms-seg.naovisto`, ...), não identificador: traduzir estes valores apagaria
+  // a cor das faixas sem o `tsc`, o guarda de idioma ou um teste acusarem.
+  const regions: { from: number; to: number; cls: string; text: string }[] = [];
+  if (s.partitioning) {
+    const firstUnseen = (s.probing >= 0 ? s.probing : s.greaterUpTo) + 1;
+    if (s.lessUpTo >= s.lo) regions.push({ from: s.lo, to: s.lessUpTo, cls: "menor", text: "<= pivô" });
+    if (s.greaterUpTo > s.lessUpTo) regions.push({ from: s.lessUpTo + 1, to: s.greaterUpTo, cls: "maior", text: "> pivô" });
+    if (s.probing >= 0) regions.push({ from: s.probing, to: s.probing, cls: "exame", text: "em exame" });
+    if (s.hi - 1 >= firstUnseen) regions.push({ from: firstUnseen, to: s.hi - 1, cls: "naovisto", text: "não vistos" });
+    regions.push({ from: s.hi, to: s.hi, cls: "pivo", text: "pivô" });
   }
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · quick sort: a partição e o pivô que fica pronto</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => pickPreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
             A invariante da partição <em>o que o algoritmo já sabe sobre cada faixa</em>
           </div>
           <div className="ms-nivel-faixa" style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}>
-            {regioes.length > 0 ? (
-              regioes.map((r) => (
-                <span key={r.cls} className={`ms-seg ${r.cls}`} style={{ gridColumn: `${r.de + 1} / ${r.ate + 2}` }}>
-                  {r.txt}
+            {regions.length > 0 ? (
+              regions.map((r) => (
+                <span key={r.cls} className={`ms-seg ${r.cls}`} style={{ gridColumn: `${r.from + 1} / ${r.to + 2}` }}>
+                  {r.text}
                 </span>
               ))
             ) : (
@@ -416,13 +384,13 @@ export function QuickSortVisualizer() {
             )}
           </div>
           <div className="hp-arr" style={{ marginTop: 8 }}>
-            {p.arr.map((v, k) => {
+            {s.arr.map((v, k) => {
               const cls = ["hp-cel"];
-              if (fixos.has(k)) cls.push("fixo");
-              else if (k < p.lo || k > p.hi) cls.push("fantasma");
-              if (k === p.pivoIdx) cls.push("pivo");
-              else if (k === p.j) cls.push("par");
-              else if (k === p.i) cls.push("alvo");
+              if (fixed.has(k)) cls.push("fixo");
+              else if (k < s.lo || k > s.hi) cls.push("fantasma");
+              if (k === s.pivotIdx) cls.push("pivo");
+              else if (k === s.j) cls.push("par");
+              else if (k === s.i) cls.push("alvo");
               return (
                 <span key={k} className={cls.join(" ")}>
                   <i>{k}</i>
@@ -433,37 +401,39 @@ export function QuickSortVisualizer() {
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">quick_sort.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">quick_sort.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === s.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">trecho ativo</span>
               <span className="viz-var-val best">
-                {p.lo}..{p.hi}
+                {s.lo}..{s.hi}
               </span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">i (fronteira) / j (varre)</span>
               <span className="viz-var-val">
-                {p.i >= 0 ? p.i : "-"} / {p.j >= 0 ? p.j : "-"}
+                {s.i >= 0 ? s.i : "-"} / {s.j >= 0 ? s.j : "-"}
               </span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">chamadas esperando</span>
-              <span className="viz-var-val">{p.pilha.length > 0 ? p.pilha.join(" ") : "nenhuma"}</span>
+              <span className="viz-var-val">{s.stack.length > 0 ? s.stack.join(" ") : "nenhuma"}</span>
             </div>
           </div>
         </div>
@@ -471,69 +441,20 @@ export function QuickSortVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comp}</strong>
+            <strong>{s.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>trocas executadas</span>
-            <strong>{p.trocas}</strong>
+            <strong>{s.swaps}</strong>
           </div>
           <div className="bigo-stat">
             <span>trocas sem efeito</span>
-            <strong>{p.semEfeito}</strong>
+            <strong>{s.noOpSwaps}</strong>
           </div>
           <div className="bigo-stat">
             <span>profundidade da recursão</span>
-            <strong>{p.prof}</strong>
+            <strong>{s.depth}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -543,21 +464,8 @@ export function QuickSortVisualizer() {
           do selection sort.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -117,14 +117,23 @@ Três notas de execução, todas medidas:
   protege literais a deixa para trás: em `Omit<Step, "slots" | "desloc">` o
   `"desloc"` precisava virar `"shifts"` junto com o campo. Aqui só o `tsc`
   pegou — o guarda de idioma, por construção, nunca vai pegar;
-- **valor de união que vira SUFIXO DE CLASSE é contrato com o CSS**, e esse
-  ninguém guarda. No `HeapSortVisualizer` a união `"construir" | "ordenar" |
-  "fim"` entra em `` `hs-fase f-${fase}` ``, e o `globals.css` compartilhado
-  define `.hs-fase.f-ordenar` e `.hs-fase.f-fim`. Traduzir a união apagaria a
-  cor de duas fases **sem nada acusar**: o `tsc` continua coerente, o guarda não
-  vê (não é texto de tela) e o teste não pega (é cor). Antes de renomear uma
-  união, **faça `grep` do valor no `globals.css`**; se ele estiver lá, use um
-  mapa (`PHASE_CLASS`) em vez de interpolar o valor cru.
+- **qualquer literal que vira NOME DE CLASSE é contrato com o CSS**, e esse
+  ninguém guarda. Ele passa pelo `tsc` (o tipo continua coerente), pelo guarda
+  de idioma (não é texto de tela) e pelo teste (é cor). As três formas medidas,
+  em ordem de quão fácil é não vê-las:
+
+  | forma | exemplo | o que aponta para ele |
+  |---|---|---|
+  | valor de **união** interpolado | `` `hs-fase f-${fase}` `` com `"construir" \| "ordenar" \| "fim"` | o tipo — dá para achar pela declaração |
+  | **literal cru** num ternário | `` `hs-fase ${gap === 1 ? "f-fim" : "f-ordenar"}` `` | **nada**: não há tipo, não há `Record`, não há declaração |
+  | literal com **dois papéis** | `"quase"` é chave de preset **e** classe de célula | o guarda **engana**: lista como sumido enquanto ele segue no arquivo, e pede a reação que re-quebra o rename |
+
+  A segunda forma é a pior de achar e foi medida no `ShellSortVisualizer`:
+  trocar por `f-end`/`f-sort` **compila, passa no guarda e apaga a cor de duas
+  fases**. Antes de renomear qualquer literal, **faça `grep` do valor no
+  `globals.css`**. Se ele estiver lá, use um mapa (`PHASE_CLASS`,
+  `CELL_CLASS`) e deixe a classe em português — o nome da classe não é
+  identificador do seu componente, é API compartilhada.
 
 Depois de tudo isso, confira no navegador: contador, botões, notas, rótulos e o
 bloco de código.
@@ -337,10 +346,40 @@ pergunta certa é:
 Se o aluno não consegue mudar a dimensão por nenhum controle, ela não é eixo, e
 procurar pior caso ali é procurar no lugar errado.
 
+### Antes do degrau: o número chega a virar GEOMETRIA?
+
+A pergunta do caminho tem um pressuposto que o grupo de Ordenação derrubou:
+**que o número, alcançado, vira altura**. Nem sempre vira. Ele pode aparecer só
+como **contador num cartão** ou como uma **string de uma linha**, e aí a altura
+não sabe que ele existe.
+
+Medido no `QuickSortVisualizer`, e o sinal inverte: a profundidade da recursão
+depende do pivô, como se espera — mas os três presets **degenerados** chegam a
+profundidade **8 com no máximo UMA chamada pendente** (o pivô de Lomuto cai no
+extremo e um lado nasce vazio), enquanto o **embaralhado**, de profundidade 4, é
+o único com **duas**. A ficha mede 36px nos quatro presets e nas três réguas.
+Seguir a regra do degrau sem esta pergunta mandaria caçar altura no preset mais
+baixo.
+
+> **Um número só é eixo de altura se algo na tela REPETIR com ele.** Ache o
+> elemento que se multiplica — a linha, o nível, a ficha — antes de perguntar
+> qualquer coisa sobre o valor.
+
+### E a grandeza é desenhada toda junta, ou uma de cada vez?
+
+Terceira pergunta, e ela separa duas coisas que parecem iguais. Uma grandeza
+`log₂` pode ser **espacial** (as faixas por nível de um merge sort, desenhadas
+todas ao mesmo tempo) ou **temporal** (as rodadas de um shell sort, que são
+passos consecutivos). Só a primeira é altura.
+
+Medido no `ShellSortVisualizer`: a sequência de gaps é `log₂` e o degrau seguinte
+abriria em 16 elementos — mas a pergunta nem chega a valer, porque cada rodada
+**substitui** a anterior na tela. O `.hs-fase` mede **35px nos 261 estados**.
+
 ### Eixo alcançável ainda pode ser eixo com DEGRAUS
 
-A pergunta acima tem um segundo tempo, e sem ele ela leva à conclusão errada:
-**o caminho existe, mas ele chega a atravessar um degrau?**
+Passadas as duas perguntas acima, vem o terceiro tempo, e sem ele a conclusão
+também sai errada: **o caminho existe, mas ele chega a atravessar um degrau?**
 
 A altura de uma árvore é `⌊log₂ n⌋`, uma função **degrau**. Um controle que muda
 a contagem pode variar bastante e **não mover a altura um pixel**, porque os
@@ -351,12 +390,28 @@ independentes na mesma rodada:
 |---|---|---|
 | `HeapSortVisualizer` | presets de 8 e de 10 elementos | `depth()` devolve **3 nos dois**; os quatro presets desenham **242px nos 289 estados** |
 | `BinaryHeapVisualizer` | presets de 6, 8 e 9 valores | 8 e 9 dão o **mesmo desenho ao pixel** (252px); 6 dá 192. Os 50% a mais compram um nível, o elemento seguinte compra **zero** |
+| `MergeSortVisualizer` | presets de 7 e de 8 elementos | os mesmos **4 níveis**; `.ms-niveis` mede **163px nos 358 estados**. O degrau seguinte só abre em **9**, e nenhum chip chega lá — o vão é de **um elemento** |
 
 **Varrer os presets pode medir dois pontos achando que mediu quatro.** Antes de
 concluir "não tem pior caso", calcule em que valores o degrau muda e veja se
 algum controle chega lá. E quando o eixo satura, diga isso com o número — no
 heap binário, dos 327px entre o estado mais alto e o mais baixo, **só 60 são o
 desenho**; o resto é a operação escolhida.
+
+### O eixo pode ser um bloco CONDICIONAL, que aparece e some
+
+O contrato até aqui só falava de blocos que **crescem**. Existe outro mecanismo,
+e ele explica picos no meio que a regra do crescimento não prevê: um bloco que
+**existe em alguns passos e não existe em outros**.
+
+Medido no `MergeSortVisualizer`: o painel de intercalação (`{s.merge ? … : null}`)
+vale **183px dos 215 de amplitude** da peça inteira. Por isso o pico cai nos
+passos 76 e 90 dos 93 — nunca no primeiro nem no último, e nunca no meio
+geométrico. Nenhum bloco da peça cresce; um deles simplesmente aparece.
+
+**Procure o `? … : null` antes de procurar o que cresce.** Se a sua peça tem um
+painel que só existe durante uma fase, ele provavelmente é o eixo, e o passo do
+pico é o primeiro em que ele aparece com o resto já cheio.
 
 ### A §3 se responde POR PEÇA, não por tópico
 

--- a/content/visualizers/ShellSortVisualizer.tsx
+++ b/content/visualizers/ShellSortVisualizer.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // ShellSortVisualizer, o insertion sort com a constante 1 virando variável.
@@ -20,23 +21,28 @@ import { createPortal } from "react-dom";
 //
 // A geometria vem do array completo e não muda com o gap, de propósito: é a
 // mesma fita, relida com passos diferentes.
+//
+// Altura: a fita é a mesma nos quatro presets (todos têm oito elementos e não
+// há campo de array), então ela mede 44px — uma linha — nos 261 estados e nas
+// três réguas. Quem move a peça é a prosa: a dica do preset (37 ou 55px) e a
+// nota do passo (22 a 63px), 59px de amplitude somados. Ver `measureOn`.
 // ---------------------------------------------------------------------------
 
-type Passo = {
+type Step = {
   arr: number[];
   gap: number;
   i: number;
   j: number;
-  atual: number;
-  cadeia: number[];
-  comp: number;
-  escritas: number;
-  linha: number;
-  nota: string;
+  current: number;
+  chain: number[];
+  comparisons: number;
+  writes: number;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "def shell_sort(a):",
   "    n = len(a)",
   "    gap = n // 2                     # sequência original de Shell",
@@ -51,104 +57,114 @@ const CODIGO = [
   "        gap //= 2                    # e no fim gap = 1: insertion sort",
 ];
 
-type Preset = { key: string; rotulo: string; valores: number[]; dica: string };
+type Preset = { key: string; label: string; values: number[]; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "embaralhado",
-    rotulo: "Embaralhado: 5 3 21 13 1 7 6 15",
-    valores: [5, 3, 21, 13, 1, 7, 6, 15],
-    dica: "Com oito elementos os gaps são 4, 2 e 1. Repare no tamanho do caminho para trás em cada rodada: no gap 4 os saltos são longos e raros, no gap 1 eles são curtíssimos, porque o trabalho pesado já foi feito.",
+    key: "shuffled",
+    label: "Embaralhado: 5 3 21 13 1 7 6 15",
+    values: [5, 3, 21, 13, 1, 7, 6, 15],
+    hint: "Com oito elementos os gaps são 4, 2 e 1. Repare no tamanho do caminho para trás em cada rodada: no gap 4 os saltos são longos e raros, no gap 1 eles são curtíssimos, porque o trabalho pesado já foi feito.",
   },
   {
-    key: "fim",
-    rotulo: "O menor lá no fim: 2 3 4 5 6 7 8 1",
-    valores: [2, 3, 4, 5, 6, 7, 8, 1],
-    dica: "O pesadelo do insertion sort: um array quase ordenado com um único elemento fora do lugar, na pior posição possível. Para trazer o 1 da última posição até a primeira, o insertion sort precisa de 7 deslocamentos, um por vizinho. Aqui bastam dois: um salto de 4 e depois um de 2.",
+    key: "last",
+    label: "O menor lá no fim: 2 3 4 5 6 7 8 1",
+    values: [2, 3, 4, 5, 6, 7, 8, 1],
+    hint: "O pesadelo do insertion sort: um array quase ordenado com um único elemento fora do lugar, na pior posição possível. Para trazer o 1 da última posição até a primeira, o insertion sort precisa de 7 deslocamentos, um por vizinho. Aqui bastam dois: um salto de 4 e depois um de 2.",
   },
   {
-    key: "invertido",
-    rotulo: "Ao contrário: 21 15 13 7 6 5 3 1",
-    valores: [21, 15, 13, 7, 6, 5, 3, 1],
-    dica: "Todas as 28 inversões possíveis, e a única entrada deste conjunto em que o shell sort já ganha com oito elementos: 22 comparações e 29 escritas, contra 28 e 35 do insertion sort. Os gaps grandes desfazem várias inversões por movimento, em vez de uma por uma.",
+    key: "reversed",
+    label: "Ao contrário: 21 15 13 7 6 5 3 1",
+    values: [21, 15, 13, 7, 6, 5, 3, 1],
+    hint: "Todas as 28 inversões possíveis, e a única entrada deste conjunto em que o shell sort já ganha com oito elementos: 22 comparações e 29 escritas, contra 28 e 35 do insertion sort. Os gaps grandes desfazem várias inversões por movimento, em vez de uma por uma.",
   },
   {
-    key: "ordenado",
-    rotulo: "Já ordenado: 1 3 5 6 7 13 15 21",
-    valores: [1, 3, 5, 6, 7, 13, 15, 21],
-    dica: "Nenhum deslocamento acontece em nenhuma rodada, e mesmo assim as comparações são feitas. É o preço de ter três rodadas em vez de uma: o shell sort perde para o insertion sort exatamente na entrada em que o insertion sort é imbatível.",
+    key: "sorted",
+    label: "Já ordenado: 1 3 5 6 7 13 15 21",
+    values: [1, 3, 5, 6, 7, 13, 15, 21],
+    hint: "Nenhum deslocamento acontece em nenhuma rodada, e mesmo assim as comparações são feitas. É o preço de ter três rodadas em vez de uma: o shell sort perde para o insertion sort exatamente na entrada em que o insertion sort é imbatível.",
   },
 ];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// O ritmo é 15 a 30% mais rápido que o `DEFAULT_SPEEDS` do hook, porque são 59
+// a 71 passos curtos: o padrão faria a reprodução arrastar.
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
-const cadeiaDe = (i: number, gap: number, n: number) => {
+const chainOf = (i: number, gap: number, n: number) => {
   const c: number[] = [];
   for (let k = i % gap; k < n; k += gap) c.push(k);
   return c;
 };
 
-export function gerarPassos(valores: number[]): Passo[] {
-  const a = [...valores];
+export function generateSteps(values: number[]): Step[] {
+  const a = [...values];
   const n = a.length;
-  const out: Passo[] = [];
-  let comp = 0;
-  let escritas = 0;
+  const out: Step[] = [];
+  let comparisons = 0;
+  let writes = 0;
   let gap = Math.floor(n / 2);
-  const base = () => ({ arr: [...a], gap, i: -1, j: -1, atual: -1, cadeia: [] as number[], comp, escritas });
+  const base = () => ({
+    arr: [...a],
+    gap,
+    i: -1,
+    j: -1,
+    current: -1,
+    chain: [] as number[],
+    comparisons,
+    writes,
+  });
 
   out.push({
     ...base(),
-    linha: 0,
-    nota: `Entrada: ${a.join(", ")}. O shell sort é o insertion sort com uma diferença: em vez de comparar com o vizinho imediato, ele compara com quem está a gap posições de distância. O gap começa grande e termina em 1.`,
+    line: 0,
+    note: `Entrada: ${a.join(", ")}. O shell sort é o insertion sort com uma diferença: em vez de comparar com o vizinho imediato, ele compara com quem está a gap posições de distância. O gap começa grande e termina em 1.`,
   });
 
   while (gap > 0) {
-    const quantas = gap;
+    const howMany = gap;
     out.push({
       ...base(),
-      linha: 3,
-      nota: `Rodada com gap ${gap}. Isso divide o array em ${quantas} subsequências entrelaçadas: os índices 0, ${gap}, ${2 * gap}... formam uma, os índices 1, ${1 + gap}... formam outra, e assim por diante. Cada uma vai ser ordenada por inserção, sem saber que as outras existem.`,
+      line: 3,
+      note: `Rodada com gap ${gap}. Isso divide o array em ${howMany} subsequências entrelaçadas: os índices 0, ${gap}, ${2 * gap}... formam uma, os índices 1, ${1 + gap}... formam outra, e assim por diante. Cada uma vai ser ordenada por inserção, sem saber que as outras existem.`,
     });
     for (let i = gap; i < n; i++) {
-      const atual = a[i];
-      const cadeia = cadeiaDe(i, gap, n);
+      const current = a[i];
+      const chain = chainOf(i, gap, n);
       out.push({
         ...base(),
         i,
-        atual,
-        cadeia,
-        linha: 5,
-        nota: `Pego ${atual} da posição ${i}. A subsequência dele é ${cadeia.join(", ")}, e é só dentro dela que ele vai procurar lugar. Tudo que está entre esses índices é problema de outra subsequência.`,
+        current,
+        chain,
+        line: 5,
+        note: `Pego ${current} da posição ${i}. A subsequência dele é ${chain.join(", ")}, e é só dentro dela que ele vai procurar lugar. Tudo que está entre esses índices é problema de outra subsequência.`,
       });
       let j = i;
-      let passos = 0;
+      let shifts = 0;
       while (j >= gap) {
-        comp++;
-        if (!(a[j - gap] > atual)) {
+        comparisons++;
+        if (!(a[j - gap] > current)) {
           out.push({
             ...base(),
             i,
             j,
-            atual,
-            cadeia,
-            linha: 7,
-            nota: `${a[j - gap]} (posição ${j - gap}) não é maior que ${atual}: parei. Dentro desta subsequência, a posição ${j} é o lugar dele.`,
+            current,
+            chain,
+            line: 7,
+            note: `${a[j - gap]} (posição ${j - gap}) não é maior que ${current}: parei. Dentro desta subsequência, a posição ${j} é o lugar dele.`,
           });
           break;
         }
         a[j] = a[j - gap];
-        escritas++;
-        passos++;
+        writes++;
+        shifts++;
         out.push({
           ...base(),
           i,
           j: j - gap,
-          atual,
-          cadeia,
-          linha: 8,
-          nota: `${a[j]} é maior que ${atual}, então empurro ele ${gap} posição${gap === 1 ? "" : "ões"} para a frente, da ${j - gap} para a ${j}. Um empurrão de ${gap} desfaz de uma vez várias inversões que o insertion sort desfaria uma a uma.`,
+          current,
+          chain,
+          line: 8,
+          note: `${a[j]} é maior que ${current}, então empurro ele ${gap} posição${gap === 1 ? "" : "ões"} para a frente, da ${j - gap} para a ${j}. Um empurrão de ${gap} desfaz de uma vez várias inversões que o insertion sort desfaria uma a uma.`,
         });
         j -= gap;
       }
@@ -157,144 +173,107 @@ export function gerarPassos(valores: number[]): Passo[] {
           ...base(),
           i,
           j,
-          atual,
-          cadeia,
-          linha: 7,
-          nota: `Cheguei ao começo da subsequência: não existe posição ${j - gap}. O lugar de ${atual} é a posição ${j}.`,
+          current,
+          chain,
+          line: 7,
+          note: `Cheguei ao começo da subsequência: não existe posição ${j - gap}. O lugar de ${current} é a posição ${j}.`,
         });
       }
-      a[j] = atual;
-      escritas++;
+      a[j] = current;
+      writes++;
       out.push({
         ...base(),
         i,
         j,
-        atual,
-        cadeia,
-        linha: 10,
-        ok: passos === 0,
-        nota:
-          passos === 0
-            ? `${atual} já estava no lugar certo dentro da subsequência dele: nenhum deslocamento. A escrita acontece do mesmo jeito, porque o código guarda o valor e devolve.`
-            : `${atual} entra na posição ${j} depois de ${passos} deslocamento${passos === 1 ? "" : "s"} de ${gap}. Ele andou ${i - j} posições no array, e para isso bastaram ${passos} escrita${passos === 1 ? "" : "s"}.`,
+        current,
+        chain,
+        line: 10,
+        ok: shifts === 0,
+        note:
+          shifts === 0
+            ? `${current} já estava no lugar certo dentro da subsequência dele: nenhum deslocamento. A escrita acontece do mesmo jeito, porque o código guarda o valor e devolve.`
+            : `${current} entra na posição ${j} depois de ${shifts} deslocamento${shifts === 1 ? "" : "s"} de ${gap}. Ele andou ${i - j} posições no array, e para isso bastaram ${shifts} escrita${shifts === 1 ? "" : "s"}.`,
       });
     }
-    const antes = gap;
+    const before = gap;
     gap = Math.floor(gap / 2);
     out.push({
       ...base(),
-      linha: 11,
+      line: 11,
       ok: true,
-      nota:
+      note:
         gap > 0
-          ? `Fim da rodada de gap ${antes}: ${a.join(", ")}. O array não está ordenado, mas está ${antes}-ordenado, ou seja, cada elemento é menor ou igual ao que está ${antes} casas à frente. Agora o gap cai para ${gap}, e o mais importante: essa propriedade não se perde nas rodadas seguintes.`
+          ? `Fim da rodada de gap ${before}: ${a.join(", ")}. O array não está ordenado, mas está ${before}-ordenado, ou seja, cada elemento é menor ou igual ao que está ${before} casas à frente. Agora o gap cai para ${gap}, e o mais importante: essa propriedade não se perde nas rodadas seguintes.`
           : `Fim da rodada de gap 1, que é o insertion sort puro: ${a.join(", ")}. Ele só teve trabalho leve porque as rodadas anteriores já tinham aproximado tudo do lugar.`,
     });
   }
 
   out.push({
     ...base(),
-    linha: 11,
+    line: 11,
     ok: true,
-    nota: `Ordenado: ${a.join(", ")}. Foram ${comp} comparações e ${escritas} escritas, sem nenhuma memória extra. A única diferença para o insertion sort é a constante 1 ter virado a variável gap.`,
+    note: `Ordenado: ${a.join(", ")}. Foram ${comparisons} comparações e ${writes} escritas, sem nenhuma memória extra. A única diferença para o insertion sort é a constante 1 ter virado a variável gap.`,
   });
   return out;
 }
 
 export function ShellSortVisualizer() {
-  const [presetKey, setPresetKey] = useState("embaralhado");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("shuffled");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.valores), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(preset.values), [preset]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · shell sort: o insertion sort com gap",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O preset é a única entrada que o aluno tem, e a fita não é eixo de altura:
+    // os quatro presets têm oito elementos, não há campo de array, e `.hp-arr`
+    // mede 44px (uma linha) nos 261 estados das três réguas — ela só quebraria
+    // na 18ª célula. O que o preset troca de verdade é a DICA, que vale 18px
+    // (37px num preset, 55 nos outros três).
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const s = steps[viz.step];
+  const inChain = new Set(s.chain);
+
+  const changePreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const naCadeia = new Set(p.cadeia);
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · shell sort: o insertion sort com gap</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
-
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => changePreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
-        <div className={`hs-fase ${p.gap === 1 ? "f-fim" : "f-ordenar"}`}>
-          <span className="hs-fase-selo">gap {p.gap}</span>
+        {/* `f-fim` e `f-ordenar` são contrato com o `globals.css`
+            (`.hs-fase.f-fim` pinta a borda e o selo de verde, `.f-ordenar` de
+            âmbar), compartilhado com o heap sort. Traduzir estes dois literais
+            apagaria a cor sem o `tsc`, o guarda de idioma ou um teste acusarem. */}
+        <div className={`hs-fase ${s.gap === 1 ? "f-fim" : "f-ordenar"}`}>
+          <span className="hs-fase-selo">gap {s.gap}</span>
           <span className="hs-fase-txt">
-            {p.gap === 1
+            {s.gap === 1
               ? "esta é a última rodada, e ela é o insertion sort puro"
-              : `o array é lido como ${p.gap} subsequências entrelaçadas, uma a cada ${p.gap} posições`}
+              : `o array é lido como ${s.gap} subsequências entrelaçadas, uma a cada ${s.gap} posições`}
           </span>
         </div>
 
@@ -303,11 +282,13 @@ export function ShellSortVisualizer() {
             O array <em>roxo = a subsequência do elemento na mão, ou seja, com quem ele pode conversar</em>
           </div>
           <div className="hp-arr">
-            {p.arr.map((v, k) => {
+            {s.arr.map((v, k) => {
+              // `alvo`, `foco` e `par` também são sufixo de classe do
+              // `globals.css` (`.hp-cel.alvo` e companhia): ficam em português.
               const cls = ["hp-cel"];
-              if (naCadeia.has(k)) cls.push("alvo");
-              if (k === p.i) cls.push("foco");
-              else if (k === p.j) cls.push("par");
+              if (inChain.has(k)) cls.push("alvo");
+              if (k === s.i) cls.push("foco");
+              else if (k === s.j) cls.push("par");
               return (
                 <span key={k} className={cls.join(" ")}>
                   <i>{k}</i>
@@ -318,33 +299,35 @@ export function ShellSortVisualizer() {
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">shell_sort.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">shell_sort.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === s.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">gap</span>
-              <span className="viz-var-val best">{p.gap}</span>
+              <span className="viz-var-val best">{s.gap}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">atual (na mão)</span>
-              <span className="viz-var-val">{p.atual >= 0 ? p.atual : "-"}</span>
+              <span className="viz-var-val">{s.current >= 0 ? s.current : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">j (posição candidata)</span>
-              <span className="viz-var-val">{p.j >= 0 ? p.j : "-"}</span>
+              <span className="viz-var-val">{s.j >= 0 ? s.j : "-"}</span>
             </div>
           </div>
         </div>
@@ -352,69 +335,20 @@ export function ShellSortVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>tamanho do array</span>
-            <strong>{p.arr.length}</strong>
+            <strong>{s.arr.length}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações</span>
-            <strong>{p.comp}</strong>
+            <strong>{s.comparisons}</strong>
           </div>
           <div className="bigo-stat">
             <span>escritas no array</span>
-            <strong>{p.escritas}</strong>
+            <strong>{s.writes}</strong>
           </div>
           <div className="bigo-stat">
             <span>subsequências deste gap</span>
-            <strong>{p.gap}</strong>
+            <strong>{s.gap}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -426,21 +360,8 @@ export function ShellSortVisualizer() {
           array crescer, que com 128 elementos abre uma diferença de mais de quatro vezes.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/tests/viz-merge-sort.spec.ts
+++ b/tests/viz-merge-sort.spec.ts
@@ -1,0 +1,295 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// A casca adaptativa do merge sort.
+//
+// A página tem TRÊS `figure.viz` (o visualizador principal, o desenho do
+// n log n e o comparador de estabilidade), e os três usam as mesmas classes com
+// sentidos diferentes: `.viz-step` casa 3 na página, `.ms-niveis` casa 2,
+// `.bigo-stat` casa 8. Por isso todo seletor daqui sai da FIGURA, nunca da
+// página — um `page.locator(".viz-step")` devolveria "3 rodadas de intercalação
+// x 8 elementos = 24 movimentos", que não é passo nenhum.
+
+const SLACK = 8;
+
+/** A figura adaptada é a primeira do artigo. */
+function figura(page: Page): Locator {
+  return page.locator("article figure.viz-fit");
+}
+
+async function abrir(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto("/topico/merge-sort/");
+  const vp = page.viewportSize();
+  expect(vp).toEqual({ width: w, height: h });
+  await page.evaluate(() => document.fonts.ready);
+  const fig = figura(page);
+  await expect(fig).toHaveCount(1);
+  // a decisão da medição já aconteceu quando `data-anim` volta para "on"
+  await expect(fig).toHaveAttribute("data-anim", "on");
+  return fig;
+}
+
+/** Altura da figura depois que a transição de 0,32s passou E ela parou de mexer. */
+async function alturaEstavel(page: Page): Promise<number> {
+  await page.waitForTimeout(450);
+  let iguais = 0;
+  let ultimo = -1;
+  for (let i = 0; i < 60; i++) {
+    const v = await page.evaluate(() => {
+      const f = document.querySelector("article figure.viz-fit") as HTMLElement;
+      return Math.round(f.getBoundingClientRect().height);
+    });
+    if (v === ultimo) iguais++;
+    else {
+      iguais = 1;
+      ultimo = v;
+    }
+    if (iguais >= 3) return v;
+    await page.waitForTimeout(50);
+  }
+  throw new Error("a altura não estabilizou");
+}
+
+/** Lê rótulo e valor do MESMO cartão de estatística. */
+async function ficha(fig: Locator, rotulo: string): Promise<string> {
+  const cartao = fig.locator(".bigo-stat").filter({ hasText: rotulo });
+  await expect(cartao).toHaveCount(1);
+  return (await cartao.locator("strong").textContent())!.trim();
+}
+
+async function andar(fig: Locator, vezes: number) {
+  const prox = fig.getByRole("button", { name: "Próximo ›" });
+  for (let i = 0; i < vezes; i++) await prox.click();
+}
+
+async function preset(fig: Locator, nome: string) {
+  await fig.getByRole("button", { name: nome }).click();
+}
+
+test.describe("merge sort · casca adaptativa", () => {
+  test("a página tem três figuras e só a primeira é a adaptada", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    // se este número mudar, todo seletor escopado deste arquivo precisa de revisão
+    await expect(page.locator("article figure.viz")).toHaveCount(3);
+    await expect(page.locator("article .viz-step")).toHaveCount(3);
+    const fig = figura(page);
+    await expect(fig.locator(".viz-step")).toHaveCount(1);
+    await expect(fig.locator(".viz-step")).toHaveText(/^passo \d+ de \d+$/);
+    await expect(fig.locator(".ms-niveis")).toHaveCount(1);
+    await expect(fig.locator(".bigo-stat")).toHaveCount(4);
+  });
+
+  test("painel: o cabeçalho e os controles ficam parados enquanto o miolo rola", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+    await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+    const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+    await expect(painel).toBeVisible();
+
+    // o pico da sobra do miolo desta peça está no MEIO da animação: é onde o
+    // painel de intercalação existe. No passo 1 e no último ele nem é desenhado.
+    await andar(painel, 10);
+    await expect(painel.locator(".viz-step")).toHaveText("passo 11 de 79");
+    await expect(painel.locator(".ms-merge")).toHaveCount(1);
+
+    const antes = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay-fit figure.viz-fit") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      // o click() do Playwright rola o contêiner para alcançar o alvo: zerar
+      // aqui é o que impede de medir a rolagem que o próprio teste causou
+      f.scrollTop = 0;
+      b.scrollTop = 0;
+      return {
+        sobraMiolo: b.scrollHeight - b.clientHeight,
+        sobraFigura: f.scrollHeight - f.clientHeight,
+        head: f.querySelector(".viz-head")!.getBoundingClientRect().top,
+        foot: f.querySelector(".viz-foot")!.getBoundingClientRect().top,
+        play: [...f.querySelectorAll("button")]
+          .find((b2) => /Rodar|Pausar/.test(b2.textContent ?? ""))!
+          .getBoundingClientRect().y,
+      };
+    });
+
+    // pré-condições: sem sobra não há o que rolar, e o teste vira decoração
+    expect(antes.sobraMiolo).toBeGreaterThan(SLACK);
+    expect(antes.sobraFigura).toBeLessThanOrEqual(SLACK);
+
+    const depois = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay-fit figure.viz-fit") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      b.scrollTop = b.scrollHeight;
+      return {
+        rolouMiolo: b.scrollTop,
+        rolouFigura: f.scrollTop,
+        head: f.querySelector(".viz-head")!.getBoundingClientRect().top,
+        foot: f.querySelector(".viz-foot")!.getBoundingClientRect().top,
+        play: [...f.querySelectorAll("button")]
+          .find((b2) => /Rodar|Pausar/.test(b2.textContent ?? ""))!
+          .getBoundingClientRect().y,
+      };
+    });
+
+    // quem rolou foi o MIOLO, e não a figura
+    expect(depois.rolouMiolo).toBeGreaterThan(0);
+    expect(depois.rolouFigura).toBe(0);
+    // a promessa da camada 1 é "parado": a posição comparada com ela mesma.
+    // `toBeInViewport()` sozinho passa nas duas pontas da rolagem e aprovaria
+    // o rodapé de volta dentro do miolo.
+    expect(Math.abs(depois.head - antes.head)).toBeLessThanOrEqual(2);
+    expect(Math.abs(depois.foot - antes.foot)).toBeLessThanOrEqual(2);
+    expect(Math.abs(depois.play - antes.play)).toBeLessThanOrEqual(2);
+    await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeInViewport({ ratio: 1 });
+  });
+
+  test("tela baixa: o botão diz Mostrar código e o bloco está recolhido", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    await expect(fig.getByRole("button", { name: /código/ })).toHaveText("Mostrar código");
+    await expect(fig.getByRole("button", { name: /código/ })).toHaveAttribute("aria-expanded", "false");
+
+    // recolher tem que tirar ALTURA, não só largura da coluna do grid: zerar a
+    // trilha da coluna deixaria rótulo e `data-codigo` certos e a peça igual
+    const slot = await fig.locator(".viz-code-slot").evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(slot).toBeLessThan(SLACK);
+
+    const recolhida = await alturaEstavel(page);
+    // premissa: com o código à mostra a peça não caberia — é o que justifica a camada 3
+    await fig.getByRole("button", { name: "Mostrar código" }).click();
+    const aberta = await alturaEstavel(page);
+    expect(aberta - recolhida).toBeGreaterThan(300);
+    expect(aberta).toBeGreaterThan(900 - 60 - 24);
+  });
+
+  test("tela alta: o bloco já vem aberto, e quem decide é a medição", async ({ page }) => {
+    const fig = await abrir(page, 1512, 1700);
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.getByRole("button", { name: /código/ })).toHaveText("Ocultar código");
+    const slot = await fig.locator(".viz-code-slot").evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(slot).toBeGreaterThan(300);
+    // e o Python está mesmo lá dentro
+    await expect(fig.locator(".viz-code-head")).toHaveText("merge_sort.py");
+    await expect(fig.locator(".viz-line")).toHaveCount(15);
+  });
+
+  test("a escolha do aluno vence a medição e sobrevive à troca de preset", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    await fig.getByRole("button", { name: "Mostrar código" }).click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+
+    // o preset é o que está em `measureOn`: trocá-lo PEDE medição nova, e a
+    // medição, sozinha, mandaria recolher nesta janela
+    await preset(fig, "Já ordenado: 1 2 3 4 5 6 7 8");
+    expect(await ficha(fig, "tamanho do array")).toBe("8");
+
+    // asserção ANTES da premissa: com a quebra aplicada a peça recolhe e
+    // encolhe, e a premissa "não cabe" viraria falsa antes da asserção rodar
+    for (let i = 0; i < 9; i++) {
+      await expect(fig).toHaveAttribute("data-codigo", "on");
+      await page.waitForTimeout(100);
+    }
+    await expect(fig.getByRole("button", { name: /código/ })).toHaveText("Ocultar código");
+
+    const aberta = await alturaEstavel(page);
+    expect(aberta).toBeGreaterThan(900 - 60 - 24);
+  });
+
+  test("painel: setas e espaço andam a animação, e o slider fica com a seta dele", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+    await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+    const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+    await expect(painel).toBeVisible();
+    // `toBeVisible()` prova que o portal montou, não que o listener de keydown
+    // já existe: ele nasce num efeito passivo. O foco entrar no painel é a
+    // pré-condição que prova o contrário, porque o efeito do foco é declarado
+    // antes do efeito do teclado.
+    await expect
+      .poll(() => page.evaluate(() => !!document.activeElement?.closest(".viz-overlay-fit")))
+      .toBe(true);
+
+    await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 79");
+    // uma tecla só, repetida: um par ida-e-volta fica verde com o roubo aplicado
+    await page.keyboard.press("ArrowRight");
+    await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 79");
+    await page.keyboard.press("ArrowRight");
+    await expect(painel.locator(".viz-step")).toHaveText("passo 3 de 79");
+    await page.keyboard.press("ArrowLeft");
+    await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 79");
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+    await page.keyboard.press(" ");
+    await expect(painel.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+
+    // com o cursor no slider, a seta é do slider: campo em edição manda
+    const slider = painel.locator("input[type=range]");
+    await expect(slider).toHaveCount(1);
+    await slider.focus();
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    const passoAntes = await painel.locator(".viz-step").textContent();
+    await page.keyboard.press("ArrowLeft");
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1x");
+    await expect(painel.locator(".viz-step")).toHaveText(passoAntes!);
+  });
+
+  test("a marcha de abertura é 1.5x, não o 1x padrão do hook", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+    await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+    const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+    await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+    await expect(painel.locator("input[type=range]")).toHaveValue("4");
+  });
+
+  test("o mapa da recursão tem log2(n) níveis, e 7 e 8 elementos caem no mesmo degrau", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+
+    // rótulo e valor lidos do MESMO cartão, nos dois presets
+    expect(await ficha(fig, "tamanho do array")).toBe("7");
+    expect(await ficha(fig, "níveis de recursão")).toBe("4");
+    await expect(fig.locator(".ms-nivel")).toHaveCount(4);
+    await expect(fig.locator(".ms-nivel-rot").first()).toHaveText("nível 0");
+    await expect(fig.locator(".ms-nivel-rot").last()).toHaveText("nível 3");
+    const alt7 = await fig.locator(".ms-niveis").evaluate((el) => Math.round(el.getBoundingClientRect().height));
+
+    await preset(fig, "Já ordenado: 1 2 3 4 5 6 7 8");
+    expect(await ficha(fig, "tamanho do array")).toBe("8");
+    // a altura da árvore é degrau: um elemento a mais NÃO compra um nível aqui
+    expect(await ficha(fig, "níveis de recursão")).toBe("4");
+    await expect(fig.locator(".ms-nivel")).toHaveCount(4);
+    const alt8 = await fig.locator(".ms-niveis").evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alt8).toBe(alt7);
+  });
+
+  test("a intercalação só é desenhada quando há dois lados prontos, e é ela que move a altura", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+
+    // passo 1: o algoritmo ainda vai descer, e não há o que intercalar
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 79");
+    await expect(fig.locator(".ms-merge")).toHaveCount(0);
+    const semMerge = await alturaEstavel(page);
+
+    await andar(fig, 10);
+    await expect(fig.locator(".viz-step")).toHaveText("passo 11 de 79");
+    await expect(fig.locator(".ms-merge")).toHaveCount(1);
+    // os três lados, com o rótulo que explica cada um
+    await expect(fig.locator(".ms-lado-rot")).toHaveText(["esquerda", "direita", "buffer de saída"]);
+    const comMerge = await alturaEstavel(page);
+
+    // o painel de intercalação é o eixo de altura desta peça: ele aparece e
+    // some no meio da animação, e o passo 1 (como o último) mostra a peça baixa
+    expect(comMerge - semMerge).toBeGreaterThan(100);
+  });
+
+  test("o contador de comparações confere com o que a legenda promete", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+    await preset(fig, "Já ordenado: 1 2 3 4 5 6 7 8");
+    await andar(fig, 92);
+    await expect(fig.locator(".viz-step")).toHaveText("passo 93 de 93");
+    expect(await ficha(fig, "comparações")).toBe("12");
+    expect(await ficha(fig, "cópias para o buffer")).toBe("24");
+
+    await preset(fig, "Pior caso: 1 3 2 7 4 6 5 8");
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 93");
+    await andar(fig, 92);
+    expect(await ficha(fig, "comparações")).toBe("17");
+    expect(await ficha(fig, "cópias para o buffer")).toBe("24");
+  });
+});

--- a/tests/viz-ordenacao-basica.spec.ts
+++ b/tests/viz-ordenacao-basica.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa do OrdenacaoBasicaVisualizer.
+//
+// A página tem TRÊS `figure.viz` (passo a passo, corrida e estabilidade), e os
+// irmãos usam as mesmas classes com outro sentido: `.viz-step` casa 3 na página
+// e diz "12 inversões na entrada" numa delas, não "passo N de M". Por isso todo
+// seletor daqui é escopado na figura — nenhum `page.locator(".viz-...")` solto.
+//
+// Réguas, medidas antes de escrever os testes:
+//   · artigo, recolhida: 757px contra 816 de orçamento a 1512x900 (antes: 1017);
+//   · painel a 1440x600: o miolo sobra 58px recolhido e 340px com o código
+//     aberto pelo aluno — é a única régua desta série em que existe o que rolar,
+//     e é por isso que o teste da camada 1 mora nela;
+//   · a 1512x1080 o ALGORITMO decide: bubble e selection recolhem (1027 e 1001
+//     contra 988 de orçamento) e o insertion fica aberto (976). É o que prova
+//     que `algo` está mesmo em `measureOn`.
+// ---------------------------------------------------------------------------
+
+const URL = "/topico/ordenacao-basica/";
+const SLACK = 8;
+
+/** A minha peça é a PRIMEIRA das três figuras do artigo. */
+function noArtigo(page: Page): Locator {
+  return page.locator("article figure.viz").first();
+}
+
+/** Expandida, a figura vai para um portal no `body`, fora do `<article>`. */
+function noPainel(page: Page): Locator {
+  return page.locator(".viz-overlay figure.viz");
+}
+
+async function abrir(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto(URL);
+  expect(page.viewportSize(), `a régua pedida foi ${w}x${h}`).toEqual({ width: w, height: h });
+  await page.evaluate(() => document.fonts.ready);
+  const fig = noArtigo(page);
+  await expect(fig).toHaveClass(/viz-fit/);
+  return fig;
+}
+
+test("a página tem três figuras, e os seletores desta suíte pegam só a minha", async ({ page }) => {
+  const fig = await abrir(page, 1512, 900);
+  // Se um dia a página perder ou ganhar uma figura, é aqui que o resto desta
+  // suíte deixa de estar falando da peça que ela pensa que está.
+  await expect(page.locator("article figure.viz")).toHaveCount(3);
+  await expect(page.locator("article .viz-step")).toHaveCount(3);
+  await expect(fig.locator(".viz-step")).toHaveCount(1);
+  await expect(fig.locator(".viz-step")).toHaveText(/^passo \d+ de \d+$/);
+  // Só a minha peça tem a casca; as outras duas não têm overlay.
+  await expect(page.locator("article figure.viz-fit")).toHaveCount(1);
+  await expect(fig.locator(".viz-foot")).toHaveCount(1);
+});
+
+test("camada 1: o miolo rola sozinho e o cabeçalho e o ▶ Rodar não se mexem", async ({ page }) => {
+  const fig = await abrir(page, 1440, 600);
+  await fig.getByRole("button", { name: /Expandir/ }).click();
+  const painel = noPainel(page);
+  await expect(painel).toHaveCount(1);
+  // Abre o código na mão para ter sobra de verdade (340px medidos) em vez dos
+  // 58 do estado recolhido: teste de rolagem sem o que rolar não testa nada.
+  await painel.getByRole("button", { name: /Mostrar código/ }).click();
+  await expect(painel.getByRole("button", { name: /Ocultar código/ })).toBeVisible();
+
+  const miolo = painel.locator(".viz-body");
+  const rodar = painel.getByRole("button", { name: /▶ Rodar/ });
+
+  // --- pré-condições: a situação que o teste afirma existe mesmo ---
+  await expect(painel.locator(".viz-foot")).toHaveCount(1);
+  // O `.viz-foot` tem que estar FORA do miolo — é isso que o deixa parado.
+  await expect(painel.locator(".viz-body .viz-foot")).toHaveCount(0);
+  await expect
+    .poll(async () => miolo.evaluate((b) => b.scrollHeight - b.clientHeight), {
+      message: "o miolo precisa estourar para haver o que rolar",
+      timeout: 5000,
+    })
+    .toBeGreaterThan(SLACK);
+
+  // Zera o scrollTop antes de ler a posição do cabeçalho: o `click()` do
+  // Playwright ROLA o contêiner para alcançar o alvo, e a medida sairia suja.
+  await miolo.evaluate((b) => {
+    b.scrollTop = 0;
+  });
+  const cabecaAntes = (await painel.locator(".viz-head").boundingBox())!;
+  const rodarAntes = (await rodar.boundingBox())!;
+
+  // --- a ação: rolar o MIOLO até o fim ---
+  await miolo.evaluate((b) => {
+    b.scrollTop = b.scrollHeight;
+  });
+  await page.waitForTimeout(150);
+
+  // foi o miolo que rolou...
+  expect(await miolo.evaluate((b) => b.scrollTop), "o miolo rolou").toBeGreaterThan(0);
+  // ...e não a figura, que é a quebra que a camada 1 conserta
+  expect(await painel.evaluate((f) => f.scrollTop), "a figura não rola").toBe(0);
+  expect(
+    await painel.evaluate((f) => f.scrollHeight - f.clientHeight),
+    "a figura não tem sobra para rolar"
+  ).toBeLessThanOrEqual(SLACK);
+
+  // --- a asserção que carrega o sentido: a posição comparada com ela mesma ---
+  const cabecaDepois = (await painel.locator(".viz-head").boundingBox())!;
+  const rodarDepois = (await rodar.boundingBox())!;
+  expect(Math.abs(cabecaDepois.y - cabecaAntes.y), "o cabeçalho não anda").toBeLessThanOrEqual(2);
+  expect(Math.abs(rodarDepois.y - rodarAntes.y), "o ▶ Rodar não anda").toBeLessThanOrEqual(2);
+  // `toBeInViewport` entra como complemento: sozinho ele passa nas DUAS pontas
+  // da rolagem mesmo com o rodapé de volta dentro do miolo.
+  await expect(rodar).toBeInViewport({ ratio: 1 });
+});
+
+test("camada 3: em tela baixa o bloco vem recolhido e o botão diz Mostrar código", async ({
+  page,
+}) => {
+  const fig = await abrir(page, 1512, 900);
+  // O rótulo é metade da asserção: comportamento certo com rótulo errado ensina
+  // errado do mesmo jeito.
+  await expect(fig.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(fig).toHaveAttribute("data-codigo", "off");
+  await expect(fig.locator(".viz-toggle-codigo")).toHaveAttribute("aria-expanded", "false");
+  // E o bloco recolheu de ALTURA, não só de largura: zerar a trilha da coluna
+  // tira a largura e deixa a linha do grid com a altura do bloco.
+  const slot = await fig.locator(".viz-code-slot").evaluate((e) => e.getBoundingClientRect().height);
+  expect(slot, "o slot do código fechou").toBeLessThan(12);
+});
+
+test("camada 3: em tela alta o bloco já vem aberto, e quem decide é o algoritmo", async ({
+  page,
+}) => {
+  // 1080px de janela = 988 de orçamento. O insertion pede 976 e cabe; o bubble
+  // pede 1027 e não cabe. Mesma peça, mesma régua, decisões opostas.
+  const fig = await abrir(page, 1512, 1080);
+  await fig.getByRole("button", { name: "Insertion sort", exact: true }).click();
+  await expect(fig.locator(".viz-code-head")).toHaveText("insertion_sort.py");
+  await expect(fig.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+
+  // O bubble, na MESMA janela, recolhe — é o que torna `algo` um eixo de verdade.
+  const limpo = await abrir(page, 1512, 1080);
+  await expect(limpo.locator(".viz-code-head")).toHaveText("bubble_sort.py");
+  await expect(limpo.getByRole("button", { name: "Mostrar código" })).toBeVisible();
+  await expect(limpo).toHaveAttribute("data-codigo", "off");
+});
+
+test("a escolha do aluno vence a medição quando o algoritmo muda", async ({ page }) => {
+  const fig = await abrir(page, 1512, 900);
+  // Aqui a medição QUER recolher (1027 contra 816 de orçamento), e recolheu.
+  await expect(fig).toHaveAttribute("data-codigo", "off");
+  await expect(fig.locator(".viz-code-head")).toHaveText("bubble_sort.py");
+
+  // O aluno discorda e abre.
+  await fig.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+
+  // Troca de algoritmo: entra em `measureOn` e MUDA a entrada da medição (o
+  // bloco vai de 10 para 9 linhas de Python). Confirmo a troca na tela antes de
+  // concluir qualquer coisa — senão a escolha "sobrevive" sem nada tê-la
+  // ameaçado.
+  await fig.getByRole("button", { name: "Selection sort", exact: true }).click();
+  await expect(fig.locator(".viz-code-head")).toHaveText("selection_sort.py");
+  await expect(fig.locator(".viz-line")).toHaveCount(9);
+
+  // A medição rodaria de novo e recolheria (1001 contra 816). A escolha vence.
+  await page.waitForTimeout(600);
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+  await expect(fig.getByRole("button", { name: "Ocultar código" })).toBeVisible();
+});
+
+test("o teclado anda o passo no painel, e o controle de velocidade fica com a seta", async ({
+  page,
+}) => {
+  const fig = await abrir(page, 1512, 900);
+  await fig.getByRole("button", { name: /Expandir/ }).click();
+  const painel = noPainel(page);
+  // Pré-condição de verdade: `toBeVisible()` NÃO quer dizer "pronto para o
+  // teclado". O hook põe o foco na figura no mesmo efeito que antecede o
+  // listener de keydown, então foco na figura é o sinal de que ele já existe.
+  await expect(painel).toBeFocused();
+  await expect(painel.locator(".viz-step")).toHaveText("passo 1 de 49");
+
+  // UMA ação, não um par que se cancela: ArrowRight seguido de ArrowLeft ficaria
+  // verde igualzinho com as duas teclas roubadas.
+  await page.keyboard.press("ArrowRight");
+  await expect(painel.locator(".viz-step")).toHaveText("passo 2 de 49");
+  await page.keyboard.press("ArrowRight");
+  await expect(painel.locator(".viz-step")).toHaveText("passo 3 de 49");
+
+  // Com o cursor no controle de velocidade, a seta é do slider: ela move a
+  // marcha e NÃO anda o passo. Leio o rótulo junto do efeito.
+  const velocidade = painel.locator(".viz-speed input[type=range]");
+  await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+  await velocidade.focus();
+  await page.keyboard.press("ArrowRight");
+  await expect(painel.locator(".viz-speed .val")).toHaveText("2x");
+  await expect(painel.locator(".viz-step")).toHaveText("passo 3 de 49");
+});
+
+test("a marcha de abertura desta peça é 1.5x, não o 1x do padrão", async ({ page }) => {
+  const fig = await abrir(page, 1512, 900);
+  await fig.getByRole("button", { name: /Expandir/ }).click();
+  const painel = noPainel(page);
+  // O ritmo é da peça: o arquivo abria em `useState(4)` antes da adaptação, e
+  // perder isso deixaria uma troca de array passando no tempo de um passo de
+  // sudoku. Rótulo, porque é o que o aluno lê.
+  await expect(painel.locator(".viz-speed .val")).toHaveText("1.5x");
+});
+
+test("recolhida, a peça cabe no orçamento do artigo a 1512x900", async ({ page }) => {
+  const fig = await abrir(page, 1512, 900);
+  await expect(fig).toHaveAttribute("data-codigo", "off");
+  const m = await fig.evaluate((f) => {
+    const hh = parseFloat(
+      getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")
+    );
+    return {
+      altura: Math.round(f.getBoundingClientRect().height),
+      orcamento: Math.round(window.innerHeight - (Number.isFinite(hh) && hh > 0 ? hh : 60) - 24),
+    };
+  });
+  // Antes da adaptação eram 1017 contra 816 — a peça não cabia em nenhum dos
+  // três algoritmos. Este número quebra no dia em que ela voltar a não caber.
+  expect(m.altura, `peça ${m.altura}px, orçamento ${m.orcamento}px`).toBeLessThanOrEqual(
+    m.orcamento
+  );
+
+  // E o miolo continua entregando o conteúdo, rótulo junto do valor no mesmo
+  // cartão: card certo com número do vizinho ensina errado do mesmo jeito.
+  const card = fig.locator(".bigo-stat").filter({ hasText: /^inversões da entrada/ });
+  await expect(card.locator("strong")).toHaveText("12");
+  const tam = fig.locator(".bigo-stat").filter({ hasText: /^tamanho do array/ });
+  await expect(tam.locator("strong")).toHaveText("8");
+});

--- a/tests/viz-quick-sort.spec.ts
+++ b/tests/viz-quick-sort.spec.ts
@@ -1,0 +1,301 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// A casca adaptativa do QuickSortVisualizer.
+//
+// A página tem TRÊS `figure.viz` (o visualizador da partição, o comparador de
+// pivôs e o de três vias) e os irmãos usam as mesmas classes com outro sentido:
+// `.viz-step` casa 3 na página e 1 nesta figura, `.viz-note` idem. Por isso
+// todo seletor daqui é escopado na figura, nunca na página.
+//
+// Só o visualizador da partição recebeu a casca, então `figure.viz-fit` o
+// identifica sozinho — e o primeiro teste confere isso em vez de supor.
+
+const SLACK = 8;
+
+/** A figura adaptada, no fluxo do artigo. */
+const figArtigo = (page: Page) => page.locator("article figure.viz-fit");
+/** A mesma figura depois de expandida: ela vai para o portal, fora do <article>. */
+const figPainel = (page: Page) => page.locator(".viz-overlay figure.viz-fit");
+
+const botao = (fig: Locator, nome: RegExp) => fig.getByRole("button", { name: nome });
+
+async function abrirPagina(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto("/topico/quick-sort/");
+  const vp = page.viewportSize();
+  expect(vp, "a janela pedida é a janela medida").toEqual({ width: w, height: h });
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+  await expect(figArtigo(page)).toHaveCount(1);
+}
+
+/** Espera o painel estar PRONTO PARA O TECLADO, que não é o mesmo que visível:
+ *  o listener de `keydown` nasce num efeito, e a tecla enviada antes some sem
+ *  erro nenhum. O sinal de que o efeito rodou é o foco ter entrado na figura. */
+async function painelPronto(page: Page) {
+  const fig = figPainel(page);
+  await expect(fig).toHaveCount(1);
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const f = document.querySelector(".viz-overlay figure.viz-fit");
+          return !!f && (f === document.activeElement || f.contains(document.activeElement));
+        }),
+      { message: "o foco entrou no painel" }
+    )
+    .toBe(true);
+}
+
+/** Lê o passo atual e o total do contador DESTA figura. */
+async function passo(fig: Locator): Promise<{ atual: number; total: number }> {
+  const txt = (await fig.locator(".viz-step").innerText()).trim();
+  const m = txt.match(/passo (\d+) de (\d+)/);
+  if (!m) throw new Error(`contador inesperado: ${JSON.stringify(txt)}`);
+  return { atual: Number(m[1]), total: Number(m[2]) };
+}
+
+test.describe("quick sort", () => {
+  test("a figura adaptada é a única com a casca, e os irmãos não contaminam os seletores", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1512, 900);
+    // Se um irmão ganhasse a casca, os seletores deste arquivo passariam a
+    // casar com ele e todos os outros testes mediriam a peça errada.
+    await expect(page.locator("article figure.viz")).toHaveCount(3);
+    await expect(page.locator("article figure.viz-fit")).toHaveCount(1);
+    await expect(page.locator(".viz-step")).toHaveCount(3);
+    await expect(figArtigo(page).locator(".viz-step")).toHaveCount(1);
+    await expect(figArtigo(page).locator(".bigo-stat")).toHaveCount(4);
+    await expect(figArtigo(page).locator(".viz-note")).toHaveCount(1);
+  });
+
+  test("no painel o cabeçalho e os controles ficam parados enquanto o miolo rola", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1440, 700);
+    await botao(figArtigo(page), /Expandir/).click();
+    await painelPronto(page);
+    const fig = figPainel(page);
+
+    // O estado que produz sobra de verdade é a escolha do aluno de MOSTRAR o
+    // código: a medição recolhe sozinha nesta janela.
+    const alternar = botao(fig, /Mostrar código/);
+    await expect(alternar).toHaveText("Mostrar código");
+    await alternar.click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await page.waitForTimeout(500); // a transição da casca dura 0,32s
+
+    const rodar = botao(fig, /Rodar|Pausar/);
+    // Zerar o scrollTop ANTES de ler: qualquer clique anterior pode ter rolado
+    // o contêiner para alcançar o alvo, e aí o cabeçalho já andou sozinho.
+    const antes = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay figure.viz-fit") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      b.scrollTop = 0;
+      f.scrollTop = 0;
+      const topo = (el: Element) =>
+        el.getBoundingClientRect().top - f.getBoundingClientRect().top;
+      return {
+        sobraMiolo: Math.round(b.scrollHeight - b.clientHeight),
+        headTop: topo(f.querySelector(".viz-head")!),
+        footTop: topo(f.querySelector(".viz-foot")!),
+      };
+    });
+    // Pré-condição: sem sobra não há rolagem, e um teste de rolagem sem o que
+    // rolar fica verde para sempre sem testar nada.
+    expect(antes.sobraMiolo, "o miolo tem o que rolar").toBeGreaterThan(SLACK);
+    const rodarAntes = (await rodar.boundingBox())!.y;
+
+    const depois = await page.evaluate(() => {
+      const f = document.querySelector(".viz-overlay figure.viz-fit") as HTMLElement;
+      const b = f.querySelector(".viz-body") as HTMLElement;
+      b.scrollTop = b.scrollHeight;
+      const topo = (el: Element) =>
+        el.getBoundingClientRect().top - f.getBoundingClientRect().top;
+      return {
+        mioloRolou: Math.round(b.scrollTop),
+        figuraRolou: Math.round(f.scrollTop),
+        sobraFigura: Math.round(f.scrollHeight - f.clientHeight),
+        headTop: topo(f.querySelector(".viz-head")!),
+        footTop: topo(f.querySelector(".viz-foot")!),
+      };
+    });
+    const rodarDepois = (await rodar.boundingBox())!.y;
+
+    // Quem rola é o MIOLO. Sem estas duas, a quebra que devolve a rolagem para
+    // a figura inteira passa: lá o `scrollTop` do miolo fica em zero e o
+    // cabeçalho "não se mexe" porque nada se mexeu.
+    expect(depois.mioloRolou, "foi o miolo que rolou").toBeGreaterThan(0);
+    expect(depois.sobraFigura, "a figura não rola").toBeLessThanOrEqual(SLACK);
+
+    // A promessa da camada 1 é PARADO, e a asserção que carrega esse sentido é
+    // a posição comparada com ela mesma. `toBeInViewport()` sozinho passa nas
+    // duas pontas da rolagem mesmo com o rodapé de volta dentro do miolo.
+    expect(Math.abs(depois.headTop - antes.headTop), "o cabeçalho não anda").toBeLessThanOrEqual(2);
+    expect(Math.abs(depois.footTop - antes.footTop), "o rodapé não anda").toBeLessThanOrEqual(2);
+    expect(Math.abs(rodarDepois - rodarAntes), "o ▶ Rodar não anda").toBeLessThanOrEqual(2);
+    await expect(rodar).toBeInViewport({ ratio: 1 });
+    // Rótulo junto do comportamento: botão parado que diga outra coisa não é
+    // o botão que faz o algoritmo andar.
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+
+  test("em tela baixa o botão diz Mostrar código e o bloco está mesmo recolhido", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1440, 700);
+    const fig = figArtigo(page);
+    await expect(botao(fig, /código/)).toHaveText("Mostrar código");
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    // O rótulo promete que o bloco sumiu; a altura do slot é quem prova.
+    // (Zerar a trilha da COLUNA tira a largura e não a altura — o `.viz-code-slot`
+    // é o que fecha de verdade.)
+    const alturaSlot = await fig
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaSlot, "o slot do código está fechado").toBeLessThan(4);
+  });
+
+  test("em tela alta o código já vem aberto", async ({ page }) => {
+    await abrirPagina(page, 1512, 1200);
+    const fig = figArtigo(page);
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(botao(fig, /código/)).toHaveText("Ocultar código");
+    const alturaSlot = await fig
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaSlot, "o slot do código está aberto").toBeGreaterThan(100);
+    // E o Python está legível, não só presente: o bloco recolhido também tem
+    // as linhas no DOM.
+    await expect(fig.locator(".viz-line").first()).toHaveText(/def quick_sort\(a, lo, hi\):/);
+  });
+
+  test("a escolha do aluno de ver o código sobrevive à troca de preset", async ({ page }) => {
+    // Janela em que a medição QUER recolher: sem isso a escolha "sobrevive"
+    // sem que nada a tenha ameaçado.
+    await abrirPagina(page, 1440, 700);
+    const fig = figArtigo(page);
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    await botao(fig, /Mostrar código/).click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+
+    // O preset está em `measureOn`, então trocá-lo dispara medição nova — que é
+    // exatamente o que precisa perder para o aluno.
+    const antes = await passo(fig);
+    await fig.getByRole("button", { name: /Já ordenado/ }).click();
+    // Confirma na TELA que a troca aconteceu: o preset novo tem outro total.
+    await expect
+      .poll(async () => (await passo(fig)).total, { message: "o preset trocou" })
+      .not.toBe(antes.total);
+    await page.waitForTimeout(600);
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(botao(fig, /código/)).toHaveText("Ocultar código");
+    const alturaSlot = await fig
+      .locator(".viz-code-slot")
+      .evaluate((el) => Math.round(el.getBoundingClientRect().height));
+    expect(alturaSlot, "o código continua à mostra depois da troca").toBeGreaterThan(100);
+  });
+
+  test("as setas andam o passo no painel e não roubam a tecla de quem edita a velocidade", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1512, 900);
+    await botao(figArtigo(page), /Expandir/).click();
+    await painelPronto(page);
+    const fig = figPainel(page);
+
+    expect((await passo(fig)).atual).toBe(1);
+    // Uma ação por vez, repetida. Um par inverso (→ depois ←) devolveria a peça
+    // ao estado de origem e ficaria verde mesmo com a tecla sendo roubada.
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(async () => (await passo(fig)).atual).toBe(2);
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(async () => (await passo(fig)).atual).toBe(3);
+    await page.keyboard.press("ArrowLeft");
+    await expect.poll(async () => (await passo(fig)).atual).toBe(2);
+
+    const rodar = botao(fig, /Rodar|Pausar/);
+    await expect(rodar).toHaveText("▶ Rodar");
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("❚❚ Pausar");
+    await page.keyboard.press("Space");
+    await expect(rodar).toHaveText("▶ Rodar");
+
+    // Campo em edição manda: com o slider em foco, seta é do slider. Uma ação
+    // só, e as duas metades medidas — o passo que NÃO anda e o valor que anda.
+    const slider = fig.locator("input[type=range]");
+    await expect(slider).toHaveCount(1);
+    // Esta peça tem marcha inicial própria (são até 115 passos num preset só, e
+    // o ritmo padrão do hook a deixa arrastada). O rótulo é quem prova.
+    await expect(fig.locator(".viz-speed .val")).toHaveText("1.5x");
+    await slider.focus();
+    const passoAntes = (await passo(fig)).atual;
+    const velAntes = await slider.inputValue();
+    await page.keyboard.press("ArrowRight");
+    await expect.poll(async () => slider.inputValue()).not.toBe(velAntes);
+    expect((await passo(fig)).atual, "a seta ficou com o slider").toBe(passoAntes);
+  });
+
+  test("os cartões dizem a profundidade do preset, com o rótulo ao lado do número", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1512, 900);
+    await botao(figArtigo(page), /Expandir/).click();
+    await painelPronto(page);
+    const fig = figPainel(page);
+
+    // Lê rótulo E valor do MESMO cartão: comportamento certo com rótulo errado
+    // ensina errado do mesmo jeito, e um rename que troque dois campos de lugar
+    // mantém o conjunto de textos idêntico.
+    const cartao = async (rotulo: string) =>
+      fig.locator(".bigo-stat").filter({ hasText: rotulo }).evaluate((el) => ({
+        rotulo: el.querySelector("span")?.textContent?.trim(),
+        valor: el.querySelector("strong")?.textContent?.trim(),
+      }));
+    const aoFim = async () => {
+      const { total } = await passo(fig);
+      for (let k = (await passo(fig)).atual; k < total; k++) await page.keyboard.press("ArrowRight");
+      await expect.poll(async () => (await passo(fig)).atual).toBe(total);
+    };
+
+    await aoFim();
+    expect(await cartao("profundidade da recursão")).toEqual({
+      rotulo: "profundidade da recursão",
+      valor: "4",
+    });
+    expect(await cartao("comparações")).toEqual({ rotulo: "comparações", valor: "14" });
+
+    // O preset "já ordenado" é o desastre: a MESMA quantidade de elementos
+    // desce o dobro de níveis, e é isso que a peça existe para mostrar.
+    await fig.getByRole("button", { name: /Já ordenado/ }).click();
+    await expect.poll(async () => (await passo(fig)).total).toBe(115);
+    await aoFim();
+    expect(await cartao("profundidade da recursão")).toEqual({
+      rotulo: "profundidade da recursão",
+      valor: "8",
+    });
+    expect(await cartao("comparações")).toEqual({ rotulo: "comparações", valor: "28" });
+  });
+
+  test("no artigo a peça recolhida cabe no orçamento de uma tela", async ({ page }) => {
+    await abrirPagina(page, 1512, 900);
+    const fig = figArtigo(page);
+    await page.waitForTimeout(600);
+    const m = await fig.evaluate((el) => ({
+      altura: Math.round(el.getBoundingClientRect().height),
+      orcamento:
+        window.innerHeight -
+        (parseFloat(getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")) ||
+          60) -
+        24,
+    }));
+    // A asserção vem ANTES da pré-condição de propósito: a quebra que inverte a
+    // decisão da medição desfaz o `data-codigo="off"`, e com a ordem trocada o
+    // teste reprovaria na pré-condição, apontando para o lugar errado.
+    expect(m.altura, `peça ${m.altura}px, orçamento ${m.orcamento}px`).toBeLessThanOrEqual(
+      m.orcamento
+    );
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+  });
+});

--- a/tests/viz-shell-sort.spec.ts
+++ b/tests/viz-shell-sort.spec.ts
@@ -1,0 +1,398 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// Casca adaptativa do ShellSortVisualizer.
+//
+// A página tem TRÊS `figure.viz` (o passo a passo, as subsequências e a corrida
+// de sequências de gap) e só uma delas é `.viz-fit`. As outras duas têm
+// `.viz-step` com outro sentido ("gap 4 · 4 subsequências...", "n = 32 ·
+// melhor com gap..."), então todo seletor aqui é escopado na figura certa e o
+// primeiro teste confere as contagens.
+//
+// Números que decidiram o escopo, medidos nos 261 estados (4 presets de 65, 66,
+// 71 e 59 passos) e nas três réguas, com `document.fonts.ready` cumprido:
+//
+//   artigo, código aberto ...... 1041..1100 (1512x900) / 1055..1114 (1440)
+//   artigo, código recolhido ...  720..779             /  734..793
+//   painel, antes .............. a FIGURA rolava 190/390/490px, e o cabeçalho
+//                                subia junto (-189/-389/-489)
+//   painel, depois ............. quem rola é o miolo; figura 0px
+
+const ORCAMENTO = (h: number) => h - 60 - 24;
+
+/** A figura adaptada, no fluxo do artigo. */
+const noArtigo = (page: Page) => page.locator("article figure.viz-fit");
+/** A figura adaptada, dentro do painel expandido. */
+const noPainel = (page: Page) => page.locator(".viz-overlay figure.viz-fit");
+
+/** Espera a casca terminar a medição: `data-anim` só vira "on" depois dela. */
+async function pronta(fig: Locator) {
+  await expect(fig).toBeVisible();
+  await expect(fig).toHaveAttribute("data-anim", "on");
+}
+
+async function abrir(page: Page) {
+  await page.goto("/topico/shell-sort/");
+  await page.evaluate(() => document.fonts.ready);
+  const fig = noArtigo(page);
+  await pronta(fig);
+  return fig;
+}
+
+/** Anda a animação até o último passo, sem depender de 65 cliques do runner. */
+async function ateOFim(fig: Locator) {
+  await fig.evaluate(async (f) => {
+    const espera = () =>
+      new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+    for (let n = 0; n < 400; n++) {
+      const b = [...f.querySelectorAll("button")].find((x) =>
+        (x.textContent || "").includes("Próximo")
+      ) as HTMLButtonElement | undefined;
+      if (!b || b.disabled) break;
+      b.click();
+      await espera();
+    }
+  });
+}
+
+/**
+ * Altura do bloco recolhível, lida mesmo quando ele está `inert` — e só depois
+ * de a transição de 0,32s parar. Duas leituras iguais não bastam: uma transição
+ * em CSS passa por patamares e duas amostras podem cair no mesmo.
+ */
+async function alturaDoCodigo(fig: Locator) {
+  const ler = () =>
+    fig.locator(".viz-code").evaluate((e) => Math.round(e.getBoundingClientRect().height));
+  let iguais = 0;
+  let anterior = await ler();
+  for (let n = 0; n < 60 && iguais < 2; n++) {
+    await fig.page().waitForTimeout(60);
+    const atual = await ler();
+    iguais = atual === anterior ? iguais + 1 : 0;
+    anterior = atual;
+  }
+  return anterior;
+}
+
+/** Anda a animação até o selo da fase mostrar o gap pedido. */
+async function ateOGap(fig: Locator, gap: number) {
+  await fig.evaluate(async (f, alvo) => {
+    const espera = () =>
+      new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+    for (let n = 0; n < 400; n++) {
+      if ((f.querySelector(".hs-fase-selo")?.textContent || "").trim() === `gap ${alvo}`) return;
+      const b = [...f.querySelectorAll("button")].find((x) =>
+        (x.textContent || "").includes("Próximo")
+      ) as HTMLButtonElement | undefined;
+      if (!b || b.disabled) return;
+      b.click();
+      await espera();
+    }
+  }, gap);
+}
+
+test.describe("shell sort · a figura certa", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("a casca alcança um dos três visualizadores, e é o do passo a passo", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+
+    // A ambiguidade é da PÁGINA, não da casca: três figuras, três `.viz-step`.
+    expect(await page.locator("article figure.viz").count()).toBe(3);
+    expect(await fig.count()).toBe(1);
+    expect(await page.locator("article .viz-step").count()).toBe(3);
+    expect(await fig.locator(".viz-step").count()).toBe(1);
+    expect(await fig.locator("input[type=range]").count()).toBe(1);
+
+    await expect(fig.locator(".viz-head-title")).toContainText(
+      "shell sort: o insertion sort com gap"
+    );
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 65");
+  });
+});
+
+test.describe("shell sort · camada 1: cabeçalho e controles parados", () => {
+  test.use({ viewport: { width: 1440, height: 600 } });
+
+  test("o miolo rola e o cabeçalho e o rodapé não saem do lugar", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+
+    await fig.locator("button", { hasText: "Expandir" }).click();
+    const painel = noPainel(page);
+    await pronta(painel);
+
+    // O aluno pede o código de volta: é o estado em que o miolo tem mais o que
+    // rolar (406px de sobra medidos), e a escolha dele vence a medição.
+    if ((await painel.getAttribute("data-codigo")) === "off") {
+      await painel.locator("button", { hasText: "Mostrar código" }).click();
+    }
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+    await expect(painel.locator("button", { hasText: "Ocultar código" })).toBeVisible();
+
+    const corpo = painel.locator(".viz-body");
+    const cabeca = painel.locator(".viz-head");
+    const rodape = painel.locator(".viz-foot");
+    const rodar = painel.locator("button", { hasText: "Rodar" });
+
+    // O `click()` do Playwright rola o contêiner para alcançar o alvo, então a
+    // posição de referência só vale com o `scrollTop` zerado.
+    await corpo.evaluate((e) => { e.scrollTop = 0; });
+
+    // Premissa: existe sobra para rolar. Sem ela o teste vira decoração verde.
+    const sobraMiolo = await corpo.evaluate((e) => e.scrollHeight - e.clientHeight);
+    expect(sobraMiolo).toBeGreaterThan(8);
+
+    const antes = {
+      cabeca: (await cabeca.boundingBox())!.y,
+      rodape: (await rodape.boundingBox())!.y,
+    };
+
+    await corpo.evaluate((e) => { e.scrollTop = e.scrollHeight; });
+
+    // Quem rolou foi o miolo — e só ele.
+    expect(await corpo.evaluate((e) => e.scrollTop)).toBeGreaterThan(0);
+    expect(await painel.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeLessThanOrEqual(8);
+    expect(await painel.evaluate((e) => e.scrollTop)).toBe(0);
+
+    // A asserção que carrega o sentido: a posição comparada com ela mesma.
+    // `toBeInViewport()` sozinho passaria com o rodapé de volta dentro do miolo.
+    const depois = {
+      cabeca: (await cabeca.boundingBox())!.y,
+      rodape: (await rodape.boundingBox())!.y,
+    };
+    expect(Math.round(depois.cabeca - antes.cabeca)).toBe(0);
+    expect(Math.round(depois.rodape - antes.rodape)).toBe(0);
+
+    // E o botão que faz o algoritmo andar continua inteiro na tela.
+    await expect(rodar).toBeInViewport({ ratio: 1 });
+    await expect(rodar).toHaveText("▶ Rodar");
+  });
+});
+
+test.describe("shell sort · camada 3: a medição recolhe o código", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("em 900px de altura o código vem recolhido, e o rótulo diz o que ele faz", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+
+    // Rótulo e valor juntos: o botão promete mostrar, e o bloco está fechado.
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    const botao = fig.locator(".viz-toggle-codigo");
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    expect(await alturaDoCodigo(fig)).toBeLessThan(10);
+
+    // Recolhido a peça cabe no orçamento; aberta não caberia. É essa diferença
+    // que justifica a camada 3 nesta peça.
+    const recolhida = await fig.evaluate((e) => Math.round(e.getBoundingClientRect().height));
+    expect(recolhida).toBeLessThan(ORCAMENTO(900));
+
+    await botao.click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    // O `.viz-code-slot` é quem devolve ALTURA: zerar a trilha da coluna tiraria
+    // só a largura.
+    expect(await alturaDoCodigo(fig)).toBeGreaterThan(300);
+    const aberta = await fig.evaluate((e) => Math.round(e.getBoundingClientRect().height));
+    expect(aberta).toBeGreaterThan(ORCAMENTO(900));
+    expect(aberta - recolhida).toBeGreaterThan(250);
+  });
+});
+
+test.describe("shell sort · camada 3: em tela alta o código já vem aberto", () => {
+  test.use({ viewport: { width: 1512, height: 1200 } });
+
+  test("com 1200px de altura a peça cabe inteira e o código não é escondido", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 1200 });
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    expect(await alturaDoCodigo(fig)).toBeGreaterThan(300);
+
+    const altura = await fig.evaluate((e) => Math.round(e.getBoundingClientRect().height));
+    expect(altura).toBeLessThan(ORCAMENTO(1200));
+  });
+});
+
+test.describe("shell sort · a escolha do aluno vence a medição", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("abrir o código sobrevive à troca de preset, que é o que dispara medição nova", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+
+    // Nesta janela a medição QUER recolher (a peça aberta pede 1100px de um
+    // orçamento de 816): a escolha do aluno está de fato ameaçada.
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    await fig.locator(".viz-toggle-codigo").click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+
+    const dica = fig.locator(".tt-legenda-arvore");
+    const dicaAntes = await dica.textContent();
+
+    // O preset é o único item de `measureOn`, então trocá-lo pede medição nova.
+    await fig.locator(".bigo-chip", { hasText: "Ao contrário" }).click();
+
+    // Confirme a troca NA TELA antes de concluir: preset que não muda a entrada
+    // da medição faz a escolha "sobreviver" sem nada tê-la ameaçado.
+    await expect(dica).not.toHaveText(dicaAntes!);
+    await expect(dica).toContainText("Todas as 28 inversões possíveis");
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 71");
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    expect(await alturaDoCodigo(fig)).toBeGreaterThan(300);
+  });
+});
+
+test.describe("shell sort · teclado do painel", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("as setas e o espaço andam a animação", async ({ page }) => {
+    const fig = await abrir(page);
+    await fig.locator("button", { hasText: "Expandir" }).click();
+    const painel = noPainel(page);
+    // `toBeVisible()` não é "pronto para o teclado": o listener de keydown nasce
+    // num efeito, e a tecla enviada antes some sem erro nenhum. `data-anim=on`
+    // só aparece depois de os efeitos da casca terem rodado.
+    await pronta(painel);
+
+    const passo = painel.locator(".viz-step");
+    await expect(passo).toHaveText("passo 1 de 65");
+
+    // Uma ação só: um par ArrowRight/ArrowLeft voltaria ao ponto de partida e
+    // ficaria verde mesmo com as duas teclas roubadas.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 2 de 65");
+
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 3 de 65");
+
+    await page.keyboard.press("ArrowLeft");
+    await expect(passo).toHaveText("passo 2 de 65");
+
+    await page.keyboard.press(" ");
+    await expect(painel.locator("button", { hasText: "Pausar" })).toHaveText("❚❚ Pausar");
+  });
+
+  test("com o controle de velocidade em foco, a seta é do slider e não do passo", async ({ page }) => {
+    const fig = await abrir(page);
+    await fig.locator("button", { hasText: "Expandir" }).click();
+    const painel = noPainel(page);
+    await pronta(painel);
+
+    const passo = painel.locator(".viz-step");
+    const marcha = painel.locator(".viz-speed .val");
+    await expect(passo).toHaveText("passo 1 de 65");
+    // A peça abre em 1.5x (`initialSpeed: 4`), que é a marcha que ela sempre
+    // teve; sem passar isso ao hook ela cairia calada para 1x.
+    await expect(marcha).toHaveText("1.5x");
+
+    await painel.locator("input[type=range]").focus();
+    await page.keyboard.press("ArrowRight");
+
+    // A tecla chegou ao slider...
+    await expect(marcha).toHaveText("2x");
+    // ...e NÃO foi roubada pelo atalho de passo.
+    await expect(passo).toHaveText("passo 1 de 65");
+  });
+});
+
+test.describe("shell sort · o que está escrito na tela", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("os cartões carregam rótulo e valor no mesmo lugar", async ({ page }) => {
+    const fig = await abrir(page);
+
+    const cartao = (rotulo: string) =>
+      fig.locator(".bigo-stat").filter({ hasText: rotulo }).locator("strong");
+
+    // No passo 1 nada foi feito ainda.
+    await expect(fig.locator(".bigo-stat").nth(0)).toContainText("tamanho do array");
+    await expect(cartao("tamanho do array")).toHaveText("8");
+    await expect(cartao("comparações")).toHaveText("0");
+    await expect(cartao("escritas no array")).toHaveText("0");
+
+    // O preset invertido é o único em que o shell sort já ganha com oito
+    // elementos, e os números aparecem na dica, na legenda e no artigo: 22
+    // comparações e 29 escritas. Mexer no gerador quebraria os três em silêncio.
+    await fig.locator(".bigo-chip", { hasText: "Ao contrário" }).click();
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 71");
+    await ateOFim(fig);
+    await expect(fig.locator(".viz-step")).toHaveText("passo 71 de 71");
+    await expect(cartao("comparações")).toHaveText("22");
+    await expect(cartao("escritas no array")).toHaveText("29");
+    await expect(fig.locator(".viz-note")).toContainText(
+      "Foram 22 comparações e 29 escritas"
+    );
+  });
+
+  test("o Python da tela e os rótulos das variáveis continuam em português", async ({ page }) => {
+    const fig = await abrir(page);
+
+    // O bloco vem recolhido nesta janela: leia por textContent, nunca por
+    // innerText, que devolveria vazio justamente para o que um rename estragaria.
+    const linhas = await fig.locator(".viz-code .viz-line").allTextContents();
+    expect(linhas).toHaveLength(12);
+    expect(linhas[5]).toContain("atual = a[i]");
+    expect(linhas[7]).toContain("while j >= gap and a[j - gap] > atual:");
+    expect(linhas[8]).toContain("a[j] = a[j - gap]    # empurra pelo gap");
+    expect(linhas[10]).toContain("a[j] = atual");
+    expect(linhas.join("\n")).toContain("sequência original de Shell");
+
+    const varDe = (nome: string) =>
+      fig.locator(".viz-var").filter({ hasText: nome }).locator(".viz-var-val");
+    await expect(varDe("atual (na mão)")).toHaveText("-");
+    await expect(varDe("j (posição candidata)")).toHaveText("-");
+    await expect(varDe("gap")).toHaveText("4");
+  });
+
+  test("o selo da fase muda de gap e de classe, que é contrato com o CSS", async ({ page }) => {
+    const fig = await abrir(page);
+    const fase = fig.locator(".hs-fase");
+
+    // `f-ordenar` e `f-fim` são sufixo de classe do globals.css: traduzi-los
+    // apagaria a cor sem o tsc, o guarda de idioma ou o build acusarem.
+    await expect(fase.locator(".hs-fase-selo")).toHaveText("gap 4");
+    await expect(fase).toHaveClass(/f-ordenar/);
+    await expect(fase.locator(".hs-fase-txt")).toHaveText(
+      "o array é lido como 4 subsequências entrelaçadas, uma a cada 4 posições"
+    );
+
+    // A última rodada é a de gap 1, e é ela que pinta `f-fim`.
+    await ateOGap(fig, 1);
+    await expect(fase.locator(".hs-fase-selo")).toHaveText("gap 1");
+    await expect(fase).toHaveClass(/f-fim/);
+    await expect(fase.locator(".hs-fase-txt")).toHaveText(
+      "esta é a última rodada, e ela é o insertion sort puro"
+    );
+
+    // E o último passo mostra "gap 0", porque o gerador só empilha o estado
+    // final depois de o laço zerar o gap. É comportamento ANTERIOR à casca
+    // (está na `main`), não uma regressão da adaptação: fica afirmado aqui para
+    // deixar de ser mudo, e vai reportado como achado editorial.
+    await ateOFim(fig);
+    await expect(fig.locator(".viz-step")).toHaveText("passo 65 de 65");
+    await expect(fase.locator(".hs-fase-selo")).toHaveText("gap 0");
+    await expect(fase).toHaveClass(/f-ordenar/);
+  });
+
+  test("a fita tem oito células em todos os presets, e é por isso que ela não é eixo de altura", async ({ page }) => {
+    const fig = await abrir(page);
+    const fita = fig.locator(".hp-arr");
+
+    for (const rotulo of ["Embaralhado", "O menor lá no fim", "Ao contrário", "Já ordenado"]) {
+      await fig.locator(".bigo-chip", { hasText: rotulo }).click();
+      await expect(fig.locator(".bigo-chip", { hasText: rotulo })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      expect(await fita.locator(".hp-cel").count()).toBe(8);
+      // Uma linha só: a fita é `flex-wrap` e só quebraria na 18ª célula.
+      expect(await fita.evaluate((e) => Math.round(e.getBoundingClientRect().height))).toBe(44);
+    }
+  });
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores do grupo **Ordenação**:
quatro tópicos, **4 visualizadores adaptados**, com um agente por tópico (janela
de 3 em paralelo) e consolidação num PR só.

## O que entrou, e o que ficou de fora

| tópico | adaptado | fora do escopo |
|---|---|---|
| `ordenacao-basica` | `OrdenacaoBasicaVisualizer` | `Corrida`, `Estabilidade` |
| `merge-sort` | `MergeSortVisualizer` | `MergeEmpate`, `MergeSortNiveis` |
| `quick-sort` | `QuickSortVisualizer` | `QuickSortPivo`, `QuickSortTresVias` |
| `shell-sort` | `ShellSortVisualizer` | `ShellSortGaps`, `ShellSortSubsequencias` |

**4 de 12.** O grupo tem a mesma forma nos quatro tópicos: um visualizador com
painel e dois cartazes estáticos ao lado. Os oito de fora foram conferidos lendo
o arquivo. `counting-sort`, `radix-sort` e `bucket-sort` estão `soon`.
**Zero linha de CSS nova.**

## Medições

Janela **1512x900**, fontes carregadas, animação congelada, orçamento no artigo
= 816px. Cada peça medida andando a animação inteira, em todos os presets e
algoritmos, e também em 1440x700 e 1440x600.

| peça | artigo antes | depois | cabeçalho ao rolar, no painel |
|---|---|---|---|
| ordenação básica | 946–1017 | **737–757** | −441 → **0** |
| merge sort | 1269–1503 | **882–1115** | −934 → **0** |
| quick sort | 1074–1134 | **687–746** | −550 → **0** |
| shell sort | 1031–1090 | **720–779** | −489 → **0** |

**Nas quatro, quem rolava no painel era a figura inteira**, e o `.viz-foot` não
existia. Três das quatro passam a **caber no artigo** a 1512x900 (ordenação
básica com 59–79px de folga, quick sort e shell sort com o código recolhido). O
merge sort segue 299px acima, com a altura quebrada por bloco no relatório.

## Testes

**37 testes novos** em quatro arquivos disjuntos, **46 quebras provadas**, todas
compilando, com build visível e resumo imprimindo `failed` **e** `passed`.

**Suíte completa na branch integrada: 427 passed, 0 failed** (`--workers=2`, com
a máquina livre, em 5,6 min). Numa execução anterior com três agentes ainda
rodando a mesma suíte deu 4 falhas em 23,8 min — todas `page.goto` estourando,
uma delas de 15 minutos num teste só. Saturação, não lógica: os arquivos que
falharam têm `git diff origin/main` vazio, e a rodada limpa passou inteira.

## Verificação da consolidação

- **Diff do texto renderizado do build inteiro** contra `origin/main`, palavra a
  palavra por página: **zero palavras perdidas** nas quatro páginas, nada
  acrescentado além das afordâncias da casca.
- **Chaves de preset:** todas em inglês nas quatro peças, sem divergência.
- **O caso do literal-vira-classe (a regra do #41) foi respeitado nos dois
  lugares onde aparecia:** o `ordenacao-basica` usou um `Record<RegionKind,
  string>` e o `quick-sort` deixou os nomes de classe em português **com
  comentário explicando que são API do CSS compartilhado**.
- **Varreduras de classe:** nenhuma marcha inicial perdida, nenhum `stepBy` com
  aritmética, nenhum rodapé escrito à mão.

## Contrato (`content/visualizers/README.md`)

A §3 tinha duas perguntas (o caminho existe? ele atravessa um degrau?). Este
grupo mostrou que **faltavam duas antes e uma categoria depois**.

### 1. Antes do degrau: o número chega a virar GEOMETRIA?

No `QuickSortVisualizer` a profundidade depende do pivô, como se espera — mas
ela só aparece como **contador num cartão**. E o sinal inverte: os três presets
**degenerados** chegam a profundidade **8 com no máximo UMA chamada pendente**
(o pivô de Lomuto cai no extremo e um lado nasce vazio), enquanto o
**embaralhado**, de profundidade 4, é o único com **duas**. A ficha mede 36px nos
quatro presets e nas três réguas.

> **Um número só é eixo de altura se algo na tela REPETIR com ele.**

Sem essa pergunta, a regra do degrau mandaria caçar altura no preset mais baixo.

### 2. A grandeza é desenhada toda junta, ou uma de cada vez?

Uma sequência `log₂` pode ser **espacial** (as faixas por nível do merge sort) ou
**temporal** (as rodadas do shell sort, onde cada uma substitui a anterior). Só a
primeira é altura: no `ShellSortVisualizer` o `.hs-fase` mede **35px nos 261
estados**, e o degrau seguinte — que abriria em 16 elementos — nem chega a
importar.

### 3. O eixo pode ser um bloco CONDICIONAL

O contrato só falava de blocos que **crescem**. No `MergeSortVisualizer` o painel
de intercalação (`{s.merge ? … : null}`) vale **183px dos 215 de amplitude**
aparecendo e sumindo — por isso o pico cai nos passos 76 e 90 de 93, e não no
meio geométrico. **Procure o ternário que devolve `null` antes de procurar o que
cresce.**

### 4. E a tabela do degrau ganha o vão mais apertado até agora

`MergeSortVisualizer`: 7 e 8 elementos dão os mesmos **4 níveis**, `.ms-niveis`
mede **163px nos 358 estados**, e o degrau seguinte só abre em **9** — o vão é de
**um elemento**.

### §0 — a regra do literal-vira-classe estava estreita demais

Eu a escrevi no #41 como "valor de **união** que vira sufixo de classe". A forma
pior não tem união nenhuma:

| forma | exemplo | o que aponta para ele |
|---|---|---|
| valor de união interpolado | `` `hs-fase f-${fase}` `` | o tipo |
| **literal cru num ternário** | `` `hs-fase ${gap === 1 ? "f-fim" : "f-ordenar"}` `` | **nada** |
| literal com **dois papéis** | `"quase"` é chave de preset **e** classe | o guarda **engana** |

A segunda foi medida no `ShellSortVisualizer`: trocar por `f-end`/`f-sort`
**compila, passa no guarda e apaga a cor de duas fases**. A terceira, no
`ordenacao-basica`: o guarda lista o literal como sumido enquanto ele segue no
arquivo, pedindo justamente a reação que re-quebra o rename.

## Idioma

Identificadores traduzidos nas quatro peças, incluindo `key` de preset e valores
de união. Dois tópicos tiveram rename atravessando para arquivos fora do escopo
(`OrdenacaoBasicaCorrida` e `MergeSortNiveis` importam símbolos das peças
adaptadas) — ajustados e conferidos. O `guarda-idioma.py` **não é prova**, e a
prova foi comparar o texto renderizado dos estados: **1.587 estados** somados
(480 + 366 + 369 + 372), com diff vazio no miolo, mais o diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
