### PR TITLE
feat(viz): casca adaptativa em Backtracking e Manipulação de Bits

### DIFF
--- a/content/visualizers/BacktrackingSudoku.tsx
+++ b/content/visualizers/BacktrackingSudoku.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BacktrackingSudoku, o mesmo template num problema que ninguém chama de
@@ -22,25 +22,34 @@ import { createPortal } from "react-dom";
 // cada decisão; os dois 9x9 são o tabuleiro que a pessoa reconhece, e neles o
 // interessante não é seguir clique a clique, é rodar até o fim e olhar a razão
 // entre tentativas e células, que vai de 4,6 no 4x4 para 18 no de 48 lacunas.
+//
+// A casca vem do `useVisualizer`. Ao contrário da árvore do visualizador
+// anterior, aqui NADA se acumula na tela: o tabuleiro é uma grade fixa e cada
+// passo substitui o anterior. Medido: a amplitude ao longo dos 956 passos do
+// preset maior é de 20px, e vem da nota ter uma ou duas linhas. Quem manda na
+// altura é o preset — 156px de grade no 4x4 contra 346px nos 9x9.
 // ---------------------------------------------------------------------------
 
-type Passo = {
-  grade: number[];
-  foco: number; // índice da célula sendo preenchida, ou -1
-  tentativa: number; // valor sendo testado
-  conflito: "linha" | "coluna" | "quadrante" | null;
-  colocou: boolean;
-  apagou: boolean;
-  tentativas: number;
-  colocacoes: number;
-  retrocessos: number;
-  prof: number;
-  linha: number;
-  nota: string;
+type Step = {
+  grid: number[];
+  focus: number; // índice da célula sendo preenchida, ou -1
+  attempt: number; // valor sendo testado
+  // Os valores desta união são TEXTO DE TELA: eles aparecem crus no painel de
+  // variáveis, na linha "regra que barrou". Traduzir os identificadores não
+  // alcança eles.
+  conflict: "linha" | "coluna" | "quadrante" | null;
+  placed: boolean;
+  erased: boolean;
+  attempts: number;
+  placements: number;
+  backtracks: number;
+  depth: number;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "def resolver(grade):",
   "    pos = primeira_vazia(grade)",
   "    if pos is None: return True      # completo",
@@ -55,11 +64,11 @@ const CODIGO = [
 
 type Preset = {
   key: string;
-  rotulo: string;
+  label: string;
   n: number; // 4 ou 9
-  caixa: [number, number]; // altura e largura do quadrante
-  dados: number[];
-  dica: string;
+  box: [number, number]; // altura e largura do quadrante
+  data: number[];
+  hint: string;
 };
 
 // prettier-ignore
@@ -75,7 +84,7 @@ const P4 = [
 // para a frente, então apagar do fim para o começo mantém o custo domável e
 // ainda assim força retrocesso.
 // prettier-ignore
-const P9_VINTE = [
+const P9_TWENTY = [
   5, 3, 4, 6, 7, 8, 9, 1, 2,
   6, 7, 2, 1, 9, 5, 3, 4, 8,
   1, 9, 8, 3, 4, 2, 5, 6, 7,
@@ -88,7 +97,7 @@ const P9_VINTE = [
 ];
 
 // prettier-ignore
-const P9_QUARENTA = [
+const P9_FORTY = [
   5, 3, 4, 6, 7, 8, 9, 1, 2,
   6, 7, 2, 1, 9, 5, 3, 4, 8,
   1, 9, 8, 3, 4, 2, 5, 6, 7,
@@ -102,150 +111,149 @@ const P9_QUARENTA = [
 
 const PRESETS: Preset[] = [
   {
-    key: "quatro",
-    rotulo: "Sudoku 4x4, para acompanhar passo a passo",
+    key: "four",
+    label: "Sudoku 4x4, para acompanhar passo a passo",
     n: 4,
-    caixa: [2, 2],
-    dados: P4,
-    dica: "As mesmas regras num tabuleiro que cabe na cabeça: dígitos de 1 a 4, sem repetir na linha, na coluna e no quadrante 2x2. Acompanhe uma célula específica e conte quantas vezes ela é escrita e apagada antes de ficar.",
+    box: [2, 2],
+    data: P4,
+    hint: "As mesmas regras num tabuleiro que cabe na cabeça: dígitos de 1 a 4, sem repetir na linha, na coluna e no quadrante 2x2. Acompanhe uma célula específica e conte quantas vezes ela é escrita e apagada antes de ficar.",
   },
   {
-    key: "vinte",
-    rotulo: "9x9 com 20 lacunas",
+    key: "twenty",
+    label: "9x9 com 20 lacunas",
     n: 9,
-    caixa: [3, 3],
-    dados: P9_VINTE,
-    dica: "O tabuleiro que a pessoa reconhece, com as duas últimas linhas em aberto. São 12 retrocessos para 20 lacunas: mesmo com o tabuleiro quase pronto, o algoritmo escreve coisa errada e precisa voltar.",
+    box: [3, 3],
+    data: P9_TWENTY,
+    hint: "O tabuleiro que a pessoa reconhece, com as duas últimas linhas em aberto. São 12 retrocessos para 20 lacunas: mesmo com o tabuleiro quase pronto, o algoritmo escreve coisa errada e precisa voltar.",
   },
   {
-    key: "quarenta",
-    rotulo: "9x9 com 48 lacunas",
+    key: "forty",
+    label: "9x9 com 48 lacunas",
     n: 9,
-    caixa: [3, 3],
-    dados: P9_QUARENTA,
-    dica: "Só as três primeiras linhas dadas. Rode até o fim e olhe a razão entre dígitos testados e lacunas. Com tão poucas pistas existem muitas soluções válidas, e é bom saber o que o algoritmo faz nesse caso: ele para na PRIMEIRA que encontrar, não na certa, porque para ele não existe uma certa.",
+    box: [3, 3],
+    data: P9_FORTY,
+    hint: "Só as três primeiras linhas dadas. Rode até o fim e olhe a razão entre dígitos testados e lacunas. Com tão poucas pistas existem muitas soluções válidas, e é bom saber o que o algoritmo faz nesse caso: ele para na PRIMEIRA que encontrar, não na certa, porque para ele não existe uma certa.",
   },
 ];
 
-const VELOCIDADES = [0, 300, 160, 80, 30, 8];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 300, 160, 80, 30, 8];
 
-const LIMITE_PASSOS = 20000;
+const STEP_LIMIT = 20000;
 
-export function gerarPassos(preset: Preset): Passo[] {
-  const { n, caixa, dados } = preset;
-  const [ch, cw] = caixa;
-  const g = [...dados];
-  const out: Passo[] = [];
-  let tentativas = 0;
-  let colocacoes = 0;
-  let retrocessos = 0;
-  let prof = 0;
-  let estourou = false;
+export function generateSteps(preset: Preset): Step[] {
+  const { n, box, data } = preset;
+  const [bh, bw] = box;
+  const g = [...data];
+  const out: Step[] = [];
+  let attempts = 0;
+  let placements = 0;
+  let backtracks = 0;
+  let depth = 0;
+  let overflowed = false;
 
-  const base = (extra: Partial<Passo>): Passo => ({
-    grade: [...g],
-    foco: -1,
-    tentativa: 0,
-    conflito: null,
-    colocou: false,
-    apagou: false,
-    tentativas,
-    colocacoes,
-    retrocessos,
-    prof,
-    linha: 0,
-    nota: "",
+  const base = (extra: Partial<Step>): Step => ({
+    grid: [...g],
+    focus: -1,
+    attempt: 0,
+    conflict: null,
+    placed: false,
+    erased: false,
+    attempts,
+    placements,
+    backtracks,
+    depth,
+    line: 0,
+    note: "",
     ...extra,
   });
 
-  const lin = (i: number) => Math.floor(i / n);
-  const col = (i: number) => i % n;
-  const quad = (i: number) => `${Math.floor(lin(i) / ch)},${Math.floor(col(i) / cw)}`;
+  const rowOf = (i: number) => Math.floor(i / n);
+  const colOf = (i: number) => i % n;
+  const boxOf = (i: number) => `${Math.floor(rowOf(i) / bh)},${Math.floor(colOf(i) / bw)}`;
 
   // Devolve qual regra barrou o dígito, ou null se ele cabe. Devolver a REGRA em
   // vez de um booleano é o que deixa a nota dizer por que não deu.
-  const conflitoDe = (i: number, d: number): "linha" | "coluna" | "quadrante" | null => {
-    for (let k = 0; k < n; k++) if (g[lin(i) * n + k] === d) return "linha";
-    for (let k = 0; k < n; k++) if (g[k * n + col(i)] === d) return "coluna";
-    for (let k = 0; k < n * n; k++) if (quad(k) === quad(i) && g[k] === d) return "quadrante";
+  const conflictOf = (i: number, d: number): "linha" | "coluna" | "quadrante" | null => {
+    for (let k = 0; k < n; k++) if (g[rowOf(i) * n + k] === d) return "linha";
+    for (let k = 0; k < n; k++) if (g[k * n + colOf(i)] === d) return "coluna";
+    for (let k = 0; k < n * n; k++) if (boxOf(k) === boxOf(i) && g[k] === d) return "quadrante";
     return null;
   };
 
-  const vazias = g.map((v, i) => (v === 0 ? i : -1)).filter((i) => i >= 0);
+  const empties = g.map((v, i) => (v === 0 ? i : -1)).filter((i) => i >= 0);
 
   out.push(
     base({
-      linha: 0,
-      nota: `Tabuleiro ${n}x${n} com ${vazias.length} lacuna${vazias.length === 1 ? "" : "s"}. As opções de cada célula são os dígitos de 1 a ${n}, a validade é a regra do sudoku (linha, coluna e quadrante) e o desfazer é apagar. O algoritmo é o mesmo de sempre.`,
+      line: 0,
+      note: `Tabuleiro ${n}x${n} com ${empties.length} lacuna${empties.length === 1 ? "" : "s"}. As opções de cada célula são os dígitos de 1 a ${n}, a validade é a regra do sudoku (linha, coluna e quadrante) e o desfazer é apagar. O algoritmo é o mesmo de sempre.`,
     })
   );
 
-  const resolver = (): boolean => {
-    if (out.length > LIMITE_PASSOS) {
-      estourou = true;
+  const solve = (): boolean => {
+    if (out.length > STEP_LIMIT) {
+      overflowed = true;
       return true;
     }
     const i = g.indexOf(0);
     if (i < 0) return true;
-    prof++;
+    depth++;
     for (let d = 1; d <= n; d++) {
-      tentativas++;
-      const c = conflitoDe(i, d);
+      attempts++;
+      const c = conflictOf(i, d);
       if (c) {
         out.push(
           base({
-            foco: i,
-            tentativa: d,
-            conflito: c,
-            linha: 4,
-            nota: `Célula da linha ${lin(i) + 1}, coluna ${col(i) + 1}: tento ${d}. Já existe um ${d} ${c === "linha" ? "nesta linha" : c === "coluna" ? "nesta coluna" : "neste quadrante"}, então este dígito não serve. Passo para o próximo.`,
+            focus: i,
+            attempt: d,
+            conflict: c,
+            line: 4,
+            note: `Célula da linha ${rowOf(i) + 1}, coluna ${colOf(i) + 1}: tento ${d}. Já existe um ${d} ${c === "linha" ? "nesta linha" : c === "coluna" ? "nesta coluna" : "neste quadrante"}, então este dígito não serve. Passo para o próximo.`,
           })
         );
         continue;
       }
       g[i] = d;
-      colocacoes++;
+      placements++;
       out.push(
         base({
-          foco: i,
-          tentativa: d,
-          colocou: true,
-          linha: 5,
-          nota: `${d} cabe na linha ${lin(i) + 1}, coluna ${col(i) + 1}: nenhum conflito nas três regras. Escrevo e desço para a próxima célula vazia. Cuidado: caber agora não quer dizer estar certo, é só uma aposta.`,
+          focus: i,
+          attempt: d,
+          placed: true,
+          line: 5,
+          note: `${d} cabe na linha ${rowOf(i) + 1}, coluna ${colOf(i) + 1}: nenhum conflito nas três regras. Escrevo e desço para a próxima célula vazia. Cuidado: caber agora não quer dizer estar certo, é só uma aposta.`,
         })
       );
-      if (resolver()) return true;
+      if (solve()) return true;
       g[i] = 0;
-      retrocessos++;
+      backtracks++;
       out.push(
         base({
-          foco: i,
-          tentativa: d,
-          apagou: true,
-          linha: 8,
-          nota: `Nenhum dígito serviu daqui para a frente, então a aposta de pôr ${d} na linha ${lin(i) + 1}, coluna ${col(i) + 1} estava errada. Apago e tento o próximo valor. É o retrocesso, e é o único jeito de descobrir que uma escolha antiga era ruim.`,
+          focus: i,
+          attempt: d,
+          erased: true,
+          line: 8,
+          note: `Nenhum dígito serviu daqui para a frente, então a aposta de pôr ${d} na linha ${rowOf(i) + 1}, coluna ${colOf(i) + 1} estava errada. Apago e tento o próximo valor. É o retrocesso, e é o único jeito de descobrir que uma escolha antiga era ruim.`,
         })
       );
     }
-    prof--;
+    depth--;
     return false;
   };
 
-  const resolveu = resolver();
-  const ok = resolveu && !estourou;
-  prof = 0;
+  const solved = solve();
+  const ok = solved && !overflowed;
+  depth = 0;
   out.push(
     base({
       // O verde do card é uma afirmação: só vale quando o tabuleiro foi mesmo
       // resolvido. Interrupção por limite e tabuleiro sem solução são os dois
       // casos em que ele mentiria.
       ok,
-      linha: 2,
-      nota: estourou
-        ? `Parei em ${LIMITE_PASSOS} passos para não travar o navegador. Isso já é a lição: este tabuleiro exige mais passos do que uma animação consegue mostrar.`
-        : resolveu
-          ? `Resolvido. Foram ${tentativas} tentativas de dígito para ${vazias.length} lacunas, com ${retrocessos} retrocessos. A razão entre esses dois primeiros números é o preço da força bruta: cada célula custou em média ${(tentativas / vazias.length).toFixed(1)} tentativas.`
+      line: 2,
+      note: overflowed
+        ? `Parei em ${STEP_LIMIT} passos para não travar o navegador. Isso já é a lição: este tabuleiro exige mais passos do que uma animação consegue mostrar.`
+        : solved
+          ? `Resolvido. Foram ${attempts} tentativas de dígito para ${empties.length} lacunas, com ${backtracks} retrocessos. A razão entre esses dois primeiros números é o preço da força bruta: cada célula custou em média ${(attempts / empties.length).toFixed(1)} tentativas.`
           : `Este tabuleiro não tem solução, e o backtracking provou isso do único jeito que ele sabe: tentando tudo.`,
     })
   );
@@ -253,104 +261,64 @@ export function gerarPassos(preset: Preset): Passo[] {
 }
 
 export function BacktrackingSudoku() {
-  const [presetKey, setPresetKey] = useState("quatro");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("four");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(preset), [preset]);
   const n = preset.n;
-  const [ch, cw] = preset.caixa;
-  const fixas = useMemo(() => new Set(preset.dados.map((v, i) => (v !== 0 ? i : -1)).filter((i) => i >= 0)), [preset]);
+  const [bh, bw] = preset.box;
+  const fixed = useMemo(() => new Set(preset.data.map((v, i) => (v !== 0 ? i : -1)).filter((i) => i >= 0)), [preset]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · o mesmo backtracking resolvendo sudoku",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O preset é o único eixo de altura da peça: ele troca a grade (156px no
+    // 4x4, 346px nos 9x9) e o tamanho da dica. O passo não entra — medido, ele
+    // vale 20px em 956 estados.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const p = steps[viz.step];
+
+  const changePreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const lacunas = preset.dados.filter((v) => v === 0).length;
+  const gaps = preset.data.filter((v) => v === 0).length;
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o mesmo backtracking resolvendo sudoku</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => changePreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
-        <div className={`hs-fase ${p.apagou ? "f-ordenar" : p.colocou ? "f-fim" : ""}`}>
+        {/* `f-ordenar` e `f-fim` são API de CSS (`.hs-fase.f-ordenar`), não
+            identificadores deste arquivo: os nomes ficam em português. */}
+        <div className={`hs-fase ${p.erased ? "f-ordenar" : p.placed ? "f-fim" : ""}`}>
           <span className="hs-fase-selo">
-            {p.apagou ? "3 · desfazer" : p.colocou ? "1 · escolher" : p.conflito ? "opção inválida" : "início"}
+            {p.erased ? "3 · desfazer" : p.placed ? "1 · escolher" : p.conflict ? "opção inválida" : "início"}
           </span>
           <span className="hs-fase-txt">
-            {p.foco >= 0
-              ? `linha ${Math.floor(p.foco / n) + 1}, coluna ${(p.foco % n) + 1} · testando ${p.tentativa}`
-              : `${lacunas} lacunas para preencher`}
+            {p.focus >= 0
+              ? `linha ${Math.floor(p.focus / n) + 1}, coluna ${(p.focus % n) + 1} · testando ${p.attempt}`
+              : `${gaps} lacunas para preencher`}
           </span>
         </div>
 
@@ -359,50 +327,55 @@ export function BacktrackingSudoku() {
             className={`bt-sudoku n${n}`}
             style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}
             role="img"
-            aria-label={`Tabuleiro de sudoku ${n} por ${n}. ${p.nota}`}
+            aria-label={`Tabuleiro de sudoku ${n} por ${n}. ${p.note}`}
           >
-            {p.grade.map((v, i) => {
+            {p.grid.map((v, i) => {
               const cls = ["bt-cel"];
-              if (fixas.has(i)) cls.push("fixa");
-              if (i === p.foco) cls.push(p.conflito ? "conflito" : p.apagou ? "apagou" : "foco");
-              if (Math.floor(i / n) % ch === 0) cls.push("topo");
-              if ((i % n) % cw === 0) cls.push("esq");
+              if (fixed.has(i)) cls.push("fixa");
+              if (i === p.focus) cls.push(p.conflict ? "conflito" : p.erased ? "apagou" : "foco");
+              if (Math.floor(i / n) % bh === 0) cls.push("topo");
+              if ((i % n) % bw === 0) cls.push("esq");
               return (
                 <span key={i} className={cls.join(" ")}>
-                  {i === p.foco && p.conflito ? p.tentativa : v === 0 ? "" : v}
+                  {i === p.focus && p.conflict ? p.attempt : v === 0 ? "" : v}
                 </span>
               );
             })}
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">sudoku.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com os 306px do
+              código (medido). O `.viz-code-slot` é o truque de grid 1fr→0fr. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">sudoku.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === p.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">dígito em teste</span>
-              <span className="viz-var-val best">{p.tentativa > 0 ? p.tentativa : "-"}</span>
+              <span className="viz-var-val best">{p.attempt > 0 ? p.attempt : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">regra que barrou</span>
-              <span className="viz-var-val">{p.conflito ?? (p.colocou ? "nenhuma" : "-")}</span>
+              <span className="viz-var-val">{p.conflict ?? (p.placed ? "nenhuma" : "-")}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">células ainda vazias</span>
-              <span className="viz-var-val">{p.grade.filter((v) => v === 0).length}</span>
+              <span className="viz-var-val">{p.grid.filter((v) => v === 0).length}</span>
             </div>
           </div>
         </div>
@@ -410,69 +383,20 @@ export function BacktrackingSudoku() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>lacunas do tabuleiro</span>
-            <strong>{lacunas}</strong>
+            <strong>{gaps}</strong>
           </div>
           <div className="bigo-stat">
             <span>dígitos testados</span>
-            <strong>{p.tentativas}</strong>
+            <strong>{p.attempts}</strong>
           </div>
           <div className="bigo-stat">
             <span>escritas na grade</span>
-            <strong>{p.colocacoes}</strong>
+            <strong>{p.placements}</strong>
           </div>
           <div className="bigo-stat">
             <span>retrocessos</span>
-            <strong>{p.retrocessos}</strong>
+            <strong>{p.backtracks}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -484,21 +408,12 @@ export function BacktrackingSudoku() {
           virou a regra do sudoku, e o desfazer virou apagar a célula.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/BacktrackingVisualizer.tsx
+++ b/content/visualizers/BacktrackingVisualizer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BacktrackingVisualizer, a árvore que não existe.
@@ -23,28 +23,34 @@ import { createPortal } from "react-dom";
 // vão ficar, e dá para seguir um ramo específico do começo ao fim. Se o layout
 // acompanhasse a exploração, tudo se moveria a cada passo e o aluno leria
 // movimento onde só houve descoberta.
+//
+// A casca (altura que cabe na tela, painel com cabeçalho e controles parados,
+// código recolhível, teclado) vem do `useVisualizer`. Medido: no fluxo do
+// artigo a peça pede 1.369px de um orçamento de 816 a 1512x900, e o pico é o
+// passo 12 de 32 — 107px acima do primeiro passo e 100 acima do último, porque
+// quem cresce é a pilha de chamadas (19 → 120px), que sobe e desce.
 // ---------------------------------------------------------------------------
 
-type Acao = "inicio" | "escolher" | "registrar" | "descer" | "retroceder" | "fim";
+type Action = "inicio" | "escolher" | "registrar" | "descer" | "retroceder" | "fim";
 
-type No = { id: string; rotulo: string; prof: number; filhos: No[]; x: number; y: number };
+type TreeNode = { id: string; label: string; depth: number; children: TreeNode[]; x: number; y: number };
 
-type Passo = {
-  noAtual: string;
-  visitados: string[];
-  registrados: string[];
-  parcial: number[];
-  pilha: string[];
-  solucoes: number[][];
-  acao: Acao;
-  nos: number;
-  retrocessos: number;
-  linha: number;
-  nota: string;
+type Step = {
+  currentNode: string;
+  visited: string[];
+  recorded: string[];
+  partial: number[];
+  stack: string[];
+  solutions: number[][];
+  action: Action;
+  nodeCount: number;
+  backtracks: number;
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "def backtrack(parcial, opcoes):",
   "    if completo(parcial):",
   "        solucoes.append(parcial[:])   # cópia, e isso importa",
@@ -56,15 +62,15 @@ const CODIGO = [
   "            parcial.pop()             # 3. desfazer",
 ];
 
-type Modo = "subconjuntos" | "permutacoes" | "combinacoes";
+type Mode = "subconjuntos" | "permutacoes" | "combinacoes";
 
-const NOMES: Record<Modo, string> = {
+const MODE_NAMES: Record<Mode, string> = {
   subconjuntos: "Subconjuntos de 1, 2, 3",
   permutacoes: "Permutações de 1, 2, 3",
   combinacoes: "Combinações de 2 entre 1, 2, 3, 4",
 };
 
-const DICAS: Record<Modo, string> = {
+const MODE_HINTS: Record<Mode, string> = {
   subconjuntos:
     "Todo nó da árvore é uma resposta, inclusive a raiz (o conjunto vazio). Repare que o algoritmo registra a solução na ENTRADA de cada chamada, antes de olhar as opções, e por isso são 2^3 = 8 respostas para 8 nós.",
   permutacoes:
@@ -73,136 +79,135 @@ const DICAS: Record<Modo, string> = {
     "Combinação fixa o tamanho: dois elementos entre quatro, sem repetir e sem ligar para a ordem. Só os nós de profundidade 2 são resposta, e a regra de nunca voltar para trás no array é o que impede 1,2 e 2,1 de aparecerem os dois.",
 };
 
-const MODOS: Modo[] = ["subconjuntos", "permutacoes", "combinacoes"];
+const MODES: Mode[] = ["subconjuntos", "permutacoes", "combinacoes"];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
-const rotuloDe = (v: number[]) => (v.length === 0 ? "∅" : v.join(" "));
+const labelOf = (v: number[]) => (v.length === 0 ? "∅" : v.join(" "));
 
 // Gera a árvore inteira e a lista de passos numa passada só. A árvore é o mapa
 // do percurso, e os passos são o percurso: os dois saem do mesmo laço, então
 // não têm como divergir.
-export function gerar(modo: Modo): { raiz: No; passos: Passo[]; folhas: number } {
-  const valores = modo === "combinacoes" ? [1, 2, 3, 4] : [1, 2, 3];
+export function generate(mode: Mode): { root: TreeNode; steps: Step[]; leaves: number } {
+  const values = mode === "combinacoes" ? [1, 2, 3, 4] : [1, 2, 3];
   const k = 2; // tamanho fixo das combinações
-  const passos: Passo[] = [];
-  const parcial: number[] = [];
-  const solucoes: number[][] = [];
-  const visitados: string[] = [];
-  const registrados: string[] = [];
-  const pilha: string[] = [];
-  let contaNos = 0;
-  let retrocessos = 0;
+  const steps: Step[] = [];
+  const partial: number[] = [];
+  const solutions: number[][] = [];
+  const visited: string[] = [];
+  const recorded: string[] = [];
+  const stack: string[] = [];
+  let nodeCount = 0;
+  let backtracks = 0;
 
-  const raiz: No = { id: "r", rotulo: "∅", prof: 0, filhos: [], x: 0, y: 0 };
+  const root: TreeNode = { id: "r", label: "∅", depth: 0, children: [], x: 0, y: 0 };
 
-  const base = (noAtual: string, acao: Acao, linha: number, nota: string, ok?: boolean): Passo => ({
-    noAtual,
-    visitados: [...visitados],
-    registrados: [...registrados],
-    parcial: [...parcial],
-    pilha: [...pilha],
-    solucoes: solucoes.map((s) => [...s]),
-    acao,
-    nos: contaNos,
-    retrocessos,
-    linha,
-    nota,
+  const base = (currentNode: string, action: Action, line: number, note: string, ok?: boolean): Step => ({
+    currentNode,
+    visited: [...visited],
+    recorded: [...recorded],
+    partial: [...partial],
+    stack: [...stack],
+    solutions: solutions.map((s) => [...s]),
+    action,
+    nodeCount,
+    backtracks,
+    line,
+    note,
     ok,
   });
 
-  const completo = () =>
-    modo === "subconjuntos" ? true : modo === "permutacoes" ? parcial.length === valores.length : parcial.length === k;
+  const isComplete = () =>
+    mode === "subconjuntos" ? true : mode === "permutacoes" ? partial.length === values.length : partial.length === k;
 
-  const explorar = (no: No, inicio: number, usados: boolean[]) => {
-    contaNos++;
-    visitados.push(no.id);
-    pilha.push(rotuloDe(parcial));
-    passos.push(
+  const explore = (node: TreeNode, start: number, used: boolean[]) => {
+    nodeCount++;
+    visited.push(node.id);
+    stack.push(labelOf(partial));
+    steps.push(
       base(
-        no.id,
+        node.id,
         "descer",
         0,
-        `Entrei na chamada com a solução parcial [${rotuloDe(parcial)}]. A pilha tem ${pilha.length} chamada${pilha.length === 1 ? "" : "s"} agora.`
+        `Entrei na chamada com a solução parcial [${labelOf(partial)}]. A pilha tem ${stack.length} chamada${stack.length === 1 ? "" : "s"} agora.`
       )
     );
 
-    if (completo()) {
-      solucoes.push([...parcial]);
-      registrados.push(no.id);
-      passos.push(
+    if (isComplete()) {
+      solutions.push([...partial]);
+      recorded.push(node.id);
+      steps.push(
         base(
-          no.id,
+          node.id,
           "registrar",
           2,
-          `[${rotuloDe(parcial)}] é uma solução completa, então guardo. Repare no [:] do código: eu guardo uma CÓPIA. A lista parcial é uma só e vai continuar mudando; sem a cópia, todas as ${solucoes.length} respostas apontariam para ela e terminariam vazias.`,
+          `[${labelOf(partial)}] é uma solução completa, então guardo. Repare no [:] do código: eu guardo uma CÓPIA. A lista parcial é uma só e vai continuar mudando; sem a cópia, todas as ${solutions.length} respostas apontariam para ela e terminariam vazias.`,
           true
         )
       );
-      if (modo !== "subconjuntos") {
-        pilha.pop();
+      if (mode !== "subconjuntos") {
+        stack.pop();
         return;
       }
     }
 
-    for (let i = modo === "permutacoes" ? 0 : inicio; i < valores.length; i++) {
-      if (modo === "permutacoes" && usados[i]) continue;
-      const v = valores[i];
-      if (modo === "combinacoes" && parcial.length + (valores.length - i) < k) break;
+    for (let i = mode === "permutacoes" ? 0 : start; i < values.length; i++) {
+      if (mode === "permutacoes" && used[i]) continue;
+      const v = values[i];
+      if (mode === "combinacoes" && partial.length + (values.length - i) < k) break;
 
-      parcial.push(v);
-      if (modo === "permutacoes") usados[i] = true;
-      const filho: No = { id: `${no.id}-${v}`, rotulo: rotuloDe(parcial), prof: no.prof + 1, filhos: [], x: 0, y: 0 };
-      no.filhos.push(filho);
-      passos.push(
+      partial.push(v);
+      if (mode === "permutacoes") used[i] = true;
+      const child: TreeNode = { id: `${node.id}-${v}`, label: labelOf(partial), depth: node.depth + 1, children: [], x: 0, y: 0 };
+      node.children.push(child);
+      steps.push(
         base(
-          filho.id,
+          child.id,
           "escolher",
           6,
-          `Escolho ${v} e ponho na solução parcial: [${rotuloDe(parcial)}]. ${
-            modo === "subconjuntos"
+          `Escolho ${v} e ponho na solução parcial: [${labelOf(partial)}]. ${
+            mode === "subconjuntos"
               ? `Como só olho do índice ${i + 1} em diante daqui para frente, nunca vou montar um subconjunto fora da ordem original.`
-              : modo === "permutacoes"
+              : mode === "permutacoes"
                 ? `Marco ${v} como usado: numa permutação cada elemento entra uma vez só, mas em qualquer posição.`
                 : `Daqui em diante só olho do índice ${i + 1} para a frente, que é o que impede 1,2 e 2,1 de contarem como combinações diferentes.`
           }`
         )
       );
 
-      explorar(filho, i + 1, usados);
+      explore(child, i + 1, used);
 
-      const removido = parcial.pop();
-      if (modo === "permutacoes") usados[i] = false;
-      retrocessos++;
-      passos.push(
+      const removed = partial.pop();
+      if (mode === "permutacoes") used[i] = false;
+      backtracks++;
+      steps.push(
         base(
-          filho.id,
+          child.id,
           "retroceder",
           8,
-          `Retrocesso: tiro ${removido} da solução parcial, que volta a ser [${rotuloDe(parcial)}]. Repare que a árvore não perdeu nada, porque ela é só o desenho do caminho. Quem encolheu foi a lista, que é a única coisa que existe de verdade na memória.`
+          `Retrocesso: tiro ${removed} da solução parcial, que volta a ser [${labelOf(partial)}]. Repare que a árvore não perdeu nada, porque ela é só o desenho do caminho. Quem encolheu foi a lista, que é a única coisa que existe de verdade na memória.`
         )
       );
     }
 
-    if (!(completo() && modo !== "subconjuntos")) pilha.pop();
+    if (!(isComplete() && mode !== "subconjuntos")) stack.pop();
   };
 
-  passos.push(
+  steps.push(
     base(
       "r",
       "inicio",
       0,
-      `${NOMES[modo]}. A solução parcial começa vazia e o algoritmo vai fazer sempre a mesma coisa: escolher uma opção, explorar tudo que sai dela, e desfazer a escolha para poder tentar a próxima.`
+      `${MODE_NAMES[mode]}. A solução parcial começa vazia e o algoritmo vai fazer sempre a mesma coisa: escolher uma opção, explorar tudo que sai dela, e desfazer a escolha para poder tentar a próxima.`
     )
   );
-  explorar(raiz, 0, new Array(valores.length).fill(false));
-  passos.push(
+  explore(root, 0, new Array(values.length).fill(false));
+  steps.push(
     base(
       "r",
       "fim",
       0,
-      `Acabou: ${solucoes.length} soluções, ${contaNos} nós visitados e ${retrocessos} retrocessos. A solução parcial voltou a ficar vazia, exatamente como começou, porque todo escolher teve o seu desfazer.`,
+      `Acabou: ${solutions.length} soluções, ${nodeCount} nós visitados e ${backtracks} retrocessos. A solução parcial voltou a ficar vazia, exatamente como começou, porque todo escolher teve o seu desfazer.`,
       true
     )
   );
@@ -210,139 +215,100 @@ export function gerar(modo: Modo): { raiz: No; passos: Passo[]; folhas: number }
   // Layout: x por posição de folha, y por profundidade. Calculado sobre a
   // árvore COMPLETA, para o desenho não se mexer durante a animação.
   let slot = 0;
-  const posicionar = (n: No): number => {
-    if (n.filhos.length === 0) {
+  const place = (n: TreeNode): number => {
+    if (n.children.length === 0) {
       n.x = slot++;
       return n.x;
     }
-    const xs = n.filhos.map(posicionar);
+    const xs = n.children.map(place);
     n.x = (xs[0] + xs[xs.length - 1]) / 2;
     return n.x;
   };
-  posicionar(raiz);
-  const marcarY = (n: No) => {
-    n.y = n.prof;
-    n.filhos.forEach(marcarY);
+  place(root);
+  const markY = (n: TreeNode) => {
+    n.y = n.depth;
+    n.children.forEach(markY);
   };
-  marcarY(raiz);
+  markY(root);
 
-  return { raiz, passos, folhas: slot };
+  return { root, steps, leaves: slot };
 }
 
-function achatar(n: No, saida: No[] = []): No[] {
-  saida.push(n);
-  n.filhos.forEach((f) => achatar(f, saida));
-  return saida;
+function flatten(n: TreeNode, out: TreeNode[] = []): TreeNode[] {
+  out.push(n);
+  n.children.forEach((f) => flatten(f, out));
+  return out;
 }
 
-const NO_R = 17;
+const NODE_R = 17;
 
 export function BacktrackingVisualizer() {
-  const [modo, setModo] = useState<Modo>("subconjuntos");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const [mode, setMode] = useState<Mode>("subconjuntos");
 
-  useEffect(() => setMounted(true), []);
+  const { root, steps, leaves } = useMemo(() => generate(mode), [mode]);
+  const allNodes = useMemo(() => flatten(root), [root]);
 
-  const { raiz, passos, folhas } = useMemo(() => gerar(modo), [modo]);
-  const nos = useMemo(() => achatar(raiz), [raiz]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const viz = useVisualizer({
+    title: "Visualizador · backtracking: escolher, explorar, desfazer",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: 4,
+    // O que muda a altura da peça é o modo: ele decide a profundidade da árvore
+    // (o desenho mede 260px com 3 níveis e 198px com 2) e o tamanho da dica.
+    // A pilha de chamadas cresce ao longo da animação e o hook não remede por
+    // passo — não precisa: o passo 0 já pede 1.262px de um orçamento de 816.
+    measureOn: [mode],
+  });
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const p = steps[viz.step];
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarModo = (m: Modo) => {
-    reiniciar();
-    setModo(m);
+  const changeMode = (m: Mode) => {
+    viz.reset();
+    setMode(m);
   };
 
-  const profMax = Math.max(...nos.map((n) => n.prof));
-  const passoX = 74;
-  const largura = Math.max(320, folhas * passoX);
-  const W = largura + NO_R * 2;
-  const H = 40 + profMax * 62 + NO_R * 2;
-  const cx = (n: No) => NO_R + ((n.x + 0.5) * largura) / folhas;
-  const cy = (n: No) => 22 + NO_R + n.y * 62;
+  const maxDepth = Math.max(...allNodes.map((n) => n.depth));
+  const stepX = 74;
+  const span = Math.max(320, leaves * stepX);
+  const W = span + NODE_R * 2;
+  const H = 40 + maxDepth * 62 + NODE_R * 2;
+  const cx = (n: TreeNode) => NODE_R + ((n.x + 0.5) * span) / leaves;
+  const cy = (n: TreeNode) => 22 + NODE_R + n.y * 62;
 
-  const vistos = new Set(p.visitados);
-  const registrados = new Set(p.registrados);
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
+  const seen = new Set(p.visited);
+  const recorded = new Set(p.recorded);
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · backtracking: escolher, explorar, desfazer</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {MODOS.map((m) => (
-            <button key={m} className={`bigo-chip${modo === m ? " on" : ""}`} onClick={() => trocarModo(m)} aria-pressed={modo === m}>
-              {NOMES[m]}
+          {MODES.map((m) => (
+            <button key={m} className={`bigo-chip${mode === m ? " on" : ""}`} onClick={() => changeMode(m)} aria-pressed={mode === m}>
+              {MODE_NAMES[m]}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{DICAS[modo]}</p>
+        <p className="tt-legenda-arvore">{MODE_HINTS[mode]}</p>
 
-        <div className={`hs-fase ${p.acao === "retroceder" ? "f-ordenar" : p.acao === "registrar" ? "f-fim" : ""}`}>
+        {/* `f-ordenar` e `f-fim` são API de CSS (`.hs-fase.f-ordenar`), não
+            identificadores deste arquivo: os nomes ficam em português. */}
+        <div className={`hs-fase ${p.action === "retroceder" ? "f-ordenar" : p.action === "registrar" ? "f-fim" : ""}`}>
           <span className="hs-fase-selo">
-            {p.acao === "escolher"
+            {p.action === "escolher"
               ? "1 · escolher"
-              : p.acao === "descer"
+              : p.action === "descer"
                 ? "2 · explorar"
-                : p.acao === "retroceder"
+                : p.action === "retroceder"
                   ? "3 · desfazer"
-                  : p.acao === "registrar"
+                  : p.action === "registrar"
                     ? "solução completa"
                     : "início"}
           </span>
           <span className="hs-fase-txt">
-            solução parcial: [{rotuloDe(p.parcial)}] · soluções guardadas: {p.solucoes.length}
+            solução parcial: [{labelOf(p.partial)}] · soluções guardadas: {p.solutions.length}
           </span>
         </div>
 
@@ -353,31 +319,31 @@ export function BacktrackingVisualizer() {
             height={H}
             viewBox={`0 0 ${W} ${H}`}
             role="img"
-            aria-label={`Árvore de decisão do backtracking. ${p.nota}`}
+            aria-label={`Árvore de decisão do backtracking. ${p.note}`}
           >
-            {nos.map((n) =>
-              n.filhos.map((f) => (
+            {allNodes.map((n) =>
+              n.children.map((f) => (
                 <line
                   key={`${n.id}->${f.id}`}
-                  className={`tt-aresta${vistos.has(f.id) ? " ativa" : ""}`}
+                  className={`tt-aresta${seen.has(f.id) ? " ativa" : ""}`}
                   x1={cx(n)}
-                  y1={cy(n) + NO_R}
+                  y1={cy(n) + NODE_R}
                   x2={cx(f)}
-                  y2={cy(f) - NO_R}
-                  opacity={vistos.has(f.id) ? 1 : 0.18}
+                  y2={cy(f) - NODE_R}
+                  opacity={seen.has(f.id) ? 1 : 0.18}
                 />
               ))
             )}
-            {nos.map((n) => {
+            {allNodes.map((n) => {
               const cls = ["tt-no", "bt-no"];
-              if (n.id === p.noAtual) cls.push("on");
-              else if (registrados.has(n.id)) cls.push("filho");
-              else if (!vistos.has(n.id)) cls.push("porvir");
+              if (n.id === p.currentNode) cls.push("on");
+              else if (recorded.has(n.id)) cls.push("filho");
+              else if (!seen.has(n.id)) cls.push("porvir");
               return (
                 <g key={n.id} className={cls.join(" ")}>
-                  <circle cx={cx(n)} cy={cy(n)} r={NO_R} />
+                  <circle cx={cx(n)} cy={cy(n)} r={NODE_R} />
                   <text x={cx(n)} y={cy(n) + 4} textAnchor="middle">
-                    {n.rotulo}
+                    {n.label}
                   </text>
                 </g>
               );
@@ -391,11 +357,11 @@ export function BacktrackingVisualizer() {
               A solução parcial <em>a única lista que existe na memória</em>
             </div>
             <div className="hp-arr">
-              {p.parcial.length === 0 ? (
+              {p.partial.length === 0 ? (
                 <span className="bb-array-nota">vazia</span>
               ) : (
-                p.parcial.map((v, k) => (
-                  <span key={k} className={`hp-cel${p.acao === "escolher" && k === p.parcial.length - 1 ? " foco troca" : " fixo"}`}>
+                p.partial.map((v, k) => (
+                  <span key={k} className={`hp-cel${p.action === "escolher" && k === p.partial.length - 1 ? " foco troca" : " fixo"}`}>
                     <i>{k}</i>
                     {v}
                   </span>
@@ -408,15 +374,15 @@ export function BacktrackingVisualizer() {
               A pilha de chamadas <em>o que a recursão guarda de verdade</em>
             </div>
             <div className="bt-pilha">
-              {p.pilha.length === 0 ? (
+              {p.stack.length === 0 ? (
                 <span className="bb-array-nota">vazia</span>
               ) : (
                 // A inversão é só do CSS (column-reverse): o primeiro quadro do
                 // array é a chamada mais antiga e aparece embaixo, o último é o
                 // topo da pilha e aparece em cima. Inverter também aqui era
                 // desfazer o efeito e deixar o destaque no quadro errado.
-                p.pilha.map((t, k) => (
-                  <span key={k} className={`bt-quadro${k === p.pilha.length - 1 ? " topo" : ""}`}>
+                p.stack.map((t, k) => (
+                  <span key={k} className={`bt-quadro${k === p.stack.length - 1 ? " topo" : ""}`}>
                     backtrack([{t}])
                   </span>
                 ))
@@ -430,45 +396,50 @@ export function BacktrackingVisualizer() {
             As soluções guardadas <em>cada uma é uma cópia, tirada no instante em que foi encontrada</em>
           </div>
           <div className="bt-solucoes">
-            {p.solucoes.length === 0 ? (
+            {p.solutions.length === 0 ? (
               <span className="bb-array-nota">nenhuma ainda</span>
             ) : (
-              p.solucoes.map((s, k) => (
-                <span key={k} className={`bt-sol${k === p.solucoes.length - 1 && p.acao === "registrar" ? " nova" : ""}`}>
-                  [{rotuloDe(s)}]
+              p.solutions.map((s, k) => (
+                <span key={k} className={`bt-sol${k === p.solutions.length - 1 && p.action === "registrar" ? " nova" : ""}`}>
+                  [{labelOf(s)}]
                 </span>
               ))
             )}
           </div>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">backtrack.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com os 281px do
+              código (medido). O `.viz-code-slot` é o truque de grid 1fr→0fr. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">backtrack.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === p.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">parcial</span>
-              <span className="viz-var-val best">[{rotuloDe(p.parcial)}]</span>
+              <span className="viz-var-val best">[{labelOf(p.partial)}]</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">profundidade da pilha</span>
-              <span className="viz-var-val">{p.pilha.length}</span>
+              <span className="viz-var-val">{p.stack.length}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">soluções guardadas</span>
-              <span className="viz-var-val">{p.solucoes.length}</span>
+              <span className="viz-var-val">{p.solutions.length}</span>
             </div>
           </div>
         </div>
@@ -476,69 +447,20 @@ export function BacktrackingVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>nós visitados</span>
-            <strong>{p.nos}</strong>
+            <strong>{p.nodeCount}</strong>
           </div>
           <div className="bigo-stat">
             <span>soluções encontradas</span>
-            <strong>{p.solucoes.length}</strong>
+            <strong>{p.solutions.length}</strong>
           </div>
           <div className="bigo-stat">
             <span>retrocessos</span>
-            <strong>{p.retrocessos}</strong>
+            <strong>{p.backtracks}</strong>
           </div>
           <div className="bigo-stat">
             <span>nós da árvore inteira</span>
-            <strong>{nos.length}</strong>
+            <strong>{allNodes.length}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -548,21 +470,12 @@ export function BacktrackingVisualizer() {
           retrocessos é sempre igual ao de arestas da árvore: todo escolher tem exatamente um desfazer.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/BinarioComplemento.tsx
+++ b/content/visualizers/BinarioComplemento.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinarioComplemento, os dois passos que viram o sinal.
@@ -21,22 +22,33 @@ import { createPortal } from "react-dom";
 // ausência de ambiguidade, porque o vai-um estoura e some) e o 128, cujo oposto
 // é ele mesmo. Preset que só mostra o caso bonito ensina a receita, não a
 // regra.
+//
+// A casca vem do `useVisualizer`: medição de altura, painel com cabeçalho e
+// controles parados, código recolhível e os controles de reprodução. Aqui fica
+// só o que é DESTE visualizador. Contrato em `content/visualizers/README.md`.
+//
+// Sobre a altura: a largura da palavra é constante (`N = 8`) e não há controle
+// nenhum que a alcance, então a fita de bits nunca é eixo de altura. O que move
+// a peça são os dois blocos CONDICIONAIS — a linha do vai-um e o painel da
+// prova —, que não crescem: eles aparecem. Medido a 1512x900, no fluxo do
+// artigo: 919px sem os dois, 945 com o vai-um, 1089 com a prova junto. Os 170px
+// de amplitude são inteiramente deles.
 // ---------------------------------------------------------------------------
 
 const N = 8;
 
-type Passo = {
+type Step = {
   bits: number[];
-  destaque: number;
+  highlight: number;
   carry: number[]; // vai-um por posição, -1 quando não se aplica
-  fase: "inicio" | "inverter" | "somar" | "pronto" | "prova";
-  soma: number[] | null; // resultado da prova x + (-x)
-  linha: number;
-  nota: string;
+  phase: "start" | "invert" | "add" | "done" | "proof";
+  sum: number[] | null; // resultado da prova x + (-x)
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "# complemento de dois, em 8 bits",
   "positivo = 0b00011010            # 26",
   "invertido = ~positivo & 0xFF     # 1. inverte todos",
@@ -46,147 +58,174 @@ const CODIGO = [
   "(positivo + negativo) & 0xFF     # o vai-um cai fora",
 ];
 
-type Preset = { key: string; rotulo: string; valor: number; dica: string };
+type Preset = { key: string; label: string; value: number; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "vinteseis",
-    rotulo: "26",
-    valor: 26,
-    dica: "O caso comum. Acompanhe os dois passos e depois a prova: somar 26 com o resultado tem que dar zero em oito bits, senão a representação não serviria para o processador fazer subtração somando.",
+    key: "twentysix",
+    label: "26",
+    value: 26,
+    hint: "O caso comum. Acompanhe os dois passos e depois a prova: somar 26 com o resultado tem que dar zero em oito bits, senão a representação não serviria para o processador fazer subtração somando.",
   },
   {
-    key: "um",
-    rotulo: "1",
-    valor: 1,
-    dica: "O menor caso, e o mais revelador: o oposto de 1 é 11111111, ou seja, todos os bits ligados. Faz sentido, porque somar 1 a 11111111 dá zero com um vai-um que cai fora.",
+    key: "one",
+    label: "1",
+    value: 1,
+    hint: "O menor caso, e o mais revelador: o oposto de 1 é 11111111, ou seja, todos os bits ligados. Faz sentido, porque somar 1 a 11111111 dá zero com um vai-um que cai fora.",
   },
   {
-    key: "cento",
-    rotulo: "127, o maior positivo",
-    valor: 127,
-    dica: "O teto do lado positivo com 8 bits. Repare que o resultado, 10000001, tem o bit de sinal ligado e é lido como -127. Um a mais no positivo já não caberia: 128 não existe no tipo com sinal.",
+    key: "maxpositive",
+    label: "127, o maior positivo",
+    value: 127,
+    hint: "O teto do lado positivo com 8 bits. Repare que o resultado, 10000001, tem o bit de sinal ligado e é lido como -127. Um a mais no positivo já não caberia: 128 não existe no tipo com sinal.",
   },
   {
     key: "zero",
-    rotulo: "0, o teste da ambiguidade",
-    valor: 0,
-    dica: "Aqui está o motivo de o complemento de dois ter vencido. Inverter dá 11111111, somar 1 estoura e volta a 00000000: o oposto de zero é o próprio zero, e existe UMA representação só. Nas outras duas convenções existem duas, e a máquina precisa decidir o que fazer com a segunda.",
+    label: "0, o teste da ambiguidade",
+    value: 0,
+    hint: "Aqui está o motivo de o complemento de dois ter vencido. Inverter dá 11111111, somar 1 estoura e volta a 00000000: o oposto de zero é o próprio zero, e existe UMA representação só. Nas outras duas convenções existem duas, e a máquina precisa decidir o que fazer com a segunda.",
   },
   {
-    key: "cento28",
-    rotulo: "128, o que é o próprio oposto",
-    valor: 128,
-    dica: "O caso que quebra a simetria. O complemento de dois de 10000000 é 10000000: ele é o oposto de si mesmo. Por isso a faixa com sinal vai de -128 a 127, e não de -127 a 127: o -128 existe e o +128 não.",
+    key: "selfopposite",
+    label: "128, o que é o próprio oposto",
+    value: 128,
+    hint: "O caso que quebra a simetria. O complemento de dois de 10000000 é 10000000: ele é o oposto de si mesmo. Por isso a faixa com sinal vai de -128 a 127, e não de -127 a 127: o -128 existe e o +128 não.",
   },
 ];
 
-const VELOCIDADES = [0, 1400, 900, 600, 380, 220];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// Ritmo próprio: um bit invertido pede menos tempo que uma troca de array.
+const SPEEDS = [0, 1400, 900, 600, 380, 220];
+// A marcha em que a peça já vinha (o "1.5x"), preservada pelo `initialSpeed`.
+const INITIAL_SPEED = 4;
 
-const paraBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
-const paraNum = (b: number[]) => b.reduce((acc, x, k) => acc + (x << (N - 1 - k)), 0);
-const comSinal = (b: number[]) => (b[0] === 1 ? paraNum(b) - 256 : paraNum(b));
+const toBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
+const toNumber = (b: number[]) => b.reduce((acc, x, k) => acc + (x << (N - 1 - k)), 0);
+const toSigned = (b: number[]) => (b[0] === 1 ? toNumber(b) - 256 : toNumber(b));
 
-export function gerarPassos(valor: number): Passo[] {
-  const out: Passo[] = [];
-  const original = paraBits(valor);
-  const semCarry = new Array(N).fill(-1);
+/** A fita de oito células. `signMark` troca o expoente do bit da esquerda pelo papel dele. */
+function BitStrip({ bits, highlight, signMark }: { bits: number[]; highlight: number; signMark?: boolean }) {
+  return (
+    <div className="bn-fita">
+      {bits.map((b, k) => (
+        // `estatico`, `on`, `novo` e `sinal` são classes do CSS (bloco `.bn-bit`
+        // do `globals.css`), não identificadores deste arquivo: ficam como estão.
+        <span key={k} className={`bn-bit estatico${b ? " on" : ""}${k === highlight ? " novo" : ""}${k === 0 ? " sinal" : ""}`}>
+          <span className="bn-bit-val">{b}</span>
+          <span className="bn-bit-exp">
+            {k === 0 && signMark ? (
+              "sinal"
+            ) : (
+              <>
+                2<sup>{N - 1 - k}</sup>
+              </>
+            )}
+          </span>
+          <span className="bn-bit-peso">{k === 0 && signMark ? "-128" : 1 << (N - 1 - k)}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export function generateSteps(value: number): Step[] {
+  const out: Step[] = [];
+  const start = toBits(value);
+  const noCarry = new Array(N).fill(-1);
 
   out.push({
-    bits: [...original],
-    destaque: -1,
-    carry: semCarry,
-    fase: "inicio",
-    soma: null,
-    linha: 1,
-    nota: `Ponto de partida: ${valor} em oito bits é ${original.join("")}. O objetivo é achar a representação de -${valor} sem inventar um símbolo de menos, usando só os mesmos oito bits.`,
+    bits: [...start],
+    highlight: -1,
+    carry: noCarry,
+    phase: "start",
+    sum: null,
+    line: 1,
+    note: `Ponto de partida: ${value} em oito bits é ${start.join("")}. O objetivo é achar a representação de -${value} sem inventar um símbolo de menos, usando só os mesmos oito bits.`,
   });
 
   // ---- passo 1: inverter -----------------------------------------------
-  const invertido: number[] = original.map((b) => (b === 1 ? 0 : 1));
+  const inverted: number[] = start.map((b) => (b === 1 ? 0 : 1));
   for (let k = 0; k < N; k++) {
-    const parcial = original.map((b, i) => (i <= k ? (b === 1 ? 0 : 1) : b));
+    const partial = start.map((b, i) => (i <= k ? (b === 1 ? 0 : 1) : b));
     out.push({
-      bits: parcial,
-      destaque: k,
-      carry: semCarry,
-      fase: "inverter",
-      soma: null,
-      linha: 2,
-      nota: `Passo 1, inverter: o bit de expoente ${N - 1 - k} era ${original[k]} e vira ${1 - original[k]}. Isto sozinho é o complemento de UM, e ele já quase funciona: o problema dele é que sobra um zero a mais.`,
+      bits: partial,
+      highlight: k,
+      carry: noCarry,
+      phase: "invert",
+      sum: null,
+      line: 2,
+      note: `Passo 1, inverter: o bit de expoente ${N - 1 - k} era ${start[k]} e vira ${1 - start[k]}. Isto sozinho é o complemento de UM, e ele já quase funciona: o problema dele é que sobra um zero a mais.`,
     });
   }
 
   // ---- passo 2: somar 1 -------------------------------------------------
-  const resultado = [...invertido];
+  const result = [...inverted];
   const carry = new Array(N).fill(-1);
-  let vai = 1;
+  let carryIn = 1;
   for (let k = N - 1; k >= 0; k--) {
-    const soma = resultado[k] + vai;
-    const bit = soma % 2;
-    const novoVai = soma > 1 ? 1 : 0;
-    carry[k] = novoVai;
-    resultado[k] = bit;
+    const digit = result[k] + carryIn;
+    const bit = digit % 2;
+    const carryOut = digit > 1 ? 1 : 0;
+    carry[k] = carryOut;
+    result[k] = bit;
     out.push({
-      bits: [...resultado],
-      destaque: k,
+      bits: [...result],
+      highlight: k,
       carry: [...carry],
-      fase: "somar",
-      soma: null,
-      linha: 3,
-      nota:
-        vai === 0
+      phase: "add",
+      sum: null,
+      line: 3,
+      note:
+        carryIn === 0
           ? `Não há mais vai-um, então os bits à esquerda ficam como estão. A soma acabou de fato aqui.`
-          : `Passo 2, somar 1: nesta posição tenho ${invertido[k]} + ${vai}. ${
-              soma > 1
+          : `Passo 2, somar 1: nesta posição tenho ${inverted[k]} + ${carryIn}. ${
+              digit > 1
                 ? `Em binário 1 + 1 é 0 e vai um, exatamente como 5 + 5 é 0 e vai um no decimal. Escrevo ${bit} e levo o vai-um para a esquerda.`
                 : `Dá ${bit}, sem vai-um, e a propagação para aqui.`
             }`,
     });
-    vai = novoVai;
-    if (vai === 0) {
+    carryIn = carryOut;
+    if (carryIn === 0) {
       // os bits restantes não mudam; um passo só resume isso
       break;
     }
   }
 
-  const valorFinal = comSinal(resultado);
+  const finalValue = toSigned(result);
   out.push({
-    bits: [...resultado],
-    destaque: -1,
-    carry: semCarry,
-    fase: "pronto",
-    soma: null,
-    linha: 3,
+    bits: [...result],
+    highlight: -1,
+    carry: noCarry,
+    phase: "done",
+    sum: null,
+    line: 3,
     ok: true,
-    nota: `Pronto: ${resultado.join("")}. Lendo com o truque do peso negativo, o bit da esquerda vale -128 em vez de +128, então isto é ${resultado
+    note: `Pronto: ${result.join("")}. Lendo com o truque do peso negativo, o bit da esquerda vale -128 em vez de +128, então isto é ${result
       .map((b, k) => (b === 1 ? (k === 0 ? -128 : 1 << (N - 1 - k)) : 0))
       .filter((x) => x !== 0)
       .join(" + ")
-      .replace(/\+ -/g, "- ")} = ${valorFinal}.`,
+      .replace(/\+ -/g, "- ")} = ${finalValue}.`,
   });
 
   // ---- a prova: x + (-x) --------------------------------------------------
-  const soma: number[] = new Array(N).fill(0);
-  const carrySoma = new Array(N).fill(-1);
-  let v2 = 0;
+  const sum: number[] = new Array(N).fill(0);
+  const proofCarry = new Array(N).fill(-1);
+  let proofCarryIn = 0;
   for (let k = N - 1; k >= 0; k--) {
-    const s = original[k] + resultado[k] + v2;
-    soma[k] = s % 2;
-    carrySoma[k] = s > 1 ? 1 : 0;
-    v2 = s > 1 ? 1 : 0;
+    const digit = start[k] + result[k] + proofCarryIn;
+    sum[k] = digit % 2;
+    proofCarry[k] = digit > 1 ? 1 : 0;
+    proofCarryIn = digit > 1 ? 1 : 0;
   }
   out.push({
-    bits: [...resultado],
-    destaque: -1,
-    carry: carrySoma,
-    fase: "prova",
-    soma: [...soma],
-    linha: 6,
+    bits: [...result],
+    highlight: -1,
+    carry: proofCarry,
+    phase: "proof",
+    sum: [...sum],
+    line: 6,
     ok: true,
-    nota: `A prova: ${original.join("")} + ${resultado.join("")} = ${soma.join("")}${
-      v2 === 1
+    note: `A prova: ${start.join("")} + ${result.join("")} = ${sum.join("")}${
+      proofCarryIn === 1
         ? `, com um vai-um sobrando na ponta esquerda. Esse nono bit não cabe em oito, então o tipo simplesmente o descarta, e o que fica é zero. Não é um acidente conveniente: é o motivo de a convenção ser esta, porque assim o processador subtrai somando, sem nenhum circuito a mais.`
         : `. Somar um número com o oposto dele dá zero, que é a definição de oposto.`
     }`,
@@ -196,119 +235,60 @@ export function gerarPassos(valor: number): Passo[] {
 }
 
 export function BinarioComplemento() {
-  const [presetKey, setPresetKey] = useState("vinteseis");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("twentysix");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.valor), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
-  const original = useMemo(() => paraBits(preset.valor), [preset]);
+  const steps = useMemo(() => generateSteps(preset.value), [preset]);
+  const startBits = useMemo(() => toBits(preset.value), [preset]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · complemento de dois: inverter e somar 1",
+    total: steps.length,
+    speeds: SPEEDS,
+    initialSpeed: INITIAL_SPEED,
+    // O preset é o único controle da peça: ele troca a dica (a de maior está
+    // 3 linhas acima da menor) e o número de passos. A largura da palavra é
+    // constante, então a fita não entra na conta.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const p = steps[viz.step];
+
+  const pickPreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const rotuloFase =
-    p.fase === "inverter" ? "1 · inverter todos os bits" : p.fase === "somar" ? "2 · somar 1" : p.fase === "prova" ? "a prova: x + (-x)" : p.fase === "pronto" ? "resultado" : "início";
+  const phaseLabel =
+    p.phase === "invert" ? "1 · inverter todos os bits" : p.phase === "add" ? "2 · somar 1" : p.phase === "proof" ? "a prova: x + (-x)" : p.phase === "done" ? "resultado" : "início";
 
-  const Fita = ({ bits, destaque, marca }: { bits: number[]; destaque: number; marca?: string }) => (
-    <div className="bn-fita">
-      {bits.map((b, k) => (
-        <span key={k} className={`bn-bit estatico${b ? " on" : ""}${k === destaque ? " novo" : ""}${k === 0 ? " sinal" : ""}`}>
-          <span className="bn-bit-val">{b}</span>
-          <span className="bn-bit-exp">
-            {k === 0 && marca === "sinal" ? (
-              "sinal"
-            ) : (
-              <>
-                2<sup>{N - 1 - k}</sup>
-              </>
-            )}
-          </span>
-          <span className="bn-bit-peso">{k === 0 && marca === "sinal" ? "-128" : 1 << (N - 1 - k)}</span>
-        </span>
-      ))}
-    </div>
-  );
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · complemento de dois: inverter e somar 1</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
-
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => pickPreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
-        <div className={`hs-fase ${p.fase === "prova" || p.fase === "pronto" ? "f-fim" : p.fase === "somar" ? "f-ordenar" : ""}`}>
-          <span className="hs-fase-selo">{rotuloFase}</span>
+        {/* `f-fim` e `f-ordenar` são classes do bloco `.hs-fase` no `globals.css`:
+            literais crus que nada mais aponta, e trocá-los apaga a cor da faixa
+            sem quebrar o build. Ficam em português de propósito. */}
+        <div className={`hs-fase ${p.phase === "proof" || p.phase === "done" ? "f-fim" : p.phase === "add" ? "f-ordenar" : ""}`}>
+          <span className="hs-fase-selo">{phaseLabel}</span>
           <span className="hs-fase-txt">
-            {preset.valor} · em construção: {p.bits.join("")} ({comSinal(p.bits)} lido com sinal)
+            {preset.value} · em construção: {p.bits.join("")} ({toSigned(p.bits)} lido com sinal)
           </span>
         </div>
 
@@ -316,14 +296,14 @@ export function BinarioComplemento() {
           <div className="tt-painel-tit">
             O positivo de partida <em>o bit da esquerda desligado quer dizer positivo</em>
           </div>
-          <Fita bits={original} destaque={-1} />
+          <BitStrip bits={startBits} highlight={-1} />
         </div>
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
-            Em construção <em>{p.fase === "somar" ? "somando 1, com o vai-um andando para a esquerda" : "invertendo bit a bit"}</em>
+            Em construção <em>{p.phase === "add" ? "somando 1, com o vai-um andando para a esquerda" : "invertendo bit a bit"}</em>
           </div>
-          <Fita bits={p.bits} destaque={p.destaque} marca="sinal" />
+          <BitStrip bits={p.bits} highlight={p.highlight} signMark />
           {p.carry.some((c) => c >= 0) ? (
             <div className="bn-carrys">
               {p.carry.map((c, k) => (
@@ -336,93 +316,50 @@ export function BinarioComplemento() {
           ) : null}
         </div>
 
-        {p.soma ? (
+        {p.sum ? (
           <div className="hp-bloco">
             <div className="tt-painel-tit">
               A prova <em>somar o número com o oposto dele</em>
             </div>
-            <Fita bits={p.soma} destaque={-1} />
+            <BitStrip bits={p.sum} highlight={-1} />
           </div>
         ) : null}
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">complemento.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          {/* A moldura extra existe para a ALTURA: zerar a trilha da coluna só
+              tira a largura, e a linha do grid continuaria com a altura inteira
+              do código (contrato §7). O código fica no DOM mesmo recolhido, que
+              é o que permite medir o pior caso; `inert` o tira do teclado. */}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">complemento.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === p.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">positivo</span>
-              <span className="viz-var-val best">{preset.valor}</span>
+              <span className="viz-var-val best">{preset.value}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">em construção (sem sinal)</span>
-              <span className="viz-var-val">{paraNum(p.bits)}</span>
+              <span className="viz-var-val">{toNumber(p.bits)}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">em construção (com sinal)</span>
-              <span className="viz-var-val">{comSinal(p.bits)}</span>
+              <span className="viz-var-val">{toSigned(p.bits)}</span>
             </div>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -432,21 +369,12 @@ export function BinarioComplemento() {
           sinal vai de -128 a 127 e não é simétrica.
         </p>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/content/visualizers/BinarioDivisoes.tsx
+++ b/content/visualizers/BinarioDivisoes.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+import { useMemo, useState } from "react";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinarioDivisoes, o caminho de volta: de decimal para binário.
@@ -19,21 +20,38 @@ import { createPortal } from "react-dom";
 // O passo a passo tem linha do tempo porque aqui existe uma sequência de
 // verdade, com estado que evolui, ao contrário do conversor ao lado, em que a
 // variável é o número.
+//
+// Altura: esta é uma das poucas peças da série em que o eixo é o DESENHO, e não
+// a prosa. A lista de divisões ACUMULA — cada passo acrescenta uma linha sem
+// apagar a anterior —, então o `log₂` vira geometria: 36px por linha, medidos.
+// A fita tem sempre 8 células (uma linha, 63px, por causa do `Math.max(8, …)`),
+// os quatro cartões medem 64px e a dica mede 37px em todos os presets e nas
+// três réguas; quem move a peça é o `.bb-passos`, de 27px (nenhuma divisão) a
+// 282px (oito). Ver `measureOn`.
+//
+// O degrau é atravessado pelos presets: 53 dá 6 divisões (210px), 64 dá 7
+// (246px) e 201 e 255 dão 8 (282px) — os dois últimos medem igual ao pixel. O
+// degrau seguinte abriria em 256, e não há campo numérico livre: os quatro
+// chips são o único caminho, então oito linhas é o pior caso alcançável.
+//
+// E o pico não é o último passo, é o PENÚLTIMO: o estado final tem as mesmas
+// oito linhas, mas a nota de fechamento é mais curta que a de uma divisão
+// (42px contra 63px), o que devolve 21px.
 // ---------------------------------------------------------------------------
 
-type Linha = { n: number; quociente: number; resto: number };
+type Row = { n: number; quotient: number; remainder: number };
 
-type Passo = {
-  linhas: Linha[];
+type Step = {
+  rows: Row[];
   bits: (number | null)[];
-  destaque: number; // índice da linha em foco
-  posicao: number; // posição do bit que acabou de ser escrito
-  linha: number;
-  nota: string;
+  highlight: number; // índice da linha em foco
+  position: number; // posição do bit que acabou de ser escrito
+  line: number;
+  note: string;
   ok?: boolean;
 };
 
-const CODIGO = [
+const CODE = [
   "def para_binario(n):",
   "    if n == 0: return '0'",
   "    bits = ''",
@@ -43,64 +61,65 @@ const CODIGO = [
   "    return bits",
 ];
 
-type Preset = { key: string; rotulo: string; valor: number; dica: string };
+type Preset = { key: string; label: string; value: number; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "duzentos",
-    rotulo: "201",
-    valor: 201,
-    dica: "Oito divisões para oito bits. Acompanhe a fita da direita: o primeiro resto ocupa a última posição, e não a primeira. É esse detalhe que faz a regra de ler os restos de baixo para cima.",
+    key: "mixed",
+    label: "201",
+    value: 201,
+    hint: "Oito divisões para oito bits. Acompanhe a fita da direita: o primeiro resto ocupa a última posição, e não a primeira. É esse detalhe que faz a regra de ler os restos de baixo para cima.",
   },
   {
-    key: "cinquenta",
-    rotulo: "53",
-    valor: 53,
-    dica: "O mesmo número do visualizador anterior, agora pelo caminho inverso. Se as duas contas fecharem no mesmo 00110101, é porque as duas são a mesma ideia lida em direções opostas.",
+    key: "sameNumber",
+    label: "53",
+    value: 53,
+    hint: "O mesmo número do visualizador anterior, agora pelo caminho inverso. Se as duas contas fecharem no mesmo 00110101, é porque as duas são a mesma ideia lida em direções opostas.",
   },
   {
-    key: "potencia",
-    rotulo: "64, uma potência de dois",
-    valor: 64,
-    dica: "Potência de dois é o caso mais limpo: todas as divisões dão resto zero até a última. Um número com um bit ligado só é um número que se divide por 2 sem sobra até virar 1.",
+    key: "powerOfTwo",
+    label: "64, uma potência de dois",
+    value: 64,
+    hint: "Potência de dois é o caso mais limpo: todas as divisões dão resto zero até a última. Um número com um bit ligado só é um número que se divide por 2 sem sobra até virar 1.",
   },
   {
-    key: "impar",
-    rotulo: "255, todos ímpares",
-    valor: 255,
-    dica: "O oposto: toda divisão sobra 1, então todos os bits saem ligados. Repare que o resto de dividir por 2 é exatamente a pergunta se o número é ímpar, e ímpar em binário é bit da direita ligado.",
+    key: "allOnes",
+    label: "255, todos ímpares",
+    value: 255,
+    hint: "O oposto: toda divisão sobra 1, então todos os bits saem ligados. Repare que o resto de dividir por 2 é exatamente a pergunta se o número é ímpar, e ímpar em binário é bit da direita ligado.",
   },
 ];
 
-const VELOCIDADES = [0, 1200, 800, 520, 320, 180];
-const ROTULOS_VEL = ["", "0.5x", "0.75x", "1x", "1.5x", "2x"];
+// Ritmo próprio, 15% a 30% mais rápido que o padrão do hook: cada passo aqui é
+// uma divisão, e uma divisão se lê mais depressa que uma troca de array.
+const SPEEDS = [0, 1200, 800, 520, 320, 180];
 
-export function gerarPassos(valor: number): Passo[] {
-  const largura = Math.max(8, valor.toString(2).length);
-  const out: Passo[] = [];
-  const linhas: Linha[] = [];
-  const bits: (number | null)[] = new Array(largura).fill(null);
-  let n = valor;
-  let pos = largura - 1;
+export function generateSteps(value: number): Step[] {
+  const width = Math.max(8, value.toString(2).length);
+  const out: Step[] = [];
+  const rows: Row[] = [];
+  const bits: (number | null)[] = new Array(width).fill(null);
+  let n = value;
+  let pos = width - 1;
 
   out.push({
-    linhas: [],
+    rows: [],
     bits: [...bits],
-    destaque: -1,
-    posicao: -1,
-    linha: 0,
-    nota: `Vou converter ${valor} para binário dividindo por 2 sem parar. Cada divisão responde a uma pergunta só: "sobra alguma coisa?". O resto é o bit, e o quociente é o que ainda falta converter.`,
+    highlight: -1,
+    position: -1,
+    line: 0,
+    note: `Vou converter ${value} para binário dividindo por 2 sem parar. Cada divisão responde a uma pergunta só: "sobra alguma coisa?". O resto é o bit, e o quociente é o que ainda falta converter.`,
   });
 
-  if (valor === 0) {
+  if (value === 0) {
     out.push({
-      linhas: [],
+      rows: [],
       bits: bits.map(() => 0),
-      destaque: -1,
-      posicao: -1,
-      linha: 1,
+      highlight: -1,
+      position: -1,
+      line: 1,
       ok: true,
-      nota: "O zero é o único caso que o laço não trata, porque ele nem chega a rodar. Por isso o código devolve '0' antes de começar.",
+      note: "O zero é o único caso que o laço não trata, porque ele nem chega a rodar. Por isso o código devolve '0' antes de começar.",
     });
     return out;
   }
@@ -108,19 +127,19 @@ export function gerarPassos(valor: number): Passo[] {
   while (n > 0) {
     const q = Math.floor(n / 2);
     const r = n % 2;
-    linhas.push({ n, quociente: q, resto: r });
+    rows.push({ n, quotient: q, remainder: r });
     bits[pos] = r;
     out.push({
-      linhas: [...linhas],
+      rows: [...rows],
       bits: [...bits],
-      destaque: linhas.length - 1,
-      posicao: pos,
-      linha: 4,
-      nota: `${n} dividido por 2 dá ${q} com resto ${r}. ${
+      highlight: rows.length - 1,
+      position: pos,
+      line: 4,
+      note: `${n} dividido por 2 dá ${q} com resto ${r}. ${
         r === 1
           ? `Sobrou 1, ou seja, ${n} é ímpar, e todo número ímpar tem o bit da direita ligado.`
           : `Não sobrou nada, ou seja, ${n} é par, e todo número par tem o bit da direita desligado.`
-      } Esse resto vai para a posição ${largura - 1 - pos === 0 ? "mais à direita" : `de expoente ${largura - 1 - pos}`} da fita, e não para a próxima posição livre da esquerda: cada divisão pergunta por um bit mais significativo que a anterior.`,
+      } Esse resto vai para a posição ${width - 1 - pos === 0 ? "mais à direita" : `de expoente ${width - 1 - pos}`} da fita, e não para a próxima posição livre da esquerda: cada divisão pergunta por um bit mais significativo que a anterior.`,
     });
     n = q;
     pos--;
@@ -128,120 +147,84 @@ export function gerarPassos(valor: number): Passo[] {
 
   const bin = bits.map((b) => b ?? 0);
   out.push({
-    linhas: [...linhas],
+    rows: [...rows],
     bits: bin,
-    destaque: -1,
-    posicao: -1,
-    linha: 6,
+    highlight: -1,
+    position: -1,
+    line: 6,
     ok: true,
-    nota: `Cheguei a zero, então acabou: ${valor} em binário é ${bin.join("")}. Foram ${linhas.length} divisões para ${linhas.length} bits significativos, e os zeros à esquerda entram só para completar o byte. Conferindo pelo outro caminho: ${bits
-      .map((b, k) => (b ? 1 << (largura - 1 - k) : 0))
+    note: `Cheguei a zero, então acabou: ${value} em binário é ${bin.join("")}. Foram ${rows.length} divisões para ${rows.length} bits significativos, e os zeros à esquerda entram só para completar o byte. Conferindo pelo outro caminho: ${bits
+      .map((b, k) => (b ? 1 << (width - 1 - k) : 0))
       .filter((x) => x > 0)
-      .join(" + ")} = ${valor}.`,
+      .join(" + ")} = ${value}.`,
   });
   return out;
 }
 
 export function BinarioDivisoes() {
-  const [presetKey, setPresetKey] = useState("duzentos");
-  const [passo, setPasso] = useState(0);
-  const [tocando, setTocando] = useState(false);
-  const [velocidade, setVelocidade] = useState(4);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-
-  useEffect(() => setMounted(true), []);
+  const [presetKey, setPresetKey] = useState("mixed");
 
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
-  const passos = useMemo(() => gerarPassos(preset.valor), [preset]);
-  const total = passos.length;
-  const idx = Math.min(passo, total - 1);
-  const p = passos[idx];
+  const steps = useMemo(() => generateSteps(preset.value), [preset]);
 
-  const parar = useCallback(() => {
-    if (timer.current) {
-      clearInterval(timer.current);
-      timer.current = null;
-    }
-  }, []);
-  useEffect(() => () => parar(), [parar]);
-  useEffect(() => {
-    parar();
-    if (!tocando) return;
-    timer.current = setInterval(() => setPasso((s) => (s >= total - 1 ? s : s + 1)), VELOCIDADES[velocidade]);
-    return parar;
-  }, [tocando, velocidade, total, parar]);
-  useEffect(() => {
-    if (tocando && idx >= total - 1) setTocando(false);
-  }, [tocando, idx, total]);
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setExpanded(false);
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const viz = useVisualizer({
+    title: "Visualizador · de decimal para binário, dividindo por 2",
+    total: steps.length,
+    speeds: SPEEDS,
+    // A peça sempre abriu em 1.5x; sem isto ela cairia calada para o 1x do hook.
+    initialSpeed: 4,
+    // O preset é a única entrada do aluno, e aqui ele mexe no DESENHO, não na
+    // prosa: a dica mede 37px nos quatro, e a lista de divisões vai de 210px
+    // (53, seis divisões) a 282px (201 e 255, oito). São 72px entre presets,
+    // dois degraus de 36px cada.
+    measureOn: [presetKey],
+  });
 
-  const reiniciar = () => {
-    parar();
-    setTocando(false);
-    setPasso(0);
-  };
-  const trocarPreset = (k: string) => {
-    reiniciar();
+  const s = steps[viz.step];
+  const width = s.bits.length;
+
+  const changePreset = (k: string) => {
+    viz.reset();
     setPresetKey(k);
   };
 
-  const pctPasso = Math.round(((idx + 1) / total) * 100);
-  const largura = p.bits.length;
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz} />
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · de decimal para binário, dividindo por 2</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            passo {idx + 1} de {total}
-          </span>
-          <button className="viz-expand" onClick={() => setExpanded((e) => !e)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
-
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
-              onClick={() => trocarPreset(pr.key)}
+              onClick={() => changePreset(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
             A fita de bits <em>preenchida da direita para a esquerda, um por divisão</em>
           </div>
           <div className="bn-fita">
-            {p.bits.map((b, k) => (
-              <span key={k} className={`bn-bit estatico${b === 1 ? " on" : ""}${b === null ? " vazio" : ""}${k === p.posicao ? " novo" : ""}`}>
+            {/* `estatico`, `on`, `vazio` e `novo` são sufixo de classe do
+                `globals.css` (`.bn-bit.estatico` tira o cursor de mão,
+                `.bn-bit.novo` dispara a pulsação, e as duas são compartilhadas
+                com os visualizadores de binário negativo). Traduzi-los apagaria
+                estilo sem o `tsc`, o guarda de idioma ou um teste acusarem. */}
+            {s.bits.map((b, k) => (
+              <span key={k} className={`bn-bit estatico${b === 1 ? " on" : ""}${b === null ? " vazio" : ""}${k === s.position ? " novo" : ""}`}>
                 <span className="bn-bit-val">{b === null ? "?" : b}</span>
                 <span className="bn-bit-exp">
-                  2<sup>{largura - 1 - k}</sup>
+                  2<sup>{width - 1 - k}</sup>
                 </span>
-                <span className="bn-bit-peso">{1 << (largura - 1 - k)}</span>
+                <span className="bn-bit-peso">{1 << (width - 1 - k)}</span>
               </span>
             ))}
           </div>
@@ -251,51 +234,56 @@ export function BinarioDivisoes() {
           <div className="tt-painel-tit">
             As divisões <em>o quociente vira a próxima linha, o resto vira um bit</em>
           </div>
+          {/* É esta lista que ACUMULA, e é ela o eixo de altura da peça: 36px
+              por divisão, de 27px (nenhuma) a 282px (oito). `foco` também é
+              classe do `globals.css` (`.bb-passos li.foco`). */}
           <ol className="bb-passos">
-            {p.linhas.length === 0 ? (
+            {s.rows.length === 0 ? (
               <li>
                 <span>nenhuma divisão ainda</span>
               </li>
             ) : (
-              p.linhas.map((l, k) => (
-                <li key={k} className={k === p.destaque ? "foco" : ""}>
+              s.rows.map((l, k) => (
+                <li key={k} className={k === s.highlight ? "foco" : ""}>
                   <span>
-                    {l.n} ÷ 2 = {l.quociente}
+                    {l.n} ÷ 2 = {l.quotient}
                   </span>
-                  <b>resto {l.resto}</b>
+                  <b>resto {l.remainder}</b>
                 </li>
               ))
             )}
           </ol>
         </div>
 
-        <p className={"viz-note" + (p.ok ? " ok" : "")}>{p.nota}</p>
+        <p className={"viz-note" + (s.ok ? " ok" : "")}>{s.note}</p>
 
         <div className="viz-split">
-          <div className="viz-code">
-            <div className="viz-code-head">para_binario.py</div>
-            <div className="viz-code-body">
-              {CODIGO.map((txt, k) => (
-                <div key={k} className={`viz-line${k === p.linha ? " on" : ""}`}>
-                  <span className="ln">{k + 1}</span>
-                  {txt}
-                </div>
-              ))}
+          <div className="viz-code-slot">
+            <div className="viz-code" {...viz.blockProps}>
+              <div className="viz-code-head">para_binario.py</div>
+              <div className="viz-code-body">
+                {CODE.map((txt, k) => (
+                  <div key={k} className={`viz-line${k === s.line ? " on" : ""}`}>
+                    <span className="ln">{k + 1}</span>
+                    {txt}
+                  </div>
+                ))}
+              </div>
             </div>
           </div>
-          <div className="viz-vars">
+          <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
             <div className="viz-var">
               <span className="viz-var-name">n (o que falta converter)</span>
-              <span className="viz-var-val best">{p.linhas.length > 0 ? p.linhas[p.linhas.length - 1].quociente : preset.valor}</span>
+              <span className="viz-var-val best">{s.rows.length > 0 ? s.rows[s.rows.length - 1].quotient : preset.value}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">último resto</span>
-              <span className="viz-var-val">{p.linhas.length > 0 ? p.linhas[p.linhas.length - 1].resto : "-"}</span>
+              <span className="viz-var-val">{s.rows.length > 0 ? s.rows[s.rows.length - 1].remainder : "-"}</span>
             </div>
             <div className="viz-var">
               <span className="viz-var-name">bits já escritos</span>
-              <span className="viz-var-val">{p.bits.filter((b) => b !== null).length}</span>
+              <span className="viz-var-val">{s.bits.filter((b) => b !== null).length}</span>
             </div>
           </div>
         </div>
@@ -303,69 +291,20 @@ export function BinarioDivisoes() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>número de partida</span>
-            <strong>{preset.valor}</strong>
+            <strong>{preset.value}</strong>
           </div>
           <div className="bigo-stat">
             <span>divisões feitas</span>
-            <strong>{p.linhas.length}</strong>
+            <strong>{s.rows.length}</strong>
           </div>
           <div className="bigo-stat">
             <span>bits significativos</span>
-            <strong>{preset.valor.toString(2).length}</strong>
+            <strong>{preset.value.toString(2).length}</strong>
           </div>
           <div className="bigo-stat">
             <span>bits já ligados na fita</span>
-            <strong>{p.bits.filter((b) => b === 1).length}</strong>
+            <strong>{s.bits.filter((b) => b === 1).length}</strong>
           </div>
-        </div>
-
-        <div className="viz-controls">
-          <button className="viz-btn" title="Reiniciar" onClick={reiniciar}>
-            ↺
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === 0}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.max(0, s - 1));
-            }}
-          >
-            ‹ Anterior
-          </button>
-          <button
-            className="viz-play"
-            onClick={() => {
-              if (tocando) {
-                setTocando(false);
-                return;
-              }
-              setPasso(idx >= total - 1 ? 0 : idx);
-              setTocando(true);
-            }}
-          >
-            {tocando ? "❚❚ Pausar" : "▶ Rodar"}
-          </button>
-          <button
-            className="viz-btn"
-            disabled={idx === total - 1}
-            onClick={() => {
-              parar();
-              setTocando(false);
-              setPasso((s) => Math.min(s + 1, total - 1));
-            }}
-          >
-            Próximo ›
-          </button>
-          <div className="viz-speed">
-            <span>Velocidade</span>
-            <input type="range" min={1} max={5} step={1} value={velocidade} onChange={(e) => setVelocidade(parseInt(e.target.value, 10))} />
-            <span className="val">{ROTULOS_VEL[velocidade]}</span>
-          </div>
-        </div>
-        <div className="viz-progress">
-          <div className="viz-progress-fill" style={{ width: `${pctPasso}%` }} />
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
@@ -374,21 +313,8 @@ export function BinarioDivisoes() {
           escrita de outro jeito: dividir por dois repetidamente chega ao fim depressa.
         </p>
       </div>
+
+      <VizFooter viz={viz} />
     </figure>
   );
-
-  if (expanded && mounted) {
-    return createPortal(
-      <div
-        className="viz-overlay"
-        onClick={(e) => {
-          if (e.target === e.currentTarget) setExpanded(false);
-        }}
-      >
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
 }

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -117,6 +117,13 @@ Três notas de execução, todas medidas:
   protege literais a deixa para trás: em `Omit<Step, "slots" | "desloc">` o
   `"desloc"` precisava virar `"shifts"` junto com o campo. Aqui só o `tsc`
   pegou — o guarda de idioma, por construção, nunca vai pegar;
+- **valor de união que É TEXTO DE TELA**, e o espelho do caso acima. Em
+  `conflict: "linha" | "coluna" | "quadrante"` (`BacktrackingSudoku`) os valores
+  são renderizados crus no painel "regra que barrou": traduzi-los **compila,
+  passa no guarda e troca o que o aluno lê**. A união *parece* identificador e
+  *é* conteúdo — enquanto o sufixo de classe *parece* conteúdo e *é* API. Antes
+  de traduzir uma união, **procure onde os valores dela aparecem**: se algum
+  chega ao JSX sem passar por um mapa, ele é texto de tela;
 - **qualquer literal que vira NOME DE CLASSE é contrato com o CSS**, e esse
   ninguém guarda. Ele passa pelo `tsc` (o tipo continua coerente), pelo guarda
   de idioma (não é texto de tela) e pelo teste (é cor). As três formas medidas,
@@ -375,6 +382,18 @@ passos consecutivos). Só a primeira é altura.
 Medido no `ShellSortVisualizer`: a sequência de gaps é `log₂` e o degrau seguinte
 abriria em 16 elementos — mas a pergunta nem chega a valer, porque cada rodada
 **substitui** a anterior na tela. O `.hs-fase` mede **35px nos 261 estados**.
+
+> **O lado SIM, para saber quando você o encontrou.** O sinal no código é o
+> gerador **acumulando**: `rows: [...rows, novaLinha]` em vez de `rows:
+> [novaLinha]`. Medido no `BinarioDivisoes`, onde a lista de divisões acumula:
+> o `⌈log₂ n⌉` vira geometria a **36px por linha exatos**, de 27px (nenhuma) a
+> 282px (oito), e isso é **255 dos 276px de amplitude** da peça. Aí o pior caso
+> da entrada é real e vale caçar.
+>
+> Dois detalhes que só aparecem medindo esse caso: **quatro controles podem
+> medir três pontos** (201 e 255 dão oito divisões e a mesma altura ao pixel), e
+> **o pico pode ser o penúltimo passo** — o último tem as mesmas oito linhas e
+> uma nota 21px mais curta.
 
 ### Eixo alcançável ainda pode ser eixo com DEGRAUS
 
@@ -732,10 +751,29 @@ os dois passando contra a quebra antes de serem consertados:
 
   A asserção que carrega o sentido é **a posição comparada com ela mesma** — o
   `boundingBox().y` do controle antes e depois de o miolo rolar — e o
-  `toBeInViewport({ ratio: 1 })` entra como complemento, não como prova. É o que
-  os testes bons deste repo já fazem: `headMoveu === 0`, `footMoveu === 0`,
-  `sobraFigura <= 8`. Se o seu teste de camada 1 não tem um desses, ele está
-  aprovando a quebra.
+  `toBeInViewport({ ratio: 1 })` entra como complemento, não como prova.
+
+  **E é MENOS gente trabalhando do que parece.** Contra a quebra canônica, num
+  teste de cinco asserções, **quatro passaram** — medido no `backtracking` e
+  confirmado independentemente no `binary-numbers`:
+
+  | asserção | contra a quebra |
+  |---|---|
+  | o miolo estoura (`scrollHeight - clientHeight > SLACK`) | **passa** |
+  | o miolo rolou (`scrollTop > 0`) | **passa** |
+  | a figura não rola (`sobraFigura <= 8`) | **passa** — o miolo absorve o rodapé |
+  | **o cabeçalho não anda** (`headMoveu === 0`) | **passa** |
+  | **a posição do controle de reprodução, comparada com ela mesma** | **reprova** (−227px, −425px, −488px) |
+
+  As três primeiras são as **premissas** que esta seção manda exigir, e elas
+  continuam certas — elas provam que o teste está medindo a coisa certa, não que
+  a camada funciona. E a do **cabeçalho**, que é a formulação mais natural de "a
+  camada 1 funciona", passa: com o rodapé dentro do miolo o cabeçalho continua
+  parado, porque o defeito é do rodapé.
+
+  **Escreva a asserção do rodapé.** Um teste de camada 1 sem a posição do
+  `▶ Rodar` (ou do controle que a peça tiver) medida antes e depois da rolagem
+  aprova a quebra que a camada existe para impedir.
 
 ---
 
@@ -812,6 +850,16 @@ seção.** O custo não é de adotar a casca: é de **ter um `.viz-foot`**. As t
 primeiras peças pagam porque, mesmo sem linha do tempo, elas têm controles
 próprios no rodapé. As duas últimas não têm rodapé nenhum — `total: 1` **e** sem
 `children` fazem o `VizFooter` sumir inteiro —, e aí a casca **devolve** 4px.
+
+**E o saldo pode ser MUITO negativo quando a peça tem bloco E rodapé.** O
+`BinarioDivisoes` ficou **184px mais baixo** no artigo, e a aritmética mostra que
+não há mecanismo novo: o `.viz-split` cai de 230 para 36px (−194) porque o bloco
+de código sai do fluxo lateral e vai para o `.viz-code-slot`, e o `.viz-foot`
+cobra os +10 de sempre. −194 + 10 = −184.
+
+Ou seja, o `+10` desta seção é o **custo fixo do rodapé**, e o que decide o sinal
+é quanto a camada 3 devolve. Não cite nenhum dos dois números sem medir a sua
+peça: a série já tem +28, +10, −4 e −184.
 
 **São 4px nas duas, em peças sem nenhum parentesco**, em todos os estados e em
 todas as réguas: 10 estados × 3 réguas numa, 7 estados na outra. Repetir o

--- a/tests/viz-backtracking.spec.ts
+++ b/tests/viz-backtracking.spec.ts
@@ -1,0 +1,245 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// A casca adaptativa nas duas peças de `backtracking`: a árvore de decisão e o
+// sudoku. A terceira figura da página (`BacktrackingPoda`) não tem overlay e
+// ficou fora — por isso todo seletor daqui é escopado na figura, e as contagens
+// são afirmadas nos dois níveis (página e figura). Sem isso, `.viz-step` casa
+// duas figuras e a leitura sai da peça errada.
+//
+// Medido antes de escrever: no expandido a figura inteira rolava, e o
+// `▶ Rodar` era desenhado 335px (árvore, 1512x900) e 590px (sudoku, 1440x600)
+// abaixo do pé visível da peça. É isso que a camada 1 conserta, e é a posição
+// do controle comparada com ela mesma que prova — `toBeInViewport()` sozinho
+// passa nas duas pontas da rolagem.
+
+const URL = "/topico/backtracking/";
+
+const ARVORE = 0;
+const SUDOKU = 1;
+
+/** Folga de subpixel, igual à do hook. */
+const SLACK = 8;
+
+async function abrirPagina(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  expect(page.viewportSize()).toEqual({ width: w, height: h });
+  await page.goto(URL);
+  await expect(page.locator("article figure.viz")).toHaveCount(3);
+}
+
+/** A figura da peça, com as contagens afirmadas nos dois níveis. */
+async function figura(page: Page, i: number): Promise<Locator> {
+  const fig = page.locator("article figure.viz").nth(i);
+  await expect(fig).toHaveClass(/viz-fit/);
+  // Na página `.viz-step` casa TRÊS, e o terceiro não é um contador de passo: o
+  // `BacktrackingPoda` usa a mesma classe para dizer "6 rainhas · 4 soluções ·
+  // 2.6x menos nós com poda". Escopar na figura não é preciosismo — sem isso a
+  // leitura sai da peça errada e o teste fica verde medindo outra coisa.
+  await expect(page.locator("article figure.viz .viz-step")).toHaveCount(3);
+  await expect(page.locator("article figure.viz:not(.viz-fit) .viz-step")).not.toContainText("passo");
+  await expect(fig.locator(".viz-step")).toHaveCount(1);
+  await expect(fig.locator(".viz-step")).toContainText("passo");
+  // O bloco recolhível existe só nas duas peças adaptadas.
+  await expect(page.locator("article figure.viz .viz-code")).toHaveCount(2);
+  await expect(fig.locator(".viz-code")).toHaveCount(1);
+  return fig;
+}
+
+/** Anda `n` passos pelo botão, que é o caminho do aluno. */
+async function avancar(fig: Locator, n: number) {
+  const proximo = fig.locator("button", { hasText: "Próximo" });
+  for (let i = 0; i < n; i++) await proximo.click();
+}
+
+/** Expande e espera o painel estar PRONTO PARA O TECLADO, não só visível. */
+async function expandir(page: Page, fig: Locator): Promise<Locator> {
+  await fig.locator("button", { hasText: "Expandir" }).click();
+  const painel = page.locator(".viz-overlay-fit figure.viz");
+  await expect(painel).toHaveCount(1);
+  // O hook põe o foco na figura e registra o `keydown` no mesmo commit: o foco
+  // chegando é a prova de que o listener existe. `toBeVisible()` não é.
+  await expect(painel).toBeFocused();
+  return painel;
+}
+
+// ---------------------------------------------------------------------------
+// Camada 1 — cabeçalho e controles parados, só o miolo rola.
+// ---------------------------------------------------------------------------
+
+for (const caso of [
+  // O passo é o do PICO medido, não o primeiro: na árvore a pilha de chamadas
+  // cresce e desce, e no passo 1 o miolo ainda não tem sobra suficiente.
+  { nome: "árvore", i: ARVORE, passos: 11, w: 1440, h: 700 },
+  { nome: "sudoku", i: SUDOKU, passos: 0, w: 1440, h: 700, preset: "9x9 com 20 lacunas" },
+]) {
+  test(`${caso.nome}: no expandido o miolo rola e o ▶ Rodar não anda`, async ({ page }) => {
+    await abrirPagina(page, caso.w, caso.h);
+    const fig = await figura(page, caso.i);
+    if (caso.preset) {
+      await fig.locator("button", { hasText: caso.preset }).click();
+      await expect(fig.locator(".bt-cel")).toHaveCount(81);
+    }
+    await avancar(fig, caso.passos);
+
+    const painel = await expandir(page, fig);
+    const miolo = painel.locator(".viz-body");
+    const rodar = painel.locator(".viz-play");
+    const cabeca = painel.locator(".viz-head");
+
+    // Rótulo junto do comportamento: o controle que não pode sumir é o que diz
+    // "▶ Rodar", não um botão qualquer.
+    await expect(rodar).toHaveText("▶ Rodar");
+
+    // Premissa: existe sobra para rolar. Sem ela o teste vira decoração verde.
+    const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
+    expect(sobra).toBeGreaterThan(SLACK);
+
+    // O `click()` do Playwright rola o contêiner para alcançar o alvo, então a
+    // leitura de referência só vale com o `scrollTop` zerado.
+    await miolo.evaluate((el) => { el.scrollTop = 0; });
+    const antes = {
+      cabeca: (await cabeca.boundingBox())!.y,
+      rodar: (await rodar.boundingBox())!.y,
+    };
+
+    await miolo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    // Quem rolou foi o miolo, e não a figura: é essa a diferença que a camada 1
+    // faz, e é o que a quebra canônica (devolver o rodapé ao miolo) desfaz.
+    expect(await miolo.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+    expect(await painel.evaluate((el) => el.scrollHeight - el.clientHeight)).toBeLessThanOrEqual(SLACK);
+
+    const depois = {
+      cabeca: (await cabeca.boundingBox())!.y,
+      rodar: (await rodar.boundingBox())!.y,
+    };
+    expect(Math.round(depois.cabeca - antes.cabeca)).toBe(0);
+    // A asserção que carrega o sentido: o controle comparado com ele mesmo.
+    expect(Math.round(depois.rodar - antes.rodar)).toBe(0);
+    await expect(rodar).toBeInViewport({ ratio: 1 });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Camada 3 — o bloco recolhível, e quem decide é a medição.
+// ---------------------------------------------------------------------------
+
+for (const caso of [
+  { nome: "árvore", i: ARVORE },
+  { nome: "sudoku", i: SUDOKU },
+]) {
+  test(`${caso.nome}: em tela baixa o código vem recolhido, com o rótulo certo`, async ({ page }) => {
+    await abrirPagina(page, 1440, 700);
+    const fig = await figura(page, caso.i);
+    const botao = fig.locator(".viz-toggle-codigo");
+
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    // Recolhido não é só invisível: sai do teclado e dos leitores de tela.
+    await expect(fig.locator(".viz-code")).toHaveAttribute("aria-hidden", "true");
+  });
+
+  test(`${caso.nome}: em tela alta o código já vem aberto`, async ({ page }) => {
+    await abrirPagina(page, 1512, 1600);
+    const fig = await figura(page, caso.i);
+    const botao = fig.locator(".viz-toggle-codigo");
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(botao).toHaveText("Ocultar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "true");
+    // O texto do bloco é lido por `textContent` (as `.viz-line`), nunca por
+    // `innerText`: recolhido, o `innerText` devolve vazio justo para o Python.
+    await expect(fig.locator(".viz-code .viz-line").first()).toContainText("def ");
+  });
+}
+
+// A escolha do aluno vence a medição — e o estado trocado precisa ser um que
+// DISPARE medição nova (`measureOn`), senão nada ameaçou a escolha.
+test("árvore: mostrar o código sobrevive à troca de modo", async ({ page }) => {
+  await abrirPagina(page, 1440, 700);
+  const fig = await figura(page, ARVORE);
+  const cartao = fig.locator(".bigo-stat", { hasText: "nós da árvore inteira" });
+
+  await expect(fig).toHaveAttribute("data-codigo", "off");
+  await expect(cartao).toContainText("8");
+
+  await fig.locator(".viz-toggle-codigo").click();
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+
+  // `measureOn: [mode]` — trocar o modo troca a profundidade da árvore e pede
+  // medição nova, que numa janela de 700px recolheria.
+  await fig.locator("button", { hasText: "Combinações de 2 entre 1, 2, 3, 4" }).click();
+  // A troca aconteceu mesmo na tela: rótulo e valor no MESMO cartão.
+  await expect(cartao).toContainText("nós da árvore inteira");
+  await expect(cartao).toContainText("10");
+
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+  await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+});
+
+test("sudoku: mostrar o código sobrevive à troca de preset", async ({ page }) => {
+  await abrirPagina(page, 1440, 700);
+  const fig = await figura(page, SUDOKU);
+  const cartao = fig.locator(".bigo-stat", { hasText: "lacunas do tabuleiro" });
+
+  await expect(fig).toHaveAttribute("data-codigo", "off");
+  await expect(fig.locator(".bt-cel")).toHaveCount(16);
+  await expect(cartao).toContainText("11");
+
+  await fig.locator(".viz-toggle-codigo").click();
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+
+  // `measureOn: [presetKey]` — o 9x9 traz uma grade 190px mais alta.
+  await fig.locator("button", { hasText: "9x9 com 20 lacunas" }).click();
+  await expect(fig.locator(".bt-cel")).toHaveCount(81);
+  await expect(cartao).toContainText("lacunas do tabuleiro");
+  await expect(cartao).toContainText("20");
+
+  await expect(fig).toHaveAttribute("data-codigo", "on");
+  await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+});
+
+// ---------------------------------------------------------------------------
+// Teclado — e o inverso dele, que é o que importa mais.
+// ---------------------------------------------------------------------------
+
+for (const caso of [
+  { nome: "árvore", i: ARVORE, total: 32 },
+  { nome: "sudoku", i: SUDOKU, total: 60 },
+]) {
+  test(`${caso.nome}: a seta anda o passo no painel`, async ({ page }) => {
+    await abrirPagina(page, 1440, 700);
+    const fig = await figura(page, caso.i);
+    const painel = await expandir(page, fig);
+    const contador = painel.locator(".viz-step");
+
+    await expect(contador).toHaveText(`passo 1 de ${caso.total}`);
+    // Uma ação só: um par inverso (→ depois ←) devolveria a peça ao começo e
+    // ficaria verde mesmo com a tecla sendo roubada.
+    await page.keyboard.press("ArrowRight");
+    await expect(contador).toHaveText(`passo 2 de ${caso.total}`);
+    await page.keyboard.press("ArrowRight");
+    await expect(contador).toHaveText(`passo 3 de ${caso.total}`);
+  });
+
+  test(`${caso.nome}: a seta não é roubada de quem está no controle de velocidade`, async ({ page }) => {
+    await abrirPagina(page, 1440, 700);
+    const fig = await figura(page, caso.i);
+    const painel = await expandir(page, fig);
+    const contador = painel.locator(".viz-step");
+    const marcha = painel.locator(".viz-speed .val");
+    const slider = painel.locator("input[type=range]");
+    await expect(slider).toHaveCount(1);
+
+    await expect(contador).toHaveText(`passo 1 de ${caso.total}`);
+    await expect(marcha).toHaveText("1.5x");
+
+    await slider.focus();
+    await page.keyboard.press("ArrowRight");
+
+    // A tecla foi para o slider: a marcha subiu…
+    await expect(marcha).toHaveText("2x");
+    // …e o passo não andou. Campo em edição manda.
+    await expect(contador).toHaveText(`passo 1 de ${caso.total}`);
+  });
+}

--- a/tests/viz-binary-numbers.spec.ts
+++ b/tests/viz-binary-numbers.spec.ts
@@ -1,0 +1,439 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// Casca adaptativa do BinarioDivisoes.
+//
+// A página tem TRÊS `figure.viz` (o conversor de binário para decimal, as
+// divisões sucessivas e a tabela de bases) e só a do meio é `.viz-fit` — as
+// outras duas não têm overlay, então não há painel para arrumar nelas. Todo
+// seletor daqui é escopado na figura certa, e o primeiro teste confere as
+// contagens na página e na figura.
+//
+// Esta peça é uma das poucas da série em que o eixo de altura é o DESENHO e não
+// a prosa: a lista de divisões acumula uma linha por passo, 36px cada. Números
+// medidos nos 37 estados (4 presets de 10, 8, 9 e 10 passos) e nas três réguas:
+//
+//   .bb-passos ......... 27px (nenhuma divisão), depois 30/66/102/138/174/210/
+//                        246/282 — exatamente 36px por linha
+//   presets ............ 53 dá 6 divisões (210px), 64 dá 7 (246), 201 e 255
+//                        dão 8 (282) e medem IGUAL ao pixel
+//   .bn-fita ........... 63px, uma linha, 8 células nos 111 estados
+//   .bigo-stats ........ 64px nas três réguas
+//   dica do preset ..... 37px nos quatro presets e nas três réguas
+//   artigo, antes ...... 899..1175 (1512x900) / 914..1190 (1440), com o código
+//                        sempre à mostra e orçamentos de 816 / 616 / 516
+//   artigo, depois ..... 715..991 / 730..1006, com o código recolhido
+//   painel, antes ...... a FIGURA rolava 337/537/637px no passo do pico, o
+//                        cabeçalho subia junto (25 → -312/-512/-612) e o
+//                        `▶ Rodar` era desenhado 260/460/560px abaixo do pé
+//                        visível da peça
+//   painel, depois ..... quem rola é o miolo (84/275/370px de sobra); a figura
+//                        rola 0px e o cabeçalho não sai do lugar
+
+const ORCAMENTO = (h: number) => h - 60 - 24;
+
+/** O passo mais alto do preset padrão: oito divisões na lista e a nota longa. */
+const PICO = 9;
+
+/** A figura adaptada, no fluxo do artigo. */
+const noArtigo = (page: Page) => page.locator("article figure.viz-fit");
+/** A figura adaptada, dentro do painel expandido. */
+const noPainel = (page: Page) => page.locator(".viz-overlay figure.viz-fit");
+
+/** Espera a casca terminar a medição: `data-anim` só vira "on" depois dela. */
+async function pronta(fig: Locator) {
+  await expect(fig).toBeVisible();
+  await expect(fig).toHaveAttribute("data-anim", "on");
+}
+
+async function abrir(page: Page) {
+  await page.goto("/topico/binary-numbers/");
+  await page.evaluate(() => document.fonts.ready);
+  const fig = noArtigo(page);
+  await pronta(fig);
+  return fig;
+}
+
+/**
+ * Anda até o passo pedido pelo botão, confirmando o contador a cada clique.
+ * Lê o passo ATUAL antes de andar: uma versão que sempre parte do 1 anda de
+ * mais quando é chamada duas vezes no mesmo teste, e o erro sai três asserções
+ * adiante, longe da causa.
+ */
+async function atePasso(fig: Locator, alvo: number, total: number) {
+  const texto = (await fig.locator(".viz-step").textContent()) || "";
+  const atual = Number(texto.replace("passo ", "").split(" de ")[0]);
+  expect(Number.isFinite(atual)).toBe(true);
+  for (let i = atual + 1; i <= alvo; i++) {
+    await fig.locator("button", { hasText: "Próximo" }).click();
+    await expect(fig.locator(".viz-step")).toHaveText(`passo ${i} de ${total}`);
+  }
+  await expect(fig.locator(".viz-step")).toHaveText(`passo ${alvo} de ${total}`);
+}
+
+/**
+ * Altura do bloco recolhível, lida mesmo `inert` e só depois de a transição de
+ * 0,32s acabar. Espera fixa ANTES de contar leituras iguais: com `.viz-split` em
+ * `align-items: start`, a figura fica num patamar enquanto o código cresce, e
+ * "três leituras iguais" sozinho já devolveu 254px de erro noutro tópico.
+ */
+async function alturaDoCodigo(fig: Locator) {
+  await fig.page().waitForTimeout(450);
+  const ler = () =>
+    fig.locator(".viz-code").evaluate((e) => Math.round(e.getBoundingClientRect().height));
+  let iguais = 0;
+  let anterior = await ler();
+  for (let n = 0; n < 60 && iguais < 2; n++) {
+    await fig.page().waitForTimeout(60);
+    const atual = await ler();
+    iguais = atual === anterior ? iguais + 1 : 0;
+    anterior = atual;
+  }
+  return anterior;
+}
+
+const alturaDa = (loc: Locator) =>
+  loc.evaluate((e) => Math.round(e.getBoundingClientRect().height));
+
+test.describe("binary numbers · a figura certa", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("a casca alcança um dos três visualizadores, e é o das divisões", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+
+    // A ambiguidade é da PÁGINA, não da casca: três figuras no mesmo documento.
+    expect(await page.locator("article figure.viz").count()).toBe(3);
+    expect(await fig.count()).toBe(1);
+    // Os três `.viz-step` da página dizem coisas DIFERENTES — "00110101 = 53" no
+    // conversor e "255 = 0xFF = 0b11111111" na tabela de bases —, e só o do meio
+    // é um contador de passo. Um seletor não escopado pega o primeiro em
+    // silêncio, e `split(" de ")[1]` viraria `NaN` sem ninguém reclamar.
+    expect(await page.locator("article .viz-step").count()).toBe(3);
+    expect(await fig.locator(".viz-step").count()).toBe(1);
+    await expect(page.locator("article .viz-step").first()).toHaveText("00110101 = 53");
+    expect(await fig.locator("input[type=range]").count()).toBe(1);
+    expect(await fig.locator(".viz-foot").count()).toBe(1);
+    expect(await fig.locator(".viz-code-slot").count()).toBe(1);
+
+    await expect(fig.locator(".viz-head-title")).toContainText(
+      "de decimal para binário, dividindo por 2"
+    );
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 10");
+  });
+});
+
+test.describe("binary numbers · camada 1: cabeçalho e controles parados", () => {
+  test.use({ viewport: { width: 1440, height: 600 } });
+
+  test("o miolo rola e o cabeçalho e o rodapé não saem do lugar", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1440, height: 600 });
+
+    await atePasso(fig, PICO, 10);
+    await fig.locator("button", { hasText: "Expandir" }).click();
+    const painel = noPainel(page);
+    await pronta(painel);
+    await expect(painel.locator(".viz-step")).toHaveText(`passo ${PICO} de 10`);
+
+    // O aluno pede o código de volta: é o estado com mais coisa para rolar, e a
+    // escolha dele vence a medição.
+    if ((await painel.getAttribute("data-codigo")) === "off") {
+      await painel.locator("button", { hasText: "Mostrar código" }).click();
+    }
+    await expect(painel).toHaveAttribute("data-codigo", "on");
+    await expect(painel.locator("button", { hasText: "Ocultar código" })).toBeVisible();
+
+    const corpo = painel.locator(".viz-body");
+    const cabeca = painel.locator(".viz-head");
+    const rodape = painel.locator(".viz-foot");
+    const rodar = painel.locator("button", { hasText: "Rodar" });
+
+    // O `click()` do Playwright rola o contêiner para alcançar o alvo, então a
+    // posição de referência só vale com o `scrollTop` zerado.
+    await corpo.evaluate((e) => { e.scrollTop = 0; });
+
+    const antes = {
+      cabeca: (await cabeca.boundingBox())!.y,
+      rodape: (await rodape.boundingBox())!.y,
+      rodar: (await rodar.boundingBox())!.y,
+    };
+
+    await corpo.evaluate((e) => { e.scrollTop = e.scrollHeight; });
+
+    // A asserção que carrega o sentido: a posição comparada com ela mesma.
+    // `toBeInViewport()` sozinho passaria com o rodapé de volta dentro do miolo,
+    // porque ele aceita qualquer interseção nas DUAS pontas da rolagem.
+    const depois = {
+      cabeca: (await cabeca.boundingBox())!.y,
+      rodape: (await rodape.boundingBox())!.y,
+      rodar: (await rodar.boundingBox())!.y,
+    };
+    expect(Math.round(depois.cabeca - antes.cabeca)).toBe(0);
+    expect(Math.round(depois.rodape - antes.rodape)).toBe(0);
+    expect(Math.round(depois.rodar - antes.rodar)).toBe(0);
+
+    // E o botão que faz o algoritmo andar continua inteiro na tela.
+    await expect(rodar).toBeInViewport({ ratio: 1 });
+    await expect(rodar).toHaveText("▶ Rodar");
+
+    // Premissas DEPOIS das asserções, de propósito: a quebra canônica desta
+    // camada (devolver o rodapé para dentro do miolo) desfaz a primeira delas, e
+    // o teste reprovaria na premissa em vez de na asserção que importa.
+    expect(await corpo.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeGreaterThan(8);
+    expect(await corpo.evaluate((e) => e.scrollTop)).toBeGreaterThan(0);
+    expect(await painel.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeLessThanOrEqual(8);
+    expect(await painel.evaluate((e) => e.scrollTop)).toBe(0);
+  });
+});
+
+test.describe("binary numbers · camada 3: a medição recolhe o código", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("em 900px de altura o código vem recolhido, e o rótulo diz o que ele faz", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+
+    // Rótulo e valor juntos: o botão promete mostrar, e o bloco está fechado.
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    const botao = fig.locator(".viz-toggle-codigo");
+    await expect(botao).toHaveText("Mostrar código");
+    await expect(botao).toHaveAttribute("aria-expanded", "false");
+    // O que devolve ALTURA é o `.viz-code-slot`; zerar a trilha da coluna tiraria
+    // só a largura, e o bloco seguiria com os seus 230px.
+    expect(await alturaDoCodigo(fig)).toBeLessThan(10);
+
+    const recolhida = await alturaDa(fig);
+    expect(recolhida).toBeLessThan(ORCAMENTO(900));
+
+    await botao.click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    expect(await alturaDoCodigo(fig)).toBeGreaterThan(200);
+
+    // Aberta ela não caberia: é essa diferença que justifica a camada 3 aqui.
+    const aberta = await alturaDa(fig);
+    expect(aberta).toBeGreaterThan(ORCAMENTO(900));
+    expect(aberta - recolhida).toBeGreaterThan(180);
+  });
+});
+
+test.describe("binary numbers · camada 3: em tela alta o código já vem aberto", () => {
+  test.use({ viewport: { width: 1512, height: 1200 } });
+
+  test("com 1200px de altura a peça cabe inteira e o código não é escondido", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 1200 });
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    expect(await alturaDoCodigo(fig)).toBeGreaterThan(200);
+    expect(await alturaDa(fig)).toBeLessThan(ORCAMENTO(1200));
+  });
+});
+
+test.describe("binary numbers · a escolha do aluno vence a medição", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("abrir o código sobrevive à troca de preset, que é o que dispara medição nova", async ({ page }) => {
+    const fig = await abrir(page);
+    expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+
+    // Nesta janela a medição QUER recolher: a peça aberta pede 909px de um
+    // orçamento de 816. A escolha do aluno está de fato ameaçada.
+    await expect(fig).toHaveAttribute("data-codigo", "off");
+    await fig.locator(".viz-toggle-codigo").click();
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+
+    const dica = fig.locator(".tt-legenda-arvore");
+    const dicaAntes = await dica.textContent();
+
+    // O preset é o único item de `measureOn`, e aqui ele muda o DESENHO: 53 tem
+    // seis divisões contra as oito do 201, dois degraus de 36px a menos.
+    await fig.locator(".bigo-chip", { hasText: "53" }).click();
+
+    // Confirme a troca NA TELA antes de concluir: preset que não muda a entrada
+    // da medição faz a escolha "sobreviver" sem nada tê-la ameaçado.
+    await expect(dica).not.toHaveText(dicaAntes!);
+    await expect(dica).toContainText("O mesmo número do visualizador anterior");
+    await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 8");
+
+    await expect(fig).toHaveAttribute("data-codigo", "on");
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    expect(await alturaDoCodigo(fig)).toBeGreaterThan(200);
+  });
+});
+
+test.describe("binary numbers · teclado do painel", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  /** `toBeVisible()` não é "pronto para o teclado": o listener nasce num efeito. */
+  async function expandir(page: Page) {
+    const fig = await abrir(page);
+    await fig.locator("button", { hasText: "Expandir" }).click();
+    const painel = noPainel(page);
+    await pronta(painel);
+    await expect
+      .poll(() => page.evaluate(() => !!document.activeElement?.closest(".viz-overlay-fit")))
+      .toBe(true);
+    return painel;
+  }
+
+  test("as setas e o espaço andam a animação", async ({ page }) => {
+    const painel = await expandir(page);
+    const passo = painel.locator(".viz-step");
+    await expect(passo).toHaveText("passo 1 de 10");
+
+    // Uma ação só por vez: um par ArrowRight/ArrowLeft voltaria ao ponto de
+    // partida e ficaria verde mesmo com as duas teclas roubadas.
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 2 de 10");
+    await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("passo 3 de 10");
+    await page.keyboard.press("ArrowLeft");
+    await expect(passo).toHaveText("passo 2 de 10");
+
+    await page.keyboard.press(" ");
+    await expect(painel.locator("button", { hasText: "Pausar" })).toHaveText("❚❚ Pausar");
+  });
+
+  test("com o controle de velocidade em foco, a seta é do slider e não do passo", async ({ page }) => {
+    const painel = await expandir(page);
+    const passo = painel.locator(".viz-step");
+    const marcha = painel.locator(".viz-speed .val");
+    await expect(passo).toHaveText("passo 1 de 10");
+    // A peça sempre abriu em 1.5x (`initialSpeed: 4`); sem passar isso ao hook
+    // ela cairia calada para 1x, e nenhum outro teste notaria.
+    await expect(marcha).toHaveText("1.5x");
+
+    await painel.locator("input[type=range]").focus();
+    await page.keyboard.press("ArrowRight");
+
+    // A tecla chegou ao slider...
+    await expect(marcha).toHaveText("2x");
+    // ...e NÃO foi roubada pelo atalho de passo.
+    await expect(passo).toHaveText("passo 1 de 10");
+  });
+});
+
+test.describe("binary numbers · o que está escrito na tela", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("os cartões carregam rótulo e valor no mesmo lugar", async ({ page }) => {
+    const fig = await abrir(page);
+    const cartao = (rotulo: string) =>
+      fig.locator(".bigo-stat").filter({ hasText: rotulo }).locator("strong");
+
+    expect(await fig.locator(".bigo-stat").count()).toBe(4);
+    // No passo 1 nenhuma divisão foi feita ainda, e a fita está toda com "?".
+    await expect(fig.locator(".bigo-stat").nth(0)).toContainText("número de partida");
+    await expect(cartao("número de partida")).toHaveText("201");
+    await expect(cartao("divisões feitas")).toHaveText("0");
+    await expect(cartao("bits significativos")).toHaveText("8");
+    await expect(cartao("bits já ligados na fita")).toHaveText("0");
+
+    // No fim, 201 = 11001001: oito divisões e quatro bits ligados. O rótulo diz
+    // "já ligados NA FITA", e o número tem que ser o da fita, não o de bits
+    // escritos — comportamento certo com rótulo errado ensina errado igual.
+    await atePasso(fig, 10, 10);
+    await expect(cartao("divisões feitas")).toHaveText("8");
+    await expect(cartao("bits já ligados na fita")).toHaveText("4");
+    expect(
+      await fig.locator(".bn-bit.on").count()
+    ).toBe(4);
+    await expect(fig.locator(".viz-note")).toContainText(
+      "201 em binário é 11001001"
+    );
+    await expect(fig.locator(".viz-note")).toContainText("128 + 64 + 8 + 1 = 201");
+  });
+
+  test("o Python da tela e os rótulos das variáveis continuam em português", async ({ page }) => {
+    const fig = await abrir(page);
+
+    // O bloco vem recolhido nesta janela: leia por `textContent` (é o que as
+    // `.viz-line` dão), nunca por `innerText`, que devolveria vazio justamente
+    // para o que um rename estragaria.
+    const linhas = await fig.locator(".viz-code .viz-line").allTextContents();
+    expect(linhas).toHaveLength(7);
+    expect(linhas[0]).toContain("def para_binario(n):");
+    expect(linhas[2]).toContain("bits = ''");
+    expect(linhas[4]).toContain("bits = str(n % 2) + bits   # o resto entra na FRENTE");
+    expect(linhas[5]).toContain("n = n // 2                 # e o número encolhe pela metade");
+    await expect(fig.locator(".viz-code-head")).toHaveText("para_binario.py");
+
+    const varDe = (nome: string) =>
+      fig.locator(".viz-var").filter({ hasText: nome }).locator(".viz-var-val");
+    expect(await fig.locator(".viz-var").count()).toBe(3);
+    await expect(varDe("n (o que falta converter)")).toHaveText("201");
+    await expect(varDe("último resto")).toHaveText("-");
+    await expect(varDe("bits já escritos")).toHaveText("0");
+
+    await atePasso(fig, 2, 10);
+    await expect(varDe("n (o que falta converter)")).toHaveText("100");
+    await expect(varDe("último resto")).toHaveText("1");
+    await expect(varDe("bits já escritos")).toHaveText("1");
+  });
+});
+
+test.describe("binary numbers · o eixo de altura é a lista que acumula", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("cada passo acrescenta uma linha de 36px sem apagar a anterior", async ({ page }) => {
+    const fig = await abrir(page);
+    const lista = fig.locator(".bb-passos");
+
+    // Passo 1: nenhuma divisão, uma linha de aviso.
+    expect(await lista.locator("li").count()).toBe(1);
+    await expect(lista.locator("li")).toHaveText("nenhuma divisão ainda");
+    const vazia = await alturaDa(lista);
+
+    // A lista ACUMULA: no passo k há k-1 divisões, e a primeira continua lá.
+    await atePasso(fig, 2, 10);
+    await expect(lista.locator("li").first()).toContainText("201 ÷ 2 = 100");
+    const uma = await alturaDa(lista);
+
+    await atePasso(fig, PICO, 10);
+    expect(await lista.locator("li").count()).toBe(8);
+    // A primeira divisão continua na tela oito passos depois — é isso que faz
+    // desta peça um eixo de altura de verdade, e não uma grandeza temporal.
+    await expect(lista.locator("li").first()).toContainText("201 ÷ 2 = 100");
+    await expect(lista.locator("li").nth(7)).toContainText("1 ÷ 2 = 0");
+    await expect(lista.locator("li").nth(7)).toHaveClass(/foco/);
+    const oito = await alturaDa(lista);
+
+    expect(vazia).toBeLessThan(uma);
+    // 36px por linha: sete linhas a mais valem 252px.
+    expect(oito - uma).toBe(252);
+    expect(oito).toBe(282);
+  });
+
+  test("o degrau do log2 é atravessado pelos presets, e a fita não é eixo", async ({ page }) => {
+    const fig = await abrir(page);
+    const lista = fig.locator(".bb-passos");
+    const fita = fig.locator(".bn-fita");
+
+    // 53 → 6 divisões, 64 → 7, 201 e 255 → 8. Três patamares, e os dois de oito
+    // medem igual ao pixel: varrer quatro presets mede TRÊS pontos, não quatro.
+    const casos: [string, number, number, number][] = [
+      ["53", 8, 6, 210],
+      ["64, uma potência de dois", 9, 7, 246],
+      ["255, todos ímpares", 10, 8, 282],
+      ["201", 10, 8, 282],
+    ];
+    for (const [rotulo, total, divisoes, altura] of casos) {
+      await fig.locator(".bigo-chip", { hasText: rotulo }).click();
+      await expect(fig.locator(".bigo-chip", { hasText: rotulo })).toHaveAttribute(
+        "aria-pressed",
+        "true"
+      );
+      await expect(fig.locator(".viz-step")).toHaveText(`passo 1 de ${total}`);
+      await atePasso(fig, total - 1, total);
+      expect(await lista.locator("li").count()).toBe(divisoes);
+      expect(await alturaDa(lista)).toBe(altura);
+
+      // A fita tem oito células em todos eles (`Math.max(8, ...)`) e cabe numa
+      // linha só, então ela não entra na conta da altura.
+      expect(await fita.locator(".bn-bit").count()).toBe(8);
+      expect(await alturaDa(fita)).toBe(63);
+    }
+  });
+});

--- a/tests/viz-negative-binary.spec.ts
+++ b/tests/viz-negative-binary.spec.ts
@@ -1,0 +1,250 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// Casca adaptativa do BinarioComplemento (tópico negative-binary).
+//
+// A página tem TRÊS `figure.viz` — o complemento, as três formas e a faixa —, e
+// só a primeira é adaptada. Todo seletor daqui é escopado nela, e as contagens
+// são afirmadas nos dois níveis (página e figura), porque um seletor que casa
+// com o irmão errado devolve um número plausível e nunca reclama.
+
+const URL = "/topico/negative-binary/";
+// Mesma folga de subpixel do hook (`SLACK` em src/lib/visualizer.tsx).
+const SLACK = 8;
+
+function figura(page: Page): Locator {
+  return page.locator("article figure.viz").first();
+}
+
+/** Congela transição e animação: ler altura com a transição em voo devolve o meio do caminho. */
+async function congelar(page: Page) {
+  await page.addStyleTag({
+    content: "*, *::before, *::after { transition: none !important; animation: none !important; }",
+  });
+  await page.evaluate(() => document.fonts.ready);
+}
+
+async function abrir(page: Page, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto(URL);
+  const vp = page.viewportSize();
+  expect(vp, "o viewport pedido tem que ser o viewport real").toEqual({ width: w, height: h });
+  await congelar(page);
+}
+
+/** Anda até o último passo, que é onde o painel da prova existe (o pico de altura). */
+async function irAoFim(f: Locator) {
+  const proximo = f.getByRole("button", { name: "Próximo ›" });
+  const total = parseInt((await f.locator(".viz-step").innerText()).match(/de (\d+)/)![1], 10);
+  for (let i = 0; i < total - 1; i++) await proximo.click();
+  await expect(proximo).toBeDisabled();
+  return total;
+}
+
+test("a página tem três visualizadores e só o complemento ganhou a casca", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  await expect(page.locator("article figure.viz")).toHaveCount(3);
+  await expect(page.locator("article figure.viz-fit")).toHaveCount(1);
+
+  const f = figura(page);
+  await expect(f).toHaveClass(/viz-fit/);
+  await expect(f.locator(".viz-head-title")).toContainText("complemento de dois: inverter e somar 1");
+  // Dentro da figura os seletores da casca casam UM elemento cada; na página
+  // eles casam mais, porque os irmãos usam as mesmas classes.
+  await expect(f.locator(".viz-step")).toHaveCount(1);
+  await expect(f.locator(".viz-code")).toHaveCount(1);
+  await expect(f.locator(".viz-code-slot")).toHaveCount(1);
+  await expect(f.locator(".bigo-chip")).toHaveCount(5);
+  expect(await page.locator("article figure.viz .viz-step").count()).toBeGreaterThan(1);
+});
+
+test("a marcha inicial da peça sobreviveu: o rótulo diz 1.5x ao lado do valor 4", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  const f = figura(page);
+  await f.getByRole("button", { name: "⤢ Expandir" }).click();
+  const p = page.locator(".viz-overlay figure.viz");
+  await expect(p).toBeVisible();
+  const vel = p.locator(".viz-speed");
+  // Rótulo e valor lidos JUNTOS: "1.5x" ao lado de um slider em 3 seria o
+  // rótulo de outra marcha, e a peça teria perdido o ritmo dela.
+  await expect(vel.locator("input[type=range]")).toHaveValue("4");
+  await expect(vel.locator(".val")).toHaveText("1.5x");
+  await expect(vel).toContainText("Velocidade");
+});
+
+test("no painel o cabeçalho e os controles não andam quando o miolo rola", async ({ page }) => {
+  // 1440x700 e o último passo: é onde o painel da prova existe e o miolo tem
+  // 175px de sobra. No passo 1, a 1512x900, não há o que rolar e o teste seria
+  // decoração verde.
+  await abrir(page, 1440, 700);
+  const f = figura(page);
+  await f.getByRole("button", { name: "⤢ Expandir" }).click();
+  const p = page.locator(".viz-overlay figure.viz");
+  await expect(p).toBeVisible();
+  await irAoFim(p);
+
+  const play = p.getByRole("button", { name: "▶ Rodar" });
+  const antes = await play.boundingBox();
+  const cabeca = p.locator(".viz-head");
+  const cabecaAntes = await cabeca.boundingBox();
+
+  const m = await p.evaluate((el, slack) => {
+    const body = el.querySelector(".viz-body") as HTMLElement;
+    body.scrollTop = 0;
+    const sobra = body.scrollHeight - body.clientHeight;
+    body.scrollTop = body.scrollHeight;
+    return {
+      sobraMiolo: sobra,
+      rolouMiolo: Math.round(body.scrollTop),
+      sobraFigura: el.scrollHeight - el.clientHeight,
+      folga: slack,
+    };
+  }, SLACK);
+
+  // A ASSERÇÃO QUE CARREGA O SENTIDO: a posição comparada com ela mesma.
+  // `toBeInViewport()` sozinho passa com o rodapé de volta dentro do miolo.
+  const depois = await play.boundingBox();
+  const cabecaDepois = await cabeca.boundingBox();
+  expect(Math.round(depois!.y - antes!.y), "o ▶ Rodar não anda quando o miolo rola").toBe(0);
+  expect(Math.round(cabecaDepois!.y - cabecaAntes!.y), "o cabeçalho não anda quando o miolo rola").toBe(0);
+  await expect(play).toBeInViewport({ ratio: 1 });
+
+  // Premissas depois das asserções: se a quebra desfizer a situação, a mensagem
+  // que aparece é a da asserção que importa, não a da premissa.
+  expect(m.sobraMiolo, "o miolo precisa ter o que rolar, senão o teste é decoração").toBeGreaterThan(SLACK);
+  expect(m.rolouMiolo, "quem rola é o MIOLO").toBeGreaterThan(0);
+  expect(m.sobraFigura, "a figura inteira NÃO rola").toBeLessThanOrEqual(SLACK);
+});
+
+test("em tela baixa o botão diz Mostrar código e o bloco está recolhido de fato", async ({ page }) => {
+  await abrir(page, 1440, 700);
+  const f = figura(page);
+  const botao = f.locator(".viz-toggle-codigo");
+  // rótulo e estado no mesmo elemento: rótulo certo com bloco aberto ensina errado.
+  await expect(botao).toHaveText("Mostrar código");
+  await expect(botao).toHaveAttribute("aria-expanded", "false");
+  await expect(f).toHaveAttribute("data-codigo", "off");
+
+  const alturaCodigo = await f.locator(".viz-code").evaluate((el) => el.getBoundingClientRect().height);
+  expect(Math.round(alturaCodigo), "recolhido é ALTURA zero, não só coluna zerada").toBeLessThanOrEqual(SLACK);
+  // O código continua no DOM (é o que permite medir o pior caso), mas fora do
+  // teclado e dos leitores de tela.
+  await expect(f.locator(".viz-code")).toHaveAttribute("aria-hidden", "true");
+  expect(await f.locator(".viz-code .viz-line").count()).toBe(7);
+});
+
+test("em tela alta o código já vem aberto, com o rótulo invertido", async ({ page }) => {
+  await abrir(page, 1440, 1200);
+  const f = figura(page);
+  const botao = f.locator(".viz-toggle-codigo");
+  await expect(botao).toHaveText("Ocultar código");
+  await expect(botao).toHaveAttribute("aria-expanded", "true");
+  await expect(f).toHaveAttribute("data-codigo", "on");
+
+  const alturaCodigo = await f.locator(".viz-code").evaluate((el) => el.getBoundingClientRect().height);
+  expect(alturaCodigo, "aberto é altura de verdade, não `visibility`").toBeGreaterThan(100);
+  // Lê o texto do bloco pelas `.viz-line`: `innerText` devolve vazio quando ele
+  // está recolhido, e a varredura sai "limpa" sobre o que não olhou.
+  await expect(f.locator(".viz-code-head")).toHaveText("complemento.py");
+  const linhas = await f.locator(".viz-code .viz-line").allTextContents();
+  expect(linhas[2]).toContain("invertido = ~positivo & 0xFF");
+  expect(linhas[3]).toContain("negativo  = (invertido + 1) & 0xFF");
+});
+
+test("a escolha do aluno vence a medição ao trocar de preset", async ({ page }) => {
+  // A medição fecha o código no preset "26" e fecharia também no "0, o teste da
+  // ambiguidade", cuja dica é a mais alta das cinco — ou seja, a troca dispara
+  // medição nova (o preset está em `measureOn`) e a medição DISCORDA do aluno.
+  // Sem isso o teste aprovaria sozinho.
+  //
+  // 1440x700, e não a régua de 1512x900 do contrato, POR MEDIÇÃO: com o código
+  // aberto o miolo pede 724px nas duas. A 1512x900 ele tem 708 e estoura por
+  // 16px, contra um SLACK de 8 — oito pixels de margem, que a suíte cheia já
+  // virou (a precondição recebeu "on"). A 1440x700 ele tem 517 e estoura por
+  // 207. Precondição que afirma o veredito da medição precisa da MARGEM medida,
+  // não de uma observação.
+  await abrir(page, 1440, 700);
+  const f = figura(page);
+  await f.getByRole("button", { name: "⤢ Expandir" }).click();
+  const p = page.locator(".viz-overlay figure.viz");
+  await expect(p).toBeVisible();
+  await expect(p).toHaveAttribute("data-codigo", "off");
+
+  await p.getByRole("button", { name: "Mostrar código" }).click();
+  await expect(p).toHaveAttribute("data-codigo", "on");
+
+  await p.getByRole("button", { name: "0, o teste da ambiguidade", exact: true }).click();
+  // Confirma na TELA que o estado trocou mesmo, antes de concluir qualquer coisa.
+  await expect(p.locator(".tt-legenda-arvore")).toContainText("o motivo de o complemento de dois ter vencido");
+  await expect(p.locator(".viz-step")).toHaveText("passo 1 de 19");
+
+  // Amostra ao longo do intervalo: "está aberto agora" não é "continua aberto".
+  for (let i = 0; i < 5; i++) {
+    await expect(p).toHaveAttribute("data-codigo", "on");
+    await expect(p.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
+    await page.waitForTimeout(120);
+  }
+});
+
+test("as setas e o espaço andam a animação no painel", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  const f = figura(page);
+  await f.getByRole("button", { name: "⤢ Expandir" }).click();
+  const p = page.locator(".viz-overlay figure.viz");
+  await expect(p).toBeVisible();
+  // `toBeVisible()` NÃO é "pronto para o teclado": o listener nasce num efeito.
+  // O mesmo commit que dá foco à figura registra o `keydown`, então esperar o
+  // foco é a pré-condição que fecha a corrida.
+  await expect(p).toBeFocused();
+  await expect(p.locator(".viz-step")).toHaveText("passo 1 de 13");
+
+  // UMA ação, não um par que se cancela: ArrowRight seguido de ArrowLeft volta
+  // ao estado de origem e fica verde mesmo com a tecla sequestrada.
+  await page.keyboard.press("ArrowRight");
+  await expect(p.locator(".viz-step")).toHaveText("passo 2 de 13");
+  await page.keyboard.press("ArrowRight");
+  await expect(p.locator(".viz-step")).toHaveText("passo 3 de 13");
+
+  await page.keyboard.press(" ");
+  await expect(p.getByRole("button", { name: "❚❚ Pausar" })).toBeVisible();
+  await page.keyboard.press(" ");
+  await expect(p.getByRole("button", { name: "▶ Rodar" })).toBeVisible();
+});
+
+test("a seta no controle de velocidade é do slider, e não do passo", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  const f = figura(page);
+  await f.getByRole("button", { name: "⤢ Expandir" }).click();
+  const p = page.locator(".viz-overlay figure.viz");
+  await expect(p).toBeVisible();
+  await expect(p).toBeFocused();
+
+  const slider = p.locator(".viz-speed input[type=range]");
+  await expect(p.locator(".viz-speed input[type=range]")).toHaveCount(1);
+  await slider.focus();
+  await expect(slider).toBeFocused();
+  await expect(p.locator(".viz-step")).toHaveText("passo 1 de 13");
+
+  await page.keyboard.press("ArrowRight");
+  // A tecla foi para o slider: a marcha subiu e o rótulo ao lado acompanhou.
+  await expect(slider).toHaveValue("5");
+  await expect(p.locator(".viz-speed .val")).toHaveText("2x");
+  // E o passo NÃO andou.
+  await expect(p.locator(".viz-step")).toHaveText("passo 1 de 13");
+});
+
+test("o painel da prova só existe no último passo, e é ele que move a altura", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  const f = figura(page);
+  await expect(f.locator(".hp-bloco")).toHaveCount(2);
+  const antes = (await f.boundingBox())!.height;
+
+  await irAoFim(f);
+  await expect(f.locator(".hp-bloco")).toHaveCount(3);
+  // Rótulo junto do conteúdo: o terceiro bloco é o da prova, não um repetido.
+  await expect(f.locator(".hp-bloco").nth(2).locator(".tt-painel-tit")).toContainText("A prova");
+  await expect(f.locator(".hp-bloco").nth(2).locator(".tt-painel-tit em")).toHaveText(
+    "somar o número com o oposto dele"
+  );
+  const depois = (await f.boundingBox())!.height;
+  expect(Math.round(depois - antes), "o bloco condicional é o eixo de altura desta peça").toBeGreaterThan(100);
+});


### PR DESCRIPTION
Aplica a casca adaptativa (`.viz-fit`) nos visualizadores dos grupos
**Backtracking** e **Manipulação de Bits**: três tópicos, **4 visualizadores
adaptados**, com um agente por tópico em paralelo e consolidação num PR só.

**Depois deste PR resta um único visualizador** para os 62 estarem na casca: o
`BigOChartVisualizer`, do tópico `big-o`.

## O que entrou, e o que ficou de fora

| tópico | adaptados | fora do escopo |
|---|---|---|
| `backtracking` | `BacktrackingVisualizer`, `BacktrackingSudoku` | `BacktrackingPoda` |
| `binary-numbers` | `BinarioDivisoes` | `BinarioBases`, `BinarioConversor` |
| `negative-binary` | `BinarioComplemento` | `BinarioFaixa`, `BinarioTresFormas` |

**4 de 9.** Os cinco de fora não têm overlay — conferidos lendo o arquivo, não só
pela coluna do inventário. `operacoes-bitwise` está `soon`. **Zero linha de CSS
nova.**

## Medições

Janela **1512x900**, fontes carregadas, animação congelada, orçamento no artigo
= 816px. Cada peça medida andando a animação inteira, em todos os presets, e
também em 1440x700 e 1440x600.

| peça | artigo antes | depois | no painel, antes |
|---|---|---|---|
| árvore de backtracking | 1369 | **1135** | figura rolava 547px; `▶ Rodar` 335px fora |
| sudoku | 1009–1217 | **749–957** | figura rolava 290px |
| divisões sucessivas | 899–1175 | **715–991** | cabeçalho subia 312px; `▶ Rodar` 260px fora |
| complemento de dois | 919–1089 | **735–906** | cabeçalho subia 236px; `▶ Rodar` 159px fora |

**Nas quatro, quem rolava no painel era a figura inteira.** Agora o cabeçalho não
anda 1px em nenhuma das três réguas e todo controle fica dentro da janela. O
sudoku e o complemento passam a **caber no artigo** (o complemento sai de 103px
estourando para 81px de folga).

A árvore de backtracking segue 319px acima do orçamento com o código já
recolhido — limite do §9, reportado com número.

## Testes

**32 testes novos** em três arquivos disjuntos, **27 quebras provadas**, todas
compilando, com build visível e resumo imprimindo `failed` **e** `passed`.

**Suíte completa na branch integrada: 459 passed, 0 failed** (`--workers=2`, com
a máquina livre).

## Verificação da consolidação

- **Diff do texto renderizado do build inteiro** contra `origin/main`, palavra a
  palavra: **zero palavras perdidas** nas três páginas.
- **Varreduras de classe:** nenhuma marcha inicial perdida, nenhum `stepBy` com
  aritmética, nenhum rodapé escrito à mão, nenhum CSS novo.
- **Chaves de preset:** todas em inglês. E a união `conflict` do sudoku ficou
  **em português de propósito** — ela é texto de tela, não identificador (ver §0
  abaixo).

## Contrato (`content/visualizers/README.md`)

### §8 — a asserção do cabeçalho NÃO pega a quebra da camada 1

Esta seção mandava exigir três premissas (o miolo estoura, ele rolou, a figura
não rola) e afirmava que os testes bons deste repo já as tinham. Duas peças
mediram o que acontece contra a quebra canônica — o `<VizFooter>` de volta ao
`.viz-body` — e **das cinco asserções, quatro passam**:

| asserção | contra a quebra |
|---|---|
| o miolo estoura | **passa** |
| o miolo rolou | **passa** |
| a figura não rola | **passa** — o miolo absorve o rodapé |
| **o cabeçalho não anda** | **passa** |
| **a posição do controle de reprodução, comparada com ela mesma** | **reprova** (−227, −425, −488px) |

As três premissas continuam certas — elas provam que o teste mede a coisa certa,
não que a camada funciona. E a do cabeçalho, que é a formulação mais natural de
"a camada 1 funciona", passa porque **o defeito é do rodapé**. Medido no
`backtracking` e confirmado independentemente no `binary-numbers`.

### §3 — o lado SIM da pergunta "junta ou uma de cada vez"

Faltava desde o shell sort, que mediu o lado NÃO. O sinal no código é o gerador
**acumulando** (`rows: [...rows, nova]`), e no `BinarioDivisoes` isso vira
geometria a **36px por linha exatos** — 255 dos 276px de amplitude. Com dois
detalhes que só esse caso mostra: **quatro controles podem medir três pontos**
(201 e 255 dão a mesma altura ao pixel), e **o pico pode ser o penúltimo passo**.

### §0 — a quarta fronteira do idioma, espelho do sufixo de classe

`conflict: "linha" | "coluna" | "quadrante"` (`BacktrackingSudoku`) é renderizada
**crua** no painel "regra que barrou". Traduzir compila, passa no guarda e
**troca o que o aluno lê**. A união *parece* identificador e *é* conteúdo —
enquanto o sufixo de classe *parece* conteúdo e *é* API.

### §9 — o saldo pode ser MUITO negativo

O `BinarioDivisoes` ficou **184px mais baixo** no artigo. A aritmética fecha sem
mecanismo novo: o `.viz-split` cai de 230 para 36px (−194) porque o bloco sai do
fluxo lateral, e o `.viz-foot` cobra os +10 de sempre. **A série já tem +28, +10,
−4 e −184** — não cite nenhum sem medir a sua peça.

## Um caso que confirma "a §3 se responde por peça"

As duas peças de `backtracking` rodam **o mesmo algoritmo** e caem em lados
opostos: a árvore desenha o percurso inteiro (profundidade vira geometria, 260px
com 3 níveis contra 198 com 2, pico no passo 12 de 32), e o sudoku **não acumula
nada** — amplitude de **20px em 956 passos**, toda da nota. `measureOn: [mode]`
numa, `[presetKey]` na outra.

## Idioma

Identificadores traduzidos nas quatro peças. O `guarda-idioma.py` **não é prova**,
e a prova foi comparar o texto renderizado dos estados: **1.512 estados** somados
(1.362 + 37 + 75 + 38), com diff vazio no miolo, mais o diff do build acima.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDjaWpe9Dgr7XoqJBpH4GD
