### PR TITLE
feat(viz): põe o gráfico do Big O na casca adaptativa

### DIFF
--- a/content/visualizers/BigOChartVisualizer.tsx
+++ b/content/visualizers/BigOChartVisualizer.tsx
@@ -1,15 +1,21 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
+
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BigOChartVisualizer, as curvas de crescimento desenhadas num canvas.
 //
 // Foge um pouco do padrão "gerador puro de passos" dos outros visualizadores
 // porque aqui não existe um algoritmo rodando passo a passo: o que se aprende
-// é a FORMA de cada família quando a entrada cresce. A casca (viz-head,
-// viz-body, controles, Expandir) é a mesma dos demais.
+// é a FORMA de cada família quando a entrada cresce. Por isso ele entra na
+// casca com `total: 1` (sem linha do tempo) e `collapsible: false` (o canvas é
+// o conteúdo, não há bloco dispensável para recolher).
+//
+// A casca vem do `useVisualizer`: painel com cabeçalho e controles parados,
+// foco, Tab circulando e Esc. Aqui fica só o que é DESTE visualizador.
+// Contrato em `content/visualizers/README.md`.
 //
 // Toda família é definida em duas versões: `val` (o número de operações, que
 // estoura para Infinity em 2^n e n!) e `log10` (o mesmo valor em log, sempre
@@ -17,11 +23,11 @@ import { createPortal } from "react-dom";
 // consegue mais representar.
 // ---------------------------------------------------------------------------
 
-type Familia = {
+type Family = {
   key: string;
-  rotulo: string;
-  cor: string;
-  exemplo: string;
+  label: string;
+  color: string;
+  example: string;
   val: (n: number) => number;
   log10: (n: number) => number;
 };
@@ -31,41 +37,41 @@ const LN10 = Math.LN10;
 // log10(n!) por Stirling com o termo de correção 1/(12n). Contínua (a curva
 // sai lisa em vez de escadinha) e barata mesmo com n na casa do milhão, onde
 // somar log de cada termo seria inviável a cada ponto do gráfico.
-function log10Fatorial(n: number): number {
+function log10Factorial(n: number): number {
   const x = Math.max(1, n);
   return (x * Math.log(x) - x + 0.5 * Math.log(2 * Math.PI * x) + 1 / (12 * x)) / LN10;
 }
 
-function fatorial(n: number): number {
+function factorial(n: number): number {
   if (n > 170) return Infinity;
   let f = 1;
   for (let i = 2; i <= Math.floor(n); i++) f *= i;
   return f;
 }
 
-const FAMILIAS: Familia[] = [
-  { key: "c", rotulo: "O(1)", cor: "#34d399", exemplo: "acesso por índice",
+const FAMILIES: Family[] = [
+  { key: "c", label: "O(1)", color: "#34d399", example: "acesso por índice",
     val: () => 1, log10: () => 0 },
-  { key: "log", rotulo: "O(log n)", cor: "#22d3ee", exemplo: "busca binária",
+  { key: "log", label: "O(log n)", color: "#22d3ee", example: "busca binária",
     val: (n) => Math.max(1, Math.log2(n)), log10: (n) => Math.log10(Math.max(1, Math.log2(n))) },
-  { key: "n", rotulo: "O(n)", cor: "#60a5fa", exemplo: "busca linear",
+  { key: "n", label: "O(n)", color: "#60a5fa", example: "busca linear",
     val: (n) => n, log10: (n) => Math.log10(n) },
-  { key: "nlog", rotulo: "O(n log n)", cor: "#a78bfa", exemplo: "merge sort",
+  { key: "nlog", label: "O(n log n)", color: "#a78bfa", example: "merge sort",
     val: (n) => n * Math.max(1, Math.log2(n)), log10: (n) => Math.log10(n) + Math.log10(Math.max(1, Math.log2(n))) },
-  { key: "n2", rotulo: "O(n²)", cor: "#fbbf24", exemplo: "dois laços aninhados",
+  { key: "n2", label: "O(n²)", color: "#fbbf24", example: "dois laços aninhados",
     val: (n) => n * n, log10: (n) => 2 * Math.log10(n) },
-  { key: "n3", rotulo: "O(n³)", cor: "#fb923c", exemplo: "três laços aninhados",
+  { key: "n3", label: "O(n³)", color: "#fb923c", example: "três laços aninhados",
     val: (n) => n * n * n, log10: (n) => 3 * Math.log10(n) },
-  { key: "exp", rotulo: "O(2ⁿ)", cor: "#f87171", exemplo: "fibonacci recursivo",
+  { key: "exp", label: "O(2ⁿ)", color: "#f87171", example: "fibonacci recursivo",
     val: (n) => (n > 1023 ? Infinity : Math.pow(2, n)), log10: (n) => n * Math.log10(2) },
-  { key: "fat", rotulo: "O(n!)", cor: "#f472b6", exemplo: "permutações, caixeiro viajante",
-    val: (n) => fatorial(n), log10: (n) => log10Fatorial(n) },
+  { key: "fat", label: "O(n!)", color: "#f472b6", example: "permutações, caixeiro viajante",
+    val: (n) => factorial(n), log10: (n) => log10Factorial(n) },
 ];
 
 // Entradas em passos redondos, do "cabe na cabeça" ao "escala de produção".
-const ENTRADAS = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 100000, 1000000];
+const INPUT_SIZES = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 100000, 1000000];
 
-const PADRAO = new Set(["c", "log", "n", "nlog", "n2"]);
+const DEFAULT_KEYS = new Set(["c", "log", "n", "nlog", "n2"]);
 
 // Formatação determinística (nada de Intl, para o HTML do servidor e do
 // cliente baterem exatamente na hidratação).
@@ -90,61 +96,59 @@ function fmtLog(log10v: number): string {
 }
 
 // Rótulo do eixo Y em escala log: sempre uma potência de 10 redonda.
-function decada(exp: number): string {
+function decade(exp: number): string {
   if (exp === 0) return "1";
   if (exp <= 6) return num(Math.pow(10, exp));
   return `10^${exp}`;
 }
 
 export function BigOChartVisualizer() {
-  const [iEntrada, setIEntrada] = useState(3); // 100
-  const [logaritmica, setLogaritmica] = useState(false);
-  const [ativas, setAtivas] = useState<Set<string>>(new Set(PADRAO));
-  const [marcadorPct, setMarcadorPct] = useState(0.62);
-  const [expanded, setExpanded] = useState(false);
-  const [mounted, setMounted] = useState(false);
-  const [largura, setLargura] = useState(720);
+  const [sizeIndex, setSizeIndex] = useState(3); // 100
+  const [logScale, setLogScale] = useState(false);
+  const [activeKeys, setActiveKeys] = useState<Set<string>>(new Set(DEFAULT_KEYS));
+  const [markerPct, setMarkerPct] = useState(0.62);
+  const [width, setWidth] = useState(720);
 
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
 
-  useEffect(() => setMounted(true), []);
+  // `total: 1` porque não há linha do tempo: o aluno lê uma curva, não uma
+  // animação. `collapsible: false` porque o canvas É o conteúdo — não existe
+  // bloco dispensável aqui, e o contrato proíbe inventar um só para ter o botão.
+  const viz = useVisualizer({
+    title: "Visualizador · como cada família cresce",
+    total: 1,
+    collapsible: false,
+  });
 
-  useEffect(() => {
-    if (!expanded) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") setExpanded(false); };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [expanded]);
+  const nMax = INPUT_SIZES[sizeIndex];
+  const nMarker = Math.max(1, Math.round(nMax * markerPct));
+  const visible = useMemo(() => FAMILIES.filter((f) => activeKeys.has(f.key)), [activeKeys]);
 
-  const nMax = ENTRADAS[iEntrada];
-  const nMarcador = Math.max(1, Math.round(nMax * marcadorPct));
-  const visiveis = useMemo(() => FAMILIAS.filter((f) => ativas.has(f.key)), [ativas]);
-
-  const alternar = useCallback((key: string) => {
-    setAtivas((s) => {
-      const novo = new Set(s);
-      if (novo.has(key)) novo.delete(key); else novo.add(key);
-      return novo.size ? novo : new Set([key]);
+  const toggleFamily = useCallback((key: string) => {
+    setActiveKeys((s) => {
+      const next = new Set(s);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next.size ? next : new Set([key]);
     });
   }, []);
 
   // Largura real do canvas: o gráfico é redesenhado quando o container muda
   // (troca de viewport, abrir/fechar o Expandir).
-  const medir = useCallback((el: HTMLDivElement | null) => {
+  const measure = useCallback((el: HTMLDivElement | null) => {
     wrapRef.current = el;
-    if (el) setLargura(el.clientWidth || 720);
+    if (el) setWidth(el.clientWidth || 720);
   }, []);
 
   useEffect(() => {
     const el = wrapRef.current;
     if (!el || typeof ResizeObserver === "undefined") return;
-    const ro = new ResizeObserver(() => setLargura(el.clientWidth || 720));
+    const ro = new ResizeObserver(() => setWidth(el.clientWidth || 720));
     ro.observe(el);
     return () => ro.disconnect();
-  }, [expanded, mounted]);
+  }, [viz.expanded]);
 
-  const altura = expanded ? 400 : 300;
+  const height = viz.expanded ? 400 : 300;
 
   useEffect(() => {
     const cv = canvasRef.current;
@@ -153,31 +157,31 @@ export function BigOChartVisualizer() {
     if (!ctx) return;
 
     const dpr = Math.min(window.devicePixelRatio || 1, 2);
-    const W = Math.max(280, largura);
-    const H = altura;
+    const W = Math.max(280, width);
+    const H = height;
     cv.width = Math.round(W * dpr);
     cv.height = Math.round(H * dpr);
     cv.style.height = `${H}px`;
     ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
     ctx.clearRect(0, 0, W, H);
 
-    const padE = 72, padD = 16, padT = 26, padB = 34;
-    const gw = W - padE - padD;
+    const padL = 72, padR = 16, padT = 26, padB = 34;
+    const gw = W - padL - padR;
     const gh = H - padT - padB;
     const mono = '11px ui-monospace, SFMono-Regular, Menlo, monospace';
 
     // Teto do eixo Y. Na linear, o maior valor visível; na log, a maior ordem
     // de grandeza arredondada para um número redondo de décadas por linha,
     // para os rótulos saírem sempre como potências inteiras de 10.
-    const topoLog = Math.max(1, ...visiveis.map((f) => f.log10(nMax)));
-    const passoLog = Math.max(1, Math.ceil(topoLog / 5));
-    const yMaxLog = passoLog * Math.ceil(topoLog / passoLog);
-    const brutos = visiveis.map((f) => f.val(nMax)).filter((v) => isFinite(v));
-    const yMax = brutos.length ? Math.max(10, Math.max(...brutos)) : 10;
+    const logTop = Math.max(1, ...visible.map((f) => f.log10(nMax)));
+    const logStep = Math.max(1, Math.ceil(logTop / 5));
+    const yMaxLog = logStep * Math.ceil(logTop / logStep);
+    const rawValues = visible.map((f) => f.val(nMax)).filter((v) => isFinite(v));
+    const yMax = rawValues.length ? Math.max(10, Math.max(...rawValues)) : 10;
 
-    const px = (n: number) => padE + ((n - 1) / Math.max(1, nMax - 1)) * gw;
-    const py = (f: Familia, n: number) => {
-      if (logaritmica) {
+    const px = (n: number) => padL + ((n - 1) / Math.max(1, nMax - 1)) * gw;
+    const py = (f: Family, n: number) => {
+      if (logScale) {
         const v = Math.max(0, f.log10(n));
         return padT + gh - (v / yMaxLog) * gh;
       }
@@ -193,23 +197,23 @@ export function BigOChartVisualizer() {
     ctx.lineWidth = 1;
     ctx.textAlign = "right";
     ctx.textBaseline = "middle";
-    const linhas = logaritmica ? Math.round(yMaxLog / passoLog) : 5;
-    for (let i = 0; i <= linhas; i++) {
-      const y = padT + gh - (i / linhas) * gh;
+    const lines = logScale ? Math.round(yMaxLog / logStep) : 5;
+    for (let i = 0; i <= lines; i++) {
+      const y = padT + gh - (i / lines) * gh;
       ctx.beginPath();
-      ctx.moveTo(padE, Math.round(y) + 0.5);
-      ctx.lineTo(padE + gw, Math.round(y) + 0.5);
+      ctx.moveTo(padL, Math.round(y) + 0.5);
+      ctx.lineTo(padL + gw, Math.round(y) + 0.5);
       ctx.stroke();
-      const rotulo = logaritmica ? decada(i * passoLog) : fmt((i / linhas) * yMax);
-      ctx.fillText(rotulo, padE - 8, y);
+      const label = logScale ? decade(i * logStep) : fmt((i / lines) * yMax);
+      ctx.fillText(label, padL - 8, y);
     }
 
     // Eixo X
     ctx.textAlign = "center";
     ctx.textBaseline = "top";
-    const marcasX = 4;
-    for (let i = 0; i <= marcasX; i++) {
-      const n = 1 + ((nMax - 1) * i) / marcasX;
+    const xTicks = 4;
+    for (let i = 0; i <= xTicks; i++) {
+      const n = 1 + ((nMax - 1) * i) / xTicks;
       const x = px(n);
       ctx.beginPath();
       ctx.strokeStyle = "rgba(255,255,255,0.04)";
@@ -222,23 +226,23 @@ export function BigOChartVisualizer() {
 
     ctx.textAlign = "left";
     ctx.fillStyle = "#4c5f79";
-    ctx.fillText("n (tamanho da entrada) →", padE, padT + gh + 21);
-    ctx.fillText(logaritmica ? "↑ operações (escala logarítmica)" : "↑ operações", padE, 7);
+    ctx.fillText("n (tamanho da entrada) →", padL, padT + gh + 21);
+    ctx.fillText(logScale ? "↑ operações (escala logarítmica)" : "↑ operações", padL, 7);
 
     // Curvas, recortadas na área do gráfico
     ctx.save();
     ctx.beginPath();
-    ctx.rect(padE, padT - 1, gw, gh + 2);
+    ctx.rect(padL, padT - 1, gw, gh + 2);
     ctx.clip();
     ctx.lineWidth = 2;
     ctx.lineJoin = "round";
     ctx.lineCap = "round";
-    const amostras = Math.max(80, Math.round(gw));
-    for (const f of visiveis) {
-      ctx.strokeStyle = f.cor;
+    const samples = Math.max(80, Math.round(gw));
+    for (const f of visible) {
+      ctx.strokeStyle = f.color;
       ctx.beginPath();
-      for (let i = 0; i <= amostras; i++) {
-        const n = 1 + ((nMax - 1) * i) / amostras;
+      for (let i = 0; i <= samples; i++) {
+        const n = 1 + ((nMax - 1) * i) / samples;
         const x = px(n);
         const y = py(f, n);
         if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
@@ -247,7 +251,7 @@ export function BigOChartVisualizer() {
     }
 
     // Marcador: linha vertical + bolinha em cada curva
-    const xm = px(nMarcador);
+    const xm = px(nMarker);
     ctx.setLineDash([4, 4]);
     ctx.strokeStyle = "rgba(255,255,255,0.28)";
     ctx.lineWidth = 1;
@@ -256,10 +260,10 @@ export function BigOChartVisualizer() {
     ctx.lineTo(Math.round(xm) + 0.5, padT + gh);
     ctx.stroke();
     ctx.setLineDash([]);
-    for (const f of visiveis) {
-      const y = py(f, nMarcador);
+    for (const f of visible) {
+      const y = py(f, nMarker);
       if (y < padT - 2 || y > padT + gh + 2) continue;
-      ctx.fillStyle = f.cor;
+      ctx.fillStyle = f.color;
       ctx.beginPath();
       ctx.arc(xm, y, 3.5, 0, Math.PI * 2);
       ctx.fill();
@@ -272,166 +276,163 @@ export function BigOChartVisualizer() {
     // Moldura
     ctx.strokeStyle = "rgba(255,255,255,0.08)";
     ctx.lineWidth = 1;
-    ctx.strokeRect(padE + 0.5, padT + 0.5, gw - 1, gh - 1);
-  }, [visiveis, nMax, nMarcador, logaritmica, largura, altura]);
+    ctx.strokeRect(padL + 0.5, padT + 0.5, gw - 1, gh - 1);
+  }, [visible, nMax, nMarker, logScale, width, height]);
 
   // Só move com o ponteiro pressionado (o texto embaixo do gráfico pede para
   // arrastar). Seguir o hover redesenharia o canvas a cada mousemove.
-  const moverMarcador = (e: React.PointerEvent<HTMLCanvasElement>) => {
+  const moveMarker = (e: React.PointerEvent<HTMLCanvasElement>) => {
     const cv = canvasRef.current;
     if (!cv) return;
     const r = cv.getBoundingClientRect();
-    const padE = 72, padD = 16;
-    const gw = r.width - padE - padD;
-    const pct = (e.clientX - r.left - padE) / Math.max(1, gw);
-    setMarcadorPct(Math.min(1, Math.max(0.001, pct)));
+    const padL = 72, padR = 16;
+    const gw = r.width - padL - padR;
+    const pct = (e.clientX - r.left - padL) / Math.max(1, gw);
+    setMarkerPct(Math.min(1, Math.max(0.001, pct)));
   };
 
   // O marcador também anda pelo teclado: o canvas é um slider ao longo do eixo
   // n, então setas andam de pouco em pouco, PageUp/PageDown de muito em muito e
-  // Home/End vão para as pontas.
-  const aoTeclar = (e: React.KeyboardEvent<HTMLCanvasElement>) => {
-    const passos: Record<string, number> = {
+  // Home/End vão para as pontas. As setas continuam sendo do canvas mesmo no
+  // painel expandido: sem linha do tempo, o hook não sequestra tecla nenhuma.
+  const onCanvasKey = (e: React.KeyboardEvent<HTMLCanvasElement>) => {
+    const steps: Record<string, number> = {
       ArrowLeft: -0.02, ArrowRight: 0.02, ArrowDown: -0.02, ArrowUp: 0.02,
       PageDown: -0.1, PageUp: 0.1,
     };
     if (e.key === "Home" || e.key === "End") {
       e.preventDefault();
-      setMarcadorPct(e.key === "Home" ? 0.001 : 1);
+      setMarkerPct(e.key === "Home" ? 0.001 : 1);
       return;
     }
-    const d = passos[e.key];
+    const d = steps[e.key];
     if (d === undefined) return;
     e.preventDefault();
-    setMarcadorPct((p) => Math.min(1, Math.max(0.001, p + d)));
+    setMarkerPct((p) => Math.min(1, Math.max(0.001, p + d)));
   };
 
   // Capturar o ponteiro mantém o arrasto vivo mesmo com o cursor saindo do
   // canvas. É um extra: se o navegador recusar o id, o arrasto normal segue
   // funcionando, então a falha é engolida de propósito.
-  const capturar = (e: React.PointerEvent<HTMLCanvasElement>) => {
+  const capture = (e: React.PointerEvent<HTMLCanvasElement>) => {
     try { e.currentTarget.setPointerCapture(e.pointerId); } catch { /* segue sem captura */ }
   };
-  const soltar = (e: React.PointerEvent<HTMLCanvasElement>) => {
+  const release = (e: React.PointerEvent<HTMLCanvasElement>) => {
     try { e.currentTarget.releasePointerCapture(e.pointerId); } catch { /* nada a soltar */ }
   };
 
-  const leitura = visiveis.map((f) => ({
+  const readings = visible.map((f) => ({
     key: f.key,
-    rotulo: f.rotulo,
-    cor: f.cor,
-    exemplo: f.exemplo,
-    valor: f.log10(nMarcador) >= 15 ? fmtLog(f.log10(nMarcador)) : fmt(f.val(nMarcador)),
+    label: f.label,
+    color: f.color,
+    example: f.example,
+    value: f.log10(nMarker) >= 15 ? fmtLog(f.log10(nMarker)) : fmt(f.val(nMarker)),
   }));
 
-  const viz = (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · como cada família cresce</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">n = {num(nMarcador)}</span>
-          <button className="viz-expand" onClick={() => setExpanded((v) => !v)}>
-            {expanded ? "✕ Fechar" : "⤢ Expandir"}
-          </button>
-        </div>
-      </div>
+  const frame = (
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo, o número que resume o estado entra onde ficaria o
+          "passo N de M" — com o rótulo junto, que é o que lhe dá contexto. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">n = {num(nMarker)}</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {FAMILIAS.map((f) => {
-            const on = ativas.has(f.key);
+          {FAMILIES.map((f) => {
+            const on = activeKeys.has(f.key);
             return (
               <button
                 key={f.key}
                 className={`bigo-chip${on ? " on" : ""}`}
-                style={on ? { borderColor: f.cor, color: f.cor } : undefined}
-                onClick={() => alternar(f.key)}
+                style={on ? { borderColor: f.color, color: f.color } : undefined}
+                onClick={() => toggleFamily(f.key)}
                 aria-pressed={on}
               >
-                <span className="sw" style={{ background: on ? f.cor : "#3a4a60" }} />
-                {f.rotulo}
+                <span className="sw" style={{ background: on ? f.color : "#3a4a60" }} />
+                {f.label}
               </button>
             );
           })}
         </div>
 
-        <div className="bigo-canvas-wrap" ref={medir}>
+        <div className="bigo-canvas-wrap" ref={measure}>
           <canvas
             ref={canvasRef}
             className="bigo-canvas"
-            style={{ height: altura }}
+            style={{ height }}
             role="slider"
             tabIndex={0}
             aria-label="Marcador do gráfico de crescimento: escolhe o tamanho da entrada lido nas curvas"
             aria-valuemin={1}
             aria-valuemax={nMax}
-            aria-valuenow={nMarcador}
-            aria-valuetext={`n igual a ${num(nMarcador)}, ${leitura.map((l) => `${l.valor} operações em ${l.rotulo}`).join(", ")}`}
-            onKeyDown={aoTeclar}
-            onPointerDown={(e) => { moverMarcador(e); capturar(e); }}
-            onPointerMove={(e) => { if (e.buttons === 1) moverMarcador(e); }}
-            onPointerUp={soltar}
-            onPointerCancel={soltar}
+            aria-valuenow={nMarker}
+            aria-valuetext={`n igual a ${num(nMarker)}, ${readings.map((l) => `${l.value} operações em ${l.label}`).join(", ")}`}
+            onKeyDown={onCanvasKey}
+            onPointerDown={(e) => { moveMarker(e); capture(e); }}
+            onPointerMove={(e) => { if (e.buttons === 1) moveMarker(e); }}
+            onPointerUp={release}
+            onPointerCancel={release}
           />
         </div>
 
         <p className="viz-note">
-          Com <strong>n = {num(nMarcador)}</strong>, {leitura.length === 1 ? "a família marcada faz" : "as famílias marcadas fazem"}{" "}
-          {leitura.map((l, i) => (
+          Com <strong>n = {num(nMarker)}</strong>, {readings.length === 1 ? "a família marcada faz" : "as famílias marcadas fazem"}{" "}
+          {readings.map((l, i) => (
             <span key={l.key}>
-              {i > 0 ? (i === leitura.length - 1 ? " e " : ", ") : ""}
-              <strong style={{ color: l.cor }}>{l.valor}</strong> operações em {l.rotulo}
+              {i > 0 ? (i === readings.length - 1 ? " e " : ", ") : ""}
+              <strong style={{ color: l.color }}>{l.value}</strong> operações em {l.label}
             </span>
           ))}
           . Arraste sobre o gráfico, ou use as setas do teclado, para mover o marcador.
         </p>
 
         <div className="bigo-grid">
-          {leitura.map((l) => (
-            <div className="bigo-card" key={l.key} style={{ borderLeftColor: l.cor }}>
+          {readings.map((l) => (
+            <div className="bigo-card" key={l.key} style={{ borderLeftColor: l.color }}>
               <div className="bigo-card-top">
-                <span className="bigo-card-nome" style={{ color: l.cor }}>{l.rotulo}</span>
-                <span className="bigo-card-val">{l.valor}</span>
+                <span className="bigo-card-nome" style={{ color: l.color }}>{l.label}</span>
+                <span className="bigo-card-val">{l.value}</span>
               </div>
-              <div className="bigo-card-ex">{l.exemplo}</div>
+              <div className="bigo-card-ex">{l.example}</div>
             </div>
           ))}
         </div>
-
-        <div className="viz-controls">
-          <div className="viz-field grow">
-            <span>Entrada máxima: n até {num(nMax)}</span>
-            <input
-              type="range"
-              min={0}
-              max={ENTRADAS.length - 1}
-              step={1}
-              value={iEntrada}
-              onChange={(e) => setIEntrada(parseInt(e.target.value, 10))}
-              style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
-            />
-          </div>
-          <button className="viz-btn" onClick={() => setLogaritmica((v) => !v)}>
-            Escala: {logaritmica ? "logarítmica" : "linear"}
-          </button>
-          <button className="viz-btn" onClick={() => { setAtivas(new Set(PADRAO)); setIEntrada(3); setMarcadorPct(0.62); setLogaritmica(false); }}>
-            ↺ Reiniciar
-          </button>
-        </div>
       </div>
+
+      {/* Fora do corpo de propósito: no expandido é ele que fica parado no pé
+          da janela enquanto o miolo rola. Sem linha do tempo o `VizFooter` não
+          desenha reprodução nenhuma, só estes controles. */}
+      <VizFooter viz={viz}>
+        <div className="viz-field grow">
+          <span>Entrada máxima: n até {num(nMax)}</span>
+          <input
+            type="range"
+            min={0}
+            max={INPUT_SIZES.length - 1}
+            step={1}
+            value={sizeIndex}
+            onChange={(e) => setSizeIndex(parseInt(e.target.value, 10))}
+            style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
+          />
+        </div>
+        <button className="viz-btn" onClick={() => setLogScale((v) => !v)}>
+          Escala: {logScale ? "logarítmica" : "linear"}
+        </button>
+        <button
+          className="viz-btn"
+          onClick={() => {
+            setActiveKeys(new Set(DEFAULT_KEYS));
+            setSizeIndex(3);
+            setMarkerPct(0.62);
+            setLogScale(false);
+          }}
+        >
+          ↺ Reiniciar
+        </button>
+      </VizFooter>
     </figure>
   );
 
-  if (expanded && mounted) {
-    return createPortal(
-      <div className="viz-overlay" onClick={(e) => { if (e.target === e.currentTarget) setExpanded(false); }}>
-        {viz}
-      </div>,
-      document.body
-    );
-  }
-  return viz;
+  return viz.inPanel(frame);
 }

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -218,7 +218,37 @@ test("Big O traz o gráfico de crescimento, o contador de operações e a tabela
 // com o botão ainda escrito "Mostrar código" ensina errado do mesmo jeito.
 // ---------------------------------------------------------------------------
 
-const CONTADOR = "figure.viz-fit";
+// A página do Big O tem DUAS peças na casca desde que o gráfico de curvas
+// entrou, e o gráfico vem ANTES no DOM. `figure.viz-fit` sozinho casa 2: em
+// `page.locator()` isso é violação de strict mode, e nos `querySelector` abaixo
+// seria a peça errada EM SILÊNCIO — ela não tem `.viz-foot` nem `.viz-code`, e
+// as medições sairiam nulas sem ninguém reclamar.
+//
+// O discriminante é o SLOT do bloco recolhível, não o bloco: `.viz-code-slot`
+// existe porque a peça É recolhível (`collapsible: true`), enquanto o conteúdo
+// dentro dele é o que um dia pode virar condicional. Medido nos quatro estados
+// que estes testes atravessam — tela alta, tela baixa com o código já recolhido
+// pela medição, código recolhido na mão e painel expandido —, ele casa 1 nos
+// quatro: o contrato mantém o bloco no DOM mesmo recolhido, que é o que permite
+// medir o pior caso de altura.
+const CONTADOR = "figure.viz-fit:has(.viz-code-slot)";
+const GRAFICO = "figure.viz-fit:has(canvas)";
+
+test("Big O: o seletor do contador separa as duas peças da casca na página", async ({ page }) => {
+  await page.goto("/topico/big-o/");
+  // Se algum dia esta asserção cair, é porque uma peça entrou ou saiu da casca
+  // nesta página, e todo `CONTADOR` daqui para baixo precisa ser reconferido.
+  await expect(page.locator("figure.viz-fit")).toHaveCount(2);
+  await expect(page.locator(CONTADOR)).toHaveCount(1);
+  await expect(page.locator(GRAFICO)).toHaveCount(1);
+  // E são peças diferentes, lidas pelo rótulo do cabeçalho.
+  await expect(page.locator(`${CONTADOR} .viz-head-title`)).toHaveText(
+    "Visualizador · contando operações no mesmo array"
+  );
+  await expect(page.locator(`${GRAFICO} .viz-head-title`)).toHaveText(
+    "Visualizador · como cada família cresce"
+  );
+});
 
 /** Caixas do quadro, do cabeçalho e do rodapé + o estado da rolagem do miolo. */
 function medirCasca(page: import("@playwright/test").Page) {
@@ -303,11 +333,11 @@ test("Big O expandido: o Tab circula dentro do painel, como manda o aria-modal",
   const fugas: string[] = [];
   for (let i = 0; i < 24; i++) {
     await page.keyboard.press("Tab");
-    const onde = await page.evaluate(() => {
+    const onde = await page.evaluate((sel) => {
       const a = document.activeElement;
-      const fig = document.querySelector("figure.viz-fit");
+      const fig = document.querySelector(sel);
       return { dentro: !!(fig && a && fig.contains(a)), quem: a?.className || a?.tagName || "?" };
-    });
+    }, CONTADOR);
     if (!onde.dentro) fugas.push(`volta ${i + 1}: ${onde.quem}`);
   }
   expect(fugas, "o foco vazou do painel").toEqual([]);
@@ -316,10 +346,10 @@ test("Big O expandido: o Tab circula dentro do painel, como manda o aria-modal",
   await page.keyboard.press("Shift+Tab");
   await page.keyboard.press("Shift+Tab");
   expect(
-    await page.evaluate(() => {
-      const fig = document.querySelector("figure.viz-fit");
+    await page.evaluate((sel) => {
+      const fig = document.querySelector(sel);
       return !!(fig && document.activeElement && fig.contains(document.activeElement));
-    })
+    }, CONTADOR)
   ).toBe(true);
 
   // O código recolhido some para leitor de tela, não só para o teclado.

--- a/tests/viz-big-o.spec.ts
+++ b/tests/viz-big-o.spec.ts
@@ -1,0 +1,197 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// A casca adaptativa no `BigOChartVisualizer` (tópico `big-o`).
+//
+// A página tem TRÊS `<figure>` e DUAS delas são `figure.viz`: o cartaz estático
+// `.bigo-fam`, o gráfico de curvas (este arquivo) e o contador de operações
+// (`BigOCounterVisualizer`). Seletor não escopado pega o primeiro em silêncio,
+// então todo locator daqui é filtrado pelo conteúdo — o canvas do gráfico — e as
+// contagens são afirmadas nos DOIS níveis, página e figura.
+//
+// O gráfico entra na casca com `total: 1` (sem linha do tempo) e
+// `collapsible: false` (não há bloco dispensável). Por isso os itens 2, 3 e 4 do
+// §8 do contrato não existem aqui, e no lugar deles vale a regra que os
+// substitui: nenhum botão pode prometer esconder um bloco que a peça não tem.
+// ---------------------------------------------------------------------------
+
+const SLACK = 8;
+
+/** A figura do GRÁFICO, filtrada pelo canvas — nunca por posição. */
+function grafico(page: Page, dentroDoPainel = false): Locator {
+  const raiz = dentroDoPainel ? ".viz-overlay figure.viz" : "article figure.viz";
+  return page.locator(raiz).filter({ has: page.locator("canvas.bigo-canvas") });
+}
+
+async function abrirPainel(page: Page): Promise<Locator> {
+  await grafico(page).getByRole("button", { name: /Expandir/ }).click();
+  const painel = grafico(page, true);
+  await expect(painel).toHaveCount(1);
+  // `toBeVisible()` NÃO é "pronto para o teclado": os listeners do painel nascem
+  // num efeito passivo. O sinal de que a casca terminou de montar é o foco ter
+  // entrado na figura, que é o que o hook faz ao abrir.
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const f = document.querySelector(".viz-overlay figure.viz-fit");
+        return !!f && (f === document.activeElement || f.contains(document.activeElement));
+      })
+    )
+    .toBe(true);
+  return painel;
+}
+
+/** Liga as oito famílias: é o estado mais alto da peça (mais cartões, nota maior). */
+async function ligarTodas(fig: Locator) {
+  const chips = fig.locator(".bigo-chips .bigo-chip");
+  const n = await chips.count();
+  expect(n).toBe(8);
+  for (let i = 0; i < n; i++) {
+    const c = chips.nth(i);
+    if ((await c.getAttribute("aria-pressed")) === "false") await c.click();
+  }
+  await expect(fig.locator(".bigo-card")).toHaveCount(8);
+}
+
+test.describe("big-o · gráfico de crescimento na casca adaptativa", () => {
+  test("a página tem duas figure.viz e cada .viz-step diz uma coisa diferente", async ({ page }) => {
+    await page.goto("/topico/big-o/");
+
+    // nível PÁGINA: as duas peças estão na casca, e há dois `.viz-step` com
+    // sentidos diferentes. Um locator não escopado pegaria o primeiro calado.
+    await expect(page.locator("article figure.viz")).toHaveCount(2);
+    await expect(page.locator("article figure.viz.viz-fit")).toHaveCount(2);
+    await expect(page.locator("article figure.viz .viz-step")).toHaveCount(2);
+    await expect(page.locator("canvas.bigo-canvas")).toHaveCount(1);
+
+    // nível FIGURA: a minha tem um só, e ele mostra o n do marcador com o rótulo
+    // junto — não "passo N de M", que é o da peça vizinha.
+    const fig = grafico(page);
+    await expect(fig).toHaveCount(1);
+    await expect(fig.locator(".viz-step")).toHaveCount(1);
+    await expect(fig.locator(".viz-step")).toHaveText("n = 62");
+
+    const vizinha = page
+      .locator("article figure.viz")
+      .filter({ hasNot: page.locator("canvas.bigo-canvas") });
+    await expect(vizinha.locator(".viz-step")).toHaveText(/^passo 1 de \d+$/);
+  });
+
+  test("sem bloco dispensável, nenhum botão promete esconder coisa nenhuma", async ({ page }) => {
+    await page.goto("/topico/big-o/");
+    const fig = grafico(page);
+
+    // A peça não tem `.viz-code-slot` nem botão de recolher: `collapsible: false`.
+    await expect(fig.locator(".viz-code-slot")).toHaveCount(0);
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveCount(0);
+    await expect(fig.getByRole("button", { name: /Mostrar|Ocultar/ })).toHaveCount(0);
+
+    // E também não promete linha do tempo que não existe.
+    await expect(fig.getByRole("button", { name: /Rodar|Pausar|Próximo|Anterior/ })).toHaveCount(0);
+
+    // O único botão do cabeçalho é o Expandir, e o rótulo dele diz isso.
+    const cabecalho = fig.locator(".viz-head");
+    await expect(cabecalho.getByRole("button")).toHaveCount(1);
+    await expect(cabecalho.getByRole("button")).toHaveText("⤢ Expandir");
+
+    // O rodapé existe e é o dono dos controles do gráfico, com os rótulos deles.
+    const rodape = fig.locator(".viz-foot");
+    await expect(rodape).toHaveCount(1);
+    await expect(rodape.locator(".viz-field span")).toHaveText("Entrada máxima: n até 100");
+    await expect(rodape.getByRole("button", { name: /^Escala:/ })).toHaveText("Escala: linear");
+    await expect(rodape.getByRole("button", { name: /Reiniciar/ })).toHaveText("↺ Reiniciar");
+  });
+
+  test("no painel, cabeçalho e controles ficam parados enquanto o miolo rola", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 700 });
+    await page.goto("/topico/big-o/");
+    const painel = await abrirPainel(page);
+    await ligarTodas(painel);
+
+    const corpo = painel.locator(".viz-body");
+    const cabecalho = painel.locator(".viz-head");
+    const reiniciar = painel.getByRole("button", { name: /Reiniciar/ });
+
+    // A asserção que carrega o sentido: a posição do controle comparada com ela
+    // mesma, antes e depois de o miolo rolar. Vai ANTES das premissas porque é
+    // ela que reprova contra a quebra canônica (o rodapé de volta ao miolo).
+    const antesCtrl = (await reiniciar.boundingBox())!.y;
+    const antesHead = (await cabecalho.boundingBox())!.y;
+
+    // Premissas do §8: o miolo tem sobra, é ELE quem rola, e a figura não rola.
+    const sobraMiolo = await corpo.evaluate((el) => el.scrollHeight - el.clientHeight);
+    expect(sobraMiolo).toBeGreaterThan(SLACK);
+    await corpo.evaluate((el) => { el.scrollTop = el.scrollHeight; });
+    expect(await corpo.evaluate((el) => el.scrollTop)).toBeGreaterThan(0);
+    expect(await painel.evaluate((f) => f.scrollHeight - f.clientHeight)).toBeLessThanOrEqual(SLACK);
+
+    const depoisCtrl = (await reiniciar.boundingBox())!.y;
+    const depoisHead = (await cabecalho.boundingBox())!.y;
+    expect(Math.round(depoisCtrl - antesCtrl)).toBe(0);
+    expect(Math.round(depoisHead - antesHead)).toBe(0);
+    await expect(reiniciar).toBeInViewport({ ratio: 1 });
+    await expect(cabecalho).toBeInViewport({ ratio: 1 });
+  });
+
+  test("o gráfico continua sendo o dono das setas dentro do painel", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 700 });
+    await page.goto("/topico/big-o/");
+
+    // O canvas tem altura fixa e ela depende do estado expandido: 300 no artigo,
+    // 400 no painel. Afirmar as duas é a prova de que o `viz.expanded` do hook
+    // chegou até o desenho, e não só até a moldura.
+    const alturaCanvas = (l: Locator) =>
+      l.locator("canvas.bigo-canvas").evaluate((c) => Math.round(c.getBoundingClientRect().height));
+    expect(await alturaCanvas(grafico(page))).toBe(300);
+
+    const painel = await abrirPainel(page);
+    expect(await alturaCanvas(painel)).toBe(400);
+
+    const canvas = painel.locator("canvas.bigo-canvas");
+    const passo = painel.locator(".viz-step");
+
+    await canvas.focus();
+    await page.keyboard.press("Home");
+    await expect(passo).toHaveText("n = 1");
+    await expect(painel.locator(".viz-note")).toContainText("Com n = 1,");
+
+    // Uma ação só, repetida: um par ←/→ voltaria ao ponto de partida e a
+    // asserção ficaria verde mesmo com a tecla roubada.
+    for (let i = 0; i < 5; i++) await page.keyboard.press("ArrowRight");
+    await expect(passo).toHaveText("n = 10");
+    await expect(painel.locator(".viz-note")).toContainText("Com n = 10,");
+    // O rótulo do card lido junto com o valor: em n = 10, O(1) faz 1 operação.
+    const cardConst = painel.locator(".bigo-card").filter({ hasText: "acesso por índice" });
+    await expect(cardConst.locator(".bigo-card-nome")).toHaveText("O(1)");
+    await expect(cardConst.locator(".bigo-card-val")).toHaveText("1");
+  });
+
+  test("o painel é um diálogo: Tab circula dentro dele e Esc fecha", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 700 });
+    await page.goto("/topico/big-o/");
+    const painel = await abrirPainel(page);
+
+    const dialogo = page.locator('.viz-overlay[role="dialog"]');
+    await expect(dialogo).toHaveAttribute("aria-modal", "true");
+    await expect(dialogo).toHaveAttribute(
+      "aria-label",
+      "Visualizador · como cada família cresce"
+    );
+
+    // O foco entrou no painel, e vinte tabulações não escapam dele.
+    await expect
+      .poll(() => page.evaluate(() => !!document.activeElement?.closest(".viz-overlay")))
+      .toBe(true);
+    for (let i = 0; i < 20; i++) {
+      await page.keyboard.press("Tab");
+      const dentro = await page.evaluate(
+        () => !!document.activeElement?.closest(".viz-overlay")
+      );
+      expect(dentro, `Tab ${i + 1} saiu do painel`).toBe(true);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(grafico(page, true)).toHaveCount(0);
+    await expect(painel).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
O `BigOChartVisualizer` era o último visualizador com overlay do modelo antigo:
`grep -l 'viz-overlay' content/visualizers/*.tsx` devolvia só ele, e agora sai
vazio. Ele entra na casca com `total: 1` e `collapsible: false`, e o PR leva
junto o conserto de um seletor de teste que a própria mudança quebrou.

## O que estava errado

**1. A peça rolava inteira no painel expandido**
(`content/visualizers/BigOChartVisualizer.tsx:328`, o `<figure className="viz">`
com overlay próprio em `:430`).

O defeito não aparece na régua de 1512x900, onde a peça cabe (748px, sobra 0).
Aparece abaixo dela: com as oito famílias ligadas, o `↺ Reiniciar` era desenhado
**131px (1440x700), 231px (1440x600) e 629px (390x844) abaixo do pé visível**, e
quem rolava para alcançá-lo levava o cabeçalho para **-150, -250 e -668px**. É
exatamente o problema que motivou a casca, descrito na §1 do contrato.

**2. `tests/navegacao.spec.ts:221` tinha `const CONTADOR = "figure.viz-fit"`, sem
escopo.**

Isso casava uma figura só porque o contador de operações era a única peça do Big
O na casca. Com o gráfico dentro casa duas, e o gráfico vem **antes** no DOM
(`content/topics/big-o.mdx:63` contra `:78`). O estrago tem dois tamanhos: em
`page.locator()` é violação de strict mode, que reprova alto (cinco testes); nos
dois `document.querySelector` dentro do `page.evaluate` do teste de Tab (`:308` e
`:320` na numeração antiga) é pior, porque é **silencioso** — eles passavam a ler
o gráfico, que não está expandido e não tem `.viz-foot` nem `.viz-code`, e as
medições sairiam nulas sem ninguém reclamar.

## O que mudou

### O componente

Sai o overlay próprio (`createPortal`, o `expanded`/`mounted` locais, o efeito de
Escape, o `.viz-head` escrito à mão) e entra o `useVisualizer` com `VizHeader` e
`VizFooter`.

- **`total: 1`** porque não há linha do tempo: o aluno lê uma curva, não uma
  animação. O `n = 62` do cabeçalho vira `children` do `VizHeader`, no lugar onde
  ficaria o "passo N de M", com o rótulo junto (§6 do contrato).
- **`collapsible: false`** porque o canvas é o conteúdo. Não existe bloco
  dispensável aqui, e o contrato proíbe inventar um só para ganhar o botão. Sem
  bloco não há camada 3, e a camada 2 não alcança o fluxo do artigo (limite
  medido na §9), então no artigo o saldo é só o custo do rodapé: **+14px a 1512 e
  1440, +25px a 390**.
- Os três controles (entrada máxima, escala, reiniciar) vão como `children` do
  `VizFooter`, que é o que os deixa parados no pé do painel. O `↺ Reiniciar`
  continua sendo do componente: ele desfaz quatro estados do aluno, e o
  `viz.reset()` do hook só volta o passo.
- Identificadores em inglês, tela em português (§0 do contrato).

**Medido, com as oito famílias ligadas (o estado mais alto):**

| régua | `↺ Reiniciar` abaixo do pé visível | sobra da figura (a rolagem errada) | sobra do miolo (a certa) | artigo |
|---|---|---|---|---|
| 1512x900 | -57 → -65 (já cabia) | 0 → 0 | 0 → 0 | 735 → 749 (+14) |
| 1440x700 | **+131 → -37** | **175 → 0** | 0 → 145 | 749 → 763 (+14) |
| 1440x600 | **+231 → -35** | **275 → 0** | 0 → 240 | 749 → 763 (+14) |
| 390x844 | **+629 → -39** | **672 → 0** | 0 → 662 | 1371 → 1396 (+25) |

Rolando o miolo até o fim, o cabeçalho fica onde está (0px) nas três réguas.

### O seletor do teste

`CONTADOR` passa a ser `figure.viz-fit:has(.viz-code-slot)`, e os dois
`document.querySelector` recebem o mesmo seletor por argumento do `evaluate`.

O discriminante é o **slot** do bloco recolhível, não o bloco: `.viz-code-slot`
existe porque a peça **é** recolhível, enquanto o conteúdo dentro dele é o que um
dia pode virar condicional. Medido nos quatro estados que esses testes
atravessam (tela alta, tela baixa com o código já recolhido pela medição, código
recolhido na mão, painel expandido): casa 1 nos quatro, porque o contrato mantém
o bloco no DOM mesmo recolhido, que é o que permite medir o pior caso de altura.
Os outros candidatos (`.viz-code`, `.viz-toggle-codigo`, `.bigo-stats`) também
casam 1 nos quatro; a escolha entre eles é por estabilidade conceitual, não por
medição.

E entra um teste que **afirma os dois números** (2 na página, 1 em cada seletor),
lendo o rótulo do cabeçalho de cada peça. É ele que impede a próxima adaptação de
irmão de quebrar isto em silêncio.

## Como foi provado

`npm run test:build`: **465 passed, 0 failed**, exit 0. `npm run build` e
`npx tsc --noEmit` limpos.

**Nenhum texto de tela mudou.** O texto renderizado do build é idêntico ao da
`main` (diff vazio), e uma varredura de **265 estados** (4 conjuntos de famílias x
2 escalas x 11 entradas x 3 posições de marcador, mais o painel) sai sem uma
diferença. As duas provas são necessárias: o HTML do build só captura o estado
inicial, e o guarda de idioma não enxerga o `aria-valuetext` desta peça, que tem
crase aninhada dentro de `${...}` (o buraco documentado na §0 do contrato).

**Prova de quebra**, uma por vez, build sempre visível, alvo conferido com
`count == 1` antes de substituir, restauro por `cp` e rebuild no fim:

| quebra | resultado |
|---|---|
| A) `VizFooter` de volta para dentro do `.viz-body` (a quebra canônica da camada 1) | reprova: o controle anda **-141px** |
| B) `collapsible: true` | reprova: 1 botão prometendo esconder um bloco que não existe |
| C) sem `viz.inPanel` | reprovam 3 testes: o painel não existe |
| D) o número do cabeçalho perde a classe `.viz-step` | reprova: a página casa 1 onde espera 2 |
| E) a seta direita do canvas anda zero | reprova: `"n = 1"` onde se espera `"n = 10"` |
| F) **experimento no hook**: `hasSteps` valendo com `total: 1` | **inerte: 0 failed / 5 passed** |
| G) `CONTADOR` de volta a `figure.viz-fit` | reprova: 6 failed / 98 passed (os 5 originais + o guarda novo) |

**A F merece registro porque é a quebra que qualquer um escreveria e ela não
prova nada.** A ideia era mostrar que o hook rouba as setas de um canvas
`role="slider"` quando a peça tem linha do tempo. Não rouba: o listener do painel
é de captura no `document` e chama `preventDefault()`, **nunca
`stopPropagation()`**, então o `onKeyDown` do React no canvas dispara do mesmo
jeito e o marcador anda igual. Uma peça com `total > 1` e teclado próprio não
perde o controle para o hook, ela ganha um `stepBy` invisível de brinde. Quem
quiser provar que uma tecla é do componente precisa quebrar **o componente**.

A asserção que carrega a camada 1 é a **posição do `↺ Reiniciar` comparada com
ela mesma** antes e depois de o miolo rolar. As três premissas do §8 (o miolo
estoura, ele mesmo rola, a figura não rola) **passam** contra a quebra A, como o
contrato avisa, e por isso vêm depois da asserção que reprova.

Uma medição a mais, que é a prova de que o `viz.expanded` chegou até o desenho e
não só até a moldura: o canvas mede **300px no artigo e 400 no painel**.

Conferência de viewport em 1512x900, 1440x700 e 390x844, artigo e painel, com
cache furado: 0 overflow de página, 0 texto vazando da própria caixa, 0 rótulo
com fonte abaixo de 6px.

## O que NÃO mudou

- **Nenhum texto de tela**, provado acima nos 265 estados.
- **`src/app/globals.css`**: uma linha sequer. A medição não pediu CSS novo, e a
  camada 2 já alcança a peça pelo bloco compartilhado.
- **`src/lib/visualizer.tsx`**: quebrado como experimento (a F) e restaurado por
  `cp`; `git diff` sai vazio. Nenhuma mudança entregue.
- **`content/visualizers/README.md`**, `content/roadmap.ts`, `mdx-components.tsx`,
  `playwright.config.ts` e os `.mdx`: intocados.
- Os presets, a fórmula de Stirling, a escala logarítmica e o comportamento do
  marcador: idênticos.

## O número que este PR corrige

O placar que vinha sendo citado saía de `grep -l 'viz-overlay'`, e ele **conta só
quem tinha overlay do modelo antigo para converter**. Quem nunca teve overlay
entrava como zero, em silêncio, e é por isso que a dívida ficou invisível.
Reconferido hoje:

```
total em content/visualizers/:              87
com useVisualizer, depois deste PR:         62
com viz-overlay:                             0
fora do hook, mas vestindo figure.viz:      16
```

Ou seja: **62 de 87**, e **16 peças seguem mudas** — sem painel, sem cabeçalho
parado, sem teclado —, espalhadas por **10 páginas** (`backtracking`,
`binary-heap`, `binary-numbers`, `busca-binaria`, `heap-sort`, `merge-sort`,
`negative-binary`, `ordenacao-basica`, `quick-sort`, `shell-sort`). São elas:

`BacktrackingPoda`, `BinarioBases`, `BinarioConversor`, `BinarioFaixa`,
`BinarioTresFormas`, `BuscaBinariaOverflow`, `HeapIndicesVisualizer`,
`HeapSortEstabilidade`, `MergeEmpate`, `MergeSortNiveis`,
`OrdenacaoBasicaCorrida`, `OrdenacaoBasicaEstabilidade`, `QuickSortPivo`,
`QuickSortTresVias`, `ShellSortGaps`, `ShellSortSubsequencias`.

Elas não são o mesmo trabalho que os 62: não têm botão Expandir, então não há
painel a consertar. A pergunta para elas é outra (vale dar painel a esta peça?) e
é decisão editorial, não de adaptação.

## Nota de execução

O `node_modules` compartilhado do checkout principal está velho para a `origin/main`:
o PR #44 trouxe `@next/third-parties` e o build falha com o symlink. Esta branch
foi construída com `npm ci` na própria worktree.
