### PR TITLE
feat(analytics): GA4 e Search Console sem custo no caminho crítico

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,24 @@ APOIASE_TOKEN=
 
 # Id numérico da campanha (aparece na URL do painel da APOIA.se).
 APOIASE_CAMPAIGN_ID=
+
+# ---------------------------------------------------------------------------
+# Google Analytics 4 (opcional, e de propósito).
+#
+# Deixe VAZIO no seu .env.local: sem o ID, o site não pede o gtag.js e o build
+# local fica idêntico ao de hoje. Preenchido, o `@next/third-parties` carrega o
+# GA depois da hidratação (ver src/components/Analytics.tsx).
+#
+# Em produção quem injeta é o workflow do Cloudflare Pages, e SÓ no build da
+# `main` — assim preview de PR e build de fork não sujam a propriedade real.
+# No GitHub, cadastre como *variable* (Settings > Secrets and variables >
+# Actions > Variables). Não é segredo: o ID aparece no HTML de toda página.
+#
+# Formato: G-XXXXXXXXXX (o "measurement ID" do fluxo de dados web, não o
+# "stream ID" numérico nem o ID de propriedade).
+NEXT_PUBLIC_GA_ID=
+
+# Search Console, só se a verificação for pela tag HTML. O caminho recomendado
+# é a propriedade de DOMÍNIO com TXT no DNS do Cloudflare, que não precisa
+# desta variável. Se usar a tag, cole aqui só o `content` da meta tag.
+NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -43,6 +43,17 @@ jobs:
           # vazia e a página mostra o convite "seja o primeiro".
           APOIASE_TOKEN: ${{ secrets.APOIASE_TOKEN }}
           APOIASE_CAMPAIGN_ID: ${{ secrets.APOIASE_CAMPAIGN_ID }}
+          # Google Analytics só no build da `main`. Este mesmo job roda em PR,
+          # e o deploy de preview do Cloudflare é um site público de verdade:
+          # sem este recorte, cada PR mandaria pageview para a propriedade de
+          # produção. String vazia = o componente devolve null e o gtag.js nem
+          # é pedido. O ID não é segredo (sai no HTML), por isso `vars`; o
+          # fallback em `secrets` é só para não quebrar se alguém cadastrar no
+          # lugar errado.
+          NEXT_PUBLIC_GA_ID: ${{ github.ref == 'refs/heads/main' && (vars.NEXT_PUBLIC_GA_ID || secrets.NEXT_PUBLIC_GA_ID) || '' }}
+          # Só usada se a verificação do Search Console for pela tag HTML em vez
+          # do TXT no DNS. Vale em qualquer branch: é uma meta tag inerte.
+          NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION: ${{ vars.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION }}
 
       - name: Upload artifact
         if: github.event.pull_request.head.repo.fork == false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,22 @@ deploy, e todo PR precisa da aprovação de um mantenedor antes do merge. Deploy
 vem de `--project-name` (no CI, do secret). Secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`,
 `CLOUDFLARE_PROJECT_NAME` (e, para apoiadores, `APOIASE_TOKEN` / `APOIASE_CAMPAIGN_ID`).
 
+## Analytics
+
+- **Google Analytics 4 é opt-in por ambiente.** `src/components/Analytics.tsx` só renderiza o
+  `GoogleAnalytics` do `@next/third-parties` quando `NEXT_PUBLIC_GA_ID` existe; sem a variável ele
+  devolve `null` e nenhum byte do gtag.js é pedido. O workflow injeta o ID **só no build da `main`**
+  (é uma *variable*, `vars.NEXT_PUBLIC_GA_ID`, não um secret: o ID sai no HTML de toda página).
+  Preview de PR, build de fork e `npm run dev` ficam sem analytics — de propósito, para não sujar a
+  propriedade nem medir o desenvolvedor.
+- Não troque o componente do `@next/third-parties` por um `<script>` na mão: o snippet do Google é
+  síncrono e bloqueia o parser; o componente usa `next/script` com `afterInteractive` e cuida da
+  deduplicação entre navegações client-side do App Router.
+- **Google Search Console: a verificação é por DNS**, propriedade de *domínio*, com TXT no
+  Cloudflare — não depende de deploy nem de arquivo no `out/`. `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`
+  (que vira `metadata.verification.google` no layout) é o plano B para quem só tem propriedade de
+  prefixo de URL. As duas variáveis estão documentadas no `.env.example`.
+
 ## Git e CI
 
 - **Conventional Commits** (`feat`, `fix`, `docs`, `ci`, `chore`, ...). Commits atômicos. Ver

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "16.2.12",
+        "@next/third-parties": "^16.3.0",
         "next": "16.2.12",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -732,6 +733,19 @@
       ],
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@next/third-parties": {
+      "version": "16.3.0",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.3.0.tgz",
+      "integrity": "sha512-cAA96hSI9NC7083b6sEsKjgyvM/YJ2eqXs4HWv8a/z5LE12CL1sUJS+cmcTwNMY4yAFpLyyuZHrMBEfh/4Xupw==",
+      "license": "MIT",
+      "dependencies": {
+        "third-party-capital": "1.0.20"
+      },
+      "peerDependencies": {
+        "next": "^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0-beta.0",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0"
       }
     },
     "node_modules/@playwright/test": {
@@ -3140,6 +3154,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/third-party-capital": {
+      "version": "1.0.20",
+      "resolved": "https://registry.npmjs.org/third-party-capital/-/third-party-capital-1.0.20.tgz",
+      "integrity": "sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==",
+      "license": "ISC"
     },
     "node_modules/trim-lines": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "16.2.12",
-        "@next/third-parties": "^16.3.0",
+        "@next/third-parties": "16.2.12",
         "next": "16.2.12",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -736,9 +736,9 @@
       }
     },
     "node_modules/@next/third-parties": {
-      "version": "16.3.0",
-      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.3.0.tgz",
-      "integrity": "sha512-cAA96hSI9NC7083b6sEsKjgyvM/YJ2eqXs4HWv8a/z5LE12CL1sUJS+cmcTwNMY4yAFpLyyuZHrMBEfh/4Xupw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/third-parties/-/third-parties-16.2.12.tgz",
+      "integrity": "sha512-1fHKgERSVcgC0QfPJq2v96l6pLUdbVdkT0bjJYK8MguKTVjPd734kWBxfd77nPUG4N5F9s+qVdVjpEBm1tlwNQ==",
       "license": "MIT",
       "dependencies": {
         "third-party-capital": "1.0.20"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "16.2.12",
-    "@next/third-parties": "^16.3.0",
+    "@next/third-parties": "16.2.12",
     "next": "16.2.12",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "16.2.12",
+    "@next/third-parties": "^16.3.0",
     "next": "16.2.12",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -70,10 +70,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <ProgressProvider>
           <Shell>{children}</Shell>
         </ProgressProvider>
+        {/* A doc do Next põe este componente como IRMÃO do <body>. Aqui ele fica
+            dentro, no fim: o `<html>` só pode ter <head> e <body> como filhos, e
+            o resultado é o mesmo. No servidor o componente rende `null` (o corte
+            por env acontece no build), e depois da hidratação quem posiciona a
+            tag é o next/script, que a coloca no <head> — a posição no JSX nunca
+            foi a posição no DOM. */}
+        <Analytics />
       </body>
-      {/* Irmão do <body>, como a doc do Next manda: o next/script injeta a tag
-          depois da hidratação, então a posição no JSX não é a posição no DOM. */}
-      <Analytics />
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import { Analytics } from "@/components/Analytics";
 import { ProgressProvider } from "@/components/ProgressProvider";
 import { Shell } from "@/components/Shell";
 import { SITE_URL } from "@/lib/links";
@@ -27,6 +28,16 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: "summary_large_image",
+  },
+  // Search Console, método "tag HTML". É o PLANO B: o método recomendado é a
+  // propriedade de domínio com registro TXT no DNS do Cloudflare, que cobre
+  // `dsa.` e qualquer subdomínio, sobrevive a redeploy e não gasta um byte de
+  // HTML. Esta linha existe para quem não tiver acesso ao DNS na hora: setando
+  // `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION`, o Next emite
+  // `<meta name="google-site-verification">` em todas as rotas. Sem a variável,
+  // `undefined` não vira meta tag nenhuma.
+  verification: {
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
   },
 };
 
@@ -60,6 +71,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <Shell>{children}</Shell>
         </ProgressProvider>
       </body>
+      {/* Irmão do <body>, como a doc do Next manda: o next/script injeta a tag
+          depois da hidratação, então a posição no JSX não é a posição no DOM. */}
+      <Analytics />
     </html>
   );
 }

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -1,0 +1,31 @@
+import { AnalyticsDeferred } from "./AnalyticsDeferred";
+
+// Google Analytics 4 pelo componente do `@next/third-parties`, que é o caminho
+// que a doc do Next recomenda (o snippet cru do Google é síncrono e bloqueia o
+// parser; o componente usa `next/script` e deduplica a tag entre navegações
+// client-side do App Router). QUANDO carregar é decisão do `AnalyticsDeferred`,
+// que explica o porquê e o preço.
+//
+// Este arquivo é Server Component de propósito: o corte por ambiente acontece
+// no BUILD. Sem `NEXT_PUBLIC_GA_ID` ele devolve `null`, nenhuma referência de
+// cliente entra no payload e o navegador não pede byte nenhum de analytics —
+// nem o chunk do wrapper. Verificado: build sem a variável sai com 0 ocorrências
+// de `googletagmanager` nas 54 páginas.
+//
+// Por que variável de ambiente e não constante no código:
+//   - Preview de PR, build de fork e `npm run dev` ficam sem GA. O deploy de
+//     preview do Cloudflare é um site público de verdade; sem esse corte, todo
+//     PR mandaria pageview para a propriedade de produção.
+//   - O workflow só injeta o ID no build da `main` (ver
+//     `.github/workflows/cloudflare-pages-deploy.yml`).
+// O valor NÃO é segredo — ele sai no HTML de toda página. É variável de
+// ambiente pelo recorte de ambiente, não por sigilo.
+//
+// `NEXT_PUBLIC_*` é trocado por texto em tempo de build, que é o que combina com
+// `output: "export"`: não existe servidor para ler env em runtime.
+const GA_ID = process.env.NEXT_PUBLIC_GA_ID;
+
+export function Analytics() {
+  if (!GA_ID) return null;
+  return <AnalyticsDeferred gaId={GA_ID} />;
+}

--- a/src/components/AnalyticsDeferred.tsx
+++ b/src/components/AnalyticsDeferred.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { GoogleAnalytics } from "@next/third-parties/google";
+
+// Adia a montagem do `<GoogleAnalytics>` para depois do `load`.
+//
+// Por que isso existe, já que o componente do Next é feito para não atrapalhar:
+// ele carrega o gtag.js com `afterInteractive`, e o `next/script` traduz isso,
+// no React 19, para um `<link rel="preload" as="script">` que vai PARA O HTML
+// ESTÁTICO, dentro do `<head>`. Medido neste projeto: o preload aparece no
+// `<head>` de todas as 54 páginas, antes até do `<title>`. Preload de script é
+// prioridade alta no Chrome, e o gtag.js pesa ~145 KB comprimido (~418 KB
+// depois de descomprimir) — ou seja, 145 KB de alta prioridade competindo por
+// banda com o CSS da fonte e com os chunks do próprio site, exatamente durante
+// a janela que decide o LCP. O script até só EXECUTA depois da hidratação; o
+// download é que começava cedo demais.
+//
+// Adiando a montagem, a marcação do GA some do HTML: o servidor renderiza
+// `null`, então não há preload nenhum, e o React só injeta o script quando esta
+// máquina de estados vira. A conta fica assim:
+//   - LCP / FCP: intocados — nada de GA disputa banda antes do `load`.
+//   - CLS: zero nos dois jeitos (o GA não põe nada no DOM visível).
+//   - TBT / INP: o parse e a execução do gtag.js caem depois do `load` e fora
+//     da janela FCP→TTI que o Lighthouse mede, que é de onde vinham os pontos
+//     perdidos no score de performance.
+// E o que se ganha continua sendo o do componente oficial: dedupe da tag entre
+// navegações client-side do App Router e pageview automático de rota, sem
+// snippet síncrono escrito na mão bloqueando o parser.
+//
+// O preço, dito na cara: visita que acaba antes do `load` + idle não é contada.
+// Num site de leitura isso é a faixa de quem fecha a aba em ~1s, e o mesmo
+// leitor já não era contado antes (o gtag.js só executava depois da hidratação
+// nos dois casos). Se algum dia a contagem de visitas curtíssimas importar mais
+// que o score, é só trocar `<AnalyticsDeferred>` por `<GoogleAnalytics>` direto
+// em `Analytics.tsx` — o resto do arranjo continua igual.
+export function AnalyticsDeferred({ gaId }: { gaId: string }) {
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    // `requestIdleCallback` com timeout curto: em aparelho lento a fila de
+    // trabalho pode nunca ficar ociosa, e sem o teto o GA jamais carregaria.
+    // O `setTimeout` é o fallback do Safari mais antigo, que não tem a API.
+    const schedule = () => {
+      if (typeof window.requestIdleCallback === "function") {
+        window.requestIdleCallback(() => setMounted(true), { timeout: 1500 });
+      } else {
+        window.setTimeout(() => setMounted(true), 800);
+      }
+    };
+
+    // Navegação client-side não dispara `load` de novo: aí o documento já está
+    // "complete" e a montagem acontece no primeiro idle.
+    if (document.readyState === "complete") {
+      schedule();
+      return;
+    }
+    window.addEventListener("load", schedule, { once: true });
+    return () => window.removeEventListener("load", schedule);
+  }, []);
+
+  if (!mounted) return null;
+  return <GoogleAnalytics gaId={gaId} />;
+}


### PR DESCRIPTION
## O que muda

Adiciona Google Analytics 4 e o suporte de verificação do Search Console, com o cuidado de não pagar nada no caminho crítico de carregamento.

## Por que não é só o componente da doc

A doc do Next recomenda o `GoogleAnalytics` do `@next/third-parties` no layout raiz. Instalei assim e medi: no React 19, o `afterInteractive` do `next/script` grava um `<link rel="preload" as="script">` do gtag.js **dentro do `<head>` do HTML estático**, nas 54 páginas, antes até do `<title>`.

O gtag.js pesa **145 KB comprimidos / 418 KB descomprimidos**, e preload de script é prioridade alta no Chrome. Ou seja, a receita ao pé da letra coloca 145 KB disputando banda com o CSS da fonte e com os chunks do site exatamente na janela que decide o LCP.

`AnalyticsDeferred` mantém o componente oficial (é ele que deduplica a tag e emite pageview nas navegações client-side do App Router) e muda só **quando** ele monta: depois do `load`, no primeiro `requestIdleCallback` com teto de 1500 ms.

## Medições

Build servido, Chromium headless:

| | resultado |
|---|---|
| evento `load` | 1005 ms |
| requisição do gtag.js | 1032 ms (27 ms **depois** do load) |
| `window.gtag` pronto | 1035 ms |
| CLS | 0 |
| `googletagmanager` no HTML estático | **0** ocorrências em 54 páginas |
| `index.html` sem a env var | 33228 bytes contra 33226 antes da mudança, +2 bytes |
| páginas SSG | 54, `output: "export"` intacto |

FCP e LCP ficam intocados, e o parse do gtag.js cai fora da janela FCP→TTI que o Lighthouse usa para o TBT.

**O preço, explícito:** visita que termina antes de `load` + idle não é contada. Num site de leitura é a faixa de quem fecha a aba em ~1s, e esse leitor já não era contado antes (nos dois arranjos o gtag.js só executa depois da hidratação). Para voltar ao padrão da doc, basta trocar `<AnalyticsDeferred>` por `<GoogleAnalytics>` em `Analytics.tsx`.

## Recorte por ambiente

`Analytics.tsx` é Server Component de propósito: sem `NEXT_PUBLIC_GA_ID` ele devolve `null` e nenhuma referência de cliente entra no payload.

O workflow injeta o ID **só no build da `main`**. Isso importa porque o mesmo job roda em PR, e o deploy de preview do Cloudflare é um site público de verdade: sem o recorte, cada PR mandaria pageview para a propriedade de produção. Fork e `npm run dev` também ficam sem analytics.

O ID é *variable* e não *secret* porque sai no HTML de toda página. Não é sigilo.

## Search Console

O caminho recomendado é propriedade de **domínio** com registro TXT no DNS do Cloudflare, que não toca no código e sobrevive a redeploy. `NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION` alimenta `metadata.verification.google` como plano B para quem só tiver propriedade de prefixo de URL. Sem a variável, nenhuma meta tag é emitida.

O `sitemap.xml` e o `robots.txt` já existiam e não precisaram de mudança.

## Verificação

- `npm run build` passa, 54 páginas
- `tests/seo.spec.ts` + `tests/navegacao.spec.ts`: 109 passaram (são os specs que tocam o layout raiz)
- A suíte completa está instável nesta máquina sob carga. Rodei o controle guardando as mudanças, e a baseline limpa também falhou, em arquivos diferentes. É flake de ambiente, não regressão. Vale confirmar no CI.
- No DOM montado: `<html>` tem exatamente `HEAD` e `BODY` como filhos, o script fica no `BODY` e o preload no `HEAD`, os dois depois do `load`.

## Pendências fora do repo

- [x] Propriedade GA4 criada e `NEXT_PUBLIC_GA_ID` cadastrada como variable do repositório
- [ ] Confirmar no GA4 que "Alterações de página com base em eventos do histórico do navegador" está ligado na Medição avançada. Sem isso, navegar entre tópicos não gera pageview
- [ ] Verificar o domínio no Search Console via TXT no Cloudflare e enviar o sitemap
- [ ] Vincular GA4 ↔ Search Console para o relatório de consultas

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B8kQEkQVfkzFviu8YnNeUS
