### PR TITLE
feat(ci): guarda de idioma com parser de TSX no lugar do regex

### DIFF
--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -44,55 +44,114 @@ mesmo morando dentro de uma string no meio do código. Um `find & replace` de
 como "O array precisa estar sorted".
 
 Ao renomear em lote, **não revise o diff a olho** — ele tem centenas de linhas e
-o erro passa. Rode o guarda, que compara tudo que aparece na tela (literais de
-string **e nós de texto JSX**) antes e depois:
+o erro passa. Rode o guarda, que compara tudo que aparece na tela antes e
+depois:
 
 ```bash
 git show HEAD:content/visualizers/MeuVisualizador.tsx > /tmp/antes.tsx
 python3 scripts/guarda-idioma.py /tmp/antes.tsx content/visualizers/MeuVisualizador.tsx
+
+# ou o diretório inteiro de uma vez, com diretórios dos dois lados:
+mkdir -p /tmp/antes && git archive HEAD content/visualizers | tar -x -C /tmp/antes
+python3 scripts/guarda-idioma.py /tmp/antes/content/visualizers content/visualizers
 ```
 
-Ele sai com erro se qualquer texto de tela entrou ou saiu. O que sobrar tem que
-ser só nome de import, de hook e de prop.
+Ele sai **0** quando o texto de tela é idêntico, **1** quando mudou e **2**
+quando o próprio guarda não conseguiu rodar — nunca 0 por não ter conseguido
+olhar. O que sobrar tem que ser só nome de import, de hook e de prop.
 
-**Este guarda já passou verde três vezes com a aula estragada**, e as três por
-olhar de menos. Vale conhecer os buracos que ele tapou, porque eles dizem onde
-procurar o próximo:
+### O que o guarda olha
+
+Desde a 4ª versão ele **não casa texto por regex: ele parseia**. Quem lê o TSX é
+o compilador do TypeScript (`ts.createSourceFile`, num script Node irmão,
+`scripts/extrai-textos-tsx.mjs`); o `guarda-idioma.py` continua sendo a porta de
+entrada, com a mesma linha de comando. Ele coleta:
+
+| o quê | vira |
+|---|---|
+| literal de string e template **em qualquer nível de aninhamento** | o texto, com cada `${…}` virando `§` |
+| nós de texto JSX, **inclusive dividindo a linha com uma interpolação** | os filhos do elemento num item só: `Nós no ciclo: §` |
+| valor de atributo que o aluno lê (`alt`, `title`, `placeholder`, `aria-label`, …) | texto de tela |
+| `className`, `viewBox`, `style`, `d`, chave de tipo, especificador de import | **código**, num bloco `AVISO` separado que **não reprova** |
+
+O `AVISO` existe por causa da armadilha do literal-que-vira-classe (mais abaixo):
+antes ele se misturava ao texto de tela e pedia a reação que **re-quebra** o
+rename. Agora ele fica à parte, dizendo "confira no `globals.css`".
+
+**Este guarda já passou verde CINCO vezes com a aula estragada**, sempre por
+olhar de menos. Os buracos que ele tapou dizem onde procurar o próximo:
 
 | versão | o que não olhava | o que passou |
 |---|---|---|
 | 1ª | nós de texto JSX | `<span>Array (fica sorted)</span>` e mais dois rótulos |
 | 2ª | nó JSX **em mais de uma linha** | `inserir no fim` virou `inserir no done` |
 | 2ª | literal **dentro** de `${...}` | `reservar a capacidade certa` virou `capacity` |
+| 3ª | **crase aninhada** dentro de `${...}` | o pareamento das crases saía de sincronia e o texto do template interno **nunca era lido**: em `` `…${cycle > 0 ? `, e ${cycle} deles formam o ciclo` : ""}` `` (`LinkedListFloyd`), trocar `", e "` por `", and "` saía `SUMIRAM: nenhuma`. **27 dos 87 arquivos** têm crase aninhada, num total de 54 ocorrências (6 só no `LinkedListFloyd`) |
+| 3ª | **texto de tela colado numa interpolação** | o padrão exigia `>texto<` e o `{` cortava o casamento. Trocar `" de "` por `" of "` em `{s.round} de {LABELS.length - 1}` (`BellmanFordVisualizer:273`) saía `SUMIRAM: nenhuma / APARECERAM: nenhuma`, e o painel diria **"rodada 5 of 4"** com o guarda verde |
 
 Os dois da 2ª versão não são casos exóticos: o Prettier quebra a linha de
 qualquer elemento cujos atributos não cabem, e ternário dentro de interpolação
-é como metade das notas deste repo escolhe entre singular e plural.
+é como metade das notas deste repo escolhe entre singular e plural. Os dois da
+3ª também não: 31% do diretório tinha o gatilho do primeiro.
 
-**Mais dois buracos, medidos no `listas-ligadas`, e os dois continuam
-abertos** — porque tapá-los é reescrever o guarda com um analisador de verdade,
-e isso é PR de plataforma, não carona numa adaptação de tópico:
+**E a 3ª versão gritava, além de ser cega.** Num rename de quatro identificadores
+do `LinkedListFloyd` (`slow`/`fast`/`cycle`/`total`) ela emitia **38 linhas de
+achado, todas ruído**, com um blob de 4 mil caracteres de código no meio — e uma
+troca de rótulo de verdade escondida ali dentro. O mesmo rename no guarda novo
+emite **zero**. Um guarda que grita em tudo é tão inútil quanto um cego.
 
-| o que não olha | o que passa |
-|---|---|
-| **template dentro de `${...}`**: o casamento da crase é regex, então uma crase aninhada tira o pareamento de sincronia | o `LinkedListFloyd` tem 6 delas (``` `… ${cycle > 0 ? `, e ${cycle}…` : ""}` ```), e daí em diante o guarda compara **código** como se fosse tela: dezenas de linhas de ruído, e uma troca de rótulo de verdade some no meio |
-| **texto de tela que divide a linha com uma interpolação**: o padrão exige `>texto<`, e um `{` no meio corta o casamento | `<span>Nós no ciclo: {cycle === 0 ? … }</span>` — "Nós no ciclo: " não está em string nenhuma, não é visto pelo guarda, e um rename cego o estragaria **sem nenhum aviso** |
+### O que o guarda continua NÃO pegando
 
-O segundo é o mais perigoso dos dois, porque é silencioso: o primeiro pelo
-menos grita. E os dois têm a mesma consequência prática — **quando o arquivo
-tiver crase aninhada ou rótulo colado numa interpolação, o guarda não é prova;
-a prova é comparar o texto renderizado dos ESTADOS** (§8), que é o que pegou
-os dois aqui.
+Está aqui porque decidir com base numa promessa que ele não cumpre é como os
+cinco furos acima aconteceram. Cada linha tem um caso medido e uma fixture em
+`scripts/fixtures-guarda-idioma/`:
 
-**E um buraco continua aberto, por construção: ele compara o CONJUNTO de textos,
-não onde cada um aparece.** Trocar dois campos de lugar num rename (o subtítulo
-de um cartão indo para o corpo e vice-versa) mantém o conjunto idêntico e passa
-verde. Medido: com `{l.subtitle}` e `{l.body}` invertidos no
-`SubTypesVisualizer`, o guarda não acusa nada e a tela mente. Quem pega isso é
-teste que lê **rótulo e valor juntos**, no mesmo cartão — veja a §8.
+- **ele compara o CONJUNTO de textos, não onde cada um aparece.** Trocar dois
+  campos de lugar (o subtítulo de um cartão indo para o corpo e vice-versa)
+  mantém o conjunto idêntico e passa verde. Medido: com `{l.subtitle}` e
+  `{l.body}` invertidos no `SubTypesVisualizer`, o guarda não acusa nada e a tela
+  mente. Quem pega isso é teste que lê **rótulo e valor juntos**, no mesmo cartão
+  — veja a §8;
+- **valor de união que chega ao JSX cru** (`{p.conflict}` no
+  `BacktrackingSudoku`). O que o guarda vê é uma interpolação, e a união é um
+  tipo, ou seja, código: traduzi-la sai no `AVISO` e não reprova. A regra abaixo
+  — *procure onde os valores da união aparecem* — continua sendo sua;
+- **texto sem nenhuma letra** (`"→"`, `"3"`, `"·"`). São descartados de propósito,
+  senão toda cor em hexa e todo `path` de SVG entrariam no relatório;
+- **texto que não mora neste arquivo**: rótulo vindo do `content/roadmap.ts`, do
+  `.mdx` ou de outro componente. O guarda compara duas versões do **mesmo**
+  arquivo;
+- **texto montado por concatenação de identificador** (`"passo " + nome`), onde a
+  frase só existe em tempo de execução.
 
-Por isso, **a prova final de um rename não é o guarda, é o HTML do build**. Ele
-é o que o aluno recebe, e a comparação é objetiva:
+Quando o caso for um destes, **o guarda não é prova**: a prova é comparar o texto
+renderizado dos ESTADOS (§8) e o HTML do build (logo abaixo).
+
+### A suíte do próprio guarda
+
+Os onze casos acima — os cinco furos, o rename limpo que não pode reprovar, e os
+limites conhecidos — são executáveis:
+
+```bash
+python3 scripts/testa-guarda-idioma.py           # 11 de 11 ok
+python3 scripts/testa-guarda-idioma.py -v        # com a saída de cada caso
+python3 scripts/testa-guarda-idioma.py --guarda /tmp/versao-antiga.py
+```
+
+O `--guarda` é a prova de quebra: aponte para uma versão anterior e veja os casos
+falharem. **Guarda que você nunca viu falhar não é guarda.** Ao consertar um furo
+novo, acrescente o par `antes.tsx.txt` / `depois.tsx.txt` e a linha em `CASOS`
+antes de mexer no analisador. (A extensão é `.tsx.txt` de propósito: o
+`tsconfig.json` inclui `**/*.tsx`, e fixture com extensão de verdade entraria no
+`npx tsc --noEmit` com código que existe justamente para estar errado.)
+
+Custo: **0,22s** por par de arquivos e **0,45s** para os 87 arquivos de
+`content/visualizers/` de uma vez. Cabe em cada commit.
+
+### E a prova final continua sendo o HTML do build
+
+O guarda ficou muito melhor e **não virou a prova**: ele lê o arquivo, e o que o
+aluno recebe é a página. A comparação do HTML é objetiva:
 
 ```bash
 render() { python3 -c "
@@ -124,10 +183,12 @@ Três notas de execução, todas medidas:
   *é* conteúdo — enquanto o sufixo de classe *parece* conteúdo e *é* API. Antes
   de traduzir uma união, **procure onde os valores dela aparecem**: se algum
   chega ao JSX sem passar por um mapa, ele é texto de tela;
-- **qualquer literal que vira NOME DE CLASSE é contrato com o CSS**, e esse
-  ninguém guarda. Ele passa pelo `tsc` (o tipo continua coerente), pelo guarda
-  de idioma (não é texto de tela) e pelo teste (é cor). As três formas medidas,
-  em ordem de quão fácil é não vê-las:
+- **qualquer literal que vira NOME DE CLASSE é contrato com o CSS**, e nenhuma
+  ferramenta o **reprova**. Ele passa pelo `tsc` (o tipo continua coerente) e
+  pelo teste (é cor); o guarda de idioma agora o **mostra** — no bloco `AVISO`,
+  quando ele está num `className` —, mas não sai com erro, porque não dá para
+  saber de dentro do arquivo se aquela classe existe no `globals.css`. Conferir é
+  seu. As três formas medidas, em ordem de quão fácil é não vê-las:
 
   | forma | exemplo | o que aponta para ele |
   |---|---|---|

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -72,11 +72,37 @@ entrada, com a mesma linha de comando. Ele coleta:
 | literal de string e template **em qualquer nível de aninhamento** | o texto, com cada `${…}` virando `§` |
 | nós de texto JSX, **inclusive dividindo a linha com uma interpolação** | os filhos do elemento num item só: `Nós no ciclo: §` |
 | valor de atributo que o aluno lê (`alt`, `title`, `placeholder`, `aria-label`, …) | texto de tela |
-| `className`, `viewBox`, `style`, `d`, chave de tipo, especificador de import | **código**, num bloco `AVISO` separado que **não reprova** |
+| `className`, `class`, `key`, `ref`, chave de tipo, especificador de import, nome de propriedade escrito como literal | **código** em **qualquer** elemento, componente inclusive — num bloco `AVISO` separado que **não reprova** |
+| atributo de **elemento HTML** fora da lista de texto (`viewBox`, `style`, `d`, `type`, `role`, `fill`, …) | **código**, pelo mesmo `AVISO` |
 
 O `AVISO` existe por causa da armadilha do literal-que-vira-classe (mais abaixo):
 antes ele se misturava ao texto de tela e pedia a reação que **re-quebra** o
 rename. Agora ele fica à parte, dizendo "confira no `globals.css`".
+
+**A segunda linha vale só para elemento HTML** (`<div>`, `<svg>`, `<path>`), e a
+distinção é medível. Elemento HTML tem vocabulário fixo, então o que não está na
+lista de texto é código. **Prop de componente nosso** (`<VizFooter>`, `<Icone>`)
+cai em **tela**, porque um componente pode ter prop de rótulo com qualquer nome,
+e o falso negativo é justamente o defeito que este guarda existe para não ter.
+Consequência prática: mudar o valor de um `d=` **de componente** REPROVA, ao
+contrário do que a linha de cima sugere isoladamente. Medido no motor desta
+branch, com as mesmas três props nos dois lados:
+
+```
+<svg   viewBox="0 0 100 mesmo" style="cor" d="M0 zero L1 um" />  → codigo, codigo, codigo
+<Icone viewBox="0 0 100 mesmo" style="cor" d="M0 zero L1 um"
+       className="cx" />                                        → tela, tela, tela + codigo (só o className)
+```
+
+Os casos **12 e 13** de `scripts/testa-guarda-idioma.py` fixam esse par: a mesma
+troca de `d=`, no `<path>` passa e no `<Icone>` reprova. A regra mora em
+`elementoIntrinseco()` e `classificar()`, em `scripts/extrai-textos-tsx.mjs`.
+Hoje ninguém esbarra nela — varredura pela AST nos 87 `.tsx` de
+`content/visualizers`: **zero** ocorrências de `viewBox`/`style`/`d` em tag não
+intrínseca —, mas quem escrever a primeira precisa saber. Duas bordas do mesmo
+critério: tag com ponto (`<motion.div>`) **não** conta como intrínseca, porque o
+teste exige um `Identifier` simples; e um atributo com namespace (`xlink:href`)
+só vira código no elemento HTML, pela mesma porta.
 
 **Este guarda já passou verde CINCO vezes com a aula estragada**, sempre por
 olhar de menos. Os buracos que ele tapou dizem onde procurar o próximo:

--- a/scripts/extrai-textos-tsx.mjs
+++ b/scripts/extrai-textos-tsx.mjs
@@ -185,6 +185,10 @@ function formaDosFilhosJsx(node) {
   return out;
 }
 
+// Arquivos que o parser não conseguiu ler inteiros. Ver o `process.exit(2)` no
+// fim: a lista existe para o motor poder REPROVAR, não só avisar.
+const invalidos = [];
+
 function extrair(caminho) {
   const fonte = readFileSync(caminho, "utf-8");
   const sf = ts.createSourceFile(
@@ -214,10 +218,15 @@ function extrair(caminho) {
   andar(sf);
 
   // Erro de sintaxe faz a AST sair truncada e o guarda ficar cego em silêncio.
+  // Avisar no stderr não bastava: o motor saía 0, a fachada comparava o que
+  // conseguiu extrair de um arquivo pela metade e imprimia 0 ("a tela não
+  // mudou") ou 1 ("mudou"), que é exatamente o "0 por não ter conseguido
+  // olhar" que o contrato proíbe. Agora entra na lista e o motor sai 2.
   const diags = sf.parseDiagnostics ?? [];
   if (diags.length) {
     const msg = ts.flattenDiagnosticMessageText(diags[0].messageText, " ");
     process.stderr.write(`guarda-idioma: ${caminho} não é TSX válido (${diags.length}): ${msg}\n`);
+    invalidos.push(caminho);
   }
 
   return achados;
@@ -232,5 +241,17 @@ process.stdin.on("end", () => {
   const { files } = JSON.parse(entrada);
   const saida = {};
   for (const f of files) saida[f] = extrair(f);
+
+  // Sai 2 ANTES de escrever o JSON: extração truncada não pode chegar à
+  // fachada com cara de resultado. A fachada lê o código != 0 e morre com 2,
+  // que é o código de "o guarda não conseguiu rodar" do contrato.
+  if (invalidos.length) {
+    process.stderr.write(
+      `guarda-idioma: ${invalidos.length} arquivo(s) sem TSX válido; ` +
+        `a extração ficaria truncada e o resultado seria mentira.\n`,
+    );
+    process.exit(2);
+  }
+
   process.stdout.write(JSON.stringify(saida));
 });

--- a/scripts/extrai-textos-tsx.mjs
+++ b/scripts/extrai-textos-tsx.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Extrai, pela AST do TypeScript, TUDO que o aluno lê num arquivo .tsx —
+ * e separa disso o que é código.
+ *
+ *   entrada  stdin, JSON:  {"files": ["a.tsx", "b.tsx", ...]}
+ *   saída    stdout, JSON: {"a.tsx": {"tela": [...], "codigo": [...]}, ...}
+ *
+ * É o motor do `guarda-idioma.py`. Não é feito para ser chamado à mão.
+ *
+ * POR QUE AST E NÃO REGEX
+ * -----------------------
+ * As três primeiras versões do guarda casavam texto por expressão regular, e as
+ * três passaram verde com a aula estragada. Os dois últimos buracos, medidos no
+ * `listas-ligadas`, não têm conserto em regex:
+ *
+ *   1) crase ANINHADA dentro de `${...}`:
+ *        `... ${cycle > 0 ? `, e ${cycle} nós` : ""} ...`
+ *      um regex de crase pareia a 1ª com a 2ª, a 3ª com a 4ª, e daí em diante
+ *      o pareamento fica trocado: o guarda passa a comparar CÓDIGO achando que
+ *      é tela. No `LinkedListFloyd` (6 aninhamentos) isso vira dezenas de
+ *      linhas de ruído, e um rótulo trocado de verdade some no meio.
+ *
+ *   2) texto de tela que divide a linha com uma interpolação:
+ *        <span>Nós no ciclo: {cycle === 0 ? "nenhum" : cycle}</span>
+ *      "Nós no ciclo: " não está dentro de string nenhuma, e o padrão `>texto<`
+ *      não casa porque tem um `{` no meio. Este é o silencioso.
+ *
+ * A AST não tem pareamento a errar: um template é um nó com `head`, `spans` e
+ * `literal`s, e um nó de texto JSX é um nó, tenha quantas interpolações tiver
+ * ao lado.
+ *
+ * COMO O TEXTO É NORMALIZADO
+ * --------------------------
+ * - toda interpolação (`${...}` e `{...}` no JSX) vira `§`, para a FRASE ser
+ *   comparada e o valor interpolado não;
+ * - os filhos de um elemento JSX viram UM item só (`"Nós no ciclo: §"`), o que
+ *   mantém o rótulo colado ao contexto em vez de virar um fragmento solto;
+ * - espaço em branco é colapsado, porque a indentação não é tela;
+ * - item sem nenhuma letra é descartado (número, `§§`, pontuação solta).
+ */
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+// ---------------------------------------------------------------------------
+// A fronteira código × conteúdo.
+//
+// O critério é conservador de propósito: na dúvida, é TELA. Um falso positivo
+// custa uma linha de ruído; um falso negativo é o guarda ficando cego, que é o
+// defeito que este arquivo existe para consertar.
+// ---------------------------------------------------------------------------
+
+/** Atributos de elemento HTML cujo valor o aluno LÊ. */
+const ATRIBUTOS_DE_TEXTO = new Set([
+  "alt",
+  "title",
+  "placeholder",
+  "label",
+  "content",
+  "download",
+  "aria-label",
+  "aria-description",
+  "aria-roledescription",
+  "aria-valuetext",
+  "aria-placeholder",
+]);
+
+/** Atributos que são código em QUALQUER elemento, componente inclusive. */
+const ATRIBUTOS_DE_CODIGO = new Set(["key", "ref", "className", "class"]);
+
+function nomeDoAtributo(attr) {
+  const n = attr.name;
+  if (ts.isIdentifier(n)) return n.text;
+  // JSX namespaced (`xlink:href`) — sempre código neste repo.
+  return `${n.namespace?.text ?? ""}:${n.name?.text ?? ""}`;
+}
+
+/** `<div>` é intrínseco (vocabulário fixo); `<VizFooter>` é componente. */
+function elementoIntrinseco(attr) {
+  const dono = attr.parent?.parent; // JsxAttributes -> JsxOpening/SelfClosing
+  const tag = dono?.tagName;
+  if (!tag || !ts.isIdentifier(tag)) return false;
+  const c = tag.text.charAt(0);
+  return c === c.toLowerCase() && c !== c.toUpperCase();
+}
+
+/**
+ * O atributo JSX que envolve este literal, se houver. Sobe na árvore até achar
+ * um `JsxAttribute`, parando na fronteira do elemento — um literal que está no
+ * FILHO de um elemento não pertence ao atributo do pai.
+ */
+function atributoQueEnvolve(node) {
+  let n = node.parent;
+  while (n) {
+    if (ts.isJsxAttribute(n)) return n;
+    if (
+      ts.isJsxElement(n) ||
+      ts.isJsxFragment(n) ||
+      ts.isJsxSelfClosingElement(n) ||
+      ts.isSourceFile(n)
+    ) {
+      return null;
+    }
+    n = n.parent;
+  }
+  return null;
+}
+
+function especificadorDeModulo(node) {
+  const p = node.parent;
+  if (!p) return false;
+  if (ts.isImportDeclaration(p) && p.moduleSpecifier === node) return true;
+  if (ts.isExportDeclaration(p) && p.moduleSpecifier === node) return true;
+  if (ts.isImportTypeNode(p)) return true;
+  if (ts.isExternalModuleReference(p)) return true;
+  if (ts.isCallExpression(p) && p.arguments[0] === node) {
+    const alvo = p.expression;
+    if (alvo.kind === ts.SyntaxKind.ImportKeyword) return true;
+    if (ts.isIdentifier(alvo) && alvo.text === "require") return true;
+  }
+  return false;
+}
+
+/** `"tela"` ou `"codigo"` para um literal já reconhecido. */
+function classificar(node) {
+  const p = node.parent;
+
+  // "use client" e afins: statement de string solta é diretiva.
+  if (p && ts.isExpressionStatement(p)) return "codigo";
+
+  if (especificadorDeModulo(node)) return "codigo";
+
+  // `Omit<Step, "slots" | "desloc">` — chave de tipo é código, e o §0 do
+  // contrato já dizia que só o `tsc` pega renomeação errada aí.
+  if (p && ts.isLiteralTypeNode(p)) return "codigo";
+
+  // Nome de propriedade escrito como literal: `{ "data-x": 1 }`, `obj["k"]`.
+  if (p && (ts.isPropertyAssignment(p) || ts.isPropertySignature(p) || ts.isMethodDeclaration(p)) && p.name === node) {
+    return "codigo";
+  }
+  if (p && ts.isElementAccessExpression(p) && p.argumentExpression === node) return "codigo";
+
+  const attr = atributoQueEnvolve(node);
+  if (attr) {
+    const nome = nomeDoAtributo(attr);
+    if (ATRIBUTOS_DE_CODIGO.has(nome)) return "codigo";
+    if (ATRIBUTOS_DE_TEXTO.has(nome)) return "tela";
+    // Elemento HTML tem vocabulário fixo: o que não está na lista de texto é
+    // código (`viewBox`, `d`, `style`, `type`, `role`, `fill`...). Componente
+    // nosso pode ter prop de rótulo com qualquer nome, então fica em tela.
+    if (elementoIntrinseco(attr)) return "codigo";
+  }
+
+  return "tela";
+}
+
+// ---------------------------------------------------------------------------
+// Extração
+// ---------------------------------------------------------------------------
+
+const TEM_LETRA = /[A-Za-zÀ-ÖØ-öø-ÿ]/;
+
+function normalizar(s) {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+/** O "formato" de um template: `a ${x} b` -> "a § b". */
+function formaDoTemplate(node) {
+  let out = node.head.text;
+  for (const span of node.templateSpans) out += "§" + span.literal.text;
+  return out;
+}
+
+/**
+ * Os filhos de um elemento JSX viram UM item. Interpolação e elemento filho
+ * viram `§`; o filho é coletado por conta própria quando a varredura chegar
+ * nele.
+ */
+function formaDosFilhosJsx(node) {
+  let out = "";
+  for (const filho of node.children) {
+    if (ts.isJsxText(filho)) out += filho.text;
+    else out += "§";
+  }
+  return out;
+}
+
+function extrair(caminho) {
+  const fonte = readFileSync(caminho, "utf-8");
+  const sf = ts.createSourceFile(
+    caminho,
+    fonte,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX, // sempre TSX: as fixtures da suíte não usam extensão .tsx
+  );
+
+  const achados = { tela: [], codigo: [] };
+  const guardar = (texto, onde) => {
+    const t = normalizar(texto);
+    if (t && TEM_LETRA.test(t)) achados[onde].push(t);
+  };
+
+  const andar = (node) => {
+    if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
+      guardar(node.text, classificar(node));
+    } else if (ts.isTemplateExpression(node)) {
+      guardar(formaDoTemplate(node), classificar(node));
+    } else if (ts.isJsxElement(node) || ts.isJsxFragment(node)) {
+      guardar(formaDosFilhosJsx(node), "tela");
+    }
+    node.forEachChild(andar);
+  };
+  andar(sf);
+
+  // Erro de sintaxe faz a AST sair truncada e o guarda ficar cego em silêncio.
+  const diags = sf.parseDiagnostics ?? [];
+  if (diags.length) {
+    const msg = ts.flattenDiagnosticMessageText(diags[0].messageText, " ");
+    process.stderr.write(`guarda-idioma: ${caminho} não é TSX válido (${diags.length}): ${msg}\n`);
+  }
+
+  return achados;
+}
+
+// ---------------------------------------------------------------------------
+
+let entrada = "";
+process.stdin.setEncoding("utf-8");
+process.stdin.on("data", (c) => (entrada += c));
+process.stdin.on("end", () => {
+  const { files } = JSON.parse(entrada);
+  const saida = {};
+  for (const f of files) saida[f] = extrair(f);
+  process.stdout.write(JSON.stringify(saida));
+});

--- a/scripts/extrai-textos-tsx.mjs
+++ b/scripts/extrai-textos-tsx.mjs
@@ -135,7 +135,18 @@ function classificar(node) {
   if (p && ts.isLiteralTypeNode(p)) return "codigo";
 
   // Nome de propriedade escrito como literal: `{ "data-x": 1 }`, `obj["k"]`.
-  if (p && (ts.isPropertyAssignment(p) || ts.isPropertySignature(p) || ts.isMethodDeclaration(p)) && p.name === node) {
+  // `MethodSignature` entra na lista pelo mesmo motivo que `PropertySignature`:
+  // nome de membro declarado em tipo ou interface é CÓDIGO, nunca texto que o
+  // aluno lê. Sem ele, `interface I { "faz-algo"(): void }` cairia no default
+  // `tela` e o guarda reprovaria um rename legítimo.
+  if (
+    p &&
+    (ts.isPropertyAssignment(p) ||
+      ts.isPropertySignature(p) ||
+      ts.isMethodDeclaration(p) ||
+      ts.isMethodSignature(p)) &&
+    p.name === node
+  ) {
     return "codigo";
   }
   if (p && ts.isElementAccessExpression(p) && p.argumentExpression === node) return "codigo";

--- a/scripts/extrai-textos-tsx.mjs
+++ b/scripts/extrai-textos-tsx.mjs
@@ -200,6 +200,26 @@ function formaDosFilhosJsx(node) {
 // fim: a lista existe para o motor poder REPROVAR, não só avisar.
 const invalidos = [];
 
+// A extensão decide a gramática. Forçar TSX em TODO arquivo quebra TS puro:
+// `const f = <T>(x: T) => x` vira abertura de JSX e o parser reclama. O lado
+// Python aceita .ts/.js/.jsx em EXTENSOES, e agora que o motor REPROVA com 2
+// quando não consegue ler, um único .ts com genérico derrubaria um diretório
+// inteiro que é válido. Medido antes desta troca: 3 diagnósticos e saída 2.
+// As fixtures da suíte terminam em `.tsx.txt` e caem no fallback TSX.
+const GRAMATICAS = {
+  ts: ts.ScriptKind.TS,
+  tsx: ts.ScriptKind.TSX,
+  js: ts.ScriptKind.JS,
+  jsx: ts.ScriptKind.JSX,
+  mjs: ts.ScriptKind.JS,
+  cjs: ts.ScriptKind.JS,
+};
+
+function gramaticaDe(caminho) {
+  const m = /\.([cm]?[jt]sx?)$/i.exec(caminho);
+  return (m && GRAMATICAS[m[1].toLowerCase()]) || ts.ScriptKind.TSX;
+}
+
 function extrair(caminho) {
   const fonte = readFileSync(caminho, "utf-8");
   const sf = ts.createSourceFile(
@@ -207,7 +227,7 @@ function extrair(caminho) {
     fonte,
     ts.ScriptTarget.Latest,
     /* setParentNodes */ true,
-    ts.ScriptKind.TSX, // sempre TSX: as fixtures da suíte não usam extensão .tsx
+    gramaticaDe(caminho),
   );
 
   const achados = { tela: [], codigo: [] };

--- a/scripts/extrai-textos-tsx.mjs
+++ b/scripts/extrai-textos-tsx.mjs
@@ -71,11 +71,21 @@ const ATRIBUTOS_DE_CODIGO = new Set(["key", "ref", "className", "class"]);
 function nomeDoAtributo(attr) {
   const n = attr.name;
   if (ts.isIdentifier(n)) return n.text;
-  // JSX namespaced (`xlink:href`) — sempre código neste repo.
+  // JSX namespaced (`xlink:href`). O nome composto não está em nenhuma das duas
+  // listas, então quem decide é a mesma porta de todo mundo: código no elemento
+  // HTML, tela na prop de componente. Medido: `<use xlink:href="…">` sai em
+  // `codigo`, `<Icone xlink:href="…">` sai em `tela`.
   return `${n.namespace?.text ?? ""}:${n.name?.text ?? ""}`;
 }
 
-/** `<div>` é intrínseco (vocabulário fixo); `<VizFooter>` é componente. */
+/**
+ * `<div>` é intrínseco (vocabulário fixo); `<VizFooter>` é componente.
+ *
+ * Tag com ponto (`<motion.div>`) devolve `false`, porque `tagName` é um
+ * `PropertyAccessExpression` e não um `Identifier` — ela cai no default `tela`.
+ * É o lado conservador do critério, e hoje custa zero: a varredura pela AST nos
+ * 87 `.tsx` de `content/visualizers` não acha nenhuma tag com ponto.
+ */
 function elementoIntrinseco(attr) {
   const dono = attr.parent?.parent; // JsxAttributes -> JsxOpening/SelfClosing
   const tag = dono?.tagName;

--- a/scripts/fixtures-guarda-idioma/1-no-de-texto-jsx/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/1-no-de-texto-jsx/antes.tsx.txt
@@ -1,0 +1,11 @@
+"use client";
+// Buraco da 1ª versão do guarda: ela só olhava literais de string, e o rótulo
+// mora num nó de texto JSX. Medido no contador do Big O.
+export function Exemplo({ nums }: { nums: number[] }) {
+  return (
+    <figure className="viz">
+      <span className="viz-var-name">Array (fica ordenado)</span>
+      <span className="viz-var-val">{nums.length}</span>
+    </figure>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/1-no-de-texto-jsx/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/1-no-de-texto-jsx/depois.tsx.txt
@@ -1,0 +1,11 @@
+"use client";
+// Buraco da 1ª versão do guarda: ela só olhava literais de string, e o rótulo
+// mora num nó de texto JSX. Medido no contador do Big O.
+export function Exemplo({ nums }: { nums: number[] }) {
+  return (
+    <figure className="viz">
+      <span className="viz-var-name">Array (fica sorted)</span>
+      <span className="viz-var-val">{nums.length}</span>
+    </figure>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/10-limite-conjunto-nao-posicao/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/10-limite-conjunto-nao-posicao/antes.tsx.txt
@@ -1,0 +1,17 @@
+"use client";
+// LIMITE CONHECIDO, por construção e não por descuido: o guarda compara o
+// CONJUNTO de textos, não onde cada um aparece. Trocar dois campos de lugar
+// mantém o conjunto idêntico e sai verde — medido no `SubTypesVisualizer` com
+// {l.subtitle} e {l.body} invertidos.
+//
+// Quem pega isso é teste que lê RÓTULO E VALOR JUNTOS, no mesmo cartão (§8 do
+// contrato). Esta fixture existe para que o limite fique escrito e testado, em
+// vez de virar surpresa na próxima rodada.
+export function Exemplo({ l }: { l: { subtitle: string; body: string } }) {
+  return (
+    <div className="st-card">
+      <p className="st-sub">{l.subtitle}</p>
+      <p className="st-body">{l.body}</p>
+    </div>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/10-limite-conjunto-nao-posicao/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/10-limite-conjunto-nao-posicao/depois.tsx.txt
@@ -1,0 +1,17 @@
+"use client";
+// LIMITE CONHECIDO, por construção e não por descuido: o guarda compara o
+// CONJUNTO de textos, não onde cada um aparece. Trocar dois campos de lugar
+// mantém o conjunto idêntico e sai verde — medido no `SubTypesVisualizer` com
+// {l.subtitle} e {l.body} invertidos.
+//
+// Quem pega isso é teste que lê RÓTULO E VALOR JUNTOS, no mesmo cartão (§8 do
+// contrato). Esta fixture existe para que o limite fique escrito e testado, em
+// vez de virar surpresa na próxima rodada.
+export function Exemplo({ l }: { l: { subtitle: string; body: string } }) {
+  return (
+    <div className="st-card">
+      <p className="st-sub">{l.body}</p>
+      <p className="st-body">{l.subtitle}</p>
+    </div>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/11-limite-uniao-que-e-texto/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/11-limite-uniao-que-e-texto/antes.tsx.txt
@@ -1,0 +1,19 @@
+"use client";
+// LIMITE CONHECIDO. Um valor de união pode chegar ao JSX CRU, e aí ele é texto
+// de tela — medido no `BacktrackingSudoku`, no painel "regra que barrou". Mas o
+// que o guarda enxerga é `{p.conflict}`, uma interpolação: ele vira `§`, e a
+// palavra que o aluno lê nunca aparece como literal no JSX.
+//
+// A união em si é um tipo, e chave de tipo é CÓDIGO (§0: "em `Omit<Step,
+// 'desloc'>` só o tsc pega"). Então traduzi-la compila e não reprova o guarda —
+// ela sai no bloco AVISO, que é o mais longe que uma ferramenta pode ir sem
+// saber o que a página renderiza.
+//
+// A regra que fecha isto continua sendo a do §0: ANTES de traduzir uma união,
+// procure onde os valores dela aparecem; se algum chega ao JSX sem passar por
+// um mapa, ele é texto de tela.
+type Conflito = "linha" | "coluna" | "quadrante";
+
+export function Exemplo({ p }: { p: { conflict: Conflito } }) {
+  return <span className="bs-regra">regra que barrou: {p.conflict}</span>;
+}

--- a/scripts/fixtures-guarda-idioma/11-limite-uniao-que-e-texto/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/11-limite-uniao-que-e-texto/depois.tsx.txt
@@ -1,0 +1,19 @@
+"use client";
+// LIMITE CONHECIDO. Um valor de união pode chegar ao JSX CRU, e aí ele é texto
+// de tela — medido no `BacktrackingSudoku`, no painel "regra que barrou". Mas o
+// que o guarda enxerga é `{p.conflict}`, uma interpolação: ele vira `§`, e a
+// palavra que o aluno lê nunca aparece como literal no JSX.
+//
+// A união em si é um tipo, e chave de tipo é CÓDIGO (§0: "em `Omit<Step,
+// 'desloc'>` só o tsc pega"). Então traduzi-la compila e não reprova o guarda —
+// ela sai no bloco AVISO, que é o mais longe que uma ferramenta pode ir sem
+// saber o que a página renderiza.
+//
+// A regra que fecha isto continua sendo a do §0: ANTES de traduzir uma união,
+// procure onde os valores dela aparecem; se algum chega ao JSX sem passar por
+// um mapa, ele é texto de tela.
+type Conflito = "linha" | "column" | "quadrante";
+
+export function Exemplo({ p }: { p: { conflict: Conflito } }) {
+  return <span className="bs-regra">regra que barrou: {p.conflict}</span>;
+}

--- a/scripts/fixtures-guarda-idioma/12-prop-de-componente-e-tela/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/12-prop-de-componente-e-tela/antes.tsx.txt
@@ -1,0 +1,13 @@
+"use client";
+// O contrário do caso 13, com o mesmo atributo e o mesmo valor. `Icone` é
+// componente NOSSO, e componente pode ter prop de rótulo com qualquer nome —
+// nada garante que o `d` daqui seja geometria, e não uma descrição que o aluno
+// lê. Na dúvida o motor devolve TELA, então esta troca REPROVA. Um dia isso vai
+// custar uma linha de ruído a alguém; o defeito que ele evita é o guarda cego.
+import { Icone } from "@/components/Icone";
+
+export function Exemplo() {
+  return (
+    <Icone viewBox="0 0 40 forma" d="M0 zero L20 vinte" className="ic-seta" />
+  );
+}

--- a/scripts/fixtures-guarda-idioma/12-prop-de-componente-e-tela/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/12-prop-de-componente-e-tela/depois.tsx.txt
@@ -1,0 +1,13 @@
+"use client";
+// O contrário do caso 13, com o mesmo atributo e o mesmo valor. `Icone` é
+// componente NOSSO, e componente pode ter prop de rótulo com qualquer nome —
+// nada garante que o `d` daqui seja geometria, e não uma descrição que o aluno
+// lê. Na dúvida o motor devolve TELA, então esta troca REPROVA. Um dia isso vai
+// custar uma linha de ruído a alguém; o defeito que ele evita é o guarda cego.
+import { Icone } from "@/components/Icone";
+
+export function Exemplo() {
+  return (
+    <Icone viewBox="0 0 40 outra" d="M0 zero H20 vinte" className="ic-seta" />
+  );
+}

--- a/scripts/fixtures-guarda-idioma/13-atributo-de-elemento-html-e-codigo/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/13-atributo-de-elemento-html-e-codigo/antes.tsx.txt
@@ -1,0 +1,13 @@
+"use client";
+// Elemento HTML tem vocabulário fixo: `d` não é rótulo, é geometria. Trocar o
+// traçado do caminho é refatoração de desenho, não mexida na aula — sai no
+// bloco AVISO e o guarda continua com exit 0. Compare com o caso 12: o MESMO
+// atributo, com o MESMO valor, num componente nosso.
+export function Exemplo() {
+  return (
+    <svg viewBox="0 0 40 forma" role="img">
+      <path d="M0 zero L20 vinte" fill="none" />
+      <title>Seta do ponteiro</title>
+    </svg>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/13-atributo-de-elemento-html-e-codigo/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/13-atributo-de-elemento-html-e-codigo/depois.tsx.txt
@@ -1,0 +1,13 @@
+"use client";
+// Elemento HTML tem vocabulário fixo: `d` não é rótulo, é geometria. Trocar o
+// traçado do caminho é refatoração de desenho, não mexida na aula — sai no
+// bloco AVISO e o guarda continua com exit 0. Compare com o caso 12: o MESMO
+// atributo, com o MESMO valor, num componente nosso.
+export function Exemplo() {
+  return (
+    <svg viewBox="0 0 40 outra" role="img">
+      <path d="M0 zero H20 vinte" fill="none" />
+      <title>Seta do ponteiro</title>
+    </svg>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/2-no-jsx-em-varias-linhas/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/2-no-jsx-em-varias-linhas/antes.tsx.txt
@@ -1,0 +1,11 @@
+"use client";
+// Buraco da 2ª versão: o nó de texto JSX numa linha só. O Prettier quebra a
+// linha de qualquer elemento cujos atributos não cabem, e o rótulo cai sozinho
+// numa linha do meio.
+export function Exemplo({ pickOp }: { pickOp: (k: string) => void }) {
+  return (
+    <button className="viz-btn" onClick={() => pickOp("push-end")}>
+      inserir no fim
+    </button>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/2-no-jsx-em-varias-linhas/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/2-no-jsx-em-varias-linhas/depois.tsx.txt
@@ -1,0 +1,11 @@
+"use client";
+// Buraco da 2ª versão: o nó de texto JSX numa linha só. O Prettier quebra a
+// linha de qualquer elemento cujos atributos não cabem, e o rótulo cai sozinho
+// numa linha do meio.
+export function Exemplo({ pickOp }: { pickOp: (k: string) => void }) {
+  return (
+    <button className="viz-btn" onClick={() => pickOp("push-end")}>
+      inserir no done
+    </button>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/3-literal-dentro-da-interpolacao/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/3-literal-dentro-da-interpolacao/antes.tsx.txt
@@ -1,0 +1,8 @@
+"use client";
+// Buraco da 2ª versão: a interpolação era apagada INTEIRA, e ternário dentro de
+// `${...}` é como metade das notas deste repo escolhe entre singular e plural.
+export function passo(cap: number, n: number) {
+  return `Array cheio (${n} de ${cap}): o próximo insert vai ${
+    n === cap ? "reservar a capacidade certa" : "usar o espaço que sobra"
+  }.`;
+}

--- a/scripts/fixtures-guarda-idioma/3-literal-dentro-da-interpolacao/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/3-literal-dentro-da-interpolacao/depois.tsx.txt
@@ -1,0 +1,8 @@
+"use client";
+// Buraco da 2ª versão: a interpolação era apagada INTEIRA, e ternário dentro de
+// `${...}` é como metade das notas deste repo escolhe entre singular e plural.
+export function passo(cap: number, n: number) {
+  return `Array cheio (${n} de ${cap}): o próximo insert vai ${
+    n === cap ? "reservar a capacity certa" : "usar o espaço que sobra"
+  }.`;
+}

--- a/scripts/fixtures-guarda-idioma/4-crase-aninhada/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/4-crase-aninhada/antes.tsx.txt
@@ -1,0 +1,10 @@
+"use client";
+// Buraco da 3ª versão, medido no `LinkedListFloyd` (a linha abaixo é a dele).
+//
+// As crases desta linha são quatro: abre externa (1), abre interna (2), fecha
+// interna (3), fecha externa (4). Um regex de crase pareia 1-2 e 3-4, então o
+// trecho entre 2 e 3 — que é JUSTAMENTE o texto da tela do template interno —
+// nunca é lido. Trocar ", e " por ", and " ali saía `SUMIRAM: nenhuma`.
+export function passo(total: number, cycle: number) {
+  return `Fase 1. O lento e o rápido começam os dois na cabeça, o nó 0. A lista tem ${total} ${total === 1 ? "nó" : "nós"}${cycle > 0 ? `, e ${cycle} ${cycle === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`;
+}

--- a/scripts/fixtures-guarda-idioma/4-crase-aninhada/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/4-crase-aninhada/depois.tsx.txt
@@ -1,0 +1,10 @@
+"use client";
+// Buraco da 3ª versão, medido no `LinkedListFloyd` (a linha abaixo é a dele).
+//
+// As crases desta linha são quatro: abre externa (1), abre interna (2), fecha
+// interna (3), fecha externa (4). Um regex de crase pareia 1-2 e 3-4, então o
+// trecho entre 2 e 3 — que é JUSTAMENTE o texto da tela do template interno —
+// nunca é lido. Trocar ", e " por ", and " ali saía `SUMIRAM: nenhuma`.
+export function passo(total: number, cycle: number) {
+  return `Fase 1. O lento e o rápido começam os dois na cabeça, o nó 0. A lista tem ${total} ${total === 1 ? "nó" : "nós"}${cycle > 0 ? `, and ${cycle} ${cycle === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`;
+}

--- a/scripts/fixtures-guarda-idioma/5-rotulo-colado-na-interpolacao/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/5-rotulo-colado-na-interpolacao/antes.tsx.txt
@@ -1,0 +1,12 @@
+"use client";
+// O buraco SILENCIOSO da 3ª versão, medido no `LinkedListFloyd` (a linha do
+// <span> é a dele). O padrão do guarda antigo exigia `>texto<`, e o `{` da
+// interpolação cortava o casamento: "Nós no ciclo: " não está dentro de string
+// nenhuma e simplesmente não era visto.
+export function Exemplo({ cycle }: { cycle: number }) {
+  return (
+    <label className="viz-field grow">
+      <span>Nós no ciclo: {cycle === 0 ? "nenhum, a lista termina em None" : cycle}</span>
+    </label>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/5-rotulo-colado-na-interpolacao/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/5-rotulo-colado-na-interpolacao/depois.tsx.txt
@@ -1,0 +1,12 @@
+"use client";
+// O buraco SILENCIOSO da 3ª versão, medido no `LinkedListFloyd` (a linha do
+// <span> é a dele). O padrão do guarda antigo exigia `>texto<`, e o `{` da
+// interpolação cortava o casamento: "Nós no ciclo: " não está dentro de string
+// nenhuma e simplesmente não era visto.
+export function Exemplo({ cycle }: { cycle: number }) {
+  return (
+    <label className="viz-field grow">
+      <span>Nodes no ciclo: {cycle === 0 ? "nenhum, a lista termina em None" : cycle}</span>
+    </label>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/6-rodada-de-of/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/6-rodada-de-of/antes.tsx.txt
@@ -1,0 +1,14 @@
+"use client";
+// A demonstração que fechou o assunto (`BellmanFordVisualizer:273`): o " de "
+// entre duas interpolações. Com o guarda antigo o painel podia passar a dizer
+// "rodada 5 of 4" e a saída era `SUMIRAM: nenhuma / APARECERAM: nenhuma`.
+const LABELS = ["A", "B", "C", "D", "E"];
+
+export function Exemplo({ s }: { s: { round: number } }) {
+  return (
+    <div className="viz-var">
+      <span className="viz-var-name">rodada</span>
+      <span className="viz-var-val best">{s.round} de {LABELS.length - 1}</span>
+    </div>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/6-rodada-de-of/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/6-rodada-de-of/depois.tsx.txt
@@ -1,0 +1,14 @@
+"use client";
+// A demonstração que fechou o assunto (`BellmanFordVisualizer:273`): o " de "
+// entre duas interpolações. Com o guarda antigo o painel podia passar a dizer
+// "rodada 5 of 4" e a saída era `SUMIRAM: nenhuma / APARECERAM: nenhuma`.
+const LABELS = ["A", "B", "C", "D", "E"];
+
+export function Exemplo({ s }: { s: { round: number } }) {
+  return (
+    <div className="viz-var">
+      <span className="viz-var-name">rodada</span>
+      <span className="viz-var-val best">{s.round} of {LABELS.length - 1}</span>
+    </div>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/7-rename-limpo-com-crase-aninhada/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/7-rename-limpo-com-crase-aninhada/antes.tsx.txt
@@ -1,0 +1,28 @@
+"use client";
+// O caso NEGATIVO, e ele importa tanto quanto os outros: um guarda que grita em
+// tudo é tão inútil quanto um cego. Aqui o rename é só de identificador
+// (slow/fast/cycle/total -> slowPtr/fastPtr/cycleLen/nodeCount) e NENHUM texto
+// de tela muda. O guarda tem que sair limpo.
+//
+// Com o guarda antigo este mesmo rename saía com 40 linhas de ruído, porque a
+// crase aninhada desincronizava o pareamento e ele passava a comparar código.
+import { useState } from "react";
+
+export function Exemplo() {
+  const [total, setTotal] = useState(6);
+  const [cycle, setCycle] = useState(3);
+  const slow = 0;
+  const fast = 1;
+  const notas = [
+    `A lista tem ${total} ${total === 1 ? "nó" : "nós"}${cycle > 0 ? `, e ${cycle} ${cycle === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`,
+    `O rápido está no nó ${fast}, o lento no nó ${slow}: ${fast === slow ? `os dois no nó ${slow}` : "ainda não se encontraram"}.`,
+  ];
+  return (
+    <figure className="viz">
+      <p>{notas[0]}</p>
+      <span>Nós no ciclo: {cycle === 0 ? "nenhum, a lista termina em None" : cycle}</span>
+      <button onClick={() => setTotal(total + 1)}>mais um nó</button>
+      <button onClick={() => setCycle(0)}>tirar o ciclo</button>
+    </figure>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/7-rename-limpo-com-crase-aninhada/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/7-rename-limpo-com-crase-aninhada/depois.tsx.txt
@@ -1,0 +1,28 @@
+"use client";
+// O caso NEGATIVO, e ele importa tanto quanto os outros: um guarda que grita em
+// tudo é tão inútil quanto um cego. Aqui o rename é só de identificador
+// (slow/fast/cycle/total -> slowPtr/fastPtr/cycleLen/nodeCount) e NENHUM texto
+// de tela muda. O guarda tem que sair limpo.
+//
+// Com o guarda antigo este mesmo rename saía com 40 linhas de ruído, porque a
+// crase aninhada desincronizava o pareamento e ele passava a comparar código.
+import { useState } from "react";
+
+export function Exemplo() {
+  const [nodeCount, setNodeCount] = useState(6);
+  const [cycleLen, setCycleLen] = useState(3);
+  const slowPtr = 0;
+  const fastPtr = 1;
+  const notas = [
+    `A lista tem ${nodeCount} ${nodeCount === 1 ? "nó" : "nós"}${cycleLen > 0 ? `, e ${cycleLen} ${cycleLen === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`,
+    `O rápido está no nó ${fastPtr}, o lento no nó ${slowPtr}: ${fastPtr === slowPtr ? `os dois no nó ${slowPtr}` : "ainda não se encontraram"}.`,
+  ];
+  return (
+    <figure className="viz">
+      <p>{notas[0]}</p>
+      <span>Nós no ciclo: {cycleLen === 0 ? "nenhum, a lista termina em None" : cycleLen}</span>
+      <button onClick={() => setNodeCount(nodeCount + 1)}>mais um nó</button>
+      <button onClick={() => setCycleLen(0)}>tirar o ciclo</button>
+    </figure>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/8-atributo-que-o-aluno-le/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/8-atributo-que-o-aluno-le/antes.tsx.txt
@@ -1,0 +1,12 @@
+"use client";
+// Texto de tela que não é filho de elemento nem string solta: ele é o valor de
+// um atributo. `aria-label` e `title` são lidos (por leitor de tela e pelo
+// tooltip); `className` e `viewBox` não são. O guarda separa os dois.
+export function Exemplo() {
+  return (
+    <svg className="ll-svg" viewBox="0 0 460 130" role="img">
+      <title>Diagrama da lista com ciclo</title>
+      <circle cx={20} cy={20} r={9} fill="#0f1826" aria-label="nó da cabeça" />
+    </svg>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/8-atributo-que-o-aluno-le/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/8-atributo-que-o-aluno-le/depois.tsx.txt
@@ -1,0 +1,12 @@
+"use client";
+// Texto de tela que não é filho de elemento nem string solta: ele é o valor de
+// um atributo. `aria-label` e `title` são lidos (por leitor de tela e pelo
+// tooltip); `className` e `viewBox` não são. O guarda separa os dois.
+export function Exemplo() {
+  return (
+    <svg className="ll-svg" viewBox="0 0 460 130" role="img">
+      <title>Diagrama da lista com ciclo</title>
+      <circle cx={20} cy={20} r={9} fill="#0f1826" aria-label="head node" />
+    </svg>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/9-classe-de-css-nao-reprova/antes.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/9-classe-de-css-nao-reprova/antes.tsx.txt
@@ -1,0 +1,12 @@
+"use client";
+// O §0 do contrato: literal que vira NOME DE CLASSE é contrato com o CSS, não
+// texto de tela. Ele passa pelo `tsc`, passa pelo teste (é cor) e o guarda
+// antigo o listava como se fosse rótulo — pedindo a reação que RE-QUEBRA o
+// rename. Aqui ele sai no bloco AVISO e o guarda continua com exit 0.
+export function Exemplo({ gap }: { gap: number }) {
+  return (
+    <span className={`hs-fase ${gap === 1 ? "f-fim" : "f-ordenar"}`}>
+      gap {gap}
+    </span>
+  );
+}

--- a/scripts/fixtures-guarda-idioma/9-classe-de-css-nao-reprova/depois.tsx.txt
+++ b/scripts/fixtures-guarda-idioma/9-classe-de-css-nao-reprova/depois.tsx.txt
@@ -1,0 +1,12 @@
+"use client";
+// O §0 do contrato: literal que vira NOME DE CLASSE é contrato com o CSS, não
+// texto de tela. Ele passa pelo `tsc`, passa pelo teste (é cor) e o guarda
+// antigo o listava como se fosse rótulo — pedindo a reação que RE-QUEBRA o
+// rename. Aqui ele sai no bloco AVISO e o guarda continua com exit 0.
+export function Exemplo({ gap }: { gap: number }) {
+  return (
+    <span className={`hs-fase ${gap === 1 ? "f-end" : "f-sort"}`}>
+      gap {gap}
+    </span>
+  );
+}

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -127,7 +127,7 @@ def comparar(antes: dict, depois: dict, recuo: str = "") -> bool:
 
 def main() -> None:
     if len(sys.argv) != 3:
-        morrer("uso: guarda-idioma.py <antes> <depois>  (arquivo ou diretório)")
+        morrer("uso: python3 scripts/guarda-idioma.py <antes> <depois>  (arquivo ou diretório)")
 
     a, d = Path(sys.argv[1]), Path(sys.argv[2])
     for p in (a, d):

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -1,75 +1,161 @@
+#!/usr/bin/env python3
 """Guarda de idioma: o que o aluno lê não pode mudar num rename de identificador.
 
-    python3 guarda-idioma.py <antes.tsx> <depois.tsx>
+    python3 scripts/guarda-idioma.py <antes.tsx> <depois.tsx>
+    python3 scripts/guarda-idioma.py <dir-antes> <dir-depois>    # o tópico inteiro
 
-Compara TUDO que aparece na tela — literais de string e nós de texto JSX — e
-falha se alguma coisa entrou ou saiu. O que sobrar tem que ser só nome de
-import, de hook e de prop.
+Compara TUDO que aparece na tela — literais de string, templates (aninhados
+inclusive) e nós de texto JSX — e falha se alguma coisa entrou ou saiu.
 
-Este arquivo já teve DUAS versões que passavam verde com a aula estragada, e as
-duas falharam do mesmo jeito: por olhar de menos, não por olhar errado. Quando
-ele passar, a pergunta útil é o que ele NÃO está olhando.
+Sai 0 quando o texto de tela é idêntico, 1 quando mudou, 2 quando o próprio
+guarda não conseguiu rodar. **Nunca sai 0 por não ter conseguido olhar**: o
+histórico deste arquivo é de passar verde com a aula estragada, e um guarda que
+falha calado é pior que nenhum.
 
-  1ª versão — só literais de string, sem nó JSX. `<span>Array (fica
-     sorted)</span>` e mais dois rótulos passaram batido.
-  2ª versão — nó JSX só numa linha (`[^...\\n]`) e interpolação apagada inteira
-     (`\\$\\{[^}]*\\}` → `§`). Isso deixou de fora justamente os dois formatos
-     mais comuns do repo, e as duas brechas foram medidas em rename de verdade:
+O QUE MUDOU NESTA VERSÃO, E POR QUÊ
+-----------------------------------
+As três versões anteriores casavam texto por expressão regular, e as três
+falharam do mesmo jeito: por olhar de menos.
 
-       <button className="viz-btn" onClick={() => pickOp("push-end")}>
-         inserir no fim          ← nó JSX em linha própria: virou "inserir no done"
-       </button>
+  1ª  só literais de string, sem nó JSX
+      -> `<span>Array (fica ordenado)</span>` virou "sorted" sem um pio.
+  2ª  nó JSX só numa linha, interpolação apagada inteira
+      -> `inserir no fim` (nó JSX quebrado pelo Prettier) virou "inserir no
+         done", e `${cond ? "reservar a capacidade certa" : ...}` virou
+         "capacity".
+  3ª  passadas separadas por tipo de aspa
+      -> resolveu as duas acima e deixou DOIS buracos, medidos no
+         `listas-ligadas` e documentados no §0 do contrato:
 
-       `... ${cond ? "reservar a capacidade certa" : "..."} ...`
-                                 ↑ literal DENTRO da interpolação: virou "capacity"
+         crase ANINHADA dentro de `${...}`  — o pareamento das crases sai de
+         sincronia e o guarda passa a comparar CÓDIGO como se fosse tela. Num
+         rename de 4 identificadores do `LinkedListFloyd` isso dava 36 linhas
+         de saída, todas ruído, com um rótulo trocado de verdade escondido
+         dentro de um blob de 4 mil caracteres.
 
-Daí as duas mudanças desta versão: o nó JSX pode atravessar linhas, e os
-literais são varridos em passadas SEPARADAS, para o casamento da crase não
-engolir as aspas aninhadas nela.
+         texto de tela colado numa interpolação — `<span>Nós no ciclo: {...}`.
+         O "Nós no ciclo: " não está em string nenhuma, o padrão `>texto<` não
+         casa por causa do `{`, e o guarda saía `SUMIRAM: nenhuma`. Este era o
+         silencioso: trocar `" de "` por `" of "` em
+         `{s.round} de {LABELS.length - 1}` (`BellmanFordVisualizer`) deixava o
+         painel dizendo "rodada 5 of 4" com o guarda VERDE.
+
+A 4ª versão (esta) não casa texto: ela **parseia**. O trabalho de ler o TSX é
+do compilador do TypeScript, que já é dependência do projeto, num script Node
+irmão (`scripts/extrai-textos-tsx.mjs`). Este arquivo continua sendo a porta de
+entrada — mesmo caminho, mesma linha de comando, mesmo relatório —, porque é
+ele que o contrato, o runbook e a skill mandam chamar; o que saiu daqui foi só
+o motor, que precisa da AST, e não a comparação, que são seis linhas de
+`Counter`.
 """
-import re, sys
+import json
+import shutil
+import subprocess
+import sys
 from collections import Counter
+from pathlib import Path
 
-# Nó de texto JSX. Atravessa linhas de propósito — é assim que o Prettier
-# formata qualquer elemento cujos atributos não cabem numa linha só. Os sinais
-# de código (`{}`, `;`, `=`, `<`, `>`) seguem de fora, e o teto de tamanho
-# impede que um `>` de comparação abra um casamento que atravessa uma função.
-JSX_TEXTO = r">([^<>{};=]*[A-Za-zÀ-ÿ][^<>{};=]*)<"
-MAX_JSX = 240
-
-# Passadas SEPARADAS, e não uma alternância só: numa alternância o casamento da
-# crase consome `${cond ? "texto de tela" : "outro"}` inteiro e as aspas de
-# dentro nunca são vistas. Varrendo aspas por conta própria elas aparecem.
-ASPAS_DUPLAS = r'"([^"\\\n]*(?:\\.[^"\\\n]*)*)"'
-ASPAS_SIMPLES = r"'([^'\\\n]*(?:\\.[^'\\\n]*)*)'"
-CRASE = r"`([^`\\]*(?:\\.[^`\\]*)*)`"
+MOTOR = Path(__file__).resolve().with_name("extrai-textos-tsx.mjs")
+EXTENSOES = (".tsx", ".ts", ".jsx", ".js")
 
 
-def na_tela(caminho: str) -> Counter:
-    s = open(caminho, encoding="utf-8").read()
-    s = re.sub(r"//[^\n]*|/\*.*?\*/", "", s, flags=re.S)     # comentário não é tela
-    achados = []
-    # O teto de tamanho é do nó JSX, e só dele; a flag diz isso explicitamente
-    # em vez de perguntar `padrao is JSX_TEXTO`, que compara IDENTIDADE de
-    # objeto — funcionaria por acidente aqui e calaria se alguém montasse o
-    # padrão numa variável nova.
-    for padrao, e_jsx in ((ASPAS_DUPLAS, False), (ASPAS_SIMPLES, False),
-                          (CRASE, False), (JSX_TEXTO, True)):
-        for m in re.finditer(padrao, s, flags=re.S):
-            t = m.group(1)
-            if e_jsx and len(t) > MAX_JSX:
-                continue
-            t = re.sub(r"\$\{[^{}]*\}", "§", t)              # interpolação é código
-            t = " ".join(t.split())                          # a indentação não é tela
-            if t and re.search(r"[A-Za-zÀ-ÿ]", t):
-                achados.append(t)
-    return Counter(achados)
+def morrer(msg: str) -> None:
+    """Erro do guarda, não do arquivo: sai 2 para não ser lido como 'passou'."""
+    print(f"guarda-idioma: {msg}", file=sys.stderr)
+    raise SystemExit(2)
 
 
-antes, depois = na_tela(sys.argv[1]), na_tela(sys.argv[2])
-sumiram, apareceram = sorted(antes - depois), sorted(depois - antes)
-for rotulo, itens in (("SUMIRAM", sumiram), ("APARECERAM", apareceram)):
-    print(f"{rotulo}:")
-    for t in itens: print("   ", repr(t))
-    if not itens: print("    nenhuma")
-sys.exit(1 if (sumiram or apareceram) else 0)
+def extrair(caminhos: list[Path]) -> dict:
+    """Roda o motor Node uma vez para TODOS os arquivos e devolve o JSON."""
+    if not caminhos:
+        return {}
+    node = shutil.which("node")
+    if not node:
+        morrer("`node` não está no PATH — o guarda usa o parser do TypeScript.")
+    if not MOTOR.exists():
+        morrer(f"motor não encontrado em {MOTOR}")
+    entrada = json.dumps({"files": [str(p) for p in caminhos]})
+    r = subprocess.run([node, str(MOTOR)], input=entrada, capture_output=True, text=True)
+    if r.stderr:
+        sys.stderr.write(r.stderr)
+    if r.returncode != 0:
+        morrer(f"o motor falhou (código {r.returncode}).")
+    try:
+        return json.loads(r.stdout)
+    except json.JSONDecodeError:
+        morrer("o motor não devolveu JSON.")
+
+
+def arquivos_de(raiz: Path) -> list[str]:
+    """Caminhos relativos dos fontes sob um diretório, ordenados."""
+    return sorted(
+        str(p.relative_to(raiz))
+        for p in raiz.rglob("*")
+        if p.is_file() and p.suffix in EXTENSOES and "node_modules" not in p.parts
+    )
+
+
+def bloco(rotulo: str, itens: list[str], recuo: str = "    ") -> None:
+    print(f"{recuo}{rotulo}:")
+    for t in itens:
+        print(f"{recuo}    {repr(t)}")
+    if not itens:
+        print(f"{recuo}    nenhuma")
+
+
+def comparar(antes: dict, depois: dict, recuo: str = "") -> bool:
+    """Imprime o veredito de um par. Devolve True se o texto de tela mudou."""
+    tela_a, tela_d = Counter(antes["tela"]), Counter(depois["tela"])
+    sumiram, apareceram = sorted(tela_a - tela_d), sorted(tela_d - tela_a)
+
+    bloco("SUMIRAM", sumiram, recuo)
+    bloco("APARECERAM", apareceram, recuo)
+
+    # Literal de código que muda não reprova, mas é onde mora a armadilha do §0
+    # (o literal que vira NOME DE CLASSE do CSS): o `tsc` não vê, o teste não vê
+    # e o guarda antigo misturava com o texto de tela. Aqui ele fica à parte.
+    cod_a, cod_d = Counter(antes["codigo"]), Counter(depois["codigo"])
+    mexidos = sorted((cod_a - cod_d) + (cod_d - cod_a))
+    if mexidos:
+        print(f"{recuo}AVISO (não reprova) — literais de CÓDIGO que mudaram.")
+        print(f"{recuo}  Se algum for nome de classe, confira no globals.css (§0 do contrato):")
+        for t in mexidos:
+            print(f"{recuo}    {repr(t)}")
+
+    return bool(sumiram or apareceram)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        morrer("uso: guarda-idioma.py <antes> <depois>  (arquivo ou diretório)")
+
+    a, d = Path(sys.argv[1]), Path(sys.argv[2])
+    for p in (a, d):
+        if not p.exists():
+            morrer(f"não existe: {p}")
+    if a.is_dir() != d.is_dir():
+        morrer("os dois lados têm que ser ambos arquivo ou ambos diretório.")
+
+    if a.is_file():
+        dados = extrair([a, d])
+        raise SystemExit(1 if comparar(dados[str(a)], dados[str(d)]) else 0)
+
+    nomes = sorted(set(arquivos_de(a)) | set(arquivos_de(d)))
+    dados = extrair([a / n for n in nomes if (a / n).exists()]
+                    + [d / n for n in nomes if (d / n).exists()])
+    vazio = {"tela": [], "codigo": []}
+    quebrou = False
+    for n in nomes:
+        antes = dados.get(str(a / n), vazio)
+        depois = dados.get(str(d / n), vazio)
+        if antes == depois:
+            continue
+        print(n)
+        quebrou |= comparar(antes, depois, recuo="  ")
+    if not quebrou:
+        print(f"SUMIRAM: nenhuma / APARECERAM: nenhuma  ({len(nomes)} arquivos)")
+    raise SystemExit(1 if quebrou else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -48,6 +48,13 @@ ele que o contrato, o runbook e a skill mandam chamar; o que saiu daqui foi só
 o motor, que precisa da AST, e não a comparação, que são seis linhas de
 `Counter`.
 """
+# As anotações `list[Path]` são PEP 585 e, sem isto, o interpretador as AVALIA
+# na definição da função — em Python 3.8 o script morre no import, antes de
+# olhar arquivo nenhum. Nada aqui fixa versão de Python (nenhum workflow usa
+# `setup-python`; vale o `python3` do runner), então a linha é barata e tira a
+# suposição do caminho.
+from __future__ import annotations
+
 import json
 import shutil
 import subprocess

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -144,12 +144,25 @@ def main() -> None:
     dados = extrair([a / n for n in nomes if (a / n).exists()]
                     + [d / n for n in nomes if (d / n).exists()])
     vazio = {"tela": [], "codigo": []}
+
+    def mesmo_conjunto(x: dict, y: dict) -> bool:
+        """O guarda compara CONJUNTO, não posição — igual ao `comparar`.
+
+        Com `x == y` cru a comparação era por lista ordenada, então trocar dois
+        trechos de lugar contava o arquivo como mexido: saía o nome dele, sem
+        SUMIRAM, sem APARECERAM e sem AVISO, e o resumo final ainda mandava ver
+        blocos AVISO que não existiam. O limite "conjunto, não posição" já era o
+        contrato (fixture 10); só este laço não seguia ele.
+        """
+        return (Counter(x["tela"]) == Counter(y["tela"])
+                and Counter(x["codigo"]) == Counter(y["codigo"]))
+
     quebrou = False
     mexidos = 0
     for n in nomes:
         antes = dados.get(str(a / n), vazio)
         depois = dados.get(str(d / n), vazio)
-        if antes == depois:
+        if mesmo_conjunto(antes, depois):
             continue
         mexidos += 1
         print(n)

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -162,7 +162,7 @@ def main() -> None:
         # que sai 0 sem ter olhado nada.
         if mexidos:
             print(f"TELA intacta, mas {mexidos} de {len(nomes)} arquivo(s) mudaram "
-                  f"literais de CÓDIGO — veja os AVISO acima antes de seguir.")
+                  f"literais de CÓDIGO — veja os blocos AVISO acima antes de seguir.")
         else:
             print(f"SUMIRAM: nenhuma / APARECERAM: nenhuma  ({len(nomes)} arquivos)")
     raise SystemExit(1 if quebrou else 0)

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -145,15 +145,26 @@ def main() -> None:
                     + [d / n for n in nomes if (d / n).exists()])
     vazio = {"tela": [], "codigo": []}
     quebrou = False
+    mexidos = 0
     for n in nomes:
         antes = dados.get(str(a / n), vazio)
         depois = dados.get(str(d / n), vazio)
         if antes == depois:
             continue
+        mexidos += 1
         print(n)
         quebrou |= comparar(antes, depois, recuo="  ")
     if not quebrou:
-        print(f"SUMIRAM: nenhuma / APARECERAM: nenhuma  ({len(nomes)} arquivos)")
+        # A ÚLTIMA linha é a que fica na tela de quem rodou, e ela não pode
+        # dizer "nenhuma" quando houve AVISO acima: aviso de literal de código
+        # é justamente o que o contrato manda conferir à mão no globals.css.
+        # Resumo tranquilizador em cima de achado é a mesma armadilha do guarda
+        # que sai 0 sem ter olhado nada.
+        if mexidos:
+            print(f"TELA intacta, mas {mexidos} de {len(nomes)} arquivo(s) mudaram "
+                  f"literais de CÓDIGO — veja os AVISO acima antes de seguir.")
+        else:
+            print(f"SUMIRAM: nenhuma / APARECERAM: nenhuma  ({len(nomes)} arquivos)")
     raise SystemExit(1 if quebrou else 0)
 
 

--- a/scripts/testa-guarda-idioma.py
+++ b/scripts/testa-guarda-idioma.py
@@ -54,7 +54,18 @@ def main() -> int:
     verboso = "-v" in argv or "--verbose" in argv
     guarda = AQUI / "guarda-idioma.py"
     if "--guarda" in argv:
-        guarda = Path(argv[argv.index("--guarda") + 1]).resolve()
+        # Sem o caminho depois do flag isto era um IndexError com traceback e
+        # código 1 — o MESMO código de "um caso reprovou". Erro de uso não pode
+        # ser confundido com resultado de teste, então sai 2.
+        i = argv.index("--guarda") + 1
+        if i >= len(argv):
+            print("uso: testa-guarda-idioma.py [--guarda <caminho>] [-v]", file=sys.stderr)
+            return 2
+        alvo = Path(argv[i])
+        if not alvo.is_file():
+            print(f"guarda não encontrado: {alvo}", file=sys.stderr)
+            return 2
+        guarda = alvo.resolve()
 
     print(f"guarda: {guarda}\n")
     falhas = []

--- a/scripts/testa-guarda-idioma.py
+++ b/scripts/testa-guarda-idioma.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Suíte do próprio guarda de idioma.
+
+    python3 scripts/testa-guarda-idioma.py                 # roda o guarda atual
+    python3 scripts/testa-guarda-idioma.py --guarda <p>    # roda OUTRO guarda
+    python3 scripts/testa-guarda-idioma.py -v              # imprime a saída de cada caso
+
+O `--guarda` existe para a prova de quebra: aponte para uma cópia da versão
+anterior e veja os casos 4, 5 e 6 passarem verdes com a aula estragada. Um
+guarda que você nunca viu falhar não é guarda.
+
+Cada caso é um par de arquivos em `fixtures-guarda-idioma/<caso>/`, com
+extensão `.tsx.txt` de propósito: o `tsconfig.json` inclui `**/*.tsx`, então
+fixture com extensão de verdade entraria no `npx tsc --noEmit` e quebraria o
+typecheck com código que existe justamente para estar errado. O motor força
+`ScriptKind.TSX`, então o parser lê igual.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+AQUI = Path(__file__).resolve().parent
+FIXTURES = AQUI / "fixtures-guarda-idioma"
+
+# (pasta, deve_reprovar, o que o caso prova)
+CASOS = [
+    ("1-no-de-texto-jsx", True,
+     "nó de texto JSX (buraco da 1ª versão)"),
+    ("2-no-jsx-em-varias-linhas", True,
+     "nó de texto JSX em linha própria (buraco da 2ª versão)"),
+    ("3-literal-dentro-da-interpolacao", True,
+     "literal dentro de ${...} (buraco da 2ª versão)"),
+    ("4-crase-aninhada", True,
+     "CRASE ANINHADA: o texto do template interno (buraco da 3ª versão)"),
+    ("5-rotulo-colado-na-interpolacao", True,
+     "RÓTULO COLADO NUMA INTERPOLAÇÃO (o buraco silencioso da 3ª versão)"),
+    ("6-rodada-de-of", True,
+     "'{s.round} de {n}' -> ' of ' (a demonstração do bellman-ford)"),
+    ("7-rename-limpo-com-crase-aninhada", False,
+     "rename só de identificador NÃO reprova (o guarda não grita em tudo)"),
+    ("8-atributo-que-o-aluno-le", True,
+     "aria-label é tela; className e viewBox não são"),
+    ("9-classe-de-css-nao-reprova", False,
+     "classe de CSS vai para o AVISO e não reprova"),
+    ("10-limite-conjunto-nao-posicao", False,
+     "LIMITE: campos trocados de lugar mantêm o conjunto e passam"),
+    ("11-limite-uniao-que-e-texto", False,
+     "LIMITE: chave de tipo é código; quem pega o rename errado é o tsc"),
+]
+
+
+def main() -> int:
+    argv = sys.argv[1:]
+    verboso = "-v" in argv or "--verbose" in argv
+    guarda = AQUI / "guarda-idioma.py"
+    if "--guarda" in argv:
+        guarda = Path(argv[argv.index("--guarda") + 1]).resolve()
+
+    print(f"guarda: {guarda}\n")
+    falhas = []
+    for pasta, deve_reprovar, oquê in CASOS:
+        base = FIXTURES / pasta
+        r = subprocess.run(
+            [sys.executable, str(guarda), str(base / "antes.tsx.txt"), str(base / "depois.tsx.txt")],
+            capture_output=True, text=True,
+        )
+        reprovou = r.returncode == 1
+        if r.returncode not in (0, 1):
+            ok, nota = False, f"o guarda saiu {r.returncode}"
+        else:
+            ok = reprovou == deve_reprovar
+            nota = "" if ok else ("passou VERDE com a tela estragada"
+                                  if deve_reprovar else "reprovou sem a tela ter mudado")
+        marca = "ok  " if ok else "FALHA"
+        esperado = "reprova" if deve_reprovar else "passa"
+        print(f"  {marca}  {pasta:<38} {esperado:<8} {oquê}")
+        if nota:
+            print(f"         -> {nota}")
+        if verboso or not ok:
+            for linha in (r.stdout + r.stderr).rstrip().splitlines():
+                print(f"         | {linha[:160]}")
+        if not ok:
+            falhas.append(pasta)
+
+    print()
+    if falhas:
+        print(f"{len(falhas)} de {len(CASOS)} casos FALHARAM: {', '.join(falhas)}")
+        return 1
+    print(f"{len(CASOS)} de {len(CASOS)} casos ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/testa-guarda-idioma.py
+++ b/scripts/testa-guarda-idioma.py
@@ -75,13 +75,21 @@ def main() -> int:
             [sys.executable, str(guarda), str(base / "antes.tsx.txt"), str(base / "depois.tsx.txt")],
             capture_output=True, text=True,
         )
-        reprovou = r.returncode == 1
+        # Código inesperado é o guarda NÃO TENDO RODADO, não um caso reprovado.
+        # Contar como FALHA fazia a suíte sair 1, o mesmo código de "regressão",
+        # e escondia a diferença entre "o guarda achou um problema" e "o guarda
+        # está quebrado". Aborta na hora, com o 2 do contrato.
         if r.returncode not in (0, 1):
-            ok, nota = False, f"o guarda saiu {r.returncode}"
-        else:
-            ok = reprovou == deve_reprovar
-            nota = "" if ok else ("passou VERDE com a tela estragada"
-                                  if deve_reprovar else "reprovou sem a tela ter mudado")
+            print(f"  ERRO   {pasta:<38} o guarda saiu {r.returncode}, não 0 nem 1")
+            for linha in (r.stdout + r.stderr).rstrip().splitlines():
+                print(f"         | {linha[:160]}")
+            print("\nsuíte abortada: o guarda não conseguiu rodar (não é regressão de caso)")
+            return 2
+
+        reprovou = r.returncode == 1
+        ok = reprovou == deve_reprovar
+        nota = "" if ok else ("passou VERDE com a tela estragada"
+                              if deve_reprovar else "reprovou sem a tela ter mudado")
         marca = "ok  " if ok else "FALHA"
         esperado = "reprova" if deve_reprovar else "passa"
         print(f"  {marca}  {pasta:<38} {esperado:<8} {oquê}")

--- a/scripts/testa-guarda-idioma.py
+++ b/scripts/testa-guarda-idioma.py
@@ -46,6 +46,16 @@ CASOS = [
      "LIMITE: campos trocados de lugar mantêm o conjunto e passam"),
     ("11-limite-uniao-que-e-texto", False,
      "LIMITE: chave de tipo é código; quem pega o rename errado é o tsc"),
+    # 12 e 13 são um PAR e provam a mesma fronteira pelos dois lados: a mesma
+    # troca de `viewBox`/`d`, com os mesmos valores, muda de veredito só porque
+    # a tag é componente (`<Icone>`) ou elemento HTML (`<path>`). O contrato
+    # dizia que esses atributos eram código SEMPRE; o motor só faz isso no
+    # elemento HTML. Separados, os dois casos ficam frouxos: 12 sozinho passa
+    # com todo mundo em tela, 13 sozinho passa com todo mundo em código.
+    ("12-prop-de-componente-e-tela", True,
+     "prop de COMPONENTE é tela mesmo se chama `d`/`viewBox` (default conservador)"),
+    ("13-atributo-de-elemento-html-e-codigo", False,
+     "o MESMO `d`/`viewBox` num ELEMENTO HTML é código e não reprova"),
 ]
 
 


### PR DESCRIPTION
## O buraco

O `scripts/guarda-idioma.py` protege a regra de produto **"identificador em
inglês, tudo que o aluno lê em português"** durante renames em lote. Ele casava
texto por **expressão regular**, e tinha dois buracos medidos. Os dois são
**cegueira**, não ruído: o guarda saía `SUMIRAM: nenhuma` com a aula estragada.

### 1. Crase aninhada dentro de `${...}` — 27 dos 87 arquivos

O regex de crase pareia a 1ª com a 2ª e a 3ª com a 4ª. Numa linha assim
(`LinkedListFloyd:83`, real):

```tsx
`A lista tem ${total} ${total === 1 ? "nó" : "nós"}${cycle > 0 ? `, e ${cycle} ${cycle === 1 ? "deles forma" : "deles formam"} o ciclo` : ""}.`
```

o trecho entre a 2ª e a 3ª crase — que é **justamente o texto de tela do
template interno** — cai na lacuna entre dois casamentos e **nunca é lido**.

```
$ python3 scripts/guarda-idioma.py antes.tsx depois.tsx     # ", e " -> ", and "
SUMIRAM:
    nenhuma
APARECERAM:
    nenhuma
$ echo $?
0
```

Medido no diretório inteiro, com AST: **27 dos 87 arquivos** de
`content/visualizers/` têm template aninhado, **54 ocorrências**, 6 só no
`LinkedListFloyd`. Não é caso exótico: é 31% do corpus.

### 2. Texto de tela colado numa interpolação — o silencioso

O padrão exigia `>texto<`, e um `{` no meio corta o casamento. A demonstração
que fecha o assunto, do agente do `bellman-ford` — `BellmanFordVisualizer:273`,
trocando `" de "` por `" of "`:

```tsx
<span className="viz-var-val best">{s.round} de {LABELS.length - 1}</span>
```

```
$ python3 scripts/guarda-idioma.py bf-antes.tsx bf-depois.tsx
SUMIRAM:
    nenhuma
APARECERAM:
    nenhuma
$ echo $?
0
```

O painel diria **"rodada 5 of 4"** com o guarda verde.

### 3. E ele gritava, além de ser cego

Num rename só de identificador no `LinkedListFloyd`
(`slow`/`fast`/`cycle`/`total` → `slowPtr`/`fastPtr`/`cycleLen`/`nodeCount`),
onde **nenhum texto de tela muda**, o guarda antigo emitia **38 linhas de
achado, todas ruído** — porque a partir da primeira crase aninhada ele passa a
comparar **código** como se fosse tela. Um dos itens tem **4.045 caracteres** de
código numa linha só. Um guarda que grita em tudo é tão inútil quanto um cego,
e o pior é que ele esconde o achado de verdade no meio (medido abaixo).

---

## O que mudou

**Trocamos o regex por um analisador de verdade.** Quem lê o TSX agora é o
compilador do TypeScript — `ts.createSourceFile` + caminhada na AST —, que já é
dependência do projeto. A AST não tem pareamento a errar: um template é um nó
com `head`, `templateSpans` e `literal`s, e um nó de texto JSX é um nó, tenha
quantas interpolações tiver ao lado.

### A decisão de arquitetura, e o porquê

O motor foi para um **script Node irmão** (`scripts/extrai-textos-tsx.mjs`), e o
`scripts/guarda-idioma.py` **continua sendo a porta de entrada**, com o mesmo
caminho e a mesma linha de comando. Três razões:

1. **A invocação está escrita em três lugares** — o §0 do contrato, o runbook e
   a skill `adaptar-visualizadores-dsa` — como
   `python3 scripts/guarda-idioma.py antes.tsx depois.tsx`. Reescrever tudo em
   Node obrigaria a mexer nos três e a quebrar a memória muscular de quem já usa.
2. **Só a extração precisa da AST.** A comparação são seis linhas de `Counter`;
   movê-las de língua não compra nada.
3. **Uma chamada de `node` por execução**, com os dois lados (ou os 174 arquivos
   do modo diretório) num JSON só pelo stdin. O custo de subida do `typescript`
   é pago uma vez.

### O que o analisador coleta

| o quê | vira |
|---|---|
| literal de string e template **em qualquer nível de aninhamento** | o texto, com cada `${…}` virando `§` |
| nós de texto JSX, **inclusive dividindo a linha com uma interpolação** | os filhos do elemento num item só: `Nós no ciclo: §` |
| valor de atributo que o aluno lê (`alt`, `title`, `placeholder`, `aria-label`, …) | **tela** |
| `className`, `viewBox`, `style`, `d`, chave de tipo, especificador de import, diretiva | **código** |

A fronteira código × conteúdo é conservadora de propósito: **na dúvida, é tela**.
Um falso positivo custa uma linha de ruído; um falso negativo é o guarda ficando
cego, que é o defeito que este PR conserta. Por isso atributo de **componente**
nosso (`<VizFooter label="…">`) fica em tela, e só atributo de **elemento HTML**
— que tem vocabulário fixo — vai para código.

Literal de código que muda saiu do veredito e virou um bloco **`AVISO` que não
reprova**. Isso fecha um pedaço da armadilha do §0 (*"literal que vira nome de
classe é contrato com o CSS"*): antes ele se misturava ao texto de tela e pedia
a reação que **re-quebra** o rename; agora ele fica à parte, dizendo "confira no
`globals.css`".

### E um código de saída novo

`0` texto de tela idêntico · `1` mudou · **`2` o próprio guarda não conseguiu
rodar**. Ele nunca mais sai `0` por não ter conseguido olhar — que é exatamente
como as três versões anteriores falharam.

---

## A prova

`scripts/testa-guarda-idioma.py` roda **11 casos** contra **qualquer** guarda
(`--guarda <caminho>`), então a prova de quebra é apontar para a versão anterior
e ver os casos passarem verdes com a aula estragada.

```bash
python3 scripts/testa-guarda-idioma.py                       # 11 de 11 ok
python3 scripts/testa-guarda-idioma.py --guarda /tmp/v3.py   # 6 de 11 FALHARAM
```

| caso | esperado | ANTES (regex) | DEPOIS (AST) |
|---|---|---|---|
| `1-no-de-texto-jsx` | reprova | ✅ `reprova` | ✅ `reprova` |
| `2-no-jsx-em-varias-linhas` | reprova | ✅ `reprova` | ✅ `reprova` |
| `3-literal-dentro-da-interpolacao` | reprova | ✅ `reprova` | ✅ `reprova` |
| **`4-crase-aninhada`** | reprova | ❌ **`passa`** | ✅ `reprova` |
| **`5-rotulo-colado-na-interpolacao`** | reprova | ❌ **`passa`** | ✅ `reprova` |
| **`6-rodada-de-of`** | reprova | ❌ **`passa`** | ✅ `reprova` |
| **`7-rename-limpo-com-crase-aninhada`** | passa | ❌ `reprova` (4 itens de ruído) | ✅ `passa` |
| `8-atributo-que-o-aluno-le` | reprova | ✅ `reprova` | ✅ `reprova` |
| **`9-classe-de-css-nao-reprova`** | passa | ❌ `reprova` | ✅ `passa` (4 no `AVISO`) |
| `10-limite-conjunto-nao-posicao` | passa (LIMITE) | ✅ `passa` | ✅ `passa` |
| **`11-limite-uniao-que-e-texto`** | passa (LIMITE) | ❌ `reprova` | ✅ `passa` (2 no `AVISO`) |

Os casos 1 a 3 são os furos das versões 1 e 2, que já estavam tapados e agora
têm regressão. O **7** é o caso negativo, e importa tanto quanto os outros. O
**10** e o **11** fixam limites conhecidos, para que ficar verde ali não seja
lido como promessa.

### As saídas, lado a lado, dos três casos que fecham o assunto

**`4-crase-aninhada`** — `", e "` → `", and "` dentro do template interno:

```
ANTES (exit 0)                    DEPOIS (exit 1)
SUMIRAM:                          SUMIRAM:
    nenhuma                           ', e § § o ciclo'
APARECERAM:                       APARECERAM:
    nenhuma                           ', and § § o ciclo'
```

**`5-rotulo-colado-na-interpolacao`** — `<span>Nós no ciclo: {…}</span>`:

```
ANTES (exit 0)                    DEPOIS (exit 1)
SUMIRAM:                          SUMIRAM:
    nenhuma                           'Nós no ciclo: §'
APARECERAM:                       APARECERAM:
    nenhuma                           'Nodes no ciclo: §'
```

**`6-rodada-de-of`** — `{s.round} de {LABELS.length - 1}` → `" of "`:

```
ANTES (exit 0)                    DEPOIS (exit 1)
SUMIRAM:                          SUMIRAM:
    nenhuma                           '§ de §'
APARECERAM:                       APARECERAM:
    nenhuma                           '§ of §'
```

### E os dois que mudam de lado ao contrário (o guarda deixando de gritar)

**`9-classe-de-css-nao-reprova`** — `` `hs-fase ${gap === 1 ? "f-fim" : "f-ordenar"}` ``
virando `f-end`/`f-sort`, o caso do `ShellSortVisualizer` que o §0 já
documentava:

```
ANTES (exit 1)                    DEPOIS (exit 0)
SUMIRAM:                          SUMIRAM:
    'f-fim'                           nenhuma
    'f-ordenar'                   APARECERAM:
APARECERAM:                           nenhuma
    'f-end'                       AVISO (não reprova) — literais de CÓDIGO
    'f-sort'                        que mudaram. Se algum for nome de classe,
                                    confira no globals.css (§0 do contrato):
                                      'f-end'  'f-fim'  'f-ordenar'  'f-sort'
```

O antigo listava as classes como se fossem rótulo — e a reação natural a
`SUMIRAM: 'f-fim'` é devolver o `"f-fim"`, que **re-quebra** o rename. O novo
diz o que é e manda conferir onde dá para conferir.

---

## Medição de ruído

O rename real, no arquivo que motivou a tarefa. `LinkedListFloyd.tsx`,
`slow`/`fast`/`cycle`/`total` → `slowPtr`/`fastPtr`/`cycleLen`/`nodeCount`
(78 linhas de código alteradas, **nenhum texto de tela**):

| | linhas de achado | caracteres | maior item |
|---|---|---|---|
| ANTES (regex) | **38** | 15.716 | 4.045 caracteres de código numa linha |
| DEPOIS (AST) | **0** | 62 | — |

E o mesmo rename **com uma troca de rótulo de verdade escondida no meio**
(`"nós na lista"` → `"nodes na lista"`):

| | saída |
|---|---|
| ANTES | 42 linhas, **15.745 caracteres**. O achado real está na linha 37, depois de 36 linhas de ruído — e aparece **duas vezes**, uma delas dentro de um blob de código de 4 mil caracteres |
| DEPOIS | **4 linhas, 62 caracteres**: `SUMIRAM: 'nós na lista'` / `APARECERAM: 'nodes na lista'` |

### O tópico inteiro, sete arquivos

`listas-ligadas` (`LinkedList*` + `SkipList*`), com um rename de sete
identificadores (154 linhas de código alteradas). Três dos sete arquivos têm
achado **legítimo**, porque `total` também é palavra portuguesa na tela
(`"ponteiros no total"`, `"Azar total: …"`) — os dois guardas acham os três:

| | invocações | linhas | caracteres | achados reais | ruído |
|---|---|---|---|---|---|
| ANTES | 7 (uma por arquivo) | 64 | 16.446 | 3 | **38 linhas** |
| DEPOIS | **1** (modo diretório) | 15 | 682 | 3 | **0** |

---

## Sem regressão, e o custo

Os **87 arquivos** de `content/visualizers/` comparados contra a cópia idêntica
do `HEAD`, sem nenhuma mudança:

```
$ mkdir -p /tmp/antes && git archive HEAD content/visualizers | tar -x -C /tmp/antes
$ python3 scripts/guarda-idioma.py /tmp/antes/content/visualizers content/visualizers
SUMIRAM: nenhuma / APARECERAM: nenhuma  (87 arquivos)
$ echo $?
0
```

**Tempo**, três execuções cada:

| | tempo |
|---|---|
| um par de arquivos (o uso documentado) | **0,22 – 0,25s** |
| os 87 arquivos de uma vez (174 parses) | **0,42 – 0,47s** |

Cabe em cada commit sem discussão. O modo diretório (`<dir-antes> <dir-depois>`)
é novo e existe justamente para isso: uma subida do `typescript` em vez de 87.

Volume conferido: **6.683 itens de tela** e **4.372 de código** nos 87 arquivos
(o guarda antigo extraía 10.865 itens, com os dois papéis misturados).

---

## O que o guarda CONTINUA não pegando

Está escrito no §0 do contrato, com uma fixture executável para cada — porque
guarda com limite conhecido vale mais que guarda que promete tudo:

- **ele compara o CONJUNTO de textos, não onde cada um aparece.** Trocar dois
  campos de lugar (subtítulo indo para o corpo e vice-versa) mantém o conjunto
  idêntico e passa verde. Medido no `SubTypesVisualizer`. Quem pega é teste que
  lê **rótulo e valor juntos** (§8). Fixture `10-limite-conjunto-nao-posicao`;
- **valor de união que chega ao JSX cru** (`{p.conflict}` no
  `BacktrackingSudoku`). O guarda vê uma interpolação, e a união é um tipo, ou
  seja, código: traduzi-la sai no `AVISO` e não reprova. Fixture
  `11-limite-uniao-que-e-texto`;
- **nome de classe do CSS.** O guarda agora o **mostra** (no `AVISO`), mas não
  reprova — não dá para saber de dentro do arquivo se a classe existe no
  `globals.css`. Conferir continua sendo de quem renomeia;
- **texto sem nenhuma letra** (`"→"`, `"3"`, `"·"`), descartado de propósito:
  sem esse filtro toda cor em hexa e todo `path` de SVG entrariam no relatório;
- **texto que não mora neste arquivo** (rótulo vindo do `content/roadmap.ts`, do
  `.mdx`, de outro componente). O guarda compara duas versões do **mesmo**
  arquivo;
- **texto montado por concatenação de identificador** (`"passo " + nome`), que só
  existe em tempo de execução.

Por isso o §0 mantém, e este PR reforça, que **a prova final de um rename não é
o guarda, é o HTML do build**: o guarda lê o arquivo, e o que o aluno recebe é a
página.

---

## Verificação

| | |
|---|---|
| `npx tsc --noEmit` | ✅ passa. Conferido com `--listFilesOnly`: **nenhum** arquivo de `scripts/` entra no programa. As fixtures usam extensão `.tsx.txt` de propósito, porque o `tsconfig.json` inclui `**/*.tsx` e elas contêm código que existe justamente para estar errado |
| `npm run build` | ✅ passa, 55 páginas. Nada de `scripts/` vaza para o `out/` (`grep` conferido) |
| `npm test` | ✅ passa. Na primeira execução deu 458 passed / **1 failed** em `viz-strings.spec.ts:82` (*rotate expandido: cabeçalho e rodapé não se mexem…*), numa asserção de subpixel `toBeLessThanOrEqual(1)` — e o CI reproduziu **o mesmo teste**. É flake, provado em dois lugares: passa **isolado** aqui (`2 passed` em 17,3s) e passou no **re-run do mesmo commit** no CI (6m8s, verde). O diff deste PR é `scripts/` e um `.md`; não há uma linha que o build enxergue |
| `scripts/guarda-commit.py` | ✅ nos três commits |

Rodado na porta **4403**, em worktree própria.

## Arquivos

```
 content/visualizers/README.md          §0 (o único trecho tocado): o que ele
                                        passou a pegar e o que não pega
 scripts/guarda-idioma.py               reescrito: fachada + comparação + relatório
 scripts/extrai-textos-tsx.mjs          NOVO: o analisador, na AST do TypeScript
 scripts/testa-guarda-idioma.py         NOVO: a suíte, com --guarda para a prova
 scripts/fixtures-guarda-idioma/        NOVO: 11 pares antes/depois
```

Sem mudança no `package.json`: a suíte roda com `python3
scripts/testa-guarda-idioma.py`, e isso está documentado no §0.

Fecha a §2.1 de `backlog/pendencias-pos-casca.md`.
