### PR TITLE
test: asserções que afirmam o valor, laços que provam o percurso e guardas que não envelhecem

### DIFF
--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -966,45 +966,91 @@ test("página de introdução explica o guia e leva ao primeiro tópico", async 
 
 // Cobertura de todos os tópicos "ready": em vez de um teste artesanal por
 // página, este bloco garante o contrato que toda página completa precisa
-// cumprir. Ao promover um tópico novo, acrescente o slug aqui.
-const TOPICOS_PRONTOS = [
-  { slug: "big-o", h1: "Notação Big O", vizMin: 2 },
-  { slug: "arrays", h1: "Arrays e Listas", vizMin: 3 },
-  { slug: "strings", h1: "Strings", vizMin: 3 },
-  { slug: "subarray-substring-subsequence-subset", h1: 'Os 4 "sub"', vizMin: 1 },
-  { slug: "two-pointers", h1: "Two Pointers", vizMin: 3 },
-  { slug: "sliding-window", h1: "Sliding Window", vizMin: 3 },
-  { slug: "prefix-sum", h1: "Prefix Sum", vizMin: 2 },
-  { slug: "intervals", h1: "Intervalos", vizMin: 2 },
-  { slug: "hash-table", h1: "Tabelas Hash", vizMin: 2 },
-  { slug: "listas-ligadas", h1: "Listas Encadeadas", vizMin: 3 },
-  { slug: "skip-list", h1: "Skip List", vizMin: 2 },
-  { slug: "pilhas", h1: "Pilhas (Stacks)", vizMin: 3 },
-  { slug: "filas", h1: "Filas e Deques", vizMin: 3 },
-  { slug: "recursao", h1: "Recursão: Fundamentos", vizMin: 2 },
-  { slug: "recursao-funcional", h1: "Recursão: Programação Funcional", vizMin: 2 },
-  { slug: "tree-traversals", h1: "Percursos em Árvore (DFS/BFS)", vizMin: 1 },
-  { slug: "arvores-binarias", h1: "Árvores Binárias", vizMin: 1 },
-  { slug: "n-ary-trees", h1: "Árvores N-árias", vizMin: 1 },
-  { slug: "bst", h1: "Árvore de Busca Binária", vizMin: 1 },
-  { slug: "grafos-intro", h1: "Introdução a Grafos", vizMin: 1 },
-  { slug: "dfs-bfs", h1: "DFS e BFS em Grafos", vizMin: 1 },
-  { slug: "dijkstra", h1: "Dijkstra", vizMin: 1 },
-  { slug: "bellman-ford", h1: "Bellman-Ford", vizMin: 1 },
-  { slug: "a-star", h1: "A* (A Estrela)", vizMin: 1 },
-  { slug: "topological-sort", h1: "Ordenação Topológica", vizMin: 1 },
-  { slug: "mst", h1: "Árvore Geradora Mínima (MST)", vizMin: 1 },
-  { slug: "binary-heap", h1: "Binary Heap", vizMin: 2 },
-  { slug: "heap-sort", h1: "Heap Sort", vizMin: 2 },
-  { slug: "busca-binaria", h1: "Busca Binária", vizMin: 3 },
-  { slug: "ordenacao-basica", h1: "Ordenação Básica", vizMin: 3 },
-  { slug: "merge-sort", h1: "Merge Sort", vizMin: 3 },
-  { slug: "quick-sort", h1: "Quick Sort", vizMin: 3 },
-  { slug: "shell-sort", h1: "Shell Sort", vizMin: 3 },
-  { slug: "backtracking", h1: "Backtracking", vizMin: 3 },
-  { slug: "binary-numbers", h1: "Números Binários", vizMin: 3 },
-  { slug: "negative-binary", h1: "Binários Negativos", vizMin: 3 },
-];
+// cumprir. Quatro guardas consomem esta lista — o contrato de página abaixo, os
+// controles de reprodução, o colapso de painel no celular e o overflow no
+// mobile.
+//
+// A LISTA DE SLUGS É DERIVADA de `ALL_TOPICS`, não escrita à mão. Escrita à mão
+// ela envelhece em silêncio: promover um tópico sem lembrar de acrescentá-lo
+// aqui deixa a página nova fora dos QUATRO guardas de uma vez, com o CI verde e
+// nenhum sinal de que faltou alguma coisa. São 11 promoções pela frente.
+//
+// O que continua à mão é a DESCRIÇÃO de cada tópico, e de propósito:
+//
+// - `h1` é conferência independente. Derivá-lo de `t.name` viraria tautologia,
+//   porque a página renderiza `t.name` — o teste passaria a comparar o dado com
+//   ele mesmo e pararia de pegar título trocado;
+// - `vizMin` não existe na fonte: `viz` é o nome de UM visualizador, não a
+//   contagem dos que o MDX de fato instancia.
+const DESCRICAO: Record<string, { h1: string; vizMin: number }> = {
+  "big-o": { h1: "Notação Big O", vizMin: 2 },
+  arrays: { h1: "Arrays e Listas", vizMin: 3 },
+  strings: { h1: "Strings", vizMin: 3 },
+  "subarray-substring-subsequence-subset": { h1: 'Os 4 "sub"', vizMin: 1 },
+  "two-pointers": { h1: "Two Pointers", vizMin: 3 },
+  "sliding-window": { h1: "Sliding Window", vizMin: 3 },
+  "prefix-sum": { h1: "Prefix Sum", vizMin: 2 },
+  intervals: { h1: "Intervalos", vizMin: 2 },
+  "hash-table": { h1: "Tabelas Hash", vizMin: 2 },
+  "listas-ligadas": { h1: "Listas Encadeadas", vizMin: 3 },
+  "skip-list": { h1: "Skip List", vizMin: 2 },
+  pilhas: { h1: "Pilhas (Stacks)", vizMin: 3 },
+  filas: { h1: "Filas e Deques", vizMin: 3 },
+  recursao: { h1: "Recursão: Fundamentos", vizMin: 2 },
+  "recursao-funcional": { h1: "Recursão: Programação Funcional", vizMin: 2 },
+  "tree-traversals": { h1: "Percursos em Árvore (DFS/BFS)", vizMin: 1 },
+  "arvores-binarias": { h1: "Árvores Binárias", vizMin: 1 },
+  "n-ary-trees": { h1: "Árvores N-árias", vizMin: 1 },
+  bst: { h1: "Árvore de Busca Binária", vizMin: 1 },
+  "grafos-intro": { h1: "Introdução a Grafos", vizMin: 1 },
+  "dfs-bfs": { h1: "DFS e BFS em Grafos", vizMin: 1 },
+  dijkstra: { h1: "Dijkstra", vizMin: 1 },
+  "bellman-ford": { h1: "Bellman-Ford", vizMin: 1 },
+  "a-star": { h1: "A* (A Estrela)", vizMin: 1 },
+  "topological-sort": { h1: "Ordenação Topológica", vizMin: 1 },
+  mst: { h1: "Árvore Geradora Mínima (MST)", vizMin: 1 },
+  "binary-heap": { h1: "Binary Heap", vizMin: 2 },
+  "heap-sort": { h1: "Heap Sort", vizMin: 2 },
+  "busca-binaria": { h1: "Busca Binária", vizMin: 3 },
+  "ordenacao-basica": { h1: "Ordenação Básica", vizMin: 3 },
+  "merge-sort": { h1: "Merge Sort", vizMin: 3 },
+  "quick-sort": { h1: "Quick Sort", vizMin: 3 },
+  "shell-sort": { h1: "Shell Sort", vizMin: 3 },
+  backtracking: { h1: "Backtracking", vizMin: 3 },
+  "binary-numbers": { h1: "Números Binários", vizMin: 3 },
+  "negative-binary": { h1: "Binários Negativos", vizMin: 3 },
+};
+
+// O fallback existe para que um tópico recém-promovido JÁ ENTRE nos quatro
+// guardas, mesmo antes de alguém descrevê-lo: `t.name` é o que a página
+// renderiza e `vizMin: 1` é o piso de qualquer página completa. Quem avisa que
+// falta descrever é o teste logo abaixo, e ele reprova alto.
+const TOPICOS_PRONTOS = ALL_TOPICS.filter((t) => t.status === "ready").map((t) => ({
+  slug: t.slug,
+  h1: DESCRICAO[t.slug]?.h1 ?? t.name,
+  vizMin: DESCRICAO[t.slug]?.vizMin ?? 1,
+}));
+
+test("todo tópico 'ready' está descrito na tabela dos guardas de contrato", () => {
+  const prontos = ALL_TOPICS.filter((t) => t.status === "ready").map((t) => t.slug);
+  const semDescricao = prontos.filter((s) => !DESCRICAO[s]);
+  const descritosDeMais = Object.keys(DESCRICAO).filter((s) => !prontos.includes(s));
+
+  // Promoveu um tópico? Ele já está rodando nos quatro guardas pelo fallback.
+  // O que falta é o `h1` e o `vizMin` de verdade, que são a parte que o dado
+  // não tem: sem eles, o contrato daquela página é o piso e não o dela.
+  expect(
+    semDescricao,
+    "tópicos promovidos a 'ready' sem entrada em DESCRICAO (acrescente h1 e vizMin)"
+  ).toEqual([]);
+  // E o contrário: entrada que sobrou aponta slug renomeado ou tópico que
+  // voltou para 'soon', e vira teste que nunca mais visita página nenhuma.
+  expect(
+    descritosDeMais,
+    "entradas de DESCRICAO que não correspondem a nenhum tópico 'ready'"
+  ).toEqual([]);
+  expect(TOPICOS_PRONTOS).toHaveLength(prontos.length);
+});
 
 for (const t of TOPICOS_PRONTOS) {
   test(`tópico ${t.slug} entrega artigo, visualizadores e âncoras válidas`, async ({ page }) => {

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Locator } from "@playwright/test";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 
 test("home mostra o hero e leva para o Big O", async ({ page }) => {
@@ -98,12 +98,18 @@ test("os três visualizadores de Two Pointers têm estado próprio e contam oper
   await page.goto("/topico/two-pointers/");
   const passos = page.locator(".viz-step");
   await page.getByRole("button", { name: /Próximo/ }).first().click();
-  await expect(passos.first()).toContainText("passo 2 de");
-  await expect(passos.nth(1)).toContainText("passo 1 de");
+  // regex ancorada: "passo 2 de" também é prefixo de "passo 20 de", e o número
+  // do passo é justamente o que este teste está afirmando.
+  await expect(passos.first()).toHaveText(/^passo 2 de \d+$/);
+  await expect(passos.nth(1)).toHaveText(/^passo 1 de \d+$/);
   // o preset do encontro fecha em 6 somas contra os 28 pares da força bruta
-  const convergente = page.locator(".viz").first();
+  const convergente = page.locator("figure.viz").filter({ hasText: "ponteiros convergentes" });
   await expect(convergente.getByText("pares na força bruta")).toBeVisible();
-  await expect(convergente.locator(".bigo-stat", { hasText: "pares na força bruta" })).toContainText("28");
+  // O card concatena rótulo e valor num nó só ("pares na força bruta28"), então
+  // `toContainText("28")` passaria com 128. O <strong> guarda só o número.
+  await expect(
+    convergente.locator(".bigo-stat", { hasText: "pares na força bruta" }).locator("strong")
+  ).toHaveText("28");
 });
 
 test("Strings traz os três visualizadores e os números do artigo batem com a tela", async ({ page }) => {
@@ -114,21 +120,27 @@ test("Strings traz os três visualizadores e os números do artigo batem com a t
   await expect(page.getByText("caractere, code point e byte")).toBeVisible();
   await expect(page.getByText("Rotate String, força bruta contra o truque")).toBeVisible();
 
-  // o painel de bytes vem primeiro e abre em CCC: 3 bytes em UTF-8, 6 em UTF-16
-  const bytes = page.locator(".viz").first();
-  await expect(bytes.locator(".str-enc.on .str-enc-val")).toContainText("3 bytes");
+  // As três peças são escolhidas pelo TÍTULO, não pela posição no DOM: `.nth(1)`
+  // amarra o teste à ordem do MDX e passa a testar outra peça se ela mudar.
+  // E o valor sai do <strong>: "3 bytes" é substring de "13 bytes".
+  const stat = (fig: Locator, rot: string) =>
+    fig.locator(".bigo-stat", { hasText: rot }).locator("strong");
+
+  // o painel de bytes abre em CCC: 3 bytes em UTF-8, 6 em UTF-16
+  const bytes = page.locator("figure.viz").filter({ hasText: "caractere, code point e byte" });
+  await expect(bytes.locator(".str-enc.on .str-enc-val")).toHaveText("3 bytes");
   await bytes.getByRole("button", { name: /^UTF-16/ }).click();
-  await expect(bytes.locator(".str-enc.on .str-enc-val")).toContainText("6 bytes");
+  await expect(bytes.locator(".str-enc.on .str-enc-val")).toHaveText("6 bytes");
 
   // o artigo promete 45 cópias com "s = s + c" e 9 com join para CRAFTCODE (n = 9)
-  const montagem = page.locator(".viz").nth(1);
-  await expect(montagem.locator(".bigo-stat", { hasText: "total com s = s + c" })).toContainText("45");
-  await expect(montagem.locator(".bigo-stat", { hasText: "total com join" })).toContainText("9");
+  const montagem = page.locator("figure.viz").filter({ hasText: "o custo de montar uma string" });
+  await expect(stat(montagem, "total com s = s + c")).toHaveText("45");
+  await expect(stat(montagem, "total com join")).toHaveText("9");
 
   // rotate: o preset "caso feliz" acha na 2a rotação, com 18 caracteres copiados
-  const rotate = page.locator(".viz").nth(2);
-  await expect(rotate.locator(".bigo-stat", { hasText: "pior caso com o laço" })).toContainText("45");
-  await expect(rotate.locator(".bigo-stat", { hasText: "pior caso com o truque" })).toContainText("10");
+  const rotate = page.locator("figure.viz").filter({ hasText: "Rotate String, força bruta" });
+  await expect(stat(rotate, "pior caso com o laço")).toHaveText("45");
+  await expect(stat(rotate, "pior caso com o truque")).toHaveText("10");
 
   await expect(page.getByRole("link", { name: "Rotate String", exact: true })).toHaveAttribute("href", /leetcode\.com/);
   await expect(page.getByRole("link", { name: "Longest Palindromic Substring", exact: true })).toHaveAttribute("href", /leetcode\.com/);
@@ -143,15 +155,19 @@ test("Tabelas Hash: os contadores da tela batem com os números do artigo", asyn
   await expect(page.locator(".ht-tab-table tbody tr")).toHaveCount(4);
 
   // o artigo promete: anagramas colidem em 3 e custam 6 comparações
-  const insercao = page.locator(".viz").first();
+  const insercao = page.locator("figure.viz").filter({ hasText: "inserindo chaves numa tabela hash" });
   await insercao.getByRole("button", { name: "Anagramas: o pior caso" }).click();
   const proximo = insercao.getByRole("button", { name: /Próximo/ });
   for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
-  await expect(insercao.locator(".viz-note")).toContainText("3 colisões");
-  await expect(insercao.locator(".viz-note")).toContainText("6 comparações de chave");
+  // A nota inteira, não os dois pedaços: "3 colisões" é substring de "13
+  // colisões" e "6 comparações" de "16 comparações", e os dois números são a
+  // aula do preset. Ler a frase toda ainda pega o fator de carga do lado.
+  await expect(insercao.locator(".viz-note")).toHaveText(
+    "Fim: 4 chaves em 5 buckets, fator de carga 0,80. Deu 3 colisões e 6 comparações de chave no caminho todo."
+  );
 
   // a corrida: com hash bom o pior caso com 1 milhão é 1; com hash ruim, 1 milhão
-  const busca = page.locator(".viz").nth(1);
+  const busca = page.locator("figure.viz").filter({ hasText: "busca linear x busca por hash" });
   const piorHash = busca.locator(".bigo-stat", { hasText: "pior caso · hash com 1 milhão" }).locator("strong");
   await expect(piorHash).toHaveText("1");
   await busca.getByRole("button", { name: /Hash ruim/ }).click();
@@ -174,8 +190,8 @@ test("Sliding Window reúne janela fixa e variável na mesma página", async ({ 
   // as duas instâncias têm estado próprio: avançar uma não mexe na outra
   const passos = page.locator(".viz-step");
   await page.getByRole("button", { name: /Próximo/ }).first().click();
-  await expect(passos.first()).toContainText("passo 2 de");
-  await expect(passos.nth(1)).toContainText("passo 1 de");
+  await expect(passos.first()).toHaveText(/^passo 2 de \d+$/);
+  await expect(passos.nth(1)).toHaveText(/^passo 1 de \d+$/);
   // os problemas das duas variações convivem na mesma lista
   await expect(page.getByRole("link", { name: /Maximum Average Subarray I/ }).first()).toBeVisible();
   await expect(page.getByRole("link", { name: /Minimum Size Subarray Sum/ }).first()).toBeVisible();
@@ -1218,27 +1234,29 @@ test("busca binária: descarta metade por passo e para no ponto de inserção", 
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   };
 
-  // 8 posições, alvo no meio: 3 comparações contra as 5 da busca linear
+  // 8 posições, alvo no meio: 3 comparações contra as 5 da busca linear.
+  // O card concatena rótulo e valor num nó só ("comparações até aqui3"), então
+  // `toContainText("3")` passaria com 13 ou 30. O <strong> guarda só o número,
+  // e `toHaveText` exige o valor exato.
   await irAteOFim();
-  const stat = (rot: RegExp) => viz.locator(".bigo-stat").filter({ hasText: rot });
-  await expect(stat(/^comparações até aqui\d/)).toContainText("3");
-  await expect(stat(/^busca linear gastaria\d/)).toContainText("5");
+  const stat = (rot: RegExp) => viz.locator(".bigo-stat").filter({ hasText: rot }).locator("strong");
+  await expect(stat(/^comparações até aqui\d/)).toHaveText("3");
+  await expect(stat(/^busca linear gastaria\d/)).toHaveText("5");
   // "descartadas sem ler" não conta a posição do meio, que foi lida. Com 8
   // posições, 3 lidas e 5 descartadas fecham o array inteiro, e é essa
   // invariante que mantém a estatística honesta.
-  await expect(stat(/^descartadas sem ler\d/)).toContainText("5");
+  await expect(stat(/^descartadas sem ler\d/)).toHaveText("5");
 
   // dobrar o array de 8 para 16 acrescenta UMA comparação, não dobra o trabalho
   await viz.getByRole("button", { name: /16 posições/ }).click();
   await irAteOFim();
-  await expect(stat(/^comparações até aqui\d/)).toContainText("4");
+  await expect(stat(/^comparações até aqui\d/)).toHaveText("4");
 
   // num alvo ausente a busca varre o espaço inteiro, então lidas + descartadas
   // tem que fechar exatamente em n
   await viz.getByRole("button", { name: /não existe: 40/ }).click();
   await irAteOFim();
-  const numero = async (rot: RegExp) =>
-    parseInt(((await stat(rot).textContent()) ?? "").replace(/\D+/g, "").slice(-2), 10);
+  const numero = async (rot: RegExp) => parseInt((await stat(rot).innerText()).trim(), 10);
   const lidas = await numero(/^comparações até aqui\d/);
   const cegas = await numero(/^descartadas sem ler\d/);
   expect(lidas + cegas, "toda posição é lida ou descartada, exatamente uma vez").toBe(8);
@@ -1257,8 +1275,10 @@ test("busca binária: a fórmula ingênua do meio estoura o inteiro de 32 bits",
   await viz.getByRole("button", { name: /Alguns passos depois/ }).click();
   await expect(viz.locator(".viz-step")).toHaveText("as duas discordam");
   await expect(viz.locator(".bb-bit.sinal")).toHaveClass(/\bon\b/);
-  await expect(viz.locator(".bb-formula").first().locator("li b").last()).toContainText("-397.483.648");
-  await expect(viz.locator(".bb-formula").nth(1).locator("li b").last()).toContainText("1.750.000.000");
+  // texto exato: "-397.483.648" é substring de "-1.397.483.648", e o sinal e a
+  // magnitude do estouro são a aula inteira desta peça
+  await expect(viz.locator(".bb-formula").first().locator("li b").last()).toHaveText("-397.483.648");
+  await expect(viz.locator(".bb-formula").nth(1).locator("li b").last()).toHaveText("1.750.000.000");
 });
 
 test("fronteira: a mesma busca devolve primeira, última e ponto de inserção", async ({ page }) => {
@@ -1269,34 +1289,38 @@ test("fronteira: a mesma busca devolve primeira, última e ponto de inserção",
     await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
-    return viz.locator(".bigo-stat").filter({ hasText: rot });
+    // O card concatena rótulo e valor num nó só, então uma asserção de substring
+    // no card inteiro passa com qualquer número que contenha o esperado ("1"
+    // passa com -10). O <strong> guarda só o valor.
+    return viz.locator(".bigo-stat").filter({ hasText: rot }).locator("strong");
   };
 
   // [1, 3, 3, 3, 5, 8, 8, 11, 14] procurando 3: bloco nas posições 1, 2 e 3
-  await expect(await resposta(/^primeira ocorrência/)).toContainText("1");
+  await expect(await resposta(/^primeira ocorrência/)).toHaveText("1");
   await viz.getByRole("button", { name: "última ocorrência" }).click();
-  await expect(await resposta(/^última ocorrência/)).toContainText("3");
+  await expect(await resposta(/^última ocorrência/)).toHaveText("3");
 
   // um valor ausente: a busca falha, mas a posição de inserção sai de graça
   await viz.getByRole("button", { name: "onde entraria" }).click();
   await viz.getByRole("button", { name: /não existe: 7/ }).click();
-  await expect(await resposta(/^onde o valor entraria/)).toContainText("5");
+  await expect(await resposta(/^onde o valor entraria/)).toHaveText("5");
   // o retorno negativo é o do caso de FALHA: -(5) - 1
-  const retorno = viz.locator(".bigo-stat").filter({ hasText: /^retorno do Arrays/ });
-  await expect(retorno).toContainText("-6");
+  const retorno = viz.locator(".bigo-stat").filter({ hasText: /^retorno do Arrays/ }).locator("strong");
+  await expect(retorno).toHaveText("-6");
 
   // Regressão: com o alvo PRESENTE o card mostrava o negativo do mesmo jeito,
   // mas aí o Arrays.binarySearch devolve o índice. O 3 existe na posição 1.
+  // `toHaveText("1")` já reprova qualquer negativo, então o `not.toContainText`
+  // que existia aqui virou redundante.
   await viz.getByRole("button", { name: /bloco de três iguais/ }).click();
   await resposta(/^onde o valor entraria/);
-  await expect(retorno).toContainText("1");
-  await expect(retorno).not.toContainText("-");
+  await expect(retorno).toHaveText("1");
 
   // Borda de cima: a esquerda para em 9, que é o tamanho do array e não indexa
   // ninguém. É onde a checagem de existência leria fora do intervalo.
   await viz.getByRole("button", { name: /Maior que tudo/ }).click();
-  await expect(await resposta(/^onde o valor entraria/)).toContainText("9");
-  await expect(retorno).toContainText("-10");
+  await expect(await resposta(/^onde o valor entraria/)).toHaveText("9");
+  await expect(retorno).toHaveText("-10");
 });
 
 test("ordenação básica: o selection sort não tem melhor caso", async ({ page }) => {
@@ -1352,7 +1376,11 @@ test("ordenação básica: as barras batem com o passo a passo e a lei das inver
 
   // preset embaralhado (12 inversões): os números são os mesmos que o
   // visualizador de passo a passo mostra, porque saem do mesmo gerador
-  await expect(corrida.locator(".viz-step")).toContainText("12 inversões");
+  // a linha inteira: "12 inversões" é substring de "112 inversões", e os três
+  // números (inversões, piso e teto) são o que as barras abaixo têm que bater
+  await expect(corrida.locator(".viz-step")).toHaveText(
+    "12 inversões na entrada · piso 7, teto 28 comparações"
+  );
   await expect(barras(0)).toHaveText(["25", "24"]); // bubble: 2 x 12 inversões
   await expect(barras(1)).toHaveText(["28", "12"]); // selection: sempre 28
   await expect(barras(2)).toHaveText(["17", "19"]); // insertion: 12 + 7 colocações
@@ -1416,7 +1444,9 @@ test("merge sort: o custo não depende dos dados, e o empate depende do sinal", 
   await expect(niveis.locator(".ms-nivel")).toHaveCount(5);
   await niveis.getByRole("button", { name: "n = 64" }).click();
   await expect(niveis.locator(".ms-nivel")).toHaveCount(7);
-  await expect(niveis.locator(".viz-step")).toContainText("6 rodadas de intercalação x 64 elementos = 384");
+  await expect(niveis.locator(".viz-step")).toHaveText(
+    "6 rodadas de intercalação x 64 elementos = 384 movimentos"
+  );
 
   // estabilidade: o mesmo merge com <= e com <, e só o segundo inverte empates
   const empate = page.locator("figure.viz").filter({ hasText: "o sinal que decide a estabilidade" });
@@ -1482,13 +1512,23 @@ test("quick sort: o pior caso mora nas entradas mais comuns", async ({ page }) =
 
   // três vias: com o array constante a faixa dos iguais sai da recursão inteira
   const vias = page.locator("figure.viz").filter({ hasText: "o que fazer com os iguais" });
-  await expect(vias.locator(".ms-op").nth(0)).toContainText("28 comparações · profundidade 8");
-  await expect(vias.locator(".ms-op").nth(1)).toContainText("16 comparações · profundidade 1");
-  await expect(vias.locator(".ms-op").nth(1)).toContainText("nenhum subproblema");
+  // O selo é o nó que guarda só os dois números: no `.ms-op` inteiro,
+  // "28 comparações" passaria com "128 comparações" e "profundidade 1" com
+  // "profundidade 10", que é a diferença entre as duas partições.
+  const selo = (i: number) => vias.locator(".ms-op").nth(i).locator(".bb-formula-selo");
+  await expect(selo(0)).toHaveText("28 comparações · profundidade 8");
+  await expect(selo(1)).toHaveText("16 comparações · profundidade 1");
+  // BUG DE PRODUTO (não é desta lane): o ramo sem subproblema entra no meio da
+  // frase e produz "sobram nenhum subproblema: acabou aqui para a recursão
+  // resolver" — QuickSortTresVias.tsx:186-192. A asserção grava o texto ATUAL,
+  // para que o conserto seja um diff visível em vez de passar despercebido.
+  await expect(vias.locator(".ms-op").nth(1).locator(".bb-formula-fim")).toHaveText(
+    "Depois da primeira partição sobram nenhum subproblema: acabou aqui para a recursão resolver."
+  );
   // sem repetidos ela não é melhor: mesma profundidade e o dobro de comparações
   await vias.getByRole("button", { name: /Sem repetição/ }).click();
-  await expect(vias.locator(".ms-op").nth(0)).toContainText("18 comparações · profundidade 5");
-  await expect(vias.locator(".ms-op").nth(1)).toContainText("35 comparações · profundidade 5");
+  await expect(selo(0)).toHaveText("18 comparações · profundidade 5");
+  await expect(selo(1)).toHaveText("35 comparações · profundidade 5");
 });
 
 test("shell sort: a h-ordenação não se perde e o gap só compensa com n grande", async ({ page }) => {
@@ -1515,7 +1555,7 @@ test("shell sort: a h-ordenação não se perde e o gap só compensa com n grand
   await sub.getByRole("button", { name: "Rodada 3: gap 1" }).click();
   await expect(selos).toHaveText(["4-ordenado: sim", "2-ordenado: sim", "1-ordenado: sim"]);
   // com gap 1 existe uma subsequência só, e ela é o array inteiro
-  await expect(sub.locator(".viz-step")).toContainText("1 subsequência de 8 elementos");
+  await expect(sub.locator(".viz-step")).toHaveText("gap 1 · 1 subsequência de 8 elementos");
 
   // o cruzamento: com 8 elementos o shell sort perde, com 128 ele ganha de longe
   const gaps = page.locator("figure.viz").filter({ hasText: "a partir de que tamanho o gap compensa" });
@@ -1560,8 +1600,14 @@ test("backtracking: escolher, explorar e desfazer, com a lista voltando ao iníc
   await expect(stat(/^soluções encontradas\d/)).toHaveText("8");
   // a invariante: um retrocesso por aresta, ou seja, nós - 1
   await expect(stat(/^retrocessos\d/)).toHaveText("7");
-  // e a solução parcial termina vazia, porque todo escolher teve o seu desfazer
-  await expect(viz.locator(".hp-bloco").first()).toContainText("vazia");
+  // e a solução parcial termina vazia, porque todo escolher teve o seu desfazer.
+  // O bloco é escolhido pelo TÍTULO, não por `.first()`: a peça tem três
+  // `.hp-bloco` (parcial, pilha de chamadas e soluções) e dois deles também
+  // sabem escrever "vazia", então o `.first()` fazia a asserção depender da
+  // ordem no DOM para não estar lendo o painel errado.
+  await expect(
+    viz.locator(".hp-bloco").filter({ hasText: "A solução parcial" }).locator(".bb-array-nota")
+  ).toHaveText("vazia");
 
   // permutações: só as folhas são resposta, então 16 nós para 6 soluções
   await viz.getByRole("button", { name: /Permutações/ }).click();
@@ -1638,8 +1684,12 @@ test("números binários: a soma das posições ligadas e as divisões por 2", a
   for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
   await expect(proximo).toBeDisabled();
   await expect(div.locator(".bigo-stat").filter({ hasText: /^divisões feitas\d/ }).locator("strong")).toHaveText("8");
-  await expect(div.locator(".viz-note")).toContainText("11001001");
-  await expect(div.locator(".viz-note")).toContainText("128 + 64 + 8 + 1 = 201");
+  // A nota inteira: "11001001" é substring de "111001001" e a contagem de
+  // divisões dita a de bits significativos, então os dois números só provam
+  // alguma coisa lidos junto com a frase que os relaciona.
+  await expect(div.locator(".viz-note")).toHaveText(
+    "Cheguei a zero, então acabou: 201 em binário é 11001001. Foram 8 divisões para 8 bits significativos, e os zeros à esquerda entram só para completar o byte. Conferindo pelo outro caminho: 128 + 64 + 8 + 1 = 201."
+  );
 
   // as bases: o mesmo número escrito de quatro formas, e hexa em grupos de 4 bits
   const bases = page.locator("figure.viz").filter({ hasText: "a base é um parâmetro" });
@@ -1663,10 +1713,15 @@ test("binários negativos: complemento de dois, zero único e o padrão sem sina
   await expect(comp.locator(".viz-note")).toContainText("11100110");
   await expect(comp.locator(".viz-note")).toContainText("vai-um sobrando");
 
-  // o zero é o caso que prova a ausência de ambiguidade: o oposto dele é ele
+  // O zero é o caso que prova a ausência de ambiguidade: o oposto dele é ele.
+  // Rótulo e valor no mesmo par, e valor exato: `.nth(2)` dependia da ordem das
+  // três fichas, e `toContainText("0")` passava com 10, -128 ou 0x00 — inclusive
+  // com o número que este teste existe para descartar.
   await comp.getByRole("button", { name: /teste da ambiguidade/ }).click();
   await irAteOFim();
-  await expect(comp.locator(".viz-var").nth(2)).toContainText("0");
+  await expect(
+    comp.locator(".viz-var").filter({ hasText: "em construção (com sinal)" }).locator(".viz-var-val")
+  ).toHaveText("0");
 
   // as três convenções: só o complemento de dois tem um zero e soma zero
   const tres = page.locator("figure.viz").filter({ hasText: "três formas de escrever um negativo" });

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -158,7 +158,11 @@ test("Tabelas Hash: os contadores da tela batem com os números do artigo", asyn
   const insercao = page.locator("figure.viz").filter({ hasText: "inserindo chaves numa tabela hash" });
   await insercao.getByRole("button", { name: "Anagramas: o pior caso" }).click();
   const proximo = insercao.getByRole("button", { name: /Próximo/ });
+  // O laço sai CALADO se o limite estourar, e a asserção seguinte roda num passo
+  // do meio. Exigir o botão desabilitado é o que transforma "andei até o fim" em
+  // fato verificado.
   for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
+  await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   // A nota inteira, não os dois pedaços: "3 colisões" é substring de "13
   // colisões" e "6 comparações" de "16 comparações", e os dois números são a
   // aula do preset. Ler a frase toda ainda pega o fator de carga do lado.
@@ -1029,6 +1033,9 @@ test("percursos em árvore: trocar a ordem muda a saída, não o caminho", async
   const irAteOFim = async () => {
     const proximo = viz.getByRole("button", { name: "Próximo ›" });
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
+    // Sem isto o laço sai calado quando o limite estoura e a saída é lida num
+    // passo do meio — que, num percurso, é um prefixo válido da lista esperada.
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   };
 
   // as quatro sequências da árvore do artigo (raiz 1, esquerda 2 com 4 e 5, direita 3 com 6)
@@ -1159,6 +1166,7 @@ test("heap: remover o topo repetidamente devolve os valores em ordem", async ({ 
   await viz.getByRole("button", { name: "remover o topo" }).click();
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
   for (let i = 0; i < 200 && (await proximo.isEnabled()); i++) await proximo.click();
+  await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   // asserção web-first: reconsulta até a saída completa aparecer
   await expect(viz.locator(".tt-saida-item")).toHaveText(["1", "2", "3", "4", "5", "6"]);
 });
@@ -1196,6 +1204,7 @@ test("heap sort: a fronteira anda e o array sai ordenado", async ({ page }) => {
   const viz = page.locator("figure.viz").filter({ hasText: "heap sort: duas fases no mesmo array" });
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
   for (let i = 0; i < 200 && (await proximo.isEnabled()); i++) await proximo.click();
+  await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   // no fim, toda posição está congelada e na ordem crescente
   await expect(viz.locator(".hp-cel.fixo")).toHaveCount(10);
   // cada célula concatena índice e valor: posição 0 com o valor 1 lê "01"

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -158,6 +158,11 @@ test("Tabelas Hash: os contadores da tela batem com os números do artigo", asyn
   const insercao = page.locator("figure.viz").filter({ hasText: "inserindo chaves numa tabela hash" });
   await insercao.getByRole("button", { name: "Anagramas: o pior caso" }).click();
   const proximo = insercao.getByRole("button", { name: /Próximo/ });
+  // `isEnabled()` lê UMA vez: logo depois de trocar de preset ele ainda pode
+  // devolver o estado desabilitado do fim da rodada anterior, o laço não clica e
+  // o `toBeDisabled()` do fim passa sobre esse mesmo estado velho — a asserção
+  // volta a ser vazia pelo outro lado da janela.
+  await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
   // O laço sai CALADO se o limite estourar, e a asserção seguinte roda num passo
   // do meio. Exigir o botão desabilitado é o que transforma "andei até o fim" em
   // fato verificado.
@@ -1032,6 +1037,10 @@ test("percursos em árvore: trocar a ordem muda a saída, não o caminho", async
   const viz = page.locator("figure.viz").first();
   const irAteOFim = async () => {
     const proximo = viz.getByRole("button", { name: "Próximo ›" });
+    // Este helper roda logo depois de trocar a ordem do percurso, que é o caso
+    // exato em que a leitura única de `isEnabled()` devolve o estado da rodada
+    // anterior e o laço inteiro é pulado.
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
     // Sem isto o laço sai calado quando o limite estoura e a saída é lida num
     // passo do meio — que, num percurso, é um prefixo válido da lista esperada.
@@ -1165,6 +1174,7 @@ test("heap: remover o topo repetidamente devolve os valores em ordem", async ({ 
   const viz = page.locator("figure.viz").filter({ hasText: "a árvore e o array do heap se movendo juntos" });
   await viz.getByRole("button", { name: "remover o topo" }).click();
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
   for (let i = 0; i < 200 && (await proximo.isEnabled()); i++) await proximo.click();
   await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   // asserção web-first: reconsulta até a saída completa aparecer
@@ -1203,6 +1213,7 @@ test("heap sort: a fronteira anda e o array sai ordenado", async ({ page }) => {
   await page.goto("/topico/heap-sort/");
   const viz = page.locator("figure.viz").filter({ hasText: "heap sort: duas fases no mesmo array" });
   const proximo = viz.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
   for (let i = 0; i < 200 && (await proximo.isEnabled()); i++) await proximo.click();
   await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
   // no fim, toda posição está congelada e na ordem crescente

--- a/tests/viz-arrays.spec.ts
+++ b/tests/viz-arrays.spec.ts
@@ -268,6 +268,7 @@ test("array dinâmico: a nota do fim explica a capacidade reservada em portuguê
 
   const proximo = fig.getByRole("button", { name: /Próximo/ });
   for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
+  await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
 
   const [atual, total] = await passo(fig);
   expect(atual, "a animação não chegou ao último passo").toBe(total);

--- a/tests/viz-arrays.spec.ts
+++ b/tests/viz-arrays.spec.ts
@@ -267,6 +267,9 @@ test("array dinâmico: a nota do fim explica a capacidade reservada em portuguê
   await fig.getByRole("button", { name: "capacidade reservada" }).click();
 
   const proximo = fig.getByRole("button", { name: /Próximo/ });
+  // Depois do clique no preset, a leitura única de `isEnabled()` pode devolver
+  // o estado do fim da rodada anterior e pular o laço inteiro.
+  await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
   for (let i = 0; i < 60 && (await proximo.isEnabled()); i++) await proximo.click();
   await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
 

--- a/tests/viz-arrays.spec.ts
+++ b/tests/viz-arrays.spec.ts
@@ -215,7 +215,9 @@ test("memória contígua: clicar numa célula muda o índice, o endereço e a co
 
   // O rótulo ao lado do número, não só o número: base + 6 × 4 = 0x1018.
   await expect(fig.locator(".arr-formula")).toHaveText(/nums\[6\] = 0x1000 \+ 6 × 4 = 0x1018/);
-  await expect(fig.locator(".viz-var").filter({ hasText: "endereço" })).toContainText("0x1018");
+  await expect(
+    fig.locator(".viz-var").filter({ hasText: "endereço" }).locator(".viz-var-val")
+  ).toHaveText("0x1018");
   expect((await passo(fig))[0]).toBe(7);
   await expect(fig.locator(".viz-note")).toContainText("multiplico 6 × 4 = 24 bytes");
 });
@@ -252,7 +254,11 @@ test("array dinâmico: dobrar copia menos que crescer de um em um", async ({ pag
   const dobrar = await cartao("dobrar (×2)").locator(".bigo-card-val").innerText();
   const umPorVez = await cartao("uma vaga por vez (+1)").locator(".bigo-card-val").innerText();
   expect(parseFloat(dobrar.replace(",", "."))).toBeLessThan(parseFloat(umPorVez.replace(",", ".")));
-  await expect(cartao("capacidade reservada")).toContainText("0 realocações");
+  // A linha inteira, no nó que a guarda: "0 realocações" é substring de
+  // "10 realocações", e zero realocação é exatamente o que este preset promete.
+  await expect(cartao("capacidade reservada").locator(".bigo-card-ex").first()).toHaveText(
+    "0 cópias · 0 realocações · capacidade final 20"
+  );
 });
 
 test("array dinâmico: a nota do fim explica a capacidade reservada em português", async ({ page }) => {
@@ -297,7 +303,9 @@ test("memória contígua: dois cliques rápidos param na célula clicada por úl
   // conta do endereço e o painel de variáveis. 0x1000 + 2 × 4 = 0x1008.
   expect((await passo(fig))[0]).toBe(3);
   await expect(fig.locator(".arr-formula")).toHaveText(/nums\[2\] = 0x1000 \+ 2 × 4 = 0x1008/);
-  await expect(fig.locator(".viz-var").filter({ hasText: "endereço" })).toContainText("0x1008");
+  await expect(
+    fig.locator(".viz-var").filter({ hasText: "endereço" }).locator(".viz-var-val")
+  ).toHaveText("0x1008");
   await expect(fig.getByRole("button", { name: "Índice 2, valor 45, endereço 0x1008" })).toHaveAttribute(
     "aria-pressed",
     "true"

--- a/tests/viz-backtracking.spec.ts
+++ b/tests/viz-backtracking.spec.ts
@@ -159,9 +159,12 @@ test("árvore: mostrar o código sobrevive à troca de modo", async ({ page }) =
   await abrirPagina(page, 1440, 700);
   const fig = await figura(page, ARVORE);
   const cartao = fig.locator(".bigo-stat", { hasText: "nós da árvore inteira" });
+  // O card concatena rótulo e valor num nó só ("nós da árvore inteira8"), então
+  // `toContainText("8")` passa com 18 ou 80. O <strong> guarda só o número.
+  const valor = cartao.locator("strong");
 
   await expect(fig).toHaveAttribute("data-codigo", "off");
-  await expect(cartao).toContainText("8");
+  await expect(valor).toHaveText("8");
 
   await fig.locator(".viz-toggle-codigo").click();
   await expect(fig).toHaveAttribute("data-codigo", "on");
@@ -171,7 +174,7 @@ test("árvore: mostrar o código sobrevive à troca de modo", async ({ page }) =
   await fig.locator("button", { hasText: "Combinações de 2 entre 1, 2, 3, 4" }).click();
   // A troca aconteceu mesmo na tela: rótulo e valor no MESMO cartão.
   await expect(cartao).toContainText("nós da árvore inteira");
-  await expect(cartao).toContainText("10");
+  await expect(valor).toHaveText("10");
 
   await expect(fig).toHaveAttribute("data-codigo", "on");
   await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");
@@ -181,10 +184,12 @@ test("sudoku: mostrar o código sobrevive à troca de preset", async ({ page }) 
   await abrirPagina(page, 1440, 700);
   const fig = await figura(page, SUDOKU);
   const cartao = fig.locator(".bigo-stat", { hasText: "lacunas do tabuleiro" });
+  // Mesmo motivo do teste acima: no card inteiro, "11" passa com 11, 110 ou 211.
+  const valor = cartao.locator("strong");
 
   await expect(fig).toHaveAttribute("data-codigo", "off");
   await expect(fig.locator(".bt-cel")).toHaveCount(16);
-  await expect(cartao).toContainText("11");
+  await expect(valor).toHaveText("11");
 
   await fig.locator(".viz-toggle-codigo").click();
   await expect(fig).toHaveAttribute("data-codigo", "on");
@@ -193,7 +198,7 @@ test("sudoku: mostrar o código sobrevive à troca de preset", async ({ page }) 
   await fig.locator("button", { hasText: "9x9 com 20 lacunas" }).click();
   await expect(fig.locator(".bt-cel")).toHaveCount(81);
   await expect(cartao).toContainText("lacunas do tabuleiro");
-  await expect(cartao).toContainText("20");
+  await expect(valor).toHaveText("20");
 
   await expect(fig).toHaveAttribute("data-codigo", "on");
   await expect(fig.locator(".viz-toggle-codigo")).toHaveText("Ocultar código");

--- a/tests/viz-busca-binaria.spec.ts
+++ b/tests/viz-busca-binaria.spec.ts
@@ -327,6 +327,10 @@ test.describe("as contas que a tela promete", () => {
     await fig.getByRole("button", { name: "Um valor que não existe: 40" }).click();
 
     const proximo = fig.getByRole("button", { name: "Próximo ›" });
+    // `isDisabled()` lê UMA vez, e o laço vem logo depois de trocar de preset:
+    // com o estado velho o laço não clica e o `toBeDisabled()` abaixo passa
+    // sobre esse mesmo estado, sem um único passo andado.
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 40 && !(await proximo.isDisabled()); i++) await proximo.click();
     await expect(proximo).toBeDisabled();
 
@@ -356,6 +360,7 @@ test.describe("as contas que a tela promete", () => {
     await fig.getByRole("button", { name: "onde entraria", exact: true }).click();
 
     const proximo = fig.getByRole("button", { name: "Próximo ›" });
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 40 && !(await proximo.isDisabled()); i++) await proximo.click();
     await expect(proximo).toBeDisabled();
 

--- a/tests/viz-filas.spec.ts
+++ b/tests/viz-filas.spec.ts
@@ -346,11 +346,15 @@ test("o contador de movimentações separa a fila ingênua do buffer circular", 
 
   // Rótulo e valor no MESMO cartão: é o par que ensina, e é o par que um rename
   // com dois campos trocados de lugar quebraria sem o guarda de idioma acusar.
-  await expect(movs).toContainText("0");
+  // O `filter` prende o rótulo; o `<strong>` isola o valor, porque no card
+  // inteiro `toContainText("0")` passa com 10, 20 ou 70 — e "0 contra 7" é
+  // justamente o aha deste tópico.
+  const valorDe = (card: typeof movs) => card.locator("strong");
+  await expect(valorDe(movs)).toHaveText("0");
   await irAteOFim(peca);
   await expect(peca.locator(".viz-step")).toHaveText("passo 27 de 27");
-  await expect(movs).toContainText("7");
-  await expect(custo).toContainText("O(n)");
+  await expect(valorDe(movs)).toHaveText("7");
+  await expect(valorDe(custo)).toHaveText("O(n)");
   await expect(peca.locator(".viz-note")).toContainText("Repare no resíduo");
 
   // O mesmo roteiro no buffer circular: zero movimentação, e o custo muda de
@@ -358,7 +362,7 @@ test("o contador de movimentações separa a fila ingênua do buffer circular", 
   await peca.getByRole("button", { name: "buffer circular" }).click();
   await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 27");
   await irAteOFim(peca);
-  await expect(movs).toContainText("0");
-  await expect(custo).toContainText("O(1)");
+  await expect(valorDe(movs)).toHaveText("0");
+  await expect(valorDe(custo)).toHaveText("O(1)");
   await expect(peca.locator(".viz-var").filter({ hasText: "devolvido" })).toContainText("B");
 });

--- a/tests/viz-hash-table.spec.ts
+++ b/tests/viz-hash-table.spec.ts
@@ -310,9 +310,12 @@ test("os cartões da busca leem rótulo e valor juntos, no mesmo cartão", async
   await expect(cartao("pior caso · lista com 1 milhão")).toHaveText("1.000.000");
   await expect(cartao("pior caso · hash com 1 milhão")).toHaveText("1");
 
-  // O título de cada painel carrega o mesmo número do cartão dele.
-  await expect(peca.locator(".ht-painel-tit").first()).toContainText("2 comparações");
-  await expect(peca.locator(".ht-painel-tit").nth(1)).toContainText("1 comparação");
+  // O título de cada painel carrega o mesmo número do cartão dele. O <em> é o
+  // nó que guarda só o par número + unidade: no título inteiro,
+  // "2 comparações" passa com "12 comparações", que é o contrário da aula.
+  const selo = (i: number) => peca.locator(".ht-painel-tit").nth(i).locator("em");
+  await expect(selo(0)).toHaveText("2 comparações");
+  await expect(selo(1)).toHaveText("1 comparação");
 
   // E com o hash ruim os dois empatam: é o O(n) do pior caso aparecendo.
   await peca.getByRole("button", { name: "Com hash ruim" }).click();

--- a/tests/viz-mst.spec.ts
+++ b/tests/viz-mst.spec.ts
@@ -107,6 +107,10 @@ async function irAoFim(page: Page, raiz: string) {
   const proximo = page.locator(raiz).getByRole("button", { name: "Próximo ›" });
   for (let i = 1; i < total; i++) await proximo.click();
   await expect(page.locator(raiz).locator(".viz-step").last()).toHaveText(`passo ${total} de ${total}`);
+  // O contador diz onde a peça está; o botão desabilitado diz que ela ACABOU.
+  // São afirmações diferentes: um `total` lido errado deixa as duas primeiras
+  // asserções coerentes entre si e erradas em relação à animação.
+  await expect(proximo, "o percurso não chegou ao fim: Próximo continua ativo").toBeDisabled();
   return total;
 }
 

--- a/tests/viz-mst.spec.ts
+++ b/tests/viz-mst.spec.ts
@@ -105,6 +105,9 @@ async function painelPronto(page: Page) {
 async function irAoFim(page: Page, raiz: string) {
   const { total } = await page.evaluate(contador, raiz);
   const proximo = page.locator(raiz).getByRole("button", { name: "Próximo ›" });
+  // Os dois lados da janela: o percurso começa no início (senão os cliques caem
+  // num botão já desabilitado e o contador nunca sai do lugar) e termina no fim.
+  await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
   for (let i = 1; i < total; i++) await proximo.click();
   await expect(page.locator(raiz).locator(".viz-step").last()).toHaveText(`passo ${total} de ${total}`);
   // O contador diz onde a peça está; o botão desabilitado diz que ela ACABOU.

--- a/tests/viz-recursao-funcional.spec.ts
+++ b/tests/viz-recursao-funcional.spec.ts
@@ -238,9 +238,11 @@ test("no expandido do comparador, o Próximo › anda o passo depois da rolagem"
   await expect(painel.locator(".tr-painel").first().locator(".viz-note")).toContainText(
     "2 frames na pilha, parados, esperando uma resposta que ainda não existe."
   );
+  // Valor no nó do valor: na ficha inteira ("frames · comum2"),
+  // `toContainText("2")` passa com 12 ou 20 — e o número é a aula do passo.
   await expect(
-    painel.locator(".viz-var").filter({ hasText: "frames · comum" })
-  ).toContainText("2");
+    painel.locator(".viz-var").filter({ hasText: "frames · comum" }).locator(".viz-var-val")
+  ).toHaveText("2");
 });
 
 test("em 1512x900 o código do comparador vem recolhido, sob o rótulo certo", async ({ page }) => {
@@ -299,12 +301,14 @@ test("a escolha de mostrar o código do comparador sobrevive a desligar o TCO", 
   // Desligar o TCO está no `measureOn` e muda a peça de verdade: o lado direito
   // passa a empilhar igual ao esquerdo. A medição roda de novo aqui.
   await peca.getByRole("button", { name: "Python, Java, C# (sem TCO)" }).click();
-  await expect(peca.locator(".bigo-stat").filter({ hasText: "espaço extra · de cauda" })).toContainText(
-    "O(n)"
-  );
-  await expect(peca.locator(".bigo-stat").filter({ hasText: "pico de frames · de cauda" })).toContainText(
-    "5"
-  );
+  // O card concatena rótulo e valor num nó só, então o <strong> é quem guarda o
+  // valor: no card inteiro, "5" passa com 15 e "O(n)" com "O(n log n)".
+  await expect(
+    peca.locator(".bigo-stat").filter({ hasText: "espaço extra · de cauda" }).locator("strong")
+  ).toHaveText("O(n)");
+  await expect(
+    peca.locator(".bigo-stat").filter({ hasText: "pico de frames · de cauda" }).locator("strong")
+  ).toHaveText("5");
 
   // "Está aberto agora" não é "continua aberto": amostro ao longo do tempo.
   // Esta é a asserção que carrega o sentido do teste, e por isso vem ANTES da
@@ -360,9 +364,9 @@ test("no expandido, seta e espaço andam o comparador e não roubam a tecla de q
 
   // E o campo continua editável: digitar muda a lista e a peça acompanha.
   await expect(passo).toHaveText("passo 1 de 5");
-  await expect(painel.locator(".bigo-stat").filter({ hasText: "pico de frames · comum" })).toContainText(
-    "3"
-  );
+  await expect(
+    painel.locator(".bigo-stat").filter({ hasText: "pico de frames · comum" }).locator("strong")
+  ).toHaveText("3");
 });
 
 test("com a lista vazia o comparador perde a linha do tempo, e o que fica tem rótulo", async ({
@@ -385,12 +389,12 @@ test("com a lista vazia o comparador perde a linha do tempo, e o que fica tem r�
 
   // O que fica continua dizendo o que é — e é o número que o artigo promete
   // para este preset: 1 frame de pico dos dois lados.
-  await expect(peca.locator(".bigo-stat").filter({ hasText: "pico de frames · comum" })).toContainText(
-    "1"
-  );
-  await expect(peca.locator(".bigo-stat").filter({ hasText: "pico de frames · de cauda" })).toContainText(
-    "1"
-  );
+  await expect(
+    peca.locator(".bigo-stat").filter({ hasText: "pico de frames · comum" }).locator("strong")
+  ).toHaveText("1");
+  await expect(
+    peca.locator(".bigo-stat").filter({ hasText: "pico de frames · de cauda" }).locator("strong")
+  ).toHaveText("1");
   // E o preset segue no miolo, que é como se volta de lá.
   await expect(peca.getByRole("button", { name: "Sete números" })).toBeVisible();
 });

--- a/tests/viz-skip-list.spec.ts
+++ b/tests/viz-skip-list.spec.ts
@@ -149,9 +149,18 @@ test("no expandido da inserção, o Próximo › anda o passo depois da rolagem"
   );
   // Valor exato no nó do valor: na ficha inteira ("nivel3"), `toContainText("3")`
   // passa com 13 ou 30, e o nível é o número que a nota acima nomeia.
-  await expect(
-    painel.locator(".viz-var").filter({ hasText: "nivel" }).first().locator(".viz-var-val")
-  ).toHaveText("3");
+  //
+  // E a ficha é escolhida pelo NOME exato, não por substring: este painel
+  // mostra `nivel` e `nivel_max`, então `filter({ hasText: "nivel" })` casa as
+  // duas (medido: 2 fichas) e o `.first()` escolhia pela ordem do DOM. Hoje as
+  // duas valem 3, então a asserção passava pelo motivo errado e continuaria
+  // passando se a ordem virasse. O `toHaveCount(1)` abaixo é o que impede a
+  // ambiguidade de voltar calada.
+  const fichaNivel = painel
+    .locator(".viz-var")
+    .filter({ has: page.locator(".viz-var-name", { hasText: /^nivel$/ }) });
+  await expect(fichaNivel).toHaveCount(1);
+  await expect(fichaNivel.locator(".viz-var-val")).toHaveText("3");
 });
 
 test("no expandido dos níveis, a pirâmide gigante rola sozinha sob o cabeçalho parado", async ({

--- a/tests/viz-skip-list.spec.ts
+++ b/tests/viz-skip-list.spec.ts
@@ -147,7 +147,11 @@ test("no expandido da inserção, o Próximo › anda o passo depois da rolagem"
   await expect(painel.locator(".viz-note")).toContainText(
     "42 não é menor que 33: se eu avançasse, passaria do ponto. Paro de andar no nível 3."
   );
-  await expect(painel.locator(".viz-var").filter({ hasText: "nivel" }).first()).toContainText("3");
+  // Valor exato no nó do valor: na ficha inteira ("nivel3"), `toContainText("3")`
+  // passa com 13 ou 30, e o nível é o número que a nota acima nomeia.
+  await expect(
+    painel.locator(".viz-var").filter({ hasText: "nivel" }).first().locator(".viz-var-val")
+  ).toHaveText("3");
 });
 
 test("no expandido dos níveis, a pirâmide gigante rola sozinha sob o cabeçalho parado", async ({

--- a/tests/viz-sliding-window.spec.ts
+++ b/tests/viz-sliding-window.spec.ts
@@ -223,7 +223,11 @@ test.describe("sliding-window · casca adaptativa", () => {
     await expect(economia).toHaveText("0%");
 
     const proximo = painel.getByRole("button", { name: "Próximo ›" });
+    // O laço sai calado se o limite estourar. Sem esta linha, os cartões abaixo
+    // seriam lidos num passo do meio — e os do passo 1 (1, 1, 0%) são valores
+    // plausíveis, então a asserção passaria dizendo o contrário do que afirma.
     for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     await expect(painel.locator(".viz-step")).toHaveText("passo 25 de 25");
 
     // [2,3,4,5,6,7,1,9] com k = 3: 6 janelas. A força bruta relê k por janela
@@ -263,6 +267,7 @@ test.describe("sliding-window · casca adaptativa", () => {
     // E a aula fecha com o mesmo número do campo: 4 + 9 + 2 = 15.
     const proximo = figura.getByRole("button", { name: "Próximo ›" });
     for (let i = 0; i < 20 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     await expect(figura.locator(".viz-note")).toHaveText(
       /a maior soma de 3 elementos seguidos é 15/
     );
@@ -275,6 +280,7 @@ test.describe("sliding-window · casca adaptativa", () => {
 
     const proximo = painel.getByRole("button", { name: "Próximo ›" });
     for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
+    await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     await expect(painel.locator(".viz-step")).toHaveText("passo 18 de 18");
 
     // [3,6,2,8,1,4,1,5] com k = 3: a janela lê 3 + 2·5 = 13; a força bruta

--- a/tests/viz-sliding-window.spec.ts
+++ b/tests/viz-sliding-window.spec.ts
@@ -223,6 +223,10 @@ test.describe("sliding-window · casca adaptativa", () => {
     await expect(economia).toHaveText("0%");
 
     const proximo = painel.getByRole("button", { name: "Próximo ›" });
+    // `isEnabled()` lê UMA vez: se o painel ainda não tiver hidratado o botão, a
+    // leitura devolve o estado velho, o laço não clica e o `toBeDisabled()` do
+    // fim passa sobre esse mesmo estado. A janela tem dois lados.
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     // O laço sai calado se o limite estourar. Sem esta linha, os cartões abaixo
     // seriam lidos num passo do meio — e os do passo 1 (1, 1, 0%) são valores
     // plausíveis, então a asserção passaria dizendo o contrário do que afirma.
@@ -266,6 +270,9 @@ test.describe("sliding-window · casca adaptativa", () => {
 
     // E a aula fecha com o mesmo número do campo: 4 + 9 + 2 = 15.
     const proximo = figura.getByRole("button", { name: "Próximo ›" });
+    // Aqui o array acabou de ser reescrito no campo, que é o caso mais claro de
+    // leitura única devolvendo o estado da entrada anterior.
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 20 && (await proximo.isEnabled()); i++) await proximo.click();
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     await expect(figura.locator(".viz-note")).toHaveText(
@@ -279,6 +286,7 @@ test.describe("sliding-window · casca adaptativa", () => {
     const painel = await abrirPainel(page, JANELA_FIXA);
 
     const proximo = painel.getByRole("button", { name: "Próximo ›" });
+    await expect(proximo, "a animação não reiniciou: Próximo já começou desabilitado").toBeEnabled();
     for (let i = 0; i < 40 && (await proximo.isEnabled()); i++) await proximo.click();
     await expect(proximo, "a animação não chegou ao fim dentro do limite do laço").toBeDisabled();
     await expect(painel.locator(".viz-step")).toHaveText("passo 18 de 18");

--- a/tests/viz-subarray-substring-subsequence-subset.spec.ts
+++ b/tests/viz-subarray-substring-subsequence-subset.spec.ts
@@ -163,17 +163,25 @@ test("trocar de Array para String troca o rótulo da fatia e as contagens", asyn
 
   // n = 4 → 10 fatias, 15 subsequências não-vazias, 16 subconjuntos.
   await expect(peca.locator(".viz-step")).toHaveText("n = 4");
+  // Número e rótulo lidos nos nós que guardam cada um: no cartão inteiro,
+  // `toContainText("10")` passa com 100 e `toContainText("16")` com 160 — e as
+  // três contagens (10, 15, 16) são a aula desta peça.
   const contas = peca.locator(".sub-conta");
-  await expect(contas.nth(0)).toContainText("10");
-  await expect(contas.nth(0)).toContainText("subarrays não-vazios · n(n+1)/2");
-  await expect(contas.nth(1)).toContainText("15");
-  await expect(contas.nth(2)).toContainText("16");
+  const val = (i: number) => contas.nth(i).locator(".sub-conta-val");
+  await expect(val(0)).toHaveText("10");
+  await expect(contas.nth(0).locator(".sub-conta-lbl")).toHaveText(
+    "subarrays não-vazios · n(n+1)/2"
+  );
+  await expect(val(1)).toHaveText("15");
+  await expect(val(2)).toHaveText("16");
 
   await peca.getByRole("button", { name: "String", exact: true }).click();
   // "code" também tem 4 elementos: o número não muda, o RÓTULO muda — que é o
   // ponto do botão (substring é subarray numa string).
   await expect(peca.locator(".viz-step")).toHaveText("n = 4");
-  await expect(contas.nth(0)).toContainText("substrings não-vazios · n(n+1)/2");
+  await expect(contas.nth(0).locator(".sub-conta-lbl")).toHaveText(
+    "substrings não-vazios · n(n+1)/2"
+  );
   await expect(veredito(peca, "Substring")).toBeVisible();
   await expect(veredito(peca, "Substring").locator(".sub-veredito-sub")).toHaveText(
     "em array, isso se chama subarray"


### PR DESCRIPTION
Este PR **não muda produto nenhum**. Ele conserta a rede de proteção: 65 asserções que
passavam com o resultado errado, 17 laços de percurso que não provavam ter percorrido nada,
e uma lista escrita à mão que deixaria as próximas 11 páginas fora de quatro guardas de uma
vez. `git diff origin/main --stat` toca só `tests/`.

A régua é a §1.4 do runbook: **verificar comportamento, não existência**. Uma asserção que
aceita substring afirma existência de um pedaço de texto; ela não afirma o valor.

---

## O que estava errado, em quatro classes

### Classe 1 — asserção numérica (e de prosa) por substring

O card de estatística concatena rótulo e valor num nó só (`"comparações28"`), então
`toContainText("28")` **passa com 128**. Os testes do PR #16 foram corrigidos para descer
até o `<strong>`; todos os anteriores seguiam na forma fraca.

Quatro casos em que a forma fraca passava com **o resultado oposto ao que o teste afirma**,
todos medidos:

| onde | asserção antiga | também passa com | por que importa |
|---|---|---|---|
| `viz-filas.spec.ts:349,352` | `movs` → `toContainText("0")` / `("7")` | 7 / 70 | 0 contra 7 é o aha do tópico (fila ingênua x buffer circular) |
| `navegacao.spec.ts:1669` | `.viz-var.nth(2)` → `toContainText("0")` | −128, 10, 0x00 | o teste da ambiguidade existe para descartar justamente esses |
| `navegacao.spec.ts:1292` | `retorno do Arrays.binarySearch` → `toContainText("1")` | −10, −1, 11 | −10 é o caso de FALHA, e a regressão é sobre o caso de sucesso |
| `viz-hash-table.spec.ts:314` | `.ht-painel-tit` → `toContainText("2 comparações")` | "12 comparações" | a lista gasta 2 e o hash gasta 1: é a corrida inteira |

**O conserto:** descer até o nó que guarda **só o valor** e usar `toHaveText`
(`<strong>` do `.bigo-stat`, `.viz-var-val`, `.sub-conta-val`, `.bb-formula-selo`,
`.bigo-card-ex`, `<em>` do `.ht-painel-tit`, `.str-enc-val`). Onde o valor mora no meio de
uma frase, a asserção passou a ser **a frase inteira**.

<details>
<summary><b>Inventário completo da classe 1 — 65 asserções, 8 arquivos</b> (linha em <code>origin/main</code>)</summary>

```
navegacao.spec.ts:101   passos.first() toContainText("passo 2 de")            → toHaveText(/^passo 2 de \d+$/)
navegacao.spec.ts:102   passos.nth(1)  toContainText("passo 1 de")            → toHaveText(/^passo 1 de \d+$/)
navegacao.spec.ts:106   .bigo-stat "pares na força bruta" ("28")              → strong toHaveText
navegacao.spec.ts:119   .str-enc-val ("3 bytes")                              → toHaveText
navegacao.spec.ts:121   .str-enc-val ("6 bytes")                              → toHaveText
navegacao.spec.ts:125   .bigo-stat "total com s = s + c" ("45")               → strong toHaveText
navegacao.spec.ts:126   .bigo-stat "total com join" ("9")                     → strong toHaveText
navegacao.spec.ts:130   .bigo-stat "pior caso com o laço" ("45")              → strong toHaveText
navegacao.spec.ts:131   .bigo-stat "pior caso com o truque" ("10")            → strong toHaveText
navegacao.spec.ts:150   .viz-note ("3 colisões")                              → nota inteira, toHaveText
navegacao.spec.ts:151   .viz-note ("6 comparações de chave")                  → idem (mesma nota)
navegacao.spec.ts:177   passos.first() toContainText("passo 2 de")            → toHaveText(/^passo 2 de \d+$/)
navegacao.spec.ts:178   passos.nth(1)  toContainText("passo 1 de")            → toHaveText(/^passo 1 de \d+$/)
navegacao.spec.ts:1224  stat(/^comparações até aqui\d/) ("3")                 → strong toHaveText
navegacao.spec.ts:1225  stat(/^busca linear gastaria\d/) ("5")                → strong toHaveText
navegacao.spec.ts:1229  stat(/^descartadas sem ler\d/) ("5")                  → strong toHaveText
navegacao.spec.ts:1234  stat(/^comparações até aqui\d/) ("4")                 → strong toHaveText
navegacao.spec.ts:1260  .bb-formula li b ("-397.483.648")                     → toHaveText
navegacao.spec.ts:1261  .bb-formula li b ("1.750.000.000")                    → toHaveText
navegacao.spec.ts:1276  resposta(/^primeira ocorrência/) ("1")                → strong toHaveText
navegacao.spec.ts:1278  resposta(/^última ocorrência/) ("3")                  → strong toHaveText
navegacao.spec.ts:1283  resposta(/^onde o valor entraria/) ("5")              → strong toHaveText
navegacao.spec.ts:1286  retorno ("-6")                                        → strong toHaveText
navegacao.spec.ts:1292  retorno ("1")                                         → strong toHaveText
navegacao.spec.ts:1293  retorno not.toContainText("-")                        → redundante, removida
navegacao.spec.ts:1298  resposta(/^onde o valor entraria/) ("9")              → strong toHaveText
navegacao.spec.ts:1299  retorno ("-10")                                       → strong toHaveText
navegacao.spec.ts:1355  .viz-step ("12 inversões")                            → linha inteira, toHaveText
navegacao.spec.ts:1419  .viz-step ("6 rodadas … = 384")                       → linha inteira, toHaveText
navegacao.spec.ts:1485  .ms-op ("28 comparações · profundidade 8")            → .bb-formula-selo toHaveText
navegacao.spec.ts:1486  .ms-op ("16 comparações · profundidade 1")            → .bb-formula-selo toHaveText
navegacao.spec.ts:1487  .ms-op ("nenhum subproblema")                         → .bb-formula-fim toHaveText
navegacao.spec.ts:1490  .ms-op ("18 comparações · profundidade 5")            → .bb-formula-selo toHaveText
navegacao.spec.ts:1491  .ms-op ("35 comparações · profundidade 5")            → .bb-formula-selo toHaveText
navegacao.spec.ts:1518  .viz-step ("1 subsequência de 8 elementos")           → linha inteira, toHaveText
navegacao.spec.ts:1564  .hp-bloco.first() ("vazia")                           → bloco por título + .bb-array-nota
navegacao.spec.ts:1641  .viz-note ("11001001")                                → nota inteira, toHaveText
navegacao.spec.ts:1642  .viz-note ("128 + 64 + 8 + 1 = 201")                  → idem (mesma nota)
navegacao.spec.ts:1669  .viz-var.nth(2) ("0")                                 → ficha por nome + .viz-var-val
viz-arrays.spec.ts:218  .viz-var "endereço" ("0x1018")                        → .viz-var-val toHaveText
viz-arrays.spec.ts:255  cartão "capacidade reservada" ("0 realocações")       → .bigo-card-ex toHaveText
viz-arrays.spec.ts:300  .viz-var "endereço" ("0x1008")                        → .viz-var-val toHaveText
viz-backtracking.spec.ts:164  cartão "nós da árvore inteira" ("8")            → strong toHaveText
viz-backtracking.spec.ts:174  cartão "nós da árvore inteira" ("10")           → strong toHaveText
viz-backtracking.spec.ts:187  cartão "lacunas do tabuleiro" ("11")            → strong toHaveText
viz-backtracking.spec.ts:196  cartão "lacunas do tabuleiro" ("20")            → strong toHaveText
viz-filas.spec.ts:349   movs ("0")                                            → strong toHaveText
viz-filas.spec.ts:352   movs ("7")                                            → strong toHaveText
viz-filas.spec.ts:353   custo ("O(n)")                                        → strong toHaveText
viz-filas.spec.ts:361   movs ("0")                                            → strong toHaveText
viz-filas.spec.ts:362   custo ("O(1)")                                        → strong toHaveText
viz-hash-table.spec.ts:314  .ht-painel-tit ("2 comparações")                  → <em> toHaveText
viz-hash-table.spec.ts:315  .ht-painel-tit ("1 comparação")                   → <em> toHaveText
viz-recursao-funcional.spec.ts:243  .viz-var "frames · comum" ("2")           → .viz-var-val toHaveText
viz-recursao-funcional.spec.ts:302  .bigo-stat "espaço extra · de cauda"      → strong toHaveText
viz-recursao-funcional.spec.ts:305  .bigo-stat "pico de frames · de cauda"    → strong toHaveText
viz-recursao-funcional.spec.ts:363  .bigo-stat "pico de frames · comum"       → strong toHaveText
viz-recursao-funcional.spec.ts:388  .bigo-stat "pico de frames · comum"       → strong toHaveText
viz-recursao-funcional.spec.ts:391  .bigo-stat "pico de frames · de cauda"    → strong toHaveText
viz-skip-list.spec.ts:150   .viz-var "nivel" ("3")                            → .viz-var-val toHaveText
viz-subarray-….spec.ts:167  contas.nth(0) ("10")                              → .sub-conta-val toHaveText
viz-subarray-….spec.ts:168  contas.nth(0) (rótulo)                            → .sub-conta-lbl toHaveText
viz-subarray-….spec.ts:169  contas.nth(1) ("15")                              → .sub-conta-val toHaveText
viz-subarray-….spec.ts:170  contas.nth(2) ("16")                              → .sub-conta-val toHaveText
viz-subarray-….spec.ts:176  contas.nth(0) (rótulo)                            → .sub-conta-lbl toHaveText
```

</details>

**Prosa.** A varredura cruzou cada `toContainText("<prosa>")` dos testes com os literais dos
visualizadores, procurando ocorrências precedidas de negação (`não`, `nunca`, `ainda`, `sem`,
`nenhum`). O caso do runbook — `"compensa"` batendo em `"ainda não compensa"` — **já estava
consertado** (`navegacao.spec.ts:1531`, com comentário). Nenhum outro caso de negação
apareceu. `toContainText` de prosa restante é código Python, título de peça ou rótulo, onde
o argumento não admite o negativo.

### Classe 2 — laço de percurso que não prova ter chegado ao fim

`for (i < N && await proximo.isEnabled()) await proximo.click()` **sai calado** quando o
limite estoura, e a asserção seguinte roda num passo do meio. **Oito laços** seguiam abertos:

| arquivo:linha (`origin/main`) | o que percorre |
|---|---|
| `navegacao.spec.ts:149` | hash-table, inserção com anagramas |
| `navegacao.spec.ts:1015` | percursos em árvore (`irAteOFim`, chamado 4x) |
| `navegacao.spec.ts:1145` | heap, remover o topo |
| `navegacao.spec.ts:1182` | heap sort, a fronteira |
| `viz-arrays.spec.ts:264` | array dinâmico, capacidade reservada |
| `viz-sliding-window.spec.ts:226` | força bruta contra janela |
| `viz-sliding-window.spec.ts:265` | janela fixa, encurtar o array |
| `viz-sliding-window.spec.ts:277` | janela fixa, leituras |
| `viz-mst.spec.ts:108` | `irAoFim` (conferia o contador, não o fim) |

Os já fechados (não mexidos): `navegacao.spec.ts` 1084, 1217, 1270, 1314, 1391, 1445, 1503,
1553, 1586, 1638, 1657 e `viz-busca-binaria.spec.ts` 330, 359.

Sobre o `viz-mst`: ele já afirmava `passo N de N`. Isso diz **onde** a peça está, não que ela
**acabou** — um `total` lido errado deixa contador e asserção coerentes entre si e errados em
relação à animação. A prova de quebra abaixo mostra exatamente esse buraco.

### Classe 3 — leitura única de estado do React mente

`isEnabled()` / `isDisabled()` leem **uma vez**. Logo após trocar de preset, de modo ou o
conteúdo de um campo, a leitura devolve o estado desabilitado do fim da rodada anterior: o
laço não clica **nenhuma vez** e o `toBeDisabled()` do fim passa sobre esse mesmo estado
velho. Fechar o fim sem fechar o começo troca uma asserção vazia por outra.

**Nove pontos** ganharam `await expect(proximo).toBeEnabled()` antes do laço:

| arquivo:linha (`origin/main`) | o que antecede o laço |
|---|---|
| `navegacao.spec.ts:149` | clique no preset "Anagramas: o pior caso" |
| `navegacao.spec.ts:1015` | clique na ordem do percurso, uma vez por preset |
| `navegacao.spec.ts:1145` | clique no modo "remover o topo" |
| `navegacao.spec.ts:1182` | carga da página |
| `viz-arrays.spec.ts:264` | clique no preset "capacidade reservada" |
| `viz-sliding-window.spec.ts:226,277` | abertura do painel expandido |
| `viz-sliding-window.spec.ts:265` | `fill()` reescrevendo o array |
| `viz-busca-binaria.spec.ts:330,359` | clique no preset |
| `viz-mst.spec.ts:108` | `irAoFim` (o outro lado da janela) |

---

### Classe 4 — lista escrita à mão que os guardas consomem

`TOPICOS_PRONTOS` (`navegacao.spec.ts:970-1007`) era uma lista de slugs digitada, e **quatro**
guardas iteram sobre ela:

| guarda | linha (`origin/main`) |
|---|---|
| contrato de página (h1, artigo, visualizadores, âncoras, problemas) | `:1009` |
| todo visualizador com passos tem controles que funcionam | `:1740` |
| no celular, nenhum painel de visualizador colapsa | `:1778` |
| nenhuma página de tópico rola na horizontal no celular | `:1802` |

Promover um tópico sem lembrar de acrescentá-lo ali deixava a página nova fora dos **quatro
de uma vez**, com o CI verde e nenhum sinal de que faltou alguma coisa. Hoje a lista bate por
acaso (36 = 36); **são 11 promoções pela frente**, cada uma uma chance de o acaso acabar.

Os slugs passam a sair de `ALL_TOPICS.filter(t => t.status === "ready")` — já importado na
linha 2 do arquivo. O que **fica à mão** é a descrição de cada tópico (`DESCRICAO`), e por
motivo, não por preguiça:

- **`h1` derivado de `t.name` viraria tautologia.** A página renderiza `t.name`
  (`src/app/topico/[slug]/page.tsx:70`), então o teste passaria a comparar o dado com ele
  mesmo e pararia de pegar título trocado;
- **`vizMin` não existe na fonte.** `viz` é o nome de **um** visualizador, não a contagem dos
  que o MDX instancia.

Um tópico recém-promovido **já entra nos quatro guardas** pelo fallback (`t.name` e
`vizMin: 1`, o piso de qualquer página completa), e um teste novo reprova alto pedindo a
descrição de verdade — nos dois sentidos, porque entrada que sobra em `DESCRICAO` aponta slug
renomeado ou tópico que voltou para `soon`, e vira teste que nunca mais visita página nenhuma.

---

## As provas de quebra

Um caso de cada classe, em **três arquivos diferentes**. Para cada uma: o produto foi
quebrado de um jeito que **compila**, o `next build` rodou **sem ser silenciado**, e o
**mesmo** artefato `out/` foi exercitado pela versão **antiga** do teste (de `origin/main`) e
pela **nova**. Nenhuma quebra foi commitada — restauração por `cp` de cópia em diretório
temporário, **nunca** `git checkout --`.

### Classe 1 — `viz-filas.spec.ts`

Quebra em `content/visualizers/QueueVisualizer.tsx:409`: o contador ganha um zero à direita
(``value: `${p.moves}` `` → ``value: `${p.moves}0` ``). O valor 0 vira `00` e o 7 vira `70`.

```
✓ Compiled successfully in 2.4s

A) TESTE ANTIGO (toContainText no card)
   1 passed (2.5s)                              ← a quebra passa despercebida

B) TESTE NOVO (toHaveText no <strong>)
   24 × locator resolved to <strong>00</strong>
      - unexpected value "00"
   > 353 |   await expect(valorDe(movs)).toHaveText("0");
   1 failed
```

### Classe 2 — `viz-sliding-window.spec.ts`

Quebra em `src/lib/visualizer.tsx:546`: o `Próximo ›` nunca chega a desabilitar
(`disabled={viz.step === viz.total - 1}` → `+ 1`, só a comparação invertida, compila). O fim
da animação deixa de ter sinal na tela.

Marcador confirmado no HTML do build, antes de rodar teste nenhum:

```
<button class="viz-btn" aria-keyshortcuts="ArrowRight">Próximo ›</button>
com disabled: 0 de 3
```

```
✓ Compiled successfully in 2.3s

A) TESTE ANTIGO (laço sem toBeDisabled)
   1 passed (3.2s)      ← o laço estoura o cap de 40, a peça grampeia no último
                          passo, "passo 25 de 25" passa e ninguém percebe

B) TESTE NOVO (mesmo laço, fechado)
   24 × locator resolved to <button class="viz-btn" …>Próximo ›</button>
      - unexpected value "enabled"
   > 234 |   await expect(proximo, "…não chegou ao fim…").toBeDisabled();
   1 failed
```

### Classe 3 — `navegacao.spec.ts`

Quebra em `content/visualizers/TreeTraversalVisualizer.tsx:320`: trocar a ordem do percurso
deixa de reiniciar a animação (`{ viz.reset(); setOrder(o); }` → `{ setOrder(o); }`).

Este é o cenário do runbook, ao pé da letra: nas ordens 2, 3 e 4 a peça já está no último
passo, o `Próximo ›` **já nasce desabilitado**, e o laço guardado por `isEnabled()` clica
**zero vezes**. Como no último passo a saída está completa para qualquer ordem, a asserção
final continua verde — ela estava afirmando nada.

```
✓ Compiled successfully in 2.1s

A) TESTE ANTIGO (laço sem toBeEnabled)
   1 passed (3.1s)                              ← 0 cliques em 3 dos 4 presets

B) TESTE NOVO (mesmo laço, com toBeEnabled antes)
   - a animação não reiniciou: Próximo já começou desabilitado
   24 × locator resolved to <button disabled class="viz-btn" …>Próximo ›</button>
      - unexpected value "disabled"
   > 1043 |   await expect(proximo, "…não reiniciou…").toBeEnabled();
   1 failed
```

### Classe 4 — `navegacao.spec.ts`, o cenário do futuro

Quebra em `content/roadmap.ts:636`: o tópico `trie` é promovido a `ready` — só o valor do
`status`, que é exatamente o que um PR de promoção faz.

```
✓ Compiled successfully in 2.3s
out/topico/trie/  ← a página foi gerada

A) SUÍTE ANTIGA (lista de slugs à mão)
   103 passed (22.9s)     ← nenhum dos quatro guardas passou pela página nova

B) SUÍTE NOVA (lista derivada de ALL_TOPICS)
   2 failed
     › todo tópico 'ready' está descrito na tabela dos guardas de contrato
     › tópico trie entrega artigo, visualizadores e âncoras válidas
       - unexpected value "1"
       > 1061 |  await expect(page.locator(".soon-badge")).toHaveCount(0);
   103 passed
```

O segundo é o mais eloquente: o contrato de página **se gerou sozinho** para o slug novo e
achou o selo "em breve" na hora. Com a lista à mão, esse teste nem chegava a existir.

Restauração conferida ao fim: `git status --short` **vazio** e `git diff origin/main --stat`
tocando **só `tests/`**.

---

## Contagem de testes

| | testes |
|---|---|
| antes (`origin/main`) | **459 passed** |
| depois (`npm run test:build`, `PORT=4404`) | **460 passed** |

O `+1` é o guarda de cobertura da classe 4. As classes 1, 2 e 3 **fortalecem asserções
existentes** e não acrescentam caso nenhum, então o saldo delas é zero de propósito.
`npx tsc --noEmit` limpo (o `tsconfig.json` inclui `**/*.ts`, então os testes são
typecheckados).

`toContainText` em `tests/`: **180 → 124**.

---

## Junto, e pelo mesmo motivo

Alguns seletores **por ordem de DOM** foram trocados por filtro de conteúdo, porque foram
achados na mesma leitura e mudam a mesma asserção:

- `navegacao.spec.ts` — `page.locator(".viz").first()` / `.nth(1)` / `.nth(2)` em
  **strings**, **two-pointers** e **hash-table**, três páginas com três `figure.viz` cada.
  Passaram a ser escolhidos pelo título da peça;
- `navegacao.spec.ts:1564` — `.hp-bloco.first()` no backtracking, onde **três** blocos
  (solução parcial, pilha de chamadas, soluções guardadas) sabem escrever "vazia";
- `navegacao.spec.ts:1669` — `.viz-var.nth(2)`, agora a ficha escolhida pelo nome.

Os dois `page.locator(".viz-step")` que sobraram em `navegacao.spec.ts` (linhas 99 e 200)
são deliberados: eles comparam o contador de **duas peças diferentes** para provar que o
estado é independente, e é justamente a posição que carrega o sentido ali.

**Varreduras que não acharam nada e não viraram commit**, para o revisor não refazê-las:

- **espera fixa no lugar de asserção web-first** — as 61 `waitForTimeout` de `tests/` são
  todas do padrão "nada aconteceu nesta janela" (a marcha padrão anda a cada 650ms, então
  esperar 1000ms e reafirmar o mesmo passo **é** o teste). Nenhuma é remendo de
  sincronização;
- **número mágico vindo do CSS** — 23 leituras do token `--ccc-header-h` já são feitas por
  valor computado; os números literais que sobram (`toBeGreaterThan(20)`,
  `toBeGreaterThan(150)`) são **pisos de premissa** ("o miolo tem o que rolar", "o bloco
  abriu mesmo"), não medidas de layout.

---

## Bugs de PRODUTO achados e **não** consertados

Esta lane não mexe em produto — um PR de testes que também muda produto perde a garantia que
o torna revisável. Os dois saíram de assertar o texto **exato** onde antes se assertava um
pedaço, e nos dois a asserção nova **grava o texto atual**, com comentário, para que o
conserto apareça como diff em vez de passar despercebido.

1. **`content/visualizers/QuickSortTresVias.tsx:186-192`** — no ramo sem subproblema, o
   trecho entra no meio da frase e o aluno lê:

   > Depois da primeira partição sobram **nenhum subproblema: acabou aqui** para a recursão resolver.

   O ramo com subproblemas sai certo ("sobram 7 elementos para a recursão resolver"). O
   conserto é a frase inteira condicional, não o miolo.

2. **`content/visualizers/QuickSortTresVias.tsx:148`** — a faixa do pivô escreve
   ``` `= pivô, ${gt - lt + 1} já resolvidos` ```, sem plural condicional. No preset
   **"Sem repetição"** o valor é 1 e a tela diz **"= pivô, 1 já resolvidos"**.

Nenhum dos dois é regressão deste PR: os dois já estavam no ar e passavam pela suíte porque
`toContainText` nunca chegou a ler a frase inteira.

---

## Coordenação com as lanes vizinhas

`tests/navegacao.spec.ts` é tocado por duas lanes desta rodada. As linhas **221, 308, 318 e
320** (o `figure.viz-fit` do contador do Big O) pertencem ao PR do `BigOChartVisualizer` — a
adaptação de lá faz aquela classe casar duas figuras na página, e o escopo é efeito direto
dela. **Nenhum hunk deste PR toca essas linhas**: os daqui estão em 1, 101-178 e 1014-1669.

E não foi tocado nada em `viz-n-ary-trees`, `viz-shell-sort`, `viz-bellman-ford` nem
`viz-big-o`, que são das outras lanes.
