### PR TITLE
fix(viz): três rótulos que não batiam com o que a peça faz

### DIFF
--- a/content/visualizers/BellmanFordVisualizer.tsx
+++ b/content/visualizers/BellmanFordVisualizer.tsx
@@ -81,6 +81,13 @@ type Step = {
   note: string;
   ok?: boolean;
   alert?: boolean;
+  /**
+   * A rodada de detecção de ciclo negativo, que roda DEPOIS das V-1. O `round`
+   * dela é V, e V não é uma das V-1: quem mostra rodada precisa perguntar por
+   * este campo antes de escrever o número. E com early exit ele nem é o número
+   * de rodadas que aconteceram — dois dos três presets param na 2.
+   */
+  extraRound?: boolean;
 };
 
 function buildSteps(edges: Edge[]): Step[] {
@@ -139,12 +146,12 @@ function buildSteps(edges: Edge[]): Step[] {
   if (culprit) {
     out.push(snap(V, culprit, true, 10,
       `RODADA EXTRA: a aresta ${LABELS[culprit.from]} → ${LABELS[culprit.to]} AINDA melhora, depois de ${V - 1} rodadas. Isso é impossível num grafo sadio, porque nenhum caminho mínimo usa mais de ${V - 1} arestas. A única explicação é ciclo negativo: dar mais uma volta barateia para sempre, e o mínimo não existe.`,
-      { alert: true }));
+      { alert: true, extraRound: true }));
   } else {
     const summary = LABELS.map((l, i) => `${l}=${dist[i] === null ? "∞" : dist[i]}`).join("  ");
     out.push(snap(V, null, false, 12,
       `RODADA EXTRA: nenhuma aresta melhora, então não existe ciclo negativo e a resposta é final. Distâncias a partir de ${LABELS[0]}: ${summary}.`,
-      { ok: true }));
+      { ok: true, extraRound: true }));
   }
   return out;
 }
@@ -172,12 +179,19 @@ export function BellmanFordVisualizer() {
   });
 
   const s = steps[viz.step];
+  // A rodada extra não é uma das V-1: ela roda DEPOIS delas, para detectar ciclo
+  // negativo. Mostrar o número dela ao lado do total dava "rodada 5 de 4", e com
+  // early exit (dois dos três presets param na rodada 2) o próprio 5 era falso.
+  // O rótulo passa a nomear a rodada em vez de numerá-la.
+  const roundLabel = s.extraRound ? "extra" : String(s.round);
 
   return viz.inPanel(
     <figure {...viz.figureProps} style={{ margin: 0 }}>
-      {/* A rodada continua à esquerda do "passo N de M", que agora é do hook. */}
+      {/* A rodada continua à esquerda do "passo N de M", que agora é do hook. O
+          `·` no fim é obrigatório: é a solução do §9 do contrato para o
+          separador que some quando o `VizHeader` já desenha o contador. */}
       <VizHeader viz={viz}>
-        <span className="viz-step">rodada {s.round} ·</span>
+        <span className="viz-step">rodada {roundLabel} ·</span>
       </VizHeader>
 
       <div {...viz.bodyProps}>
@@ -193,7 +207,7 @@ export function BellmanFordVisualizer() {
         <div className="gr-split">
           <div className="tt-arv-wrap" style={{ margin: 0 }}>
             <svg className="tt-arv" width={300} height={250} viewBox="0 0 300 250" role="img"
-              aria-label={`Grafo dirigido com pesos. Bellman-Ford, rodada ${s.round}. ${s.note}`}>
+              aria-label={`Grafo dirigido com pesos. Bellman-Ford, rodada ${roundLabel}. ${s.note}`}>
               <defs>
                 <marker id="seta-bf" viewBox="0 0 8 8" refX="7" refY="4" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
                   <path d="M 0 0 L 8 4 L 0 8 z" fill="rgba(59,130,246,0.75)" />
@@ -270,7 +284,7 @@ export function BellmanFordVisualizer() {
           </div>
           <div {...viz.varsProps}>
             <div className="viz-vars-head">Variáveis</div>
-            <div className="viz-var"><span className="viz-var-name">rodada</span><span className="viz-var-val best">{s.round} de {LABELS.length - 1}</span></div>
+            <div className="viz-var"><span className="viz-var-name">rodada</span><span className="viz-var-val best">{s.extraRound ? "extra (detecção)" : `${s.round} de ${LABELS.length - 1}`}</span></div>
             <div className="viz-var"><span className="viz-var-name">arestas por rodada</span><span className="viz-var-val">{preset.edges.length}</span></div>
             <div className="viz-var"><span className="viz-var-name">relaxamentos totais</span><span className="viz-var-val">{(LABELS.length - 1) * preset.edges.length}</span></div>
           </div>

--- a/content/visualizers/NAryTreeVisualizer.tsx
+++ b/content/visualizers/NAryTreeVisualizer.tsx
@@ -31,6 +31,10 @@ import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 // alarga e não sobe — a árvore DOM tem grau 3 e profundidade 4, e é 136px mais
 // alta que a do artigo, que tem grau 3 e profundidade 2. Largura rola sozinha,
 // porque `.tt-arv-wrap` é `overflow-x: auto`.
+//
+// A de diretórios é a demonstração disso: ela tem grau 4 e dez nós, contra grau
+// 3 e nove nós da do artigo, e as duas desenham os mesmos 196px de altura. O
+// quarto filho custou 96px de LARGURA (592 para 688) e zero de altura.
 // ---------------------------------------------------------------------------
 
 type TreeNode = { label: string; children: number[] };
@@ -67,11 +71,18 @@ const TREES: Tree[] = [
     ],
   },
   {
+    // A única das três com grau 4, e é de propósito: é ela que acende a linha
+    // do grau 4 na tabela do fim. A tabela promete "(o desta árvore)" e a
+    // promessa só vale se algum grau desenhado estiver entre os da tabela
+    // (2, 4, 8, 16, 64, 256) — com as três em grau 3, ela nunca acendia.
+    // O quarto filho da raiz é o que menos força o exemplo: uma pasta de
+    // projeto com src, testes, README e .gitignore é o caso comum, e o grau
+    // não mexe na altura do desenho (ver a nota de medição no topo).
     key: "files",
     label: "Uma árvore de diretórios",
     caption: "O exemplo mais honesto de árvore n-ária: uma pasta tem quantos filhos quiser.",
     nodes: [
-      { label: "/projeto", children: [1, 5, 8] },
+      { label: "/projeto", children: [1, 5, 8, 9] },
       { label: "src", children: [2, 3, 4] },
       { label: "app.py", children: [] },
       { label: "util.py", children: [] },
@@ -80,6 +91,7 @@ const TREES: Tree[] = [
       { label: "test_app.py", children: [] },
       { label: "test_db.py", children: [] },
       { label: "README.md", children: [] },
+      { label: ".gitignore", children: [] },
     ],
   },
   {

--- a/content/visualizers/ShellSortVisualizer.tsx
+++ b/content/visualizers/ShellSortVisualizer.tsx
@@ -46,6 +46,22 @@ type Step = {
    * de rodada precisa perguntar por este campo antes de mostrar o número.
    */
   summary?: boolean;
+  /**
+   * O gap da RODADA a que o passo pertence, que não é sempre o valor da
+   * variável `gap` naquele instante. O passo de fim de rodada roda o `gap //= 2`
+   * (linha 11), então a variável já vale o gap da PRÓXIMA rodada enquanto o
+   * passo ainda descreve a que acabou — e a faixa da fase lia a variável.
+   * Medido nos quatro passos de fim de rodada do preset padrão: a faixa dizia
+   * "gap 2" com a nota dizendo "Fim da rodada de gap 4", "gap 1" contra "gap 2",
+   * e no último "gap 0", uma rodada que não existe, pintada de âmbar
+   * (`f-ordenar`) sobre um array já ordenado.
+   *
+   * `gap` responde "quanto vale a variável", que é o que o painel de variáveis
+   * mostra; `roundGap` responde "de que rodada é este passo", que é o que a
+   * faixa e o cartão de subsequências perguntam. Dentro da rodada os dois são
+   * iguais; só o passo de fim de rodada os separa.
+   */
+  roundGap: number;
 };
 
 const CODE = [
@@ -112,6 +128,7 @@ export function generateSteps(values: number[]): Step[] {
   const base = () => ({
     arr: [...a],
     gap,
+    roundGap: gap,
     i: -1,
     j: -1,
     current: -1,
@@ -205,6 +222,9 @@ export function generateSteps(values: number[]): Step[] {
     gap = Math.floor(gap / 2);
     out.push({
       ...base(),
+      // A variável já caiu (é o que a linha 11 faz), mas o passo é o fim da
+      // rodada de `before`: é esse número que a faixa e o cartão mostram.
+      roundGap: before,
       line: 11,
       ok: true,
       note:
@@ -280,14 +300,14 @@ export function ShellSortVisualizer() {
             de anunciar uma rodada de gap 0, e a cor é a mesma do fim (`f-fim`,
             verde) em vez da de ordenar (`f-ordenar`, âmbar) — pintar de âmbar o
             array já ordenado é a mesma mentira, só que em cor. */}
-        <div className={`hs-fase ${s.summary || s.gap === 1 ? "f-fim" : "f-ordenar"}`}>
-          <span className="hs-fase-selo">{s.summary ? "ordenado" : `gap ${s.gap}`}</span>
+        <div className={`hs-fase ${s.summary || s.roundGap === 1 ? "f-fim" : "f-ordenar"}`}>
+          <span className="hs-fase-selo">{s.summary ? "ordenado" : `gap ${s.roundGap}`}</span>
           <span className="hs-fase-txt">
             {s.summary
               ? "acabaram as rodadas de gap: este passo é o resumo da execução"
-              : s.gap === 1
+              : s.roundGap === 1
                 ? "esta é a última rodada, e ela é o insertion sort puro"
-                : `o array é lido como ${s.gap} subsequências entrelaçadas, uma a cada ${s.gap} posições`}
+                : `o array é lido como ${s.roundGap} subsequências entrelaçadas, uma a cada ${s.roundGap} posições`}
           </span>
         </div>
 
@@ -362,8 +382,11 @@ export function ShellSortVisualizer() {
           <div className="bigo-stat">
             <span>subsequências deste gap</span>
             {/* No resumo não há rodada, então não há "este gap": o traço é o
-                mesmo que as variáveis usam para "não se aplica aqui". */}
-            <strong>{s.summary ? "-" : s.gap}</strong>
+                mesmo que as variáveis usam para "não se aplica aqui". E é o gap
+                DA RODADA, não a variável: no passo de fim de rodada ela já caiu
+                pela metade, e o cartão contava as subsequências da rodada
+                seguinte (ou 0, na última). */}
+            <strong>{s.summary ? "-" : s.roundGap}</strong>
           </div>
         </div>
 

--- a/content/visualizers/ShellSortVisualizer.tsx
+++ b/content/visualizers/ShellSortVisualizer.tsx
@@ -40,6 +40,12 @@ type Step = {
   line: number;
   note: string;
   ok?: boolean;
+  /**
+   * O último passo, empilhado DEPOIS do laço: é o resumo, não uma rodada. O
+   * `gap` dele vale 0 (o laço só termina quando ele zera), então tudo que fala
+   * de rodada precisa perguntar por este campo antes de mostrar o número.
+   */
+  summary?: boolean;
 };
 
 const CODE = [
@@ -212,6 +218,7 @@ export function generateSteps(values: number[]): Step[] {
     ...base(),
     line: 11,
     ok: true,
+    summary: true,
     note: `Ordenado: ${a.join(", ")}. Foram ${comparisons} comparações e ${writes} escritas, sem nenhuma memória extra. A única diferença para o insertion sort é a constante 1 ter virado a variável gap.`,
   });
   return out;
@@ -268,12 +275,19 @@ export function ShellSortVisualizer() {
             (`.hs-fase.f-fim` pinta a borda e o selo de verde, `.f-ordenar` de
             âmbar), compartilhado com o heap sort. Traduzir estes dois literais
             apagaria a cor sem o `tsc`, o guarda de idioma ou um teste acusarem. */}
-        <div className={`hs-fase ${s.gap === 1 ? "f-fim" : "f-ordenar"}`}>
-          <span className="hs-fase-selo">gap {s.gap}</span>
+        {/* O passo do resumo não é uma rodada: o `gap` dele é 0, porque o laço
+            `while gap > 0` já terminou. O selo diz o que aquele passo é, em vez
+            de anunciar uma rodada de gap 0, e a cor é a mesma do fim (`f-fim`,
+            verde) em vez da de ordenar (`f-ordenar`, âmbar) — pintar de âmbar o
+            array já ordenado é a mesma mentira, só que em cor. */}
+        <div className={`hs-fase ${s.summary || s.gap === 1 ? "f-fim" : "f-ordenar"}`}>
+          <span className="hs-fase-selo">{s.summary ? "ordenado" : `gap ${s.gap}`}</span>
           <span className="hs-fase-txt">
-            {s.gap === 1
-              ? "esta é a última rodada, e ela é o insertion sort puro"
-              : `o array é lido como ${s.gap} subsequências entrelaçadas, uma a cada ${s.gap} posições`}
+            {s.summary
+              ? "acabaram as rodadas de gap: este passo é o resumo da execução"
+              : s.gap === 1
+                ? "esta é a última rodada, e ela é o insertion sort puro"
+                : `o array é lido como ${s.gap} subsequências entrelaçadas, uma a cada ${s.gap} posições`}
           </span>
         </div>
 
@@ -347,7 +361,9 @@ export function ShellSortVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>subsequências deste gap</span>
-            <strong>{s.gap}</strong>
+            {/* No resumo não há rodada, então não há "este gap": o traço é o
+                mesmo que as variáveis usam para "não se aplica aqui". */}
+            <strong>{s.summary ? "-" : s.gap}</strong>
           </div>
         </div>
 

--- a/tests/viz-bellman-ford.spec.ts
+++ b/tests/viz-bellman-ford.spec.ts
@@ -243,6 +243,7 @@ test.describe("bellman-ford", () => {
       const { total } = await page.evaluate(passoAtual, ARTIGO);
       let fins = 0;
       let ultimaRodadaFechada = 0;
+      let prometidas = 0;
 
       for (let i = 1; i <= total; i++) {
         const tela = await page.evaluate((sel) => {
@@ -250,23 +251,36 @@ test.describe("bellman-ford", () => {
           const cab = [...f.querySelectorAll(".viz-step")].map((e) => e.textContent).join(" ");
           return {
             nota: f.querySelector(".viz-note")!.textContent!,
-            rodadaCab: parseInt(cab.match(/rodada (\d+)/)![1], 10),
+            // Pode ser um número ou a palavra "extra": a rodada de detecção não
+            // é uma das V-1 e não recebe número.
+            rodadaCab: cab.match(/rodada (\S+) ·/)![1],
             varRodada: f.querySelector(".viz-var .viz-var-val")!.textContent!,
             linhas: [...f.querySelectorAll(".bf-tab tbody tr > th")].map((e) => e.textContent!),
           };
         }, ARTIGO);
 
-        // O painel de variáveis e o cabeçalho contam a MESMA rodada. Invariante
-        // entre dois lugares da tela, sem nenhum número escrito na mão.
-        expect(tela.varRodada, `passo ${i}: cabecalho e painel discordam da rodada`).toMatch(
-          new RegExp(`^${tela.rodadaCab} de `)
-        );
+        // O painel de variáveis e o cabeçalho contam a MESMA rodada, nos dois
+        // lados da condicional. Invariante entre dois lugares da tela, sem
+        // nenhum número escrito na mão.
+        if (tela.rodadaCab === "extra") {
+          expect(tela.varRodada, `passo ${i}: a rodada extra virou fracao de novo`).toBe(
+            "extra (detecção)"
+          );
+          expect(tela.nota, `passo ${i}: o cabecalho diz extra e a nota nao`).toMatch(/^RODADA EXTRA/);
+        } else {
+          expect(tela.varRodada, `passo ${i}: cabecalho e painel discordam da rodada`).toMatch(
+            new RegExp(`^${tela.rodadaCab} de `)
+          );
+          // O denominador é V-1, e ele vem da TELA, num passo que é mesmo uma
+          // das rodadas numeradas.
+          prometidas = parseInt(tela.varRodada.match(/de (\d+)/)![1], 10);
+        }
 
         const fim = tela.nota.match(/^Fim da rodada (\d+)/);
         if (fim) {
           fins++;
           const n = parseInt(fim[1], 10);
-          expect(tela.rodadaCab, `passo ${i}: a nota fecha a rodada ${n} e o cabecalho diz outra`).toBe(n);
+          expect(tela.rodadaCab, `passo ${i}: a nota fecha a rodada ${n} e o cabecalho diz outra`).toBe(String(n));
           // A tabela guarda o histórico: uma linha "início", uma por rodada
           // fechada, e a linha "agora". A última numerada é a rodada da nota.
           const numeradas = tela.linhas.filter((t) => /^\d+$/.test(t));
@@ -286,11 +300,9 @@ test.describe("bellman-ford", () => {
 
       // E aqui está o número que eu ia escrever errado: o preset padrão promete
       // V-1 rodadas no painel ("N de 4") e para na 2, por early exit. Os dois
-      // números saem da TELA, não da minha cabeça.
-      const prometidas = await page.evaluate((sel) => {
-        const t = document.querySelector(`${sel} .viz-var .viz-var-val`)!.textContent!;
-        return parseInt(t.match(/de (\d+)/)![1], 10);
-      }, ARTIGO);
+      // números saem da TELA, não da minha cabeça — e o denominador foi lido num
+      // passo NUMERADO, porque o último não mostra mais fração nenhuma.
+      expect(prometidas, "nenhum passo numerado mostrou o total de rodadas").toBeGreaterThan(0);
       expect(fins, "nenhuma rodada fechou").toBeGreaterThan(0);
       expect(
         ultimaRodadaFechada,
@@ -299,6 +311,78 @@ test.describe("bellman-ford", () => {
       await expect(artigo.locator(".bf-tab tbody tr > th").nth(ultimaRodadaFechada)).toHaveText(
         String(ultimaRodadaFechada)
       );
+    });
+
+    // A rodada extra roda DEPOIS das V-1, então ela não é uma delas. O painel
+    // mostrava `{s.round} de {LABELS.length - 1}` com `round = V`, ou seja
+    // "5 de 4" — uma fração impossível, nos três presets. E o numerador nem era
+    // verdade: com early exit, dois dos três presets fecham a rodada 2.
+    //
+    // Os dois lados da condicional estão aqui: o passo numerado continua
+    // mostrando a fração, e o extra passa a se nomear.
+    test("a rodada extra se nomeia em vez de virar fracao, nos tres presets", async ({ page }) => {
+      expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
+      await abrirTopico(page);
+      const artigo = page.locator(ARTIGO);
+      const rodadaCab = artigo.locator(".viz-step").first();
+      // `hasText: "rodada"` casaria também o cartão "arestas por rodada": a
+      // âncora é o começo do texto do cartão, e a contagem prova que é um só.
+      const cartaoRodada = artigo.locator(".viz-var").filter({ hasText: /^rodada/ });
+      await expect(cartaoRodada).toHaveCount(1);
+      const rodadaVar = cartaoRodada.locator(".viz-var-val");
+
+      for (const preset of [
+        "Com peso negativo (funciona)",
+        "Ciclo negativo (detecta)",
+        "Só pesos positivos",
+      ]) {
+        await page.getByRole("button", { name: preset, exact: true }).click();
+        // A troca chegou à tela, e o passo voltou ao começo.
+        await expect(page.getByRole("button", { name: preset, exact: true })).toHaveAttribute(
+          "aria-pressed",
+          "true"
+        );
+
+        // Lado A: passo numerado, fração de verdade. O denominador é V-1 = 4.
+        await expect(rodadaCab).toHaveText("rodada 0 ·");
+        await expect(rodadaVar).toHaveText("0 de 4");
+        await artigo.getByRole("button", { name: "Próximo ›" }).click();
+        await expect(rodadaCab).toHaveText("rodada 1 ·");
+        await expect(rodadaVar).toHaveText("1 de 4");
+
+        // Lado B: o último passo, que é sempre a rodada extra.
+        await artigo.evaluate(async (f) => {
+          const esperar = () =>
+            new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+          for (let n = 0; n < 400; n++) {
+            const b = [...f.querySelectorAll("button")].find((x) =>
+              (x.textContent || "").includes("Próximo")
+            ) as HTMLButtonElement | undefined;
+            if (!b || b.disabled) break;
+            b.click();
+            await esperar();
+          }
+        });
+        // O laço chegou mesmo ao fim: sem isto a asserção seguinte pode estar
+        // olhando um passo do meio.
+        await expect(artigo.getByRole("button", { name: "Próximo ›" })).toBeDisabled();
+
+        await expect(rodadaVar, `${preset}: a fracao impossivel voltou`).toHaveText(
+          "extra (detecção)"
+        );
+        await expect(rodadaCab).toHaveText("rodada extra ·");
+        // O separador do §9 do contrato continua no fim: sem ele os dois
+        // `.viz-step` irmãos colam num texto só.
+        expect((await rodadaCab.textContent())!.trim().endsWith("·")).toBe(true);
+        await expect(artigo.locator(".viz-note")).toContainText("RODADA EXTRA");
+        // Nenhuma fração impossível sobrou no painel, em nenhum cartão.
+        await expect(artigo.locator(".viz-vars")).not.toContainText("5 de 4");
+        // E quem lê por leitor de tela ouve a mesma coisa que quem lê o painel.
+        await expect(artigo.locator("svg.tt-arv")).toHaveAttribute(
+          "aria-label",
+          /Bellman-Ford, rodada extra\./
+        );
+      }
     });
   });
 });

--- a/tests/viz-n-ary-trees.spec.ts
+++ b/tests/viz-n-ary-trees.spec.ts
@@ -315,11 +315,13 @@ test("n-ary: a marcha abre em 1.5x e a seta no slider é do slider", async ({ pa
 // O que a medição deste tópico contrariou, agora como regressão.
 //
 // Em árvore n-ária a tentação é medir o pior caso pelo GRAU ou pelo número de
-// nós. As três árvores desta peça têm exatamente **nove nós** e grau máximo
-// **três** — e mesmo assim os desenhos têm alturas diferentes, porque o eixo
-// que vira altura é a PROFUNDIDADE. A do DOM tem quatro níveis contra dois das
-// outras duas: ela é a mais ALTA e, ao mesmo tempo, a mais ESTREITA, porque tem
-// menos folhas. Aumentar o grau alarga sem subir.
+// nós. A árvore do artigo e a do DOM têm exatamente **nove nós** e grau máximo
+// **três**, e a de diretórios tem **dez nós e grau quatro** — e mesmo assim as
+// duas de profundidade 2 desenham a MESMA altura, porque o eixo que vira altura
+// é a PROFUNDIDADE. A do DOM tem quatro níveis: ela é a mais ALTA e, ao mesmo
+// tempo, a mais ESTREITA, porque tem menos folhas. Aumentar o grau alarga sem
+// subir — medido: o quarto filho da raiz de diretórios custou 96px de largura
+// (592 → 688) e 0px de altura.
 //
 // É esse fato que sustenta `measureOn: [treeKey, ...]`: sem ele alguém trocaria
 // a árvore por uma contagem de nós ou de grau e mediria a coisa errada.
@@ -329,14 +331,14 @@ test("n-ary: a altura do desenho vem da profundidade, não do grau nem do númer
   const fig = noArtigo(page);
   const svg = fig.locator("svg.tt-arv");
 
-  const medir = async (arvore: string) => {
+  const medir = async (arvore: string, grauEsperado: string, nosEsperados: string) => {
     await fig.getByRole("button", { name: arvore, exact: true }).click();
-    // Rótulo junto com o valor, no mesmo cartão: as três árvores têm o mesmo
-    // grau máximo e o mesmo número de nós, e é isso que dá sentido ao resto.
+    // Rótulo junto com o valor, no mesmo cartão: é a leitura do grau e da
+    // contagem de nós que dá sentido à comparação de alturas logo abaixo.
     const grau = fig.locator(".viz-var").filter({ hasText: "grau máximo" });
-    await expect(grau.locator(".viz-var-val")).toHaveText("3");
+    await expect(grau.locator(".viz-var-val")).toHaveText(grauEsperado);
     const nos = fig.locator(".viz-var").filter({ hasText: "processados" });
-    await expect(nos.locator(".viz-var-val")).toHaveText("0 de 9");
+    await expect(nos.locator(".viz-var-val")).toHaveText(`0 de ${nosEsperados}`);
     return svg.evaluate((el) => {
       const r = el.getBoundingClientRect();
       return {
@@ -347,12 +349,14 @@ test("n-ary: a altura do desenho vem da profundidade, não do grau nem do númer
     });
   };
 
-  const artigo = await medir("A árvore do artigo");
-  const diretorios = await medir("Uma árvore de diretórios");
-  const dom = await medir("Uma árvore DOM");
+  const artigo = await medir("A árvore do artigo", "3", "9");
+  const diretorios = await medir("Uma árvore de diretórios", "4", "10");
+  const dom = await medir("Uma árvore DOM", "3", "9");
 
-  // Mesmo número de nós, mesmo grau, mesma profundidade: mesma altura.
+  // Um nó a mais e um grau a mais, mesma profundidade: mesma altura ao pixel.
   expect(diretorios.alt).toBe(artigo.alt);
+  // E o que o grau a mais cobrou foi LARGURA, que rola sozinha no wrapper.
+  expect(diretorios.larg).toBeGreaterThan(artigo.larg);
   // Dois níveis a mais: 136px a mais de desenho.
   expect(dom.alt).toBeGreaterThan(artigo.alt + 100);
   // E a mais alta é a mais ESTREITA: menos folhas, menos largura.
@@ -364,6 +368,67 @@ test("n-ary: a altura do desenho vem da profundidade, não do grau nem do númer
   const [, , vw, vh] = dom.viewBox!.split(" ").map(Number);
   expect(dom.larg).toBe(vw);
   expect(dom.alt).toBe(vh);
+});
+
+// ---------------------------------------------------------------------------
+// A tabela de graus fala da árvore que está na tela — e a promessa é o sufixo
+// "(o desta árvore)" na linha destacada.
+//
+// Antes desta correção a promessa era morta: as três árvores tinham grau máximo
+// 3, e `DEGREES` é [2, 4, 8, 16, 64, 256], então `k === maxDegree` nunca era
+// verdade e nenhum aluno viu a linha acender em nenhum preset (medido no HTML do
+// build: `grep -c "o desta árvore"` dava 0). A árvore de diretórios passou a ter
+// grau 4 — uma pasta de projeto com src, testes, README e .gitignore —, que é o
+// menor empurrão possível e não mexe na altura do desenho.
+//
+// O teste cobre os DOIS lados da condicional, como manda o contrato §8: o preset
+// em que ela vale (grau na tabela: uma linha acesa, com o número certo) e os dois
+// em que não vale (grau fora da tabela: nenhuma linha acesa e nenhum sufixo
+// solto). Sem o segundo lado, um destaque em todas as linhas passaria verde.
+// ---------------------------------------------------------------------------
+test("n-ary: a linha destacada da tabela de graus é a do grau da árvore corrente", async ({ page }) => {
+  await abrir(page, ALTA);
+  const fig = noArtigo(page);
+  const tabela = fig.locator(".rec-comp");
+  // Os graus que a tabela desenha, lidos DELA: a progressão dobra o grau, e é
+  // por isso que 3 não está lá.
+  const graus = (await tabela.locator("tbody tr td:first-child").allTextContents()).map((t) =>
+    parseInt(t, 10)
+  );
+  expect(graus).toEqual([2, 4, 8, 16, 64, 256]);
+
+  const conferir = async (arvore: string, grauNaTela: string) => {
+    await fig.getByRole("button", { name: arvore, exact: true }).click();
+    // O grau vem do cartão, junto do rótulo: é o mesmo número que a tabela usa.
+    await expect(
+      fig.locator(".viz-var").filter({ hasText: "grau máximo" }).locator(".viz-var-val")
+    ).toHaveText(grauNaTela);
+
+    const acesas = tabela.locator("tbody tr.on");
+    if (graus.includes(Number(grauNaTela))) {
+      // Exatamente UMA linha acesa, e é a do grau desta árvore — com o texto.
+      await expect(acesas).toHaveCount(1);
+      await expect(acesas.locator("td").first()).toHaveText(`${grauNaTela} (o desta árvore)`);
+      // O sufixo é único na tabela: uma linha acesa não pode virar seis.
+      expect(
+        (await tabela.locator("tbody td").allTextContents()).filter((t) =>
+          t.includes("(o desta árvore)")
+        )
+      ).toHaveLength(1);
+      // E a linha acesa continua carregando a altura e as comparações do grau 4,
+      // que é o argumento da tabela.
+      await expect(acesas.locator("td")).toHaveText([`${grauNaTela} (o desta árvore)`, "11", "~22"]);
+    } else {
+      // O outro lado: grau fora da progressão não acende nada, e o sufixo não
+      // aparece solto em linha nenhuma.
+      await expect(acesas).toHaveCount(0);
+      await expect(tabela).not.toContainText("(o desta árvore)");
+    }
+  };
+
+  await conferir("A árvore do artigo", "3");
+  await conferir("Uma árvore de diretórios", "4");
+  await conferir("Uma árvore DOM", "3");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/viz-shell-sort.spec.ts
+++ b/tests/viz-shell-sort.spec.ts
@@ -386,6 +386,59 @@ test.describe("shell sort · o que está escrito na tela", () => {
     // Nenhum "gap 0" sobrou na fase, em lugar nenhum dela.
     await expect(fase).not.toContainText("gap 0");
     await expect(fase).not.toContainText("0 subsequências");
+  });
+
+  // Esta asserção olhava só o ÚLTIMO passo, e por isso ficou verde sobre um
+  // "gap 0" vivo: ele não estava no resumo, estava no passo 64 de 65, o fim da
+  // rodada de gap 1. A varredura abaixo passa por TODOS os passos, e é a única
+  // forma de a promessa "a faixa nunca fala de uma rodada que não existe" valer
+  // de verdade. Ela cobre os quatro presets porque o número de rodadas muda com
+  // a entrada, e com ele o passo em que o defeito aparece.
+  test("nenhum passo, em nenhum preset, rotula uma rodada que não existe", async ({ page }) => {
+    const fig = await abrir(page);
+    const chips = fig.locator(".bigo-chip");
+    const nomes = await chips.allTextContents();
+    for (const preset of nomes) {
+      await chips.filter({ hasText: preset }).first().click();
+      const proximo = fig.locator('button:has-text("Próximo")');
+      // Reconsulta em vez de ler uma vez: logo após trocar de preset,
+      // `isEnabled()` devolve o estado da rodada anterior, o laço não clica e a
+      // varredura passa vazia.
+      await expect(proximo).toBeEnabled();
+      const problemas: string[] = [];
+      for (let i = 0; i < 400; i++) {
+        const [selo, txt, classe, nota, card] = await Promise.all([
+          fig.locator(".hs-fase-selo").textContent(),
+          fig.locator(".hs-fase-txt").textContent(),
+          fig.locator(".hs-fase").getAttribute("class"),
+          fig.locator(".viz-note").first().textContent(),
+          fig
+            .locator(".bigo-stat")
+            .filter({ hasText: "subsequências deste gap" })
+            .locator("strong")
+            .textContent(),
+        ]);
+        if (selo?.includes("gap 0") || txt?.includes("0 subsequências") || card === "0") {
+          problemas.push(`${preset} passo ${i + 1}: selo="${selo}" cartão="${card}"`);
+        }
+        // O selo é sobre a RODADA do passo, então ele tem que bater com a nota
+        // do fim de rodada, que é a única que nomeia o gap por extenso. Era
+        // exatamente aqui que a faixa mostrava o gap da rodada SEGUINTE.
+        const fim = nota?.match(/Fim da rodada de gap (\d+)/);
+        if (fim && selo?.trim() !== `gap ${fim[1]}`) {
+          problemas.push(`${preset} passo ${i + 1}: nota diz gap ${fim[1]}, selo diz "${selo}"`);
+        }
+        // Rodada de gap 1 e resumo são o fim, e só eles pintam `f-fim`.
+        const ehFim = selo?.trim() === "gap 1" || selo?.trim() === "ordenado";
+        if (ehFim !== !!classe?.includes("f-fim")) {
+          problemas.push(`${preset} passo ${i + 1}: selo="${selo}" com classe="${classe}"`);
+        }
+        if (!(await proximo.isEnabled())) break;
+        await proximo.click();
+      }
+      await expect(proximo, `${preset} não chegou ao fim`).toBeDisabled();
+      expect(problemas, "faixa da fase falando de rodada que não existe").toEqual([]);
+    }
 
     // O cartão que contava subsequências também falava de uma rodada que não
     // existe. No resumo ele usa o mesmo traço das variáveis vazias.

--- a/tests/viz-shell-sort.spec.ts
+++ b/tests/viz-shell-sort.spec.ts
@@ -370,14 +370,36 @@ test.describe("shell sort · o que está escrito na tela", () => {
       "esta é a última rodada, e ela é o insertion sort puro"
     );
 
-    // E o último passo mostra "gap 0", porque o gerador só empilha o estado
-    // final depois de o laço zerar o gap. É comportamento ANTERIOR à casca
-    // (está na `main`), não uma regressão da adaptação: fica afirmado aqui para
-    // deixar de ser mudo, e vai reportado como achado editorial.
+    // O último passo NÃO é uma rodada: o gerador empilha o resumo depois do
+    // `while gap > 0`, com o gap já zerado. Ele mostrava "gap 0" e prometia "0
+    // subsequências entrelaçadas, uma a cada 0 posições" — duas coisas que não
+    // existem —, e ainda pintava de âmbar (`f-ordenar`) um array já ordenado.
+    // Agora o selo diz o que o passo é, e a cor é a do fim.
     await ateOFim(fig);
     await expect(fig.locator(".viz-step")).toHaveText("passo 65 de 65");
-    await expect(fase.locator(".hs-fase-selo")).toHaveText("gap 0");
-    await expect(fase).toHaveClass(/f-ordenar/);
+    await expect(fase.locator(".hs-fase-selo")).toHaveText("ordenado");
+    await expect(fase.locator(".hs-fase-txt")).toHaveText(
+      "acabaram as rodadas de gap: este passo é o resumo da execução"
+    );
+    await expect(fase).toHaveClass(/f-fim/);
+    await expect(fase).not.toHaveClass(/f-ordenar/);
+    // Nenhum "gap 0" sobrou na fase, em lugar nenhum dela.
+    await expect(fase).not.toContainText("gap 0");
+    await expect(fase).not.toContainText("0 subsequências");
+
+    // O cartão que contava subsequências também falava de uma rodada que não
+    // existe. No resumo ele usa o mesmo traço das variáveis vazias.
+    await expect(
+      fig.locator(".bigo-stat").filter({ hasText: "subsequências deste gap" }).locator("strong")
+    ).toHaveText("-");
+
+    // E o painel de VARIÁVEIS continua mostrando 0 de propósito: ali o número é
+    // o valor da variável `gap` do código, e ela é 0 mesmo — é por isso que o
+    // `while gap > 0` terminou. O que era mentira era chamar isso de rodada.
+    await expect(
+      fig.locator(".viz-var").filter({ hasText: "gap" }).locator(".viz-var-val")
+    ).toHaveText("0");
+    await expect(fig.locator(".viz-note")).toContainText("Ordenado: 1, 3, 5, 6, 7, 13, 15, 21");
   });
 
   test("a fita tem oito células em todos os presets, e é por isso que ela não é eixo de altura", async ({ page }) => {


### PR DESCRIPTION
Três defeitos anteriores à casca, da mesma classe: **um número ou um rótulo que a peça mostra e que não corresponde ao que ela faz**. Os três estavam inventariados em `backlog/pendencias-pos-casca.md` §1, achados por agentes de rodadas de adaptação que reportaram sem consertar — com razão, porque a garantia daquele trabalho é *nenhum texto de tela mudou*.

Aqui todos os três mudam texto de tela, então cada um vem com **teste que lê o texto novo** e com **prova de quebra contra o texto antigo**.

---

## 1. A tabela de graus da árvore n-ária nunca destacava nada

**O que estava errado.** `NAryTreeVisualizer.tsx:266` declara `DEGREES = [2, 4, 8, 16, 64, 256]`, e `:310` calculava `maxDegree` = **3** nas três árvores. Como `3 ∉ DEGREES`, a condição `k === maxDegree` de `:484` e `:485` nunca era verdade: **a linha destacada e o sufixo `" (o desta árvore)"` não apareciam para nenhum aluno, em nenhum preset**. Reproduzido no HTML do build:

```
$ npm run build && grep -c "o desta árvore" out/topico/n-ary-trees/index.html
0
```

**O que mudou.** A **árvore de diretórios** ganhou um quarto filho na raiz: `/projeto` agora tem `src`, `testes`, `README.md` e `.gitignore`. É o empurrão mínimo e o mais honesto para o conceito — a legenda dela já diz "uma pasta tem quantos filhos quiser", e agora ela demonstra isso. As outras duas continuam em grau 3.

**As alternativas, para o mantenedor poder redirecionar na revisão** (as três estão no backlog):

1. **acrescentar `3` ao `DEGREES`** — é a mais simples e quebra a progressão 2/4/8/16/64/256, que existe justamente para mostrar o efeito de **dobrar** o grau (e a tabela do artigo, em `n-ary-trees.mdx:117`, lista 2/4/16/256);
2. **dar grau 4 a uma das árvores** — *a escolhida*: preserva a progressão e faz a linha acender, ao custo de mexer num exemplo didático;
3. **tirar a promessa** — remover o sufixo e o destaque, deixando a tabela como referência pura. É a mais barata, e perde a ligação entre a árvore da tela e a tabela.

Por que a árvore de **diretórios** e não outra: a do artigo tem a pré-ordem saindo `1..9` na sequência, que é a graça dela (um quarto filho exigiria renumerar os nove nós); a do DOM só ganharia grau 4 com um `<li>` a mais, e três `li` idênticos na saída ensinam menos que um arquivo a mais numa pasta.

**Altura remedida** (contrato §3: mexer na árvore mexe no eixo, que é a profundidade):

| | antes | depois |
|---|---|---|
| desenho da árvore de diretórios | 592x**196** | 688x**196** |
| pico da peça no artigo, 1512x900 | 1102px | 1138px |
| pico da peça no artigo, 1440x700 | 1138px | 1138px |
| pior caso das três árvores (a do DOM) | 1238px | **1238px** |

O grau virou **largura** (+96px, que rolam no `.tt-arv-wrap`) e **zero de altura** — que é exatamente a tese que o `measureOn: [treeKey, ...]` desta peça sustenta. O pior caso continua sendo a árvore do DOM, então a decisão da medição não mudou. `useVisualizer`, `measureOn` e `initialSpeed: 4` não foram tocados.

**Uma consequência a declarar:** o `grep` do build continua dando **0**, porque a árvore padrão é a do artigo (grau 3) e o `n-ary-trees.mdx:89` manda o aluno *"depois trocar para a árvore de diretórios"* — trocar o padrão contradiria a instrução do artigo. A prova passou a ser o navegador, nos três presets.

## 2. O shell sort anunciava uma rodada de "gap 0" no resumo

**O que estava errado.** O passo final é empilhado **depois** do `while gap > 0` (`ShellSortVisualizer.tsx:123` e `:210`), com o gap já zerado. O selo de `:272` mostrava **"gap 0"**, o texto ao lado prometia **"0 subsequências entrelaçadas, uma a cada 0 posições"** e o cartão "subsequências deste gap" somava **0**. Nenhuma das três coisas existe. E a cor completava a mentira: o array já ordenado saía em `f-ordenar` (âmbar) em vez de `f-fim` (verde).

**O que mudou.** O passo do resumo passa a se nomear em vez de anunciar uma rodada que não houve:

| | antes | depois |
|---|---|---|
| selo | `gap 0` | `ordenado` |
| texto da fase | `o array é lido como 0 subsequências entrelaçadas, uma a cada 0 posições` | `acabaram as rodadas de gap: este passo é o resumo da execução` |
| cor | `f-ordenar` (âmbar) | `f-fim` (verde) |
| cartão "subsequências deste gap" | `0` | `-` |

O `-` é o mesmo traço que as variáveis desta peça já usam para "não se aplica aqui".

**O painel de variáveis continua mostrando `gap 0`, de propósito**: ali o número é o valor da variável `gap` do código Python da tela, e ela é 0 mesmo — é por isso que o laço terminou. O teste afirma isso explicitamente, para o próximo leitor não "consertar" de volta.

## 3. O Bellman-Ford mostrava "rodada 5 de 4"

**O que estava errado.** `LABELS` tem 5 vértices (`BellmanFordVisualizer.tsx:21`), a rodada extra é empilhada com `snap(V, …)` (`:140` e `:145`) e o painel de `:273` mostrava `{s.round} de {LABELS.length - 1}` — **"5 de 4"**, nos três presets. Separados, os dois números estão certos; errado era pô-los na mesma fração, porque a rodada extra não é uma das V-1.

**E o numerador nem descrevia o que aconteceu na tela.** Medido, no último passo dos três presets:

| preset | rodadas que fecharam (tabela) | o que a peça dizia |
|---|---|---|
| Com peso negativo (funciona) | início, 1, 2 | rodada **5** de 4 |
| Ciclo negativo (detecta) | início, 1, 2, 3, 4 | rodada **5** de 4 |
| Só pesos positivos | início, 1, 2 | rodada **5** de 4 |

Com early exit, dois dos três param na rodada 2 — e o cabeçalho anunciava "rodada 5" do mesmo jeito.

**O que mudou.** Os dois lugares nomeiam a rodada em vez de numerá-la, com o vocabulário que a nota daquele passo já usava (`RODADA EXTRA:`): o painel diz **`extra (detecção)`** e o cabeçalho **`rodada extra ·`**. O `aria-label` do desenho acompanha, para quem lê por leitor de tela ouvir a mesma coisa que quem lê o painel. Os passos numerados continuam mostrando `N de 4`.

**O `·` do fim do `children` do `VizHeader` continua lá** — é a solução do §9 do contrato para o separador que some —, e o teste afirma que ele continua sendo o último caractere.

---

## Como foi provado

`npm run build` ✓ · `npx tsc --noEmit` ✓ · `npm run test:build` ✓ **461 passed** (a suíte inteira, não só os testes novos).

### As três provas de quebra

Feitas com **cópia dos arquivos e `restaurar()`**, nunca com `git checkout --` (que apagaria o fix junto), e **sem silenciar o build** — as três quebras compilam, então elas chegam mesmo ao `out/` que os testes exercitam.

| # | a quebra | o teste | o que ele leu |
|---|---|---|---|
| A | a árvore de diretórios volta ao grau 3 | `linha destacada da tabela` | `Error: expect(locator).toHaveText(expected) failed / Received: "3"` → **1 failed** |
| B | o selo volta a `gap {s.gap}` | `o selo da fase muda de gap e de classe` | `Received: "gap 0"` → **1 failed** |
| C | o painel volta a `{s.round} de {LABELS.length - 1}` | `a rodada extra se nomeia` | `Received: "5 de 4"` → **1 failed** |
| D | `k === maxDegree` vira `k !== maxDegree` | `linha destacada da tabela` | `toHaveCount failed / Expected: 0 / Received: 6` → **1 failed** |

A quebra **D** existe porque o teste do item 1 promete os **dois lados** da condicional: sem ela, um destaque em todas as seis linhas passaria verde no preset em que a promessa não vale.

### Conferência de viewport, porque os três mudam string renderizada

390x844, 1440x700 e 1512x900, no último passo dos três tópicos, medindo `scrollWidth` contra `clientWidth` **de cada rótulo** (o overflow da página não pega texto vazando de dentro de um card):

- **nenhum rótulo vaza da própria caixa** em nenhuma das três réguas, incluindo `4 (o desta árvore)` (125/125 a 390px), `extra (detecção)` (130/130) e `acabaram as rodadas de gap: …` (278/278);
- **zero overflow horizontal de página** nas três;
- `.hs-fase` mede **35px em todos os estados** a 1512 e a 1440, e 74px a 390 — o texto novo do shell sort não acrescentou linha nenhuma;
- a altura do `.viz-head` do Bellman-Ford no último passo, **antes → depois**: 53 → 53px (1512x900), 81 → 81px (1440x700), 134 → **122px** (390x844). A quebra de linha a 1440 é do contador de dois dígitos (o eixo do §9 do contrato), não do rótulo novo.

## O que **não** mudou

- nada de `src/lib/visualizer.tsx`, `globals.css`, `content/roadmap.ts`, `playwright.config.ts` ou qualquer `.mdx`: **nenhuma classe nova e nenhuma linha de CSS** — os consertos reaproveitam `f-fim`, `f-ordenar` e o traço que as variáveis já usam;
- `f-fim` e `f-ordenar` **não foram renomeados**: são contrato com o `globals.css` (contrato §0, o caso do literal-vira-classe);
- `useVisualizer`, `measureOn` e `initialSpeed: 4` das três peças, intactos;
- o `·` do `VizHeader` do Bellman-Ford, intacto.

## O que a varredura de classe cobriu

Rodei a classe dos três achados como consulta nos **três arquivos**, rótulo a rótulo, olhando a expressão que alimenta cada um:

- **`NAryTreeVisualizer`** — os quatro cartões de variável (`nó atual`, `fila`/`pilha` com o rótulo trocando junto com o modo, `processados N de M`, `grau máximo`), as três colunas da tabela de graus contra `heightFor()`, a legenda do fim (`de grau 2 para 256, 20 níveis viram 4` bate com a tabela), o `aria-label` do SVG e as três legendas de árvore. **A legenda da árvore do artigo cita as três saídas na mão** (`Pré: 1 2 3 4 5 6 7 8 9 · Pós: … · Nível: …`): conferi as três contra o gerador, estão certas — mas **não há teste ligando as duas pontas**, e isso fica como fragilidade conhecida.
- **`ShellSortVisualizer`** — os quatro cartões de estatística contra os contadores do gerador (`comparações` incrementa antes de cada teste, `escritas` conta o deslocamento **e** a devolução, que é o que a nota explica), os três cartões de variável, os quatro rótulos de preset contra os `values` deles, e o título do painel: *"roxo = a subsequência do elemento na mão"* — `.hp-cel.alvo` é `rgba(167, 139, 250, …)`, que é roxo mesmo.
- **`BellmanFordVisualizer`** — o cabeçalho, os três cartões de variável, os cabeçalhos da tabela de rodadas (`início` / `N` / `agora`), a dica do preset de ciclo (`-6 + 3 + 1 = -2` bate com as arestas declaradas) e a cor de alerta, que aqui marca uma falha de verdade (o ciclo negativo) e não o estado atual.

## O que achei e **não** consertei

1. **`BellmanFordVisualizer.tsx:275` — `relaxamentos totais` mostra `(V-1) × E`**, que é o custo do algoritmo **sem** early exit. Nos presets "Com peso negativo" e "Só pesos positivos" a execução para na rodada 2, então a peça mostra 32 e 24 relaxamentos onde aconteceram 16 e 12. É defensável como "o que o algoritmo custa", e é ambíguo o bastante para ser decisão editorial — por isso ficou de fora, e não de carona.
2. **`NAryTreeVisualizer.tsx:194` — "Agora enfileiro os 1 filhos dele"**, no BFS da árvore DOM (o nó `ul` tem um filho só). O número está certo, a concordância não; é outra classe, e o arquivo já tem o idioma `n === 1 ? "filho" : "filhos"` duas linhas abaixo.
3. **`NAryTreeVisualizer.tsx:50` — o comentário "A árvore do encontro … como apareceu no quadro"** é âncora na gravação. É PR editorial próprio (`backlog/ancoras-no-encontro.md`), e comentário não é texto de tela.
4. **`content/visualizers/README.md` §3 envelheceu com este PR**: a linha *"árvore n-ária | três árvores com **9 nós e grau máximo 3** dão desenhos de 196, 196 e 332px"* passa a valer só para duas delas. Os números novos (10 nós, grau 4, os mesmos 196px) **reforçam** a tese daquela linha, mas o texto é normativo e precisa de uma passada. Não toquei porque o contrato é arquivo compartilhado, e esta rodada tem outras lanes vivas.
5. **`tests/viz-strings.spec.ts` piscou duas vezes** na primeira rodada da suíte cheia, num `expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1)` que recebeu 10,4. Isolado, o spec passa 8/8 na minha branch (duas vezes) **e** num build da `origin/main` sem as minhas mudanças. É flake sob carga (quatro agentes na mesma máquina), não regressão.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3BfAzcaMzDmPLn9xFnHVv
