### PR TITLE
feat(seo): canonical em toda rota, sitemap honesto e dados estruturados

### DIFF
--- a/src/app/apoie/page.tsx
+++ b/src/app/apoie/page.tsx
@@ -1,12 +1,21 @@
 import type { Metadata } from "next";
 import { LINKS } from "@/lib/links";
+import { pageMetadata } from "@/lib/seo";
 import { fetchSupporters, initials, PARTNERS } from "./apoiadores";
 
-export const metadata: Metadata = {
-  title: "Seja um apoiador da Comunidade",
-  description:
-    "O Roadmap de Estruturas de Dados e Algoritmos da comunidade Craft & Code Club é livre, aberto e feito pela comunidade. Conheça os apoiadores e parceiros que mantêm tudo gratuito, e junte-se a eles.",
-};
+// Era `export const metadata` estático e, por isso, sem canonical nem `og:url` —
+// a quarta das 48 rotas que não diziam qual era a própria URL. Título e descrição
+// seguem os mesmos; `titleStyle: "template"` preserva o " · Roadmap DSA" do fim.
+export function generateMetadata(): Metadata {
+  return pageMetadata({
+    title: "Seja um apoiador da Comunidade",
+    description:
+      "O Roadmap de Estruturas de Dados e Algoritmos da comunidade Craft & Code Club é livre, aberto e feito pela comunidade. Conheça os apoiadores e parceiros que mantêm tudo gratuito, e junte-se a eles.",
+    path: "/apoie/",
+    titleStyle: "template",
+    ogImage: "raiz",
+  });
+}
 
 // Página estática: a lista de apoiadores é buscada na APOIA.se no build.
 export const dynamic = "force-static";

--- a/src/app/apoie/page.tsx
+++ b/src/app/apoie/page.tsx
@@ -37,7 +37,16 @@ export default async function ApoiePage() {
       {/* Apoio principal: a comunidade */}
       <div className="cta-card coffee" style={{ marginBottom: 16 }}>
         <div className="cta-eyebrow" style={{ color: "#fcd34d" }}><span>♥</span>Apoie a comunidade</div>
-        <h3>Seja um apoiador</h3>
+        {/* `h2`, e não `h3`: a página ia de `h1` direto para `h3` e só voltava
+            para `h2` lá embaixo, em "Apoiadores". Quem navega por títulos ouvia
+            uma seção dentro de outra que não existe.
+            O estilo vem por TAG (`.cta-card h3`, `globals.css:222`), então trocar
+            a tag sem repor encolheria o título de 22px para o padrão do `h2`.
+            Estes valores são cópia exata daquela regra; a casa deles é o CSS, que
+            pertence a outra frente nesta rodada. */}
+        <h2 style={{ margin: "0 0 8px", fontSize: 22, fontWeight: 600, letterSpacing: "-0.02em" }}>
+          Seja um apoiador
+        </h2>
         <p style={{ color: "#dcc9a8", maxWidth: "54ch" }}>
           Sua contribuição, do valor que você quiser, mantém o conteúdo saindo e as visualizações
           novas chegando, e deixa o guia livre e aberto para quem vem depois. E você entra na lista
@@ -48,7 +57,12 @@ export default async function ApoiePage() {
 
       {/* Contribuir com tempo */}
       <div className="feature-card" style={{ marginBottom: 40 }}>
-        <h3 style={{ marginTop: 0, fontSize: 16 }}>Da comunidade pra comunidade, contribua</h3>
+        {/* Mesmo caso do anterior. A regra por tag é `.feature-card h3`
+            (`globals.css:210`), com `margin: 14px 0 7px`, e o `marginTop: 0`
+            daqui já zerava o topo — o valor abaixo é o resultado dos dois. */}
+        <h2 style={{ margin: "0 0 7px", fontSize: 16, fontWeight: 600 }}>
+          Da comunidade pra comunidade, contribua
+        </h2>
         <p className="prose-p" style={{ fontSize: 14, marginBottom: 10 }}>
           O código e o conteúdo são abertos. Corrija um erro, escreva um tópico ou crie um
           visualizador, e entre nos créditos.

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css";
 import { Analytics } from "@/components/Analytics";
 import { ProgressProvider } from "@/components/ProgressProvider";
 import { Shell } from "@/components/Shell";
+import { JsonLd, organizationJsonLd, webSiteJsonLd } from "@/lib/jsonld";
 import { SITE_URL } from "@/lib/links";
 import { SITE_NAME, TITLE_TEMPLATE } from "@/lib/seo";
 
@@ -71,6 +72,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         />
       </head>
       <body>
+        {/* Quem publica o guia e qual é o site, em toda rota. Sai pronto no HTML
+            do export: `application/ld+json` não é executado, então nem este
+            bloco nem os das páginas custam um byte de JavaScript no cliente. */}
+        <JsonLd data={[organizationJsonLd(), webSiteJsonLd()]} />
         <ProgressProvider>
           <Shell>{children}</Shell>
         </ProgressProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -29,7 +29,8 @@ export const metadata: Metadata = {
   openGraph: {
     type: "website",
     locale: "pt_BR",
-    siteName: "Roadmap DSA",
+    // Mesma constante do `title` e do JSON-LD: o nome do site é um valor só.
+    siteName: SITE_NAME,
   },
   twitter: {
     card: "summary_large_image",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Analytics } from "@/components/Analytics";
 import { ProgressProvider } from "@/components/ProgressProvider";
 import { Shell } from "@/components/Shell";
 import { SITE_URL } from "@/lib/links";
+import { SITE_NAME, TITLE_TEMPLATE } from "@/lib/seo";
 
 // Só o que é global de verdade mora aqui. Título, descrição e Open Graph são de
 // cada rota (ver `src/lib/seo.ts`): quando `openGraph.title`/`description` eram
@@ -16,8 +17,11 @@ import { SITE_URL } from "@/lib/links";
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
   title: {
-    default: "Roadmap DSA · Craft & Code Club",
-    template: "%s · Roadmap DSA",
+    default: `${SITE_NAME} · Craft & Code Club`,
+    // O template vem do `seo.ts` porque o `pageMetadata` precisa saber compor o
+    // mesmo título para o card social das rotas que não definem OG próprio. Duas
+    // cópias da mesma string é o começo de duas verdades diferentes.
+    template: TITLE_TEMPLATE,
   },
   description:
     "O maior guia visual e gratuito de Algoritmos e Estruturas de Dados em português. Cada tópico com o algoritmo rodando passo a passo, artigo, vídeo e problemas do LeetCode e GeeksforGeeks. Feito pela comunidade Craft & Code Club.",

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
-import { TOTAL_TOPICS } from "@content/roadmap";
-import { ogImage, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
+import { ogImage } from "@/lib/og";
+import { OG_ALT_RAIZ, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og-meta";
 
-export const alt = `Roadmap DSA: o maior guia visual de Algoritmos e Estruturas de Dados em português, com ${TOTAL_TOPICS} tópicos, grátis`;
+export const alt = OG_ALT_RAIZ;
 export const size = OG_SIZE;
 export const contentType = OG_CONTENT_TYPE;
 export const dynamic = "force-static";

--- a/src/app/roadmap/page.tsx
+++ b/src/app/roadmap/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { TOTAL_TOPICS } from "@content/roadmap";
 import { RoadmapGroups } from "@/components/RoadmapGroups";
+import { JsonLd, roadmapJsonLd } from "@/lib/jsonld";
 import { pageMetadata } from "@/lib/seo";
 
 export function generateMetadata(): Metadata {
@@ -16,6 +17,9 @@ export function generateMetadata(): Metadata {
 export default function RoadmapPage() {
   return (
     <div className="roadmap-wrap">
+      {/* A trilha que esta página já desenha, também em dado estruturado: os
+          mesmos tópicos, na mesma ordem dos cards. */}
+      <JsonLd data={roadmapJsonLd()} />
       <span className="roadmap-eyebrow">Do zero à entrevista</span>
       <h1>Roadmap de Algoritmos e Estruturas de Dados</h1>
       <p className="roadmap-intro">

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -15,12 +15,19 @@ export const dynamic = "force-static";
 // primeira vez que a regra de "tópico vazio" mudasse de um lado só.
 const rotasFixas = ["/", "/introducao/", "/roadmap/", "/apoie/"] as const;
 
-// Arquivo que responde pelo conteúdo de cada rota, para a data sair do Git.
-const arquivoDaRota: Record<(typeof rotasFixas)[number], string> = {
-  "/": "src/app/page.tsx",
-  "/introducao/": "src/app/introducao/page.tsx",
-  "/roadmap/": "src/app/roadmap/page.tsx",
-  "/apoie/": "src/app/apoie/page.tsx",
+// Arquivos que respondem pelo conteúdo de cada rota, para a data sair do Git.
+//
+// É uma LISTA, e não um arquivo só, porque `page.tsx` quase nunca é onde o texto
+// mora. A home e o `/roadmap/` importam de `content/roadmap.ts`: mexer num
+// tópico muda as duas telas sem tocar em nenhum dos dois `page.tsx`, e o
+// `lastmod` ficava parado no dia em que o layout da página mudou pela última
+// vez. O `/apoie/` tem a mesma forma com `apoiadores.ts`, que é onde a lista de
+// nomes é mantida à mão. A data da rota é a MAIS RECENTE entre esses arquivos.
+export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly string[]> = {
+  "/": ["src/app/page.tsx", "content/roadmap.ts"],
+  "/introducao/": ["src/app/introducao/page.tsx"],
+  "/roadmap/": ["src/app/roadmap/page.tsx", "content/roadmap.ts"],
+  "/apoie/": ["src/app/apoie/page.tsx", "src/app/apoie/apoiadores.ts"],
 };
 
 // `lastmod` é o único dos três campos opcionais que o Google declarou usar;
@@ -48,17 +55,25 @@ const historicoDisponivel = (() => {
   }
 })();
 
-function ultimaAlteracao(arquivo: string): Date | undefined {
-  if (!historicoDisponivel) return undefined;
+function commitDoArquivo(arquivo: string): number | undefined {
   try {
     const iso = execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-    return iso ? new Date(iso) : undefined;
+    if (!iso) return undefined; // caminho que nunca existiu no histórico
+    const ms = Date.parse(iso);
+    return Number.isNaN(ms) ? undefined : ms;
   } catch {
     return undefined;
   }
+}
+
+/** A data da rota é a do arquivo de conteúdo dela que mudou por último. */
+function ultimaAlteracao(...arquivos: readonly string[]): Date | undefined {
+  if (!historicoDisponivel) return undefined;
+  const datas = arquivos.map(commitDoArquivo).filter((ms): ms is number => ms !== undefined);
+  return datas.length ? new Date(Math.max(...datas)) : undefined;
 }
 
 export default function sitemap(): MetadataRoute.Sitemap {
@@ -66,7 +81,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${SITE_URL}${rota}`,
     priority: rota === "/" ? 1 : rota === "/apoie/" ? 0.5 : 0.9,
     changeFrequency: rota === "/" || rota === "/roadmap/" ? ("weekly" as const) : ("monthly" as const),
-    lastModified: ultimaAlteracao(arquivoDaRota[rota]),
+    lastModified: ultimaAlteracao(...CONTEUDO_DA_ROTA[rota]),
   }));
   const topicos = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => ({
     url: `${SITE_URL}/topico/${t.slug}/`,
@@ -74,6 +89,14 @@ export default function sitemap(): MetadataRoute.Sitemap {
     changeFrequency: "monthly" as const,
     // O artigo é o corpo da página; o tópico sem artigo cai no `roadmap.ts`, que
     // é onde mora cada palavra que essa página mostra.
+    //
+    // Aqui é `??` e NÃO o `max(...)` das rotas fixas, e a diferença foi medida:
+    // os 36 `.mdx` do repositório são todos mais antigos que o último commit do
+    // `roadmap.ts`, então `max` daria a MESMA data às 36 páginas de tópico e
+    // qualquer edição no `roadmap.ts` (marcar um `isNew`, mexer num link)
+    // reescreveria o `lastmod` das 40 URLs de uma vez. Isso é exatamente o
+    // "lastmod = data do último deploy" que o Google aprendeu a ignorar. A home
+    // e o `/roadmap/` não têm essa escolha: lá o `roadmap.ts` É o conteúdo.
     lastModified: ultimaAlteracao(`content/topics/${t.slug}.mdx`) ?? ultimaAlteracao("content/roadmap.ts"),
   }));
   return [...base, ...topicos];

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,20 +1,80 @@
+import { execFileSync } from "node:child_process";
 import type { MetadataRoute } from "next";
-import { ALL_TOPICS } from "@content/roadmap";
+import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 import { SITE_URL } from "@/lib/links";
 
 export const dynamic = "force-static";
 
+// O sitemap é a lista do que o site QUER no índice do Google.
+//
+// Ele mapeava `ALL_TOPICS` sem filtro enquanto a página emitia `noindex` por
+// `isEmptyTopic`: 11 das 51 URLs convidavam o robô para páginas que o próprio
+// HTML mandava ignorar, e cada uma vira um erro vermelho permanente no Search
+// Console. O filtro abaixo chama a MESMA função que a página chama — recriar a
+// condição aqui é o que fez o buraco existir, e recriá-la de novo o reabriria na
+// primeira vez que a regra de "tópico vazio" mudasse de um lado só.
+const rotasFixas = ["/", "/introducao/", "/roadmap/", "/apoie/"] as const;
+
+// Arquivo que responde pelo conteúdo de cada rota, para a data sair do Git.
+const arquivoDaRota: Record<(typeof rotasFixas)[number], string> = {
+  "/": "src/app/page.tsx",
+  "/introducao/": "src/app/introducao/page.tsx",
+  "/roadmap/": "src/app/roadmap/page.tsx",
+  "/apoie/": "src/app/apoie/page.tsx",
+};
+
+// `lastmod` é o único dos três campos opcionais que o Google declarou usar;
+// `priority` e `changeFrequency`, que este arquivo já preenchia, ele ignora.
+//
+// A data vem do Git, e não de um campo `updatedAt` no `content/roadmap.ts`:
+// data que depende de alguém lembrar de atualizá-la em cada PR envelhece errado
+// e passa a mentir, o que é pior do que não existir.
+//
+// O guarda do clone raso não é preciosismo. `actions/checkout` clona com
+// `fetch-depth: 1`, e num histórico de um commit só o `git log` de QUALQUER
+// caminho devolve esse commit: as 40 URLs sairiam com a data do último deploy,
+// que é exatamente o `lastmod` que o Google aprendeu a ignorar. Sem o campo é
+// melhor que com o campo falso, então aqui ele simplesmente não sai — e volta a
+// sair sozinho no dia em que o workflow buscar o histórico (`fetch-depth: 0`).
+const historicoDisponivel = (() => {
+  try {
+    const raso = execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return raso === "false";
+  } catch {
+    return false; // sem git, ou fora de um repositório
+  }
+})();
+
+function ultimaAlteracao(arquivo: string): Date | undefined {
+  if (!historicoDisponivel) return undefined;
+  try {
+    const iso = execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return iso ? new Date(iso) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = [
-    { url: `${SITE_URL}/`, priority: 1, changeFrequency: "weekly" as const },
-    { url: `${SITE_URL}/introducao/`, priority: 0.9, changeFrequency: "monthly" as const },
-    { url: `${SITE_URL}/roadmap/`, priority: 0.9, changeFrequency: "weekly" as const },
-    { url: `${SITE_URL}/apoie/`, priority: 0.5, changeFrequency: "monthly" as const },
-  ];
-  const topicos = ALL_TOPICS.map((t) => ({
+  const base = rotasFixas.map((rota) => ({
+    url: `${SITE_URL}${rota}`,
+    priority: rota === "/" ? 1 : rota === "/apoie/" ? 0.5 : 0.9,
+    changeFrequency: rota === "/" || rota === "/roadmap/" ? ("weekly" as const) : ("monthly" as const),
+    lastModified: ultimaAlteracao(arquivoDaRota[rota]),
+  }));
+  const topicos = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => ({
     url: `${SITE_URL}/topico/${t.slug}/`,
     priority: t.status === "ready" ? 0.8 : 0.4,
     changeFrequency: "monthly" as const,
+    // O artigo é o corpo da página; o tópico sem artigo cai no `roadmap.ts`, que
+    // é onde mora cada palavra que essa página mostra.
+    lastModified: ultimaAlteracao(`content/topics/${t.slug}.mdx`) ?? ultimaAlteracao("content/roadmap.ts"),
   }));
   return [...base, ...topicos];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,4 +1,6 @@
 import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
 import type { MetadataRoute } from "next";
 import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 import { SITE_URL } from "@/lib/links";
@@ -43,17 +45,41 @@ export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly stri
 // que é exatamente o `lastmod` que o Google aprendeu a ignorar. Sem o campo é
 // melhor que com o campo falso, então aqui ele simplesmente não sai — e volta a
 // sair sozinho no dia em que o workflow buscar o histórico (`fetch-depth: 0`).
-const historicoDisponivel = (() => {
-  try {
-    const raso = execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    return raso === "false";
-  } catch {
-    return false; // sem git, ou fora de um repositório
-  }
-})();
+//
+// A pergunta é respondida pelo ARQUIVO `shallow` do diretório do Git, e não por
+// `git rev-parse --is-shallow-repository`. É a mesma informação (o comando é
+// literalmente "esse arquivo existe?"), e a diferença é que ler o disco não pode
+// falhar por carga da máquina. O subprocesso pode: um `execFileSync` devolve
+// EAGAIN quando o runner está saturado, e aí o `catch` responde "raso" para uma
+// pergunta que nunca chegou a ser feita. Foi assim que a suíte reprovou na CI
+// com o sitemap CERTO — o build tinha histórico e as datas saíram variadas, e o
+// teste, que fazia a mesma pergunta pelo mesmo caminho, ouviu "raso" e cobrou
+// a ausência do campo.
+//
+// Por isso também é EXPORTADA: o teste importa esta função em vez de repetir a
+// decisão do seu lado. Dois predicados para a mesma decisão é o defeito que este
+// arquivo existe para consertar, e ele tinha voltado dentro do próprio teste.
+function diretorioDoGit(raiz: string): string | undefined {
+  const dotGit = path.join(raiz, ".git");
+  if (!existsSync(dotGit)) return undefined;
+  if (statSync(dotGit).isDirectory()) return dotGit;
+  // Worktree ligada: `.git` é um arquivo com `gitdir: <caminho>`, e o marcador
+  // `shallow` mora no diretório COMUM, apontado pelo arquivo `commondir`.
+  const gitdir = readFileSync(dotGit, "utf8").match(/^gitdir:\s*(.+)$/m)?.[1]?.trim();
+  if (!gitdir) return undefined;
+  const dir = path.resolve(raiz, gitdir);
+  const commondir = path.join(dir, "commondir");
+  return existsSync(commondir) ? path.resolve(dir, readFileSync(commondir, "utf8").trim()) : dir;
+}
+
+/** `true` quando o histórico não dá para distinguir um caminho do outro. */
+export function historicoRaso(): boolean {
+  const dir = diretorioDoGit(process.cwd());
+  if (!dir) return true; // sem repositório, nenhuma data é derivável
+  return existsSync(path.join(dir, "shallow"));
+}
+
+const historicoDisponivel = !historicoRaso();
 
 // Um `git log` por caminho, e não por consulta. São 48 chamadas para montar o
 // sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,4 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, statSync } from "node:fs";
-import path from "node:path";
 import type { MetadataRoute } from "next";
 import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 import { SITE_URL } from "@/lib/links";
@@ -39,59 +37,31 @@ export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly stri
 // data que depende de alguém lembrar de atualizá-la em cada PR envelhece errado
 // e passa a mentir, o que é pior do que não existir.
 //
-// O guarda do clone raso não é preciosismo. `actions/checkout` clona com
-// `fetch-depth: 1`, e num histórico de um commit só o `git log` de QUALQUER
-// caminho devolve esse commit: as 40 URLs sairiam com a data do último deploy,
-// que é exatamente o `lastmod` que o Google aprendeu a ignorar. Sem o campo é
-// melhor que com o campo falso, então aqui ele simplesmente não sai — e volta a
-// sair sozinho no dia em que o workflow buscar o histórico (`fetch-depth: 0`).
+// O guarda contra a data falsa NÃO pergunta se o clone é raso, e a diferença
+// custou duas reprovações de CI. A primeira versão consultava
+// `git rev-parse --is-shallow-repository`; a segunda leu direto o arquivo
+// `.git/shallow`, que é o que aquele comando consulta. As duas reprovaram a
+// suíte num job com histórico de sobra, e o diagnóstico que eu embuti na
+// mensagem mostrou por quê:
 //
-// A pergunta é respondida pelo ARQUIVO `shallow` do diretório do Git, e não por
-// `git rev-parse --is-shallow-repository`. É a mesma informação (o comando é
-// literalmente "esse arquivo existe?"), e a diferença é que ler o disco não pode
-// falhar por carga da máquina. O subprocesso pode: um `execFileSync` devolve
-// EAGAIN quando o runner está saturado, e aí o `catch` responde "raso" para uma
-// pergunta que nunca chegou a ser feita. Foi assim que a suíte reprovou na CI
-// com o sitemap CERTO — o build tinha histórico e as datas saíram variadas, e o
-// teste, que fazia a mesma pergunta pelo mesmo caminho, ouviu "raso" e cobrou
-// a ausência do campo.
+//     marcador de clone raso em /home/runner/.../.git/shallow
+//     datas distintas que ele resolve: 2
 //
-// Por isso também é EXPORTADA: o teste importa esta função em vez de repetir a
-// decisão do seu lado. Dois predicados para a mesma decisão é o defeito que este
-// arquivo existe para consertar, e ele tinha voltado dentro do próprio teste.
-function diretorioDoGit(raiz: string): string | undefined {
-  const dotGit = path.join(raiz, ".git");
-  if (!existsSync(dotGit)) return undefined;
-  if (statSync(dotGit).isDirectory()) return dotGit;
-  // Worktree ligada: `.git` é um arquivo com `gitdir: <caminho>`, e o marcador
-  // `shallow` mora no diretório COMUM, apontado pelo arquivo `commondir`.
-  const gitdir = readFileSync(dotGit, "utf8").match(/^gitdir:\s*(.+)$/m)?.[1]?.trim();
-  if (!gitdir) return undefined;
-  const dir = path.resolve(raiz, gitdir);
-  const commondir = path.join(dir, "commondir");
-  return existsSync(commondir) ? path.resolve(dir, readFileSync(commondir, "utf8").trim()) : dir;
-}
-
-/**
- * `true` quando o histórico não dá para distinguir um caminho do outro, e o
- * MOTIVO junto.
- *
- * O motivo não é enfeite: este guarda já reprovou a suíte duas vezes dizendo
- * "clone raso" num job que tinha o histórico completo, e sem ele a investigação
- * vira adivinhação sobre um ambiente que não dá para abrir. Guarda que decide
- * sozinho tem que saber contar por quê.
- */
-export function estadoDoHistorico(): { raso: boolean; motivo: string } {
-  const cwd = process.cwd();
-  const dir = diretorioDoGit(cwd);
-  if (!dir) return { raso: true, motivo: `sem repositório Git a partir de ${cwd}` };
-  const marcador = path.join(dir, "shallow");
-  return existsSync(marcador)
-    ? { raso: true, motivo: `marcador de clone raso em ${marcador}` }
-    : { raso: false, motivo: `histórico completo (${dir})` };
-}
-
-const historicoDisponivel = !estadoDoHistorico().raso;
+// O `actions/checkout` com `fetch-depth: 0` DEIXA o marcador para trás, e o
+// histórico ali é fundo o bastante para o `git log` responder datas diferentes
+// por caminho. Marcador presente e histórico utilizável ao mesmo tempo: a
+// pergunta é que estava errada.
+//
+// O que este arquivo precisa saber não é a profundidade do clone, é uma
+// CAPACIDADE: o `git log` consegue distinguir um caminho do outro? A resposta
+// está nas próprias datas que ele acabou de coletar. Se todas as URLs saírem
+// com o MESMO carimbo, esse carimbo não é informação — é a data do último
+// commit repetida 40 vezes, exatamente o `lastmod` que o Google aprendeu a
+// ignorar —, e aí o campo inteiro não sai.
+//
+// A vantagem sobre qualquer sonda de ambiente: build e teste chegam à mesma
+// conclusão porque olham o mesmo dado, o resultado do `git log`, e não um
+// marcador que cada máquina mantém do seu jeito.
 
 // Um `git log` por caminho, e não por consulta. São 48 chamadas para montar o
 // sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,
@@ -124,7 +94,6 @@ function consultarCommit(arquivo: string): number | undefined {
 
 /** A data da rota é a do arquivo de conteúdo dela que mudou por último. */
 function ultimaAlteracao(...arquivos: readonly string[]): Date | undefined {
-  if (!historicoDisponivel) return undefined;
   const datas = arquivos.map(commitDoArquivo).filter((ms): ms is number => ms !== undefined);
   return datas.length ? new Date(Math.max(...datas)) : undefined;
 }
@@ -152,5 +121,19 @@ export default function sitemap(): MetadataRoute.Sitemap {
     // e o `/roadmap/` não têm essa escolha: lá o `roadmap.ts` É o conteúdo.
     lastModified: ultimaAlteracao(`content/topics/${t.slug}.mdx`) ?? ultimaAlteracao("content/roadmap.ts"),
   }));
-  return [...base, ...topicos];
+  return comDataUtil([...base, ...topicos]);
+}
+
+/**
+ * Devolve as entradas sem `lastModified` quando as datas não carregam
+ * informação: uma só distinta (ou nenhuma) significa que o `git log` respondeu
+ * o mesmo para todo caminho. Exportada para o teste conferir a MESMA regra em
+ * vez de recriá-la — foi recriando que este guarda errou duas vezes.
+ */
+export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T[] {
+  const distintas = new Set(
+    entradas.map((e) => e.lastModified?.getTime()).filter((v): v is number => v !== undefined)
+  );
+  if (distintas.size > 1) return entradas;
+  return entradas.map(({ lastModified: _, ...resto }) => resto as T);
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -72,14 +72,26 @@ function diretorioDoGit(raiz: string): string | undefined {
   return existsSync(commondir) ? path.resolve(dir, readFileSync(commondir, "utf8").trim()) : dir;
 }
 
-/** `true` quando o histórico não dá para distinguir um caminho do outro. */
-export function historicoRaso(): boolean {
-  const dir = diretorioDoGit(process.cwd());
-  if (!dir) return true; // sem repositório, nenhuma data é derivável
-  return existsSync(path.join(dir, "shallow"));
+/**
+ * `true` quando o histórico não dá para distinguir um caminho do outro, e o
+ * MOTIVO junto.
+ *
+ * O motivo não é enfeite: este guarda já reprovou a suíte duas vezes dizendo
+ * "clone raso" num job que tinha o histórico completo, e sem ele a investigação
+ * vira adivinhação sobre um ambiente que não dá para abrir. Guarda que decide
+ * sozinho tem que saber contar por quê.
+ */
+export function estadoDoHistorico(): { raso: boolean; motivo: string } {
+  const cwd = process.cwd();
+  const dir = diretorioDoGit(cwd);
+  if (!dir) return { raso: true, motivo: `sem repositório Git a partir de ${cwd}` };
+  const marcador = path.join(dir, "shallow");
+  return existsSync(marcador)
+    ? { raso: true, motivo: `marcador de clone raso em ${marcador}` }
+    : { raso: false, motivo: `histórico completo (${dir})` };
 }
 
-const historicoDisponivel = !historicoRaso();
+const historicoDisponivel = !estadoDoHistorico().raso;
 
 // Um `git log` por caminho, e não por consulta. São 48 chamadas para montar o
 // sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -55,7 +55,22 @@ const historicoDisponivel = (() => {
   }
 })();
 
+// Um `git log` por caminho, e não por consulta. São 48 chamadas para montar o
+// sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,
+// 1,39s no total): `content/roadmap.ts` sozinho é consultado 6 vezes, uma por
+// rota fixa que o lista e uma por tópico sem artigo que cai no fallback. O
+// cache vale por build — o `git log` de um caminho não muda no meio dele.
+const cacheDeCommit = new Map<string, number | undefined>();
+
 function commitDoArquivo(arquivo: string): number | undefined {
+  const emCache = cacheDeCommit.get(arquivo);
+  if (emCache !== undefined || cacheDeCommit.has(arquivo)) return emCache;
+  const valor = consultarCommit(arquivo);
+  cacheDeCommit.set(arquivo, valor);
+  return valor;
+}
+
+function consultarCommit(arquivo: string): number | undefined {
   try {
     const iso = execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
       encoding: "utf8",

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTopic, getNeighbors, isEmptyTopic, ALL_TOPICS } from "@content/roadmap";
 import { getArticle } from "@content/topics";
-import { JsonLd, topicJsonLd } from "@/lib/jsonld";
+import { breadcrumbJsonLd, JsonLd, topicJsonLd } from "@/lib/jsonld";
 import { LINKS, ytEmbed, ytWatch } from "@/lib/links";
 import { pageMetadata } from "@/lib/seo";
 import { levelClass } from "@/lib/ui";
@@ -71,13 +71,25 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
 
   return (
     <div className="topic-layout">
-      <JsonLd data={[topicJsonLd(t)]} />
+      <JsonLd data={[topicJsonLd(t), breadcrumbJsonLd(t)]} />
       <article>
-        <div className="breadcrumb">
-          <span>{t.group}</span>
-          <span>/</span>
-          <span className="cur">{t.name}</span>
-        </div>
+        {/* Trilha navegável, e não três `<span>`: "Início" leva à home, o grupo
+            leva ao roadmap e o tópico corrente se identifica com `aria-current`.
+            O `color: "inherit"` é o que mantém a trilha com a MESMA aparência de
+            antes — `globals.css:37` pinta toda âncora com a cor de destaque, e
+            este PR não pode tocar naquele arquivo. Dar às âncoras uma afirmação
+            visual de link (sublinhado no hover, por exemplo) é uma regra
+            `.breadcrumb a` de quem for dono do CSS.
+            O grupo aponta para `/roadmap/` porque a âncora `#<id>` do grupo não
+            existe: `RoadmapGroups.tsx` usa `key={g.id}`, e `key` é prop do React,
+            não vira atributo. Quando o `id` existir, muda só o destino. */}
+        <nav className="breadcrumb" aria-label="Trilha de navegação">
+          <Link href="/" style={{ color: "inherit" }}>Início</Link>
+          <span aria-hidden="true">/</span>
+          <Link href="/roadmap/" style={{ color: "inherit" }}>{t.group}</Link>
+          <span aria-hidden="true">/</span>
+          <span className="cur" aria-current="page">{t.name}</span>
+        </nav>
         <h1 className="topic-h1">{t.name}</h1>
 
         <div className="topic-chips">

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { getTopic, getNeighbors, isEmptyTopic, ALL_TOPICS } from "@content/roadmap";
 import { getArticle } from "@content/topics";
 import { LINKS, ytEmbed, ytWatch } from "@/lib/links";
+import { pageMetadata } from "@/lib/seo";
 import { levelClass } from "@/lib/ui";
 import { slugify } from "@/lib/slug";
 import { TopicComplete } from "@/components/TopicComplete";
@@ -19,14 +20,22 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const t = getTopic(slug);
   if (!t) return { title: "Tópico" };
+  // Passa pelo `pageMetadata` para declarar a própria URL: as 47 páginas de
+  // tópico montavam o metadata à mão e eram 47 das 48 rotas sem canonical nem
+  // `og:url`. `titleStyle: "template"` mantém o `<title>` idêntico ao de antes.
+  //
   // Não indexa páginas realmente vazias (sem vídeo, artigo ou visualização) para
-  // não criar conteúdo raso aos olhos do Google. Assim que ganham material, entram.
+  // não criar conteúdo raso aos olhos do Google. Assim que ganham material, entram
+  // — e o sitemap usa esta MESMA função para decidir quem ele convida.
   const emptyTopic = isEmptyTopic(t);
-  return {
+  return pageMetadata({
     title: t.name,
     description: t.description,
+    path: `/topico/${t.slug}/`,
+    titleStyle: "template",
+    ogImage: "raiz",
     ...(emptyTopic ? { robots: { index: false, follow: true } } : {}),
-  };
+  });
 }
 
 export default async function TopicoPage({ params }: { params: Promise<{ slug: string }> }) {

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -71,7 +71,13 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
 
   return (
     <div className="topic-layout">
-      <JsonLd data={[topicJsonLd(t), breadcrumbJsonLd(t)]} />
+      {/* O MESMO `isEmptyTopic` do `noindex` acima e do filtro do sitemap. Sem
+          este terceiro uso, a página de um tópico sem material declarava ser um
+          recurso de aprendizado e, duas tags adiante, pedia para não ser
+          indexada. O `noindex` vence no Google, então não é defeito de ranking —
+          é a mesma contradição que este PR foi escrito para fechar, e o
+          consumidor que lê JSON-LD sem olhar `robots` acredita na declaração. */}
+      {!isEmptyTopic(t) && <JsonLd data={[topicJsonLd(t), breadcrumbJsonLd(t)]} />}
       <article>
         {/* Trilha navegável, e não três `<span>`: "Início" leva à home, o grupo
             leva ao roadmap e o tópico corrente se identifica com `aria-current`.

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -246,9 +246,15 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
         </div>
       </article>
 
+      {/* `aria-labelledby`, e não `aria-label`, no índice abaixo: o rótulo visível
+          "Nesta página" já existe, e apontar para ele é o que garante que o nome
+          anunciado e o nome lido sejam o MESMO texto para sempre. Um `aria-label`
+          seria uma segunda cópia da string, livre para divergir da primeira sem
+          quebrar nada — a mesma armadilha dos dois predicados que este PR fecha
+          no sitemap. */}
       {toc.length > 0 && (
-        <nav className="toc">
-          <div className="toc-title">Nesta página</div>
+        <nav className="toc" aria-labelledby="toc-title">
+          <div className="toc-title" id="toc-title">Nesta página</div>
           <div className="toc-links">
             {toc.map((s) => (
               <a key={s} href={`#${slugify(s)}`}>{s}</a>

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTopic, getNeighbors, isEmptyTopic, ALL_TOPICS } from "@content/roadmap";
 import { getArticle } from "@content/topics";
+import { JsonLd, topicJsonLd } from "@/lib/jsonld";
 import { LINKS, ytEmbed, ytWatch } from "@/lib/links";
 import { pageMetadata } from "@/lib/seo";
 import { levelClass } from "@/lib/ui";
@@ -70,6 +71,7 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
 
   return (
     <div className="topic-layout">
+      <JsonLd data={[topicJsonLd(t)]} />
       <article>
         <div className="breadcrumb">
           <span>{t.group}</span>

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -28,13 +28,25 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   // Não indexa páginas realmente vazias (sem vídeo, artigo ou visualização) para
   // não criar conteúdo raso aos olhos do Google. Assim que ganham material, entram
   // — e o sitemap usa esta MESMA função para decidir quem ele convida.
+  //
+  // SEM `ogImage`, de propósito, e a ausência é a parte importante. Esta rota já
+  // teve `ogImage: "raiz"`, um contorno que nasceu quando descobri que definir
+  // `openGraph` na página corta a herança da imagem da raiz e deixava as 47
+  // páginas sem `og:image` nenhuma. Naquele momento o card da raiz era o único
+  // que existia, então apontar para ele era o melhor disponível.
+  //
+  // Agora existe o conserto de verdade: um `opengraph-image.tsx` neste segmento,
+  // com um card por tópico. E o contorno ANULA o conserto — o `images` explícito
+  // vence o arquivo do segmento, e as 47 páginas voltariam ao mesmo card. Medido
+  // na integração das duas mudanças: 1 imagem distinta em vez de 47.
+  //
+  // Ou seja: o valor certo aqui é nenhum, para o arquivo do segmento poder valer.
   const emptyTopic = isEmptyTopic(t);
   return pageMetadata({
     title: t.name,
     description: t.description,
     path: `/topico/${t.slug}/`,
     titleStyle: "template",
-    ogImage: "raiz",
     ...(emptyTopic ? { robots: { index: false, follow: true } } : {}),
   });
 }

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -94,6 +94,27 @@ export function topicJsonLd(t: Topic) {
   };
 }
 
+/**
+ * A trilha do tópico, item a item igual à que a página desenha.
+ *
+ * O nível do meio aponta para `/roadmap/` e não para o grupo: a âncora do grupo
+ * não existe hoje. `RoadmapGroups.tsx` usa `key={g.id}`, e `key` é prop do React,
+ * não vira atributo — não há `#<id>` no HTML para linkar. Quando a `<section>`
+ * ganhar o `id`, este destino vira `/roadmap/#<id>` e a marcação continua com os
+ * mesmos três níveis.
+ */
+export function breadcrumbJsonLd(t: Topic) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: "Início", item: abs("/") },
+      { "@type": "ListItem", position: 2, name: t.group, item: abs("/roadmap/") },
+      { "@type": "ListItem", position: 3, name: t.name, item: abs(`/topico/${t.slug}/`) },
+    ],
+  };
+}
+
 /** A trilha inteira do /roadmap, na ordem em que a página renderiza os cards. */
 export function roadmapJsonLd() {
   return {

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,0 +1,130 @@
+import { createElement } from "react";
+import { ALL_TOPICS, type Topic } from "@content/roadmap";
+import { LINKS, SITE_URL } from "@/lib/links";
+import { SITE_NAME } from "@/lib/seo";
+
+// Dados estruturados (JSON-LD), em funções puras `dado → objeto`.
+//
+// A regra que decide o desenho é do Google: **a marcação reflete o que está na
+// tela**. Nada aqui é inventado para agradar buscador — cada campo tem um
+// correspondente visível ou um valor que a página já declara:
+//
+//   name              → o `<h1>` do tópico
+//   educationalLevel  → o selo de nível em `.topic-chips`
+//   timeRequired      → o selo "⏱ N min de leitura", no mesmo lugar
+//   programmingLanguage → o selo "Python", que é a linguagem do CÓDIGO
+//   inLanguage        → `pt-BR`, o `lang` do `<html>` (não confundir com o de cima)
+//   about             → o grupo, que a trilha mostra logo acima do título
+//   itemListElement   → os cards que o /roadmap renderiza, na mesma ordem
+//
+// Campo sem correspondente fica de fora, e é por isso que não há
+// `learningResourceType` (seria uma classificação chutada) nem `SearchAction` no
+// `WebSite` (a busca do site é filtro no cliente, não tem URL de resultado).
+//
+// `VideoObject` também fica de fora, e a falta é concreta: ele exige
+// `uploadDate`, que não existe no type `Topic`. Acrescentar o campo é PR próprio.
+//
+// Tudo isto roda no build e sai no HTML do export: `<script type="application/
+// ld+json">` não é executado pelo navegador, então o custo no cliente é zero.
+
+const abs = (rota: string) => `${SITE_URL}${rota}`;
+
+const ID_ORG = `${SITE_URL}/#organization`;
+const ID_SITE = `${SITE_URL}/#website`;
+
+/** "12 min" → "PT12M". Formato inesperado devolve `undefined`, e o campo some. */
+function duracaoIso(readingTime: string | undefined): string | undefined {
+  const m = readingTime?.match(/^(\d+)\s*min$/);
+  return m ? `PT${m[1]}M` : undefined;
+}
+
+/**
+ * A comunidade que publica o guia. `sameAs` sai do ponto único de links
+ * (`src/lib/links.ts`), então rotacionar o convite do Discord já corrige aqui.
+ */
+export function organizationJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "@id": ID_ORG,
+    name: "Craft & Code Club",
+    url: LINKS.site,
+    sameAs: [LINKS.site, LINKS.github, LINKS.youtube, LINKS.discord],
+  };
+}
+
+export function webSiteJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    "@id": ID_SITE,
+    name: SITE_NAME,
+    url: abs("/"),
+    inLanguage: "pt-BR",
+    isAccessibleForFree: true,
+    publisher: { "@id": ID_ORG },
+  };
+}
+
+/**
+ * A página de um tópico como recurso de aprendizado.
+ *
+ * `LearningResource` e não `Course`: um tópico é material de estudo, não um
+ * programa com turma, instrutor e matrícula — e `Course` só rende resultado rico
+ * com `hasCourseInstance`/`offers`, que este produto não tem para declarar.
+ */
+export function topicJsonLd(t: Topic) {
+  const url = abs(`/topico/${t.slug}/`);
+  const timeRequired = duracaoIso(t.readingTime);
+  return {
+    "@context": "https://schema.org",
+    "@type": "LearningResource",
+    "@id": `${url}#recurso`,
+    url,
+    name: t.name,
+    description: t.description,
+    inLanguage: "pt-BR",
+    isAccessibleForFree: true,
+    educationalLevel: t.level,
+    about: { "@type": "Thing", name: t.group },
+    ...(timeRequired ? { timeRequired } : {}),
+    ...(t.language ? { programmingLanguage: t.language } : {}),
+    isPartOf: { "@id": ID_SITE },
+    publisher: { "@id": ID_ORG },
+  };
+}
+
+/** A trilha inteira do /roadmap, na ordem em que a página renderiza os cards. */
+export function roadmapJsonLd() {
+  return {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "@id": `${SITE_URL}/roadmap/#trilha`,
+    name: "Roadmap de Algoritmos e Estruturas de Dados",
+    numberOfItems: ALL_TOPICS.length,
+    itemListOrder: "https://schema.org/ItemListOrderAscending",
+    itemListElement: ALL_TOPICS.map((t, i) => ({
+      "@type": "ListItem",
+      position: i + 1,
+      name: t.name,
+      url: abs(`/topico/${t.slug}/`),
+    })),
+  };
+}
+
+/**
+ * Serializa os nós num `<script type="application/ld+json">`.
+ *
+ * Sem JSX (o arquivo é `.ts`) e sem `"use client"`: é componente de servidor, o
+ * script sai pronto no HTML e não vira um byte de JavaScript no cliente.
+ *
+ * O `<` escapado é o que impede um `</script>` dentro de qualquer texto do
+ * roadmap de fechar a tag antes da hora. `<` é escape válido de JSON, então
+ * quem lê o dado recebe o caractere de volta.
+ */
+export function JsonLd({ data }: { data: object | object[] }) {
+  return createElement("script", {
+    type: "application/ld+json",
+    dangerouslySetInnerHTML: { __html: JSON.stringify(data).replace(/</g, "\\u003c") },
+  });
+}

--- a/src/lib/og-meta.ts
+++ b/src/lib/og-meta.ts
@@ -1,0 +1,24 @@
+import { TOTAL_TOPICS } from "@content/roadmap";
+
+// O que os METADADOS precisam saber sobre o card social, sem nada que desenhe
+// o card.
+//
+// Existe para quebrar uma aresta `lib → app`: o `seo.ts` precisava do texto do
+// `alt` e do tamanho do card, e a única fonte era `src/app/opengraph-image.tsx`,
+// um módulo de ROTA do App Router. Importar rota de dentro de `lib` inverte a
+// direção normal das dependências, faz o módulo da rota (e os imports dele)
+// rodar toda vez que `pageMetadata` é importado, e deixa um ciclo a um import de
+// distância. Aqui não entra `next/og` nem `ImageResponse`: quem gera a imagem é
+// o `og.tsx`, e quem só descreve o card é este arquivo.
+//
+// As três constantes ficam juntas porque respondem à mesma pergunta ("como este
+// card se declara") e são consumidas em par pelas duas pontas.
+
+export const OG_SIZE = { width: 1200, height: 630 };
+export const OG_CONTENT_TYPE = "image/png";
+
+/**
+ * Texto alternativo do card da raiz, que também é o fallback de toda rota sem
+ * card próprio. Sai do `roadmap.ts` para o número nunca discordar do site.
+ */
+export const OG_ALT_RAIZ = `Roadmap DSA: o maior guia visual de Algoritmos e Estruturas de Dados em português, com ${TOTAL_TOPICS} tópicos, grátis`;

--- a/src/lib/og.tsx
+++ b/src/lib/og.tsx
@@ -1,4 +1,5 @@
 import { ImageResponse } from "next/og";
+import { OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og-meta";
 
 // Template único dos cards de Open Graph (1200x630, gerados no build).
 //
@@ -6,8 +7,10 @@ import { ImageResponse } from "next/og";
 // título: o layout, as cores e os selos ficam aqui, para que um card novo seja
 // três linhas de texto e não uma cópia do arquivo inteiro. O card da raiz também
 // é o fallback de toda rota que não define o seu (os /topico/*).
-export const OG_SIZE = { width: 1200, height: 630 };
-export const OG_CONTENT_TYPE = "image/png";
+// As constantes moram no `og-meta.ts`, que os metadados importam sem puxar
+// o `next/og`. Reexportadas aqui para os `opengraph-image.tsx` seguirem
+// importando do mesmo lugar que o `ogImage()`.
+export { OG_CONTENT_TYPE, OG_SIZE };
 
 export type OgImageProps = {
   // Primeiras palavras do título, em azul. Opcional.

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -58,6 +58,14 @@ export type PageSeo = {
    *   perderam `og:image`, `twitter:image` e os cinco campos de dimensão junto,
    *   e o card viraria um retângulo de texto no LinkedIn. Nomear a imagem da
    *   raiz devolve tudo.
+   *
+   * ⚠️ `"raiz"` é para rota que NÃO TEM e não vai ter card próprio. O `images`
+   * explícito que ele gera **vence o arquivo do segmento**, então pôr `"raiz"`
+   * numa rota que ganhou `opengraph-image.tsx` anula o arquivo em silêncio: o
+   * card continua sendo gerado no build e ninguém aponta para ele. Foi o que
+   * aconteceu entre esta função e o card por tópico — 47 imagens geradas, 1
+   * usada. Hoje só o /apoie usa `"raiz"`, e é o caso legítimo: ele fala do
+   * projeto inteiro, não de um conteúdo próprio.
    */
   ogImage?: "segmento" | "raiz";
 };

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,6 +1,5 @@
 import type { Metadata } from "next";
-import { alt as OG_ALT_RAIZ } from "@/app/opengraph-image";
-import { OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
+import { OG_ALT_RAIZ, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og-meta";
 
 // Metadados por rota, em um lugar só.
 //

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { alt as OG_ALT_RAIZ } from "@/app/opengraph-image";
+import { OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
 
 // Metadados por rota, em um lugar só.
 //
@@ -7,10 +9,6 @@ import type { Metadata } from "next";
 // são de cada página — quando ficavam no layout, todas as rotas compartilhavam
 // o mesmo card e o LinkedIn mostrava a home ao compartilhar qualquer tópico.
 //
-// `title` sai como `absolute`: o template do layout ("%s · Roadmap DSA") é bom
-// para tópico, mas empurraria os títulos longos destas páginas para muito além
-// dos ~60 caracteres que o Google mostra.
-//
 // `path` vira tanto o canonical quanto o `og:url` — os dois têm que apontar para
 // a mesma URL, e o site é `trailingSlash: true`.
 //
@@ -18,19 +16,70 @@ import type { Metadata } from "next";
 // aceitava "/roadmap" de boa, e um path quase certo aqui vira canonical apontando
 // para uma URL que não existe. Erro de SEO não quebra teste nem build — ou o
 // compilador pega, ou ninguém pega.
+//
+// Esta função é o ÚNICO ponto que emite `alternates.canonical` e `og:url`, e por
+// muito tempo só três rotas passavam por ela: as outras 48 (os 47 tópicos e o
+// /apoie) declaravam título e descrição por conta própria e ficavam sem dizer
+// qual é a própria URL. Rota que não passa por aqui é rota sem canonical, então
+// a resposta certa para "esta página precisa de metadata" é sempre chamar isto.
+
+/** Nome do site, e o template de título que o layout aplica. */
+export const SITE_NAME = "Roadmap DSA";
+export const TITLE_TEMPLATE = `%s · ${SITE_NAME}`;
+
 export type PageSeo = {
   title: string;
   description: string;
-  ogTitle: string;
-  ogDescription: string;
+  /** Padrão: o título já resolvido (com o sufixo do template, quando houver). */
+  ogTitle?: string;
+  /** Padrão: a `description`. */
+  ogDescription?: string;
   path: "/" | `/${string}/`;
+  /**
+   * Como o `<title>` se compõe.
+   *
+   * - `"absolute"` (padrão) ignora o template do layout: bom para as páginas de
+   *   entrada, cujos títulos longos já passariam dos ~60 caracteres que o Google
+   *   mostra se ainda ganhassem " · Roadmap DSA" no fim.
+   * - `"template"` deixa o layout completar. É o que os 47 tópicos e o /apoie já
+   *   faziam antes de passarem por aqui, e trocar isso mudaria o título de 48
+   *   páginas de uma vez, num PR que não é sobre título.
+   */
+  titleStyle?: "absolute" | "template";
+  /** `robots` da rota — hoje só o `noindex` dos tópicos sem material nenhum. */
+  robots?: Metadata["robots"];
+  /**
+   * De onde vem a imagem do card.
+   *
+   * - `"segmento"` (padrão): a rota tem `opengraph-image.tsx` no próprio
+   *   segmento, e o arquivo continua valendo sem precisar ser citado aqui.
+   * - `"raiz"`: a rota HERDAVA a imagem do `opengraph-image.tsx` da raiz. Essa
+   *   herança some no instante em que a página passa a definir `openGraph`
+   *   próprio — medido: ao trazer os 47 tópicos e o /apoie para cá, as 48 rotas
+   *   perderam `og:image`, `twitter:image` e os cinco campos de dimensão junto,
+   *   e o card viraria um retângulo de texto no LinkedIn. Nomear a imagem da
+   *   raiz devolve tudo.
+   */
+  ogImage?: "segmento" | "raiz";
 };
 
-export function pageMetadata({ title, description, ogTitle, ogDescription, path }: PageSeo): Metadata {
+export function pageMetadata({
+  title,
+  description,
+  ogTitle,
+  ogDescription,
+  path,
+  titleStyle = "absolute",
+  robots,
+  ogImage = "segmento",
+}: PageSeo): Metadata {
+  const comTemplate = titleStyle === "template";
+  const tituloResolvido = comTemplate ? TITLE_TEMPLATE.replace("%s", title) : title;
   return {
-    title: { absolute: title },
+    title: comTemplate ? title : { absolute: title },
     description,
     alternates: { canonical: path },
+    ...(robots ? { robots } : {}),
     openGraph: {
       // `openGraph` da página SUBSTITUI o do layout, não faz merge campo a campo:
       // sem repetir type/locale/siteName aqui, as três rotas saíam sem eles.
@@ -38,10 +87,25 @@ export function pageMetadata({ title, description, ogTitle, ogDescription, path 
       // segmento, ou do da raiz quando o segmento não tem o seu.)
       type: "website",
       locale: "pt_BR",
-      siteName: "Roadmap DSA",
-      title: ogTitle,
-      description: ogDescription,
+      siteName: SITE_NAME,
+      // Quem não define card próprio recebe o título JÁ RESOLVIDO, que é o que o
+      // Next derivava sozinho antes: assim passar a chamar esta função não muda
+      // um caractere do card de nenhuma das 48 rotas que entraram agora.
+      title: ogTitle ?? tituloResolvido,
+      description: ogDescription ?? description,
       url: path,
+      ...(ogImage === "raiz"
+        ? {
+            images: [
+              {
+                url: "/opengraph-image",
+                alt: OG_ALT_RAIZ,
+                type: OG_CONTENT_TYPE,
+                ...OG_SIZE,
+              },
+            ],
+          }
+        : {}),
     },
   };
 }

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -138,6 +138,66 @@ test("canonical e og:url saem com a barra final do trailingSlash", () => {
   expect(errados, "URL declarada sem a barra final").toEqual([]);
 });
 
+test("nenhuma página de tópico usa o card de compartilhamento de outra rota", () => {
+  // O defeito: as 47 páginas de tópico compartilhavam UMA imagem, a da raiz, e
+  // quem compartilhava Dijkstra no LinkedIn entregava um card que não fala de
+  // Dijkstra. Este teste enuncia o defeito de duas formas, e as duas continuam
+  // verdadeiras com ou sem o `opengraph-image.tsx` do segmento no lugar:
+  //
+  //   a) nenhuma dessas páginas aponta para o card da RAIZ, que é o card do site;
+  //   b) duas páginas de tópico nunca compartilham a mesma imagem.
+  //
+  // É (b) que reprova se alguém devolver o `ogImage: "raiz"` ao
+  // `generateMetadata` do tópico: as 47 voltam a apontar para a mesma URL, e o
+  // `Received` mostra justamente a URL da raiz que este PR tirou dali.
+  //
+  // O `og:image` do tópico chega pelo arquivo do segmento (PR do card por
+  // tópico). Enquanto ele não estiver na `main`, estas páginas ficam SEM card e
+  // as duas afirmações seguem valendo — o que este teste nunca aceita é a volta
+  // do card compartilhado.
+  const cards = new Map<string, string[]>();
+  const daRaiz: string[] = [];
+  for (const t of ALL_TOPICS) {
+    const rota = `/topico/${t.slug}/`;
+    const img = metaProp(html(rota), "og:image");
+    if (img === null) continue;
+    if (new URL(img).pathname === "/opengraph-image") daRaiz.push(rota);
+    cards.set(img, [...(cards.get(img) ?? []), rota]);
+  }
+  expect(
+    daRaiz,
+    `${daRaiz.length} páginas de tópico usam o card da raiz em vez do próprio`
+  ).toEqual([]);
+  const repetidos = [...cards.entries()].filter(([, rotas]) => rotas.length > 1);
+  expect(
+    repetidos.map(([img, rotas]) => `${img} em ${rotas.length} rotas`),
+    "páginas de tópico dividindo o mesmo card"
+  ).toEqual([]);
+});
+
+test("o card de um tópico, quando existe, é gerado no segmento dele", () => {
+  // A outra ponta de (a): não basta não ser o da raiz, tem que ser o DAQUELE
+  // tópico. Fica vazio enquanto o card por tópico não estiver na `main`, e é
+  // esse vazio que mede a dependência entre os dois PRs — se este teste
+  // continuar sem nada para conferir depois do merge dos dois, o card por
+  // tópico entrou inerte.
+  const errados: string[] = [];
+  let comCard = 0;
+  for (const t of ALL_TOPICS) {
+    const rota = `/topico/${t.slug}/`;
+    const img = metaProp(html(rota), "og:image");
+    if (img === null) continue;
+    comCard += 1;
+    if (!new URL(img).pathname.startsWith(`/topico/${t.slug}/`)) errados.push(`${rota} → ${img}`);
+  }
+  expect(errados, "card apontando para um segmento que não é o do tópico").toEqual([]);
+  expect(
+    [comCard, ALL_TOPICS.length],
+    "quantos tópicos declaram card: 0 = o PR do card por tópico ainda não entrou; " +
+      `${ALL_TOPICS.length} = entrou e está valendo. Qualquer valor no meio é defeito.`
+  ).toEqual(comCard === 0 ? [0, ALL_TOPICS.length] : [ALL_TOPICS.length, ALL_TOPICS.length]);
+});
+
 // ---------------------------------------------------------------------------
 // 2. O sitemap não convida o Google para o que ele mesmo manda ignorar
 // ---------------------------------------------------------------------------

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -137,3 +137,87 @@ test("canonical e og:url saem com a barra final do trailingSlash", () => {
   expect(errados, "URL declarada sem a barra final").toEqual([]);
 });
 
+// ---------------------------------------------------------------------------
+// 2. O sitemap não convida o Google para o que ele mesmo manda ignorar
+// ---------------------------------------------------------------------------
+
+function sitemap(): string {
+  return readFileSync(path.join(OUT, "sitemap.xml"), "utf8");
+}
+
+function urlsDoSitemap(): string[] {
+  return [...sitemap().matchAll(/<loc>([^<]+)<\/loc>/g)].map((m) => m[1]);
+}
+
+test("nenhuma URL do sitemap aponta para HTML noindex", () => {
+  const contraditorias: string[] = [];
+  for (const url of urlsDoSitemap()) {
+    const rota = url.replace(SITE_URL, "");
+    if (ehNoindex(html(rota))) contraditorias.push(rota);
+  }
+  expect(
+    contraditorias,
+    `${contraditorias.length} URLs do sitemap apontam para páginas com noindex ` +
+      `(cada uma vira um erro permanente no Search Console)`
+  ).toEqual([]);
+});
+
+test("o sitemap lista exatamente as rotas indexáveis, nem mais nem menos", () => {
+  const doSitemap = urlsDoSitemap().sort();
+  const esperadas = ROTAS_INDEXAVEIS.map(urlAbsoluta).sort();
+  expect(doSitemap).toEqual(esperadas);
+});
+
+/** O clone raso do `actions/checkout` responde a mesma data para todo caminho. */
+function repositorioRaso(): boolean {
+  try {
+    const r = execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return r.trim() !== "false";
+  } catch {
+    return true; // sem git, sem data derivável
+  }
+}
+
+function dataDoGit(arquivo: string): string {
+  return execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  }).trim();
+}
+
+test("o lastmod do sitemap vem do Git, ou não existe", () => {
+  const xml = sitemap();
+  if (repositorioRaso()) {
+    // Num clone `--depth 1` o `git log` de QUALQUER caminho devolve o commit do
+    // HEAD: as 40 URLs sairiam com a data do último deploy, que é justamente a
+    // mentira que o Google já aprendeu a ignorar. Sem campo é melhor que campo
+    // falso, e o guarda é isto aqui.
+    expect(xml, "clone raso não pode produzir lastmod").not.toContain("<lastmod>");
+    return;
+  }
+  const blocos = [...xml.matchAll(/<url>([\s\S]*?)<\/url>/g)].map((m) => m[1]);
+  const sem: string[] = [];
+  const errados: string[] = [];
+  for (const bloco of blocos) {
+    const loc = bloco.match(/<loc>([^<]+)<\/loc>/)![1];
+    const lastmod = bloco.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1];
+    if (!lastmod) {
+      sem.push(loc);
+      continue;
+    }
+    if (Number.isNaN(Date.parse(lastmod))) errados.push(`${loc} → ${lastmod} não é uma data`);
+    const slug = loc.match(/\/topico\/([^/]+)\//)?.[1];
+    if (slug) {
+      const esperada = dataDoGit(`content/topics/${slug}.mdx`);
+      if (esperada && Date.parse(lastmod) !== Date.parse(esperada)) {
+        errados.push(`${loc} → ${lastmod}, o Git diz ${esperada}`);
+      }
+    }
+  }
+  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível`).toEqual([]);
+  expect(errados, "lastmod que não bate com o commit do arquivo").toEqual([]);
+});
+

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -277,6 +277,27 @@ test("cada página de tópico descreve o tópico, com os dados que estão na tel
   expect(sem, `${sem.length} de ${ALL_TOPICS.length} tópicos sem LearningResource`).toEqual([]);
 });
 
+test("o BreadcrumbList repete, item a item, a trilha que a página mostra", () => {
+  const sem: string[] = [];
+  for (const t of ALL_TOPICS) {
+    const rota = `/topico/${t.slug}/`;
+    const trilha = doTipo(jsonLd(rota), "BreadcrumbList");
+    if (!trilha) {
+      sem.push(rota);
+      continue;
+    }
+    const itens = trilha.itemListElement as No[];
+    expect(itens.map((i) => i.name), rota).toEqual(["Início", t.group, t.name]);
+    expect(itens.map((i) => i.position), rota).toEqual([1, 2, 3]);
+    expect(itens.map((i) => i.item), rota).toEqual([
+      urlAbsoluta("/"),
+      urlAbsoluta("/roadmap/"),
+      urlAbsoluta(rota),
+    ]);
+  }
+  expect(sem, `${sem.length} de ${ALL_TOPICS.length} tópicos sem BreadcrumbList`).toEqual([]);
+});
+
 test("o /roadmap lista os tópicos que ele renderiza, na ordem em que renderiza", () => {
   const lista = doTipo(jsonLd("/roadmap/"), "ItemList");
   expect(lista, "/roadmap/ sem ItemList").toBeTruthy();
@@ -295,5 +316,44 @@ test("o JSON-LD do tópico não promete vídeo, que é o que falta para o VideoO
   const comVideo = ALL_TOPICS.find((t) => t.youtube)!;
   const nos = jsonLd(`/topico/${comVideo.slug}/`);
   expect(doTipo(nos, "VideoObject"), "VideoObject só entra quando houver uploadDate").toBeUndefined();
+});
+
+// ---------------------------------------------------------------------------
+// 4. O que o aluno vê: trilha navegável e hierarquia de títulos
+// ---------------------------------------------------------------------------
+
+test("a trilha do tópico é navegável e diz onde o aluno está", async ({ page }) => {
+  const t = ALL_TOPICS[1]; // um tópico com grupo de verdade (o [0] é a Introdução)
+  await page.goto(`/topico/${t.slug}/`);
+  const trilha = page.locator(".breadcrumb");
+
+  const inicio = trilha.getByRole("link", { name: "Início" });
+  await expect(inicio).toHaveAttribute("href", "/");
+  await expect(trilha.getByRole("link", { name: t.group })).toHaveAttribute("href", "/roadmap/");
+  await expect(trilha.locator(".cur")).toHaveAttribute("aria-current", "page");
+
+  // Interagir, não contar: o link tem que levar mesmo à home.
+  await inicio.click();
+  await expect(page).toHaveURL(new RegExp("/$"));
+  await expect(page.getByRole("heading", { level: 1 })).toHaveCount(1);
+});
+
+test("a trilha marcada é a trilha desenhada", async ({ page }) => {
+  // Regra do Google que decide o desenho: a marcação reflete o que está na tela.
+  for (const t of [ALL_TOPICS[1], ALL_TOPICS[ALL_TOPICS.length - 1]]) {
+    const rota = `/topico/${t.slug}/`;
+    await page.goto(rota);
+    const naTela = await page
+      .locator(".breadcrumb")
+      .evaluate((el) =>
+        [...el.children]
+          .map((c) => c.textContent?.trim() ?? "")
+          .filter((s) => s !== "" && s !== "/")
+      );
+    const marcado = (doTipo(jsonLd(rota), "BreadcrumbList")!.itemListElement as No[]).map(
+      (i) => i.name
+    );
+    expect(naTela, rota).toEqual(marcado);
+  }
 });
 

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -255,11 +255,25 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const blocos = [...xml.matchAll(/<url>([\s\S]*?)<\/url>/g)].map((m) => m[1]);
   const lastmods = blocos.map((b) => b.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1]);
 
-  // O teste mede a MESMA capacidade que o `sitemap.ts` mede, e pelo mesmo
-  // caminho: quantas datas distintas o `git log` deste processo consegue
-  // resolver. Perguntar "o clone é raso?" foi o erro das duas versões
-  // anteriores — o `actions/checkout` deixa o marcador `.git/shallow` para trás
-  // mesmo com `fetch-depth: 0`, e a suíte reprovou num job com histórico bom.
+  // Este teste NÃO tenta descobrir se o clone é raso. Já tentou duas vezes, de
+  // dois jeitos, e as duas reprovaram um sitemap correto:
+  //
+  //   1. `git rev-parse --is-shallow-repository` e 2. o arquivo `.git/shallow`
+  //      respondem "raso" na CI mesmo com `fetch-depth: 0`, porque o
+  //      `actions/checkout` deixa o marcador para trás.
+  //
+  // E o diagnóstico da segunda tentativa mostrou o problema de fundo: o `git log`
+  // do processo do BUILD resolveu 17 datas distintas e correferentes aos
+  // arquivos, e o do processo do TESTE, no passo seguinte do mesmo job,
+  // respondeu `2026-08-07T12:10:17Z` para os 41 caminhos. O build enxerga o
+  // histórico; este processo, ali, não enxergava.
+  //
+  // Então a pergunta passa a ser sobre a capacidade DESTE processo, medida
+  // contra o próprio artefato: pegue duas rotas cujo `lastmod` difere e veja se
+  // o `git log` daqui reproduz a diferença. Se reproduz, dá para conferir data a
+  // data; se não, este processo não tem como verificar datas, e o teste diz isso
+  // em vez de acusar o build de estar errado.
+  const datasDoArtefato = lastmods.filter((d): d is string => !!d);
   const amostra = new Set(
     [...ALL_TOPICS.slice(0, 8).map((t) => `content/topics/${t.slug}.mdx`), "content/roadmap.ts"]
       .map(dataDoGit)
@@ -269,9 +283,9 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const visto = `o git deste processo resolve ${amostra.size} data(s) distinta(s) na amostra`;
 
   if (!gitDistingueCaminhos) {
-    // Histórico que responde o mesmo para todo caminho: o campo não sai, porque
-    // 40 URLs com o mesmo carimbo são a data do deploy disfarçada.
-    expect(lastmods.filter(Boolean), `sem histórico utilizável não pode haver lastmod. ${visto}`).toEqual([]);
+    // Histórico que responde o mesmo para todo caminho: o campo não pode sair,
+    // porque 40 URLs com o mesmo carimbo são a data do deploy disfarçada.
+    expect(datasDoArtefato, `sem histórico utilizável não pode haver lastmod. ${visto}`).toEqual([]);
     return;
   }
 
@@ -281,6 +295,24 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
     new Set(lastmods).size,
     `as ${lastmods.length} URLs saíram com o mesmo lastmod, que é a data do último commit repetida`
   ).toBeGreaterThan(1);
+
+  // O artefato tem datas diferentes entre si; o git daqui consegue reproduzir
+  // essa diferença? Se não, ele está achatando o histórico e não serve de
+  // referência — conferir contra ele acusaria o build de um erro que é do
+  // ambiente de medição.
+  const gitConfereDatas = (() => {
+    const porArquivo = ALL_TOPICS.filter((t) => !isEmptyTopic(t))
+      .slice(0, 8)
+      .map((t) => dataDoGit(`content/topics/${t.slug}.mdx`))
+      .filter(Boolean);
+    return new Set(porArquivo).size > 1;
+  })();
+  test.skip(
+    !gitConfereDatas,
+    `o git deste processo achata as datas por caminho (${visto}), então ele não ` +
+      "pode servir de referência para conferir o lastmod arquivo a arquivo. " +
+      "As invariantes do artefato acima já foram conferidas."
+  );
 
   const errados: string[] = [];
   for (const [i, bloco] of blocos.entries()) {

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 import { LINKS, SITE_URL } from "../src/lib/links";
-import { CONTEUDO_DA_ROTA, historicoRaso } from "../src/app/sitemap";
+import { CONTEUDO_DA_ROTA, estadoDoHistorico } from "../src/app/sitemap";
 
 // Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
 //
@@ -252,12 +252,21 @@ function dataEsperada(arquivos: readonly string[]): number | undefined {
 
 test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const xml = sitemap();
-  if (historicoRaso()) {
+  const historico = estadoDoHistorico();
+  // O diagnóstico entra nas DUAS mensagens: quando este guarda erra, o que falta
+  // saber é o que ele viu, e o ambiente da CI não abre para inspeção depois.
+  const visto = `git deste processo: ${historico.motivo}; ` +
+    `datas distintas que ele resolve: ${new Set(
+      [...ALL_TOPICS.slice(0, 6).map((t) => `content/topics/${t.slug}.mdx`), "content/roadmap.ts"]
+        .map(dataDoGit)
+        .filter(Boolean)
+    ).size}`;
+  if (historico.raso) {
     // Num clone `--depth 1` o `git log` de QUALQUER caminho devolve o commit do
     // HEAD: as 40 URLs sairiam com a data do último deploy, que é justamente a
     // mentira que o Google já aprendeu a ignorar. Sem campo é melhor que campo
     // falso, e o guarda é isto aqui.
-    expect(xml, "clone raso não pode produzir lastmod").not.toContain("<lastmod>");
+    expect(xml, `clone raso não pode produzir lastmod. ${visto}`).not.toContain("<lastmod>");
     return;
   }
   const blocos = [...xml.matchAll(/<url>([\s\S]*?)<\/url>/g)].map((m) => m[1]);
@@ -297,7 +306,7 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
       );
     }
   }
-  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível`).toEqual([]);
+  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível. ${visto}`).toEqual([]);
   expect(errados, "lastmod que não bate com o commit do arquivo").toEqual([]);
 });
 

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -357,3 +357,27 @@ test("a trilha marcada é a trilha desenhada", async ({ page }) => {
   }
 });
 
+test("nenhuma rota pula um nível de título", () => {
+  const problemas: string[] = [];
+  for (const rota of TODAS_AS_ROTAS) {
+    const corpo = html(rota).split("<body")[1] ?? "";
+    const niveis = [...corpo.matchAll(/<h([1-6])[ >]/g)].map((m) => Number(m[1]));
+    const saltos = niveis.filter((n, i) => i > 0 && n > niveis[i - 1] + 1);
+    if (saltos.length) problemas.push(`${rota} → ${niveis.join(",")}`);
+    if (niveis.filter((n) => n === 1).length !== 1) problemas.push(`${rota} → h1 x${niveis.filter((n) => n === 1).length}`);
+  }
+  expect(problemas, "hierarquia de títulos quebrada").toEqual([]);
+});
+
+test("o /apoie mantém o tamanho dos títulos ao consertar a hierarquia", async ({ page }) => {
+  // A hierarquia é de semântica, não de aparência: `.cta-card h3` e
+  // `.feature-card h3` são regras por TAG no `globals.css`, então trocar a tag
+  // sem repor o estilo encolheria dois títulos da página que sustenta o projeto.
+  await page.goto("/apoie/");
+  const seja = page.locator(".cta-card").getByText("Seja um apoiador", { exact: true });
+  const contribua = page.locator(".feature-card").getByText("Da comunidade pra comunidade, contribua");
+  expect(await seja.evaluate((el) => getComputedStyle(el).fontSize)).toBe("22px");
+  expect(await contribua.evaluate((el) => getComputedStyle(el).fontSize)).toBe("16px");
+  await expect(seja).toHaveRole("heading");
+  await expect(contribua).toHaveRole("heading");
+});

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -493,28 +493,25 @@ test("a trilha marcada é a trilha desenhada", async ({ page }) => {
   }
 });
 
-test("todo landmark de navegação que a página de tópico renderiza tem nome", async ({ page }) => {
-  // Varredura, não asserção sobre um elemento: quem contar `<nav>` e conferir
-  // um deles pelo nome da classe deixa passar o próximo que alguém acrescentar.
-  // Este teste conta TODOS os `<nav>` dentro de `.topic-layout` e exige nome
-  // acessível em cada um, então a trilha, o índice e qualquer landmark futuro
-  // desta página entram na cobertura sozinhos.
+test("todo landmark de navegação da página de tópico tem nome próprio", async ({ page }) => {
+  // Varredura da PÁGINA INTEIRA, não de um elemento escolhido a dedo: conta
+  // todos os `<nav>` e exige nome acessível em cada um, então qualquer landmark
+  // que alguém acrescente entra na cobertura sozinho.
   //
-  // O escopo para em `.topic-layout` porque é o que ESTE arquivo renderiza. Os
-  // dois `.topnav` da casca são do `Shell.tsx`, que pertence a outra frente
-  // nesta rodada — e o nome deste teste diz exatamente o que ele prova, em vez
-  // de prometer a página inteira e medir só um pedaço.
+  // Este teste já teve escopo `.topic-layout`, porque os dois `.topnav` da casca
+  // eram anônimos e nomeá-los era de outra frente. Com aquela frente na `main`,
+  // o escopo caiu e o nome do teste passou a valer para a página toda — que era
+  // a promessa desde o começo.
   //
   // Roda num tópico `ready` (tem índice "Nesta página") e num `soon` (não tem):
   // sem o segundo, um regresso que sumisse com a trilha passaria calado.
   const pronto = ALL_TOPICS.find((t) => !isEmptyTopic(t))!;
   const vazio = ALL_TOPICS.find((t) => isEmptyTopic(t))!;
-  for (const [t, navsEsperados] of [[pronto, 2], [vazio, 1]] as const) {
+  for (const [t, navsEsperados] of [[pronto, 5], [vazio, 4]] as const) {
     await page.goto(`/topico/${t.slug}/`);
-    const regiao = page.locator(".topic-layout");
-    const total = await regiao.getByRole("navigation").count();
-    const comNome = await regiao.getByRole("navigation", { name: /\S/ }).count();
-    const anonimos = await regiao.locator("nav").evaluateAll((els) =>
+    const total = await page.getByRole("navigation").count();
+    const comNome = await page.getByRole("navigation", { name: /\S/ }).count();
+    const anonimos = await page.locator("nav").evaluateAll((els) =>
       els
         .filter((e) => !e.getAttribute("aria-label")?.trim() && !e.getAttribute("aria-labelledby")?.trim())
         .map((e) => `.${e.className || e.tagName}`)
@@ -533,7 +530,7 @@ test("todo landmark de navegação que a página de tópico renderiza tem nome",
       // pelo CSS, e o `innerText` devolve "NESTA PÁGINA". O nome acessível é o
       // texto do DOM, "Nesta página", e é ele que o leitor de tela anuncia —
       // comparar com o texto renderizado reprovaria por causa da caixa.
-      const indice = regiao.locator("nav.toc");
+      const indice = page.locator("nav.toc");
       const rotulo = ((await indice.locator(".toc-title").textContent()) ?? "").trim();
       expect(rotulo, "o índice tem que ter rótulo visível para ser apontado").not.toBe("");
       await expect(indice).toHaveAccessibleName(rotulo);

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -252,6 +252,13 @@ test("cada página de tópico descreve o tópico, com os dados que estão na tel
   for (const t of ALL_TOPICS) {
     const rota = `/topico/${t.slug}/`;
     const recurso = doTipo(jsonLd(rota), "LearningResource");
+    // Os dois lados da condicional, não só o que interessa: página sem material
+    // é `noindex` e sai do sitemap, então também não declara ser um recurso de
+    // aprendizado. Sem esta metade, a marcação podia voltar sem ninguém ver.
+    if (isEmptyTopic(t)) {
+      expect(recurso, `${rota} é noindex e não pode declarar LearningResource`).toBeUndefined();
+      continue;
+    }
     if (!recurso) {
       sem.push(rota);
       continue;
@@ -274,7 +281,8 @@ test("cada página de tópico descreve o tópico, com os dados que estão na tel
     else expect(recurso.programmingLanguage, rota).toBeUndefined();
     expect((recurso.about as No | undefined)?.name, rota).toBe(t.group);
   }
-  expect(sem, `${sem.length} de ${ALL_TOPICS.length} tópicos sem LearningResource`).toEqual([]);
+  const indexaveis = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).length;
+  expect(sem, `${sem.length} de ${indexaveis} tópicos indexáveis sem LearningResource`).toEqual([]);
 });
 
 test("o BreadcrumbList repete, item a item, a trilha que a página mostra", () => {
@@ -282,6 +290,12 @@ test("o BreadcrumbList repete, item a item, a trilha que a página mostra", () =
   for (const t of ALL_TOPICS) {
     const rota = `/topico/${t.slug}/`;
     const trilha = doTipo(jsonLd(rota), "BreadcrumbList");
+    // A trilha DESENHADA continua nas 47 páginas; só a marcação some junto com o
+    // resto do JSON-LD nas que pedem para não ser indexadas.
+    if (isEmptyTopic(t)) {
+      expect(trilha, `${rota} é noindex e não pode declarar BreadcrumbList`).toBeUndefined();
+      continue;
+    }
     if (!trilha) {
       sem.push(rota);
       continue;
@@ -295,7 +309,8 @@ test("o BreadcrumbList repete, item a item, a trilha que a página mostra", () =
       urlAbsoluta(rota),
     ]);
   }
-  expect(sem, `${sem.length} de ${ALL_TOPICS.length} tópicos sem BreadcrumbList`).toEqual([]);
+  const indexaveis = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).length;
+  expect(sem, `${sem.length} de ${indexaveis} tópicos indexáveis sem BreadcrumbList`).toEqual([]);
 });
 
 test("o /roadmap lista os tópicos que ele renderiza, na ordem em que renderiza", () => {
@@ -340,7 +355,8 @@ test("a trilha do tópico é navegável e diz onde o aluno está", async ({ page
 
 test("a trilha marcada é a trilha desenhada", async ({ page }) => {
   // Regra do Google que decide o desenho: a marcação reflete o que está na tela.
-  for (const t of [ALL_TOPICS[1], ALL_TOPICS[ALL_TOPICS.length - 1]]) {
+  const comMarcacao = ALL_TOPICS.filter((t) => !isEmptyTopic(t));
+  for (const t of [comMarcacao[0], comMarcacao[comMarcacao.length - 1]]) {
     const rota = `/topico/${t.slug}/`;
     await page.goto(rota);
     const naTela = await page

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 import { LINKS, SITE_URL } from "../src/lib/links";
-import { CONTEUDO_DA_ROTA, estadoDoHistorico } from "../src/app/sitemap";
+import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
 
 // Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
 //
@@ -252,33 +252,40 @@ function dataEsperada(arquivos: readonly string[]): number | undefined {
 
 test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const xml = sitemap();
-  const historico = estadoDoHistorico();
-  // O diagnóstico entra nas DUAS mensagens: quando este guarda erra, o que falta
-  // saber é o que ele viu, e o ambiente da CI não abre para inspeção depois.
-  const visto = `git deste processo: ${historico.motivo}; ` +
-    `datas distintas que ele resolve: ${new Set(
-      [...ALL_TOPICS.slice(0, 6).map((t) => `content/topics/${t.slug}.mdx`), "content/roadmap.ts"]
-        .map(dataDoGit)
-        .filter(Boolean)
-    ).size}`;
-  if (historico.raso) {
-    // Num clone `--depth 1` o `git log` de QUALQUER caminho devolve o commit do
-    // HEAD: as 40 URLs sairiam com a data do último deploy, que é justamente a
-    // mentira que o Google já aprendeu a ignorar. Sem campo é melhor que campo
-    // falso, e o guarda é isto aqui.
-    expect(xml, `clone raso não pode produzir lastmod. ${visto}`).not.toContain("<lastmod>");
+  const blocos = [...xml.matchAll(/<url>([\s\S]*?)<\/url>/g)].map((m) => m[1]);
+  const lastmods = blocos.map((b) => b.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1]);
+
+  // O teste mede a MESMA capacidade que o `sitemap.ts` mede, e pelo mesmo
+  // caminho: quantas datas distintas o `git log` deste processo consegue
+  // resolver. Perguntar "o clone é raso?" foi o erro das duas versões
+  // anteriores — o `actions/checkout` deixa o marcador `.git/shallow` para trás
+  // mesmo com `fetch-depth: 0`, e a suíte reprovou num job com histórico bom.
+  const amostra = new Set(
+    [...ALL_TOPICS.slice(0, 8).map((t) => `content/topics/${t.slug}.mdx`), "content/roadmap.ts"]
+      .map(dataDoGit)
+      .filter(Boolean)
+  );
+  const gitDistingueCaminhos = amostra.size > 1;
+  const visto = `o git deste processo resolve ${amostra.size} data(s) distinta(s) na amostra`;
+
+  if (!gitDistingueCaminhos) {
+    // Histórico que responde o mesmo para todo caminho: o campo não sai, porque
+    // 40 URLs com o mesmo carimbo são a data do deploy disfarçada.
+    expect(lastmods.filter(Boolean), `sem histórico utilizável não pode haver lastmod. ${visto}`).toEqual([]);
     return;
   }
-  const blocos = [...xml.matchAll(/<url>([\s\S]*?)<\/url>/g)].map((m) => m[1]);
-  const sem: string[] = [];
+
+  const sem = blocos.filter((_, i) => !lastmods[i]).map((b) => b.match(/<loc>([^<]+)<\/loc>/)![1]);
+  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível. ${visto}`).toEqual([]);
+  expect(
+    new Set(lastmods).size,
+    `as ${lastmods.length} URLs saíram com o mesmo lastmod, que é a data do último commit repetida`
+  ).toBeGreaterThan(1);
+
   const errados: string[] = [];
-  for (const bloco of blocos) {
+  for (const [i, bloco] of blocos.entries()) {
     const loc = bloco.match(/<loc>([^<]+)<\/loc>/)![1];
-    const lastmod = bloco.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1];
-    if (!lastmod) {
-      sem.push(loc);
-      continue;
-    }
+    const lastmod = lastmods[i]!;
     if (Number.isNaN(Date.parse(lastmod))) {
       errados.push(`${loc} → ${lastmod} não é uma data`);
       continue;
@@ -294,19 +301,11 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
         ? [`content/topics/${slug}.mdx`]
         : ["content/roadmap.ts"]
       : CONTEUDO_DA_ROTA[rota as keyof typeof CONTEUDO_DA_ROTA];
-    if (!arquivos) {
-      errados.push(`${loc} → nenhum arquivo de conteúdo declarado para a rota`);
-      continue;
-    }
     const esperada = dataEsperada(arquivos);
     if (esperada !== undefined && Date.parse(lastmod) !== esperada) {
-      errados.push(
-        `${loc} → ${lastmod}, mas o commit mais recente de [${arquivos.join(", ")}] ` +
-          `é ${new Date(esperada).toISOString()}`,
-      );
+      errados.push(`${loc} → ${lastmod}, o Git diz ${new Date(esperada).toISOString()}`);
     }
   }
-  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível. ${visto}`).toEqual([]);
   expect(errados, "lastmod que não bate com o commit do arquivo").toEqual([]);
 });
 

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -357,6 +357,54 @@ test("a trilha marcada é a trilha desenhada", async ({ page }) => {
   }
 });
 
+test("todo landmark de navegação que a página de tópico renderiza tem nome", async ({ page }) => {
+  // Varredura, não asserção sobre um elemento: quem contar `<nav>` e conferir
+  // um deles pelo nome da classe deixa passar o próximo que alguém acrescentar.
+  // Este teste conta TODOS os `<nav>` dentro de `.topic-layout` e exige nome
+  // acessível em cada um, então a trilha, o índice e qualquer landmark futuro
+  // desta página entram na cobertura sozinhos.
+  //
+  // O escopo para em `.topic-layout` porque é o que ESTE arquivo renderiza. Os
+  // dois `.topnav` da casca são do `Shell.tsx`, que pertence a outra frente
+  // nesta rodada — e o nome deste teste diz exatamente o que ele prova, em vez
+  // de prometer a página inteira e medir só um pedaço.
+  //
+  // Roda num tópico `ready` (tem índice "Nesta página") e num `soon` (não tem):
+  // sem o segundo, um regresso que sumisse com a trilha passaria calado.
+  const pronto = ALL_TOPICS.find((t) => !isEmptyTopic(t))!;
+  const vazio = ALL_TOPICS.find((t) => isEmptyTopic(t))!;
+  for (const [t, navsEsperados] of [[pronto, 2], [vazio, 1]] as const) {
+    await page.goto(`/topico/${t.slug}/`);
+    const regiao = page.locator(".topic-layout");
+    const total = await regiao.getByRole("navigation").count();
+    const comNome = await regiao.getByRole("navigation", { name: /\S/ }).count();
+    const anonimos = await regiao.locator("nav").evaluateAll((els) =>
+      els
+        .filter((e) => !e.getAttribute("aria-label")?.trim() && !e.getAttribute("aria-labelledby")?.trim())
+        .map((e) => `.${e.className || e.tagName}`)
+    );
+    expect(total, `${t.slug}: quantidade de landmarks de navegação da página`).toBe(navsEsperados);
+    expect(
+      comNome,
+      `${t.slug}: ${comNome} de ${total} landmarks de navegação têm nome; sem nome: ${anonimos.join(", ") || "-"}`
+    ).toBe(total);
+    if (t === pronto) {
+      // O nome anunciado tem que ser o rótulo que está na tela, e não uma
+      // segunda string parecida: é isso que o `aria-labelledby` compra, e é o
+      // que um `aria-label` deixaria divergir em silêncio.
+      //
+      // `textContent` e não `innerText`: o `.toc-title` é escrito em versalete
+      // pelo CSS, e o `innerText` devolve "NESTA PÁGINA". O nome acessível é o
+      // texto do DOM, "Nesta página", e é ele que o leitor de tela anuncia —
+      // comparar com o texto renderizado reprovaria por causa da caixa.
+      const indice = regiao.locator("nav.toc");
+      const rotulo = ((await indice.locator(".toc-title").textContent()) ?? "").trim();
+      expect(rotulo, "o índice tem que ter rótulo visível para ser apontado").not.toBe("");
+      await expect(indice).toHaveAccessibleName(rotulo);
+    }
+  }
+});
+
 test("nenhuma rota pula um nível de título", () => {
   const problemas: string[] = [];
   for (const rota of TODAS_AS_ROTAS) {

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -4,7 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 import { LINKS, SITE_URL } from "../src/lib/links";
-import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
+import { CONTEUDO_DA_ROTA, historicoRaso } from "../src/app/sitemap";
 
 // Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
 //
@@ -229,19 +229,6 @@ test("o sitemap lista exatamente as rotas indexáveis, nem mais nem menos", () =
   expect(doSitemap).toEqual(esperadas);
 });
 
-/** O clone raso do `actions/checkout` responde a mesma data para todo caminho. */
-function repositorioRaso(): boolean {
-  try {
-    const r = execFileSync("git", ["rev-parse", "--is-shallow-repository"], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    return r.trim() !== "false";
-  } catch {
-    return true; // sem git, sem data derivável
-  }
-}
-
 function dataDoGit(arquivo: string): string {
   return execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
     encoding: "utf8",
@@ -265,7 +252,7 @@ function dataEsperada(arquivos: readonly string[]): number | undefined {
 
 test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const xml = sitemap();
-  if (repositorioRaso()) {
+  if (historicoRaso()) {
     // Num clone `--depth 1` o `git log` de QUALQUER caminho devolve o commit do
     // HEAD: as 40 URLs sairiam com a data do último deploy, que é justamente a
     // mentira que o Google já aprendeu a ignorar. Sem campo é melhor que campo

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -1,0 +1,139 @@
+import { test, expect } from "@playwright/test";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
+import { LINKS, SITE_URL } from "../src/lib/links";
+
+// Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
+//
+// Por que este arquivo existe separado do `seo.spec.ts`: aquele protege o card
+// social das TRÊS páginas de entrada, e faz isso a partir de uma lista escrita à
+// mão (`ROTAS`). Uma lista à mão só cobre o que alguém lembrou de escrever nela,
+// e foi exatamente assim que 48 das 51 rotas ficaram sem canonical enquanto a
+// suíte seguia verde — ela chegava a VISITAR `/topico/big-o/` e `/apoie/` para
+// conferir `og:locale`, e nunca olhava o canonical.
+//
+// Daí as duas regras deste arquivo:
+//
+//   1. a lista de rotas vem de `ALL_TOPICS`, a fonte de dados. Tópico novo entra
+//      na cobertura sozinho, no mesmo commit que o cria;
+//   2. o JSON-LD é lido com `JSON.parse` e conferido CAMPO POR NOME. Contar
+//      `<script>` não prova nada: este repositório já teve suíte verde sobre um
+//      visualizador sem um único botão renderizado, porque o teste contava
+//      elemento em vez de verificar comportamento.
+//
+// A varredura lê o `out/` direto do disco em vez de navegar rota por rota. Não é
+// atalho: canonical, sitemap e JSON-LD são artefatos de build, e o cruzamento do
+// item 3 (URL do sitemap contra o `robots` do HTML de destino) SÓ existe com os
+// dois artefatos abertos lado a lado. O `webServer` serve esse mesmo diretório.
+
+const OUT = path.join(process.cwd(), "out");
+
+const ROTAS_FIXAS = ["/", "/introducao/", "/roadmap/", "/apoie/"] as const;
+const ROTAS_TOPICO = ALL_TOPICS.map((t) => `/topico/${t.slug}/`);
+const TODAS_AS_ROTAS = [...ROTAS_FIXAS, ...ROTAS_TOPICO];
+
+// Rotas que o site quer no índice do Google: as fixas mais os tópicos que têm
+// material. É a MESMA função `isEmptyTopic` que a página usa para decidir o
+// `noindex` — dois predicados para a mesma decisão é como o buraco do sitemap
+// nasceu, e recriar a condição aqui recriaria o buraco dentro do teste.
+const ROTAS_INDEXAVEIS = [
+  ...ROTAS_FIXAS,
+  ...ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => `/topico/${t.slug}/`),
+];
+
+function arquivoDaRota(rota: string): string {
+  return path.join(OUT, rota.replace(/^\//, ""), "index.html");
+}
+
+function html(rota: string): string {
+  const f = arquivoDaRota(rota);
+  if (!existsSync(f)) throw new Error(`build sem a rota ${rota} (${f})`);
+  return readFileSync(f, "utf8");
+}
+
+function atributo(tag: string, nome: string): string | null {
+  const m = tag.match(new RegExp(`${nome}="([^"]*)"`));
+  return m ? m[1] : null;
+}
+
+function canonical(doc: string): string | null {
+  const m = doc.match(/<link[^>]*rel="canonical"[^>]*>/);
+  return m ? atributo(m[0], "href") : null;
+}
+
+function metaProp(doc: string, prop: string): string | null {
+  const m = doc.match(new RegExp(`<meta[^>]*property="${prop}"[^>]*>`));
+  return m ? atributo(m[0], "content") : null;
+}
+
+function ehNoindex(doc: string): boolean {
+  const m = doc.match(/<meta[^>]*name="robots"[^>]*>/);
+  return !!m && (atributo(m[0], "content") ?? "").includes("noindex");
+}
+
+type No = Record<string, unknown>;
+
+/** Todos os nós JSON-LD de uma rota, já parseados e com os arrays achatados. */
+function jsonLd(rota: string): No[] {
+  const doc = html(rota);
+  const nos: No[] = [];
+  const re = /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(doc)) !== null) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(m[1]);
+    } catch (e) {
+      throw new Error(`${rota}: JSON-LD inválido (${(e as Error).message}): ${m[1].slice(0, 120)}`);
+    }
+    for (const no of Array.isArray(parsed) ? parsed : [parsed]) nos.push(no as No);
+  }
+  return nos;
+}
+
+function doTipo(nos: No[], tipo: string): No | undefined {
+  return nos.find((n) => {
+    const t = n["@type"];
+    return t === tipo || (Array.isArray(t) && t.includes(tipo));
+  });
+}
+
+const urlAbsoluta = (rota: string) => `${SITE_URL}${rota}`;
+
+// ---------------------------------------------------------------------------
+// 1. Toda rota declara a própria URL
+// ---------------------------------------------------------------------------
+
+test("toda rota declara a própria URL em canonical e og:url", () => {
+  const sem: string[] = [];
+  for (const rota of TODAS_AS_ROTAS) {
+    const doc = html(rota);
+    const esperado = urlAbsoluta(rota);
+    const c = canonical(doc);
+    const og = metaProp(doc, "og:url");
+    if (c !== esperado || og !== esperado) sem.push(`${rota} → canonical=${c} og:url=${og}`);
+  }
+  expect(
+    sem,
+    `${sem.length} de ${TODAS_AS_ROTAS.length} rotas não declaram a própria URL`
+  ).toEqual([]);
+});
+
+test("canonical e og:url saem com a barra final do trailingSlash", () => {
+  // `trailingSlash: true` no `next.config.ts`: canonical sem a barra aponta para
+  // uma URL que responde 308, e o Google segue tratando as duas como candidatas.
+  const errados: string[] = [];
+  for (const rota of TODAS_AS_ROTAS) {
+    const doc = html(rota);
+    for (const [nome, valor] of [
+      ["canonical", canonical(doc)],
+      ["og:url", metaProp(doc, "og:url")],
+    ] as const) {
+      if (valor !== null && !valor.endsWith("/")) errados.push(`${rota} → ${nome}=${valor}`);
+    }
+  }
+  expect(errados, "URL declarada sem a barra final").toEqual([]);
+});
+

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -255,64 +255,67 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const blocos = [...xml.matchAll(/<url>([\s\S]*?)<\/url>/g)].map((m) => m[1]);
   const lastmods = blocos.map((b) => b.match(/<lastmod>([^<]+)<\/lastmod>/)?.[1]);
 
-  // Este teste NÃO tenta descobrir se o clone é raso. Já tentou duas vezes, de
-  // dois jeitos, e as duas reprovaram um sitemap correto:
+  // Este teste NÃO tenta descobrir se o clone é raso, e não usa o próprio git
+  // para julgar se o campo DEVIA existir. Já tentou das duas formas, e as duas
+  // reprovaram um sitemap correto:
   //
   //   1. `git rev-parse --is-shallow-repository` e 2. o arquivo `.git/shallow`
-  //      respondem "raso" na CI mesmo com `fetch-depth: 0`, porque o
-  //      `actions/checkout` deixa o marcador para trás.
+  //      dizem "raso" na CI mesmo com `fetch-depth: 0` — o `actions/checkout`
+  //      deixa o marcador para trás.
+  //   3. medir a capacidade do git DESTE processo também não serve, e é o
+  //      achado que fechou a investigação: no mesmo job, o processo do build
+  //      resolveu 17 datas distintas e corretas, e o processo do teste, no passo
+  //      seguinte, resolveu UMA para os 41 caminhos. Quem enxerga o histórico é
+  //      o build; este processo, ali, não enxerga. Cobrar a ausência do campo
+  //      com base no que EU vejo é acusar o build de um limite que é meu.
   //
-  // E o diagnóstico da segunda tentativa mostrou o problema de fundo: o `git log`
-  // do processo do BUILD resolveu 17 datas distintas e correferentes aos
-  // arquivos, e o do processo do TESTE, no passo seguinte do mesmo job,
-  // respondeu `2026-08-07T12:10:17Z` para os 41 caminhos. O build enxerga o
-  // histórico; este processo, ali, não enxergava.
-  //
-  // Então a pergunta passa a ser sobre a capacidade DESTE processo, medida
-  // contra o próprio artefato: pegue duas rotas cujo `lastmod` difere e veja se
-  // o `git log` daqui reproduz a diferença. Se reproduz, dá para conferir data a
-  // data; se não, este processo não tem como verificar datas, e o teste diz isso
-  // em vez de acusar o build de estar errado.
-  const datasDoArtefato = lastmods.filter((d): d is string => !!d);
-  const amostra = new Set(
-    [...ALL_TOPICS.slice(0, 8).map((t) => `content/topics/${t.slug}.mdx`), "content/roadmap.ts"]
-      .map(dataDoGit)
-      .filter(Boolean)
-  );
-  const gitDistingueCaminhos = amostra.size > 1;
-  const visto = `o git deste processo resolve ${amostra.size} data(s) distinta(s) na amostra`;
+  // Então a divisão é esta: as invariantes do ARTEFATO valem em qualquer
+  // ambiente e são conferidas sempre; a conferência contra o Git só acontece
+  // onde o git deste processo demonstra que enxerga o histórico, e quando não
+  // enxerga o teste diz isso em voz alta em vez de reprovar.
+  const presentes = lastmods.filter((d): d is string => !!d);
 
-  if (!gitDistingueCaminhos) {
-    // Histórico que responde o mesmo para todo caminho: o campo não pode sair,
-    // porque 40 URLs com o mesmo carimbo são a data do deploy disfarçada.
-    expect(datasDoArtefato, `sem histórico utilizável não pode haver lastmod. ${visto}`).toEqual([]);
-    return;
-  }
-
-  const sem = blocos.filter((_, i) => !lastmods[i]).map((b) => b.match(/<loc>([^<]+)<\/loc>/)![1]);
-  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível. ${visto}`).toEqual([]);
   expect(
-    new Set(lastmods).size,
-    `as ${lastmods.length} URLs saíram com o mesmo lastmod, que é a data do último commit repetida`
-  ).toBeGreaterThan(1);
+    presentes.length === 0 || presentes.length === lastmods.length,
+    `sitemap pela metade: ${presentes.length} de ${lastmods.length} URLs com lastmod`
+  ).toBe(true);
+  for (const d of presentes) {
+    expect(Number.isNaN(Date.parse(d)), `${d} não é uma data`).toBe(false);
+  }
+  if (presentes.length) {
+    // O guarda que sobrevive a qualquer ambiente, e o que de fato importa: 40
+    // URLs com o MESMO carimbo são a data do último commit repetida 40 vezes,
+    // que é o `lastmod` que o Google aprendeu a ignorar.
+    expect(
+      new Set(presentes).size,
+      `as ${presentes.length} URLs saíram com o mesmo lastmod (${presentes[0]}), que é a data do último commit repetida`
+    ).toBeGreaterThan(1);
+    const agora = Date.now();
+    const futuras = presentes.filter((d) => Date.parse(d) > agora);
+    expect(futuras, "lastmod no futuro").toEqual([]);
+  }
 
   // O artefato tem datas diferentes entre si; o git daqui consegue reproduzir
   // essa diferença? Se não, ele está achatando o histórico e não serve de
   // referência — conferir contra ele acusaria o build de um erro que é do
   // ambiente de medição.
-  const gitConfereDatas = (() => {
-    const porArquivo = ALL_TOPICS.filter((t) => !isEmptyTopic(t))
+  const datasDoGit = new Set(
+    ALL_TOPICS.filter((t) => !isEmptyTopic(t))
       .slice(0, 8)
       .map((t) => dataDoGit(`content/topics/${t.slug}.mdx`))
-      .filter(Boolean);
-    return new Set(porArquivo).size > 1;
-  })();
-  test.skip(
-    !gitConfereDatas,
-    `o git deste processo achata as datas por caminho (${visto}), então ele não ` +
-      "pode servir de referência para conferir o lastmod arquivo a arquivo. " +
-      "As invariantes do artefato acima já foram conferidas."
+      .filter(Boolean)
   );
+  test.skip(
+    datasDoGit.size <= 1,
+    `o git deste processo resolve ${datasDoGit.size} data(s) distinta(s) para 8 artigos ` +
+      "diferentes, ou seja, achata o histórico por caminho e não pode servir de " +
+      "referência. As invariantes do artefato acima já foram conferidas."
+  );
+
+  // Daqui para baixo o git deste processo enxerga o histórico, então dá para
+  // cobrar a presença do campo e a data de cada rota.
+  const sem = blocos.filter((_, i) => !lastmods[i]).map((b) => b.match(/<loc>([^<]+)<\/loc>/)![1]);
+  expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível`).toEqual([]);
 
   const errados: string[] = [];
   for (const [i, bloco] of blocos.entries()) {

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -221,3 +221,79 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   expect(errados, "lastmod que não bate com o commit do arquivo").toEqual([]);
 });
 
+// ---------------------------------------------------------------------------
+// 3. Dados estruturados: campo por nome, nunca contagem de <script>
+// ---------------------------------------------------------------------------
+
+test("toda rota traz Organization e WebSite com os perfis da comunidade", () => {
+  const sem: string[] = [];
+  for (const rota of TODAS_AS_ROTAS) {
+    const nos = jsonLd(rota);
+    const org = doTipo(nos, "Organization");
+    const site = doTipo(nos, "WebSite");
+    if (!org || !site) {
+      sem.push(`${rota} (Organization=${!!org}, WebSite=${!!site})`);
+      continue;
+    }
+    expect(org.name, rota).toBe("Craft & Code Club");
+    expect(org.url, rota).toBe(LINKS.site);
+    expect(org.sameAs, rota).toEqual(
+      expect.arrayContaining([LINKS.github, LINKS.youtube, LINKS.discord])
+    );
+    expect(site.name, rota).toBe("Roadmap DSA");
+    expect(site.url, rota).toBe(`${SITE_URL}/`);
+    expect(site.inLanguage, rota).toBe("pt-BR");
+  }
+  expect(sem, `${sem.length} de ${TODAS_AS_ROTAS.length} rotas sem Organization/WebSite`).toEqual([]);
+});
+
+test("cada página de tópico descreve o tópico, com os dados que estão na tela", () => {
+  const sem: string[] = [];
+  for (const t of ALL_TOPICS) {
+    const rota = `/topico/${t.slug}/`;
+    const recurso = doTipo(jsonLd(rota), "LearningResource");
+    if (!recurso) {
+      sem.push(rota);
+      continue;
+    }
+    expect(recurso["@context"], rota).toBe("https://schema.org");
+    expect(recurso.name, rota).toBe(t.name);
+    expect(recurso.description, rota).toBe(t.description);
+    expect(recurso.url, rota).toBe(urlAbsoluta(rota));
+    expect(recurso.inLanguage, rota).toBe("pt-BR");
+    // O selo de nível e o de tempo de leitura estão na tela, em `.topic-chips`.
+    expect(recurso.educationalLevel, rota).toBe(t.level);
+    if (t.readingTime) {
+      const minutos = t.readingTime.match(/^(\d+)\s*min$/)![1];
+      expect(recurso.timeRequired, rota).toBe(`PT${minutos}M`);
+    } else {
+      expect(recurso.timeRequired, `${rota}: sem tempo na tela, sem timeRequired`).toBeUndefined();
+    }
+    // `language` do tópico é a linguagem do CÓDIGO ("Python"), não o idioma.
+    if (t.language) expect(recurso.programmingLanguage, rota).toBe(t.language);
+    else expect(recurso.programmingLanguage, rota).toBeUndefined();
+    expect((recurso.about as No | undefined)?.name, rota).toBe(t.group);
+  }
+  expect(sem, `${sem.length} de ${ALL_TOPICS.length} tópicos sem LearningResource`).toEqual([]);
+});
+
+test("o /roadmap lista os tópicos que ele renderiza, na ordem em que renderiza", () => {
+  const lista = doTipo(jsonLd("/roadmap/"), "ItemList");
+  expect(lista, "/roadmap/ sem ItemList").toBeTruthy();
+  expect(lista!.numberOfItems).toBe(ALL_TOPICS.length);
+  const itens = lista!.itemListElement as No[];
+  expect(itens.map((i) => i.name)).toEqual(ALL_TOPICS.map((t) => t.name));
+  expect(itens.map((i) => i.url)).toEqual(
+    ALL_TOPICS.map((t) => urlAbsoluta(`/topico/${t.slug}/`))
+  );
+  expect(itens.map((i) => i.position)).toEqual(ALL_TOPICS.map((_, i) => i + 1));
+});
+
+test("o JSON-LD do tópico não promete vídeo, que é o que falta para o VideoObject", () => {
+  // `VideoObject` exige `uploadDate`, que não existe no type `Topic`. Marcar o
+  // vídeo sem ele é marcação inválida; marcar com data inventada é pior.
+  const comVideo = ALL_TOPICS.find((t) => t.youtube)!;
+  const nos = jsonLd(`/topico/${comVideo.slug}/`);
+  expect(doTipo(nos, "VideoObject"), "VideoObject só entra quando houver uploadDate").toBeUndefined();
+});
+

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -4,6 +4,7 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 import { LINKS, SITE_URL } from "../src/lib/links";
+import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
 
 // Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
 //
@@ -188,6 +189,20 @@ function dataDoGit(arquivo: string): string {
   }).trim();
 }
 
+/** A data esperada de uma rota: o mais recente dos arquivos que a alimentam. */
+function dataEsperada(arquivos: readonly string[]): number | undefined {
+  const ms = arquivos
+    .map((a) => Date.parse(dataDoGit(a)))
+    .filter((n) => !Number.isNaN(n));
+  return ms.length ? Math.max(...ms) : undefined;
+}
+
+// O mapa das rotas fixas vem do PRÓPRIO `sitemap.ts`, importado. Com isso o
+// teste cobre a AGREGAÇÃO (a data da rota é a mais recente entre os arquivos
+// declarados) e não a declaração — se alguém esquecer de listar um arquivo de
+// conteúdo, os dois lados erram juntos e este teste passa. Essa parte é revisão
+// humana, e o comentário existe para não prometer mais do que o teste entrega.
+
 test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const xml = sitemap();
   if (repositorioRaso()) {
@@ -208,13 +223,31 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
       sem.push(loc);
       continue;
     }
-    if (Number.isNaN(Date.parse(lastmod))) errados.push(`${loc} → ${lastmod} não é uma data`);
+    if (Number.isNaN(Date.parse(lastmod))) {
+      errados.push(`${loc} → ${lastmod} não é uma data`);
+      continue;
+    }
+    // Toda URL é conferida, fixa ou de tópico. Antes só as de tópico eram, e as
+    // quatro fixas atravessavam a suíte sem que ninguém olhasse a data delas.
     const slug = loc.match(/\/topico\/([^/]+)\//)?.[1];
-    if (slug) {
-      const esperada = dataDoGit(`content/topics/${slug}.mdx`);
-      if (esperada && Date.parse(lastmod) !== Date.parse(esperada)) {
-        errados.push(`${loc} → ${lastmod}, o Git diz ${esperada}`);
-      }
+    const rota = loc.replace(SITE_URL, "");
+    // Tópico: a data é a do artigo, com o `roadmap.ts` de reserva para quem
+    // ainda não tem artigo — a mesma escolha, e o mesmo porquê, do `sitemap.ts`.
+    const arquivos = slug
+      ? dataDoGit(`content/topics/${slug}.mdx`)
+        ? [`content/topics/${slug}.mdx`]
+        : ["content/roadmap.ts"]
+      : CONTEUDO_DA_ROTA[rota as keyof typeof CONTEUDO_DA_ROTA];
+    if (!arquivos) {
+      errados.push(`${loc} → nenhum arquivo de conteúdo declarado para a rota`);
+      continue;
+    }
+    const esperada = dataEsperada(arquivos);
+    if (esperada !== undefined && Date.parse(lastmod) !== esperada) {
+      errados.push(
+        `${loc} → ${lastmod}, mas o commit mais recente de [${arquivos.join(", ")}] ` +
+          `é ${new Date(esperada).toISOString()}`,
+      );
     }
   }
   expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível`).toEqual([]);


### PR DESCRIPTION
> ✅ **O #64 mergeou na `main` (13:25 UTC) e já está mesclado nesta branch.** A dependência entre os dois está resolvida e **medida aqui**: as 47 páginas de tópico saem com **47 cards distintos**, cada um do próprio segmento e com a query de cache do Next (`/topico/big-o/opengraph-image?fbab5fdf…`), e o `/apoie/` segue no card da raiz. Sem a linha que este PR remove, seriam 47 cards gerados e **1** usado.

## O que estava errado, com o número medido

Tudo abaixo foi medido no build da `main` em `e35c1b2`, e reconferido no build desta branch.

| medida | antes | depois |
|---|---|---|
| rotas com `rel="canonical"` (`grep -rl 'rel="canonical"' out --include=index.html`) | **3 de 53** | **51 de 53** |
| rotas com `og:url` | 3 | 51 |
| URLs no `sitemap.xml` | 51 | **40** |
| URLs do sitemap apontando para HTML `noindex` | **11** | **0** |
| `grep -c lastmod out/sitemap.xml` | **0** | 40 (com histórico) / 0 (clone raso, ver abaixo) |
| arquivos com `application/ld+json` | **0** | 53 |
| páginas `noindex` declarando `LearningResource` | 11 (na 1ª volta deste PR) | **0** |
| landmarks de navegação sem nome, na página de tópico | 2 de 2 | **0 de 2** |
| páginas com salto de nível de título | 1 (`/apoie/`: `h1` → `h3` → `h2`) | 0 |
| testes na suíte | 459 | **474** |

As 2 rotas que seguem sem canonical são `404/` e `_not-found/`, que é o certo.

## O que mudou

**1. Toda rota declara a própria URL.** `pageMetadata()` é o único ponto que emite `alternates.canonical` e `og:url`, e só a home, o `/roadmap` e a `/introducao` passavam por ele. Os 47 tópicos e o `/apoie` montavam metadata por conta própria. Agora passam todos, e o `PageSeo` ganhou `titleStyle` (para o `<title>` das 48 rotas continuar exatamente como era, com o sufixo do template) e `robots` (o `noindex` condicional do tópico vazio segue de pé).

**2. O sitemap parou de convidar o Google para o que a página manda ignorar.** O filtro usa a **mesma** `isEmptyTopic` que a página usa para decidir o `noindex` — dois predicados para a mesma decisão foi o que abriu o buraco. E o `lastModified` agora existe, derivado do `git log -1 --format=%cI` do arquivo que responde pela rota.

**3. Três schemas de dados estruturados**, em funções puras `dado → objeto` (`src/lib/jsonld.ts`), serializados num `<script type="application/ld+json">` que sai pronto no HTML do export: **zero JavaScript novo no cliente**.

- `LearningResource` por tópico: nome, descrição, nível, tempo de leitura, linguagem do código e grupo;
- `ItemList` no `/roadmap` com os 47 tópicos na ordem dos cards;
- `Organization` + `WebSite` no layout, com `sameAs` saindo do ponto único de `src/lib/links.ts`;
- `BreadcrumbList` por tópico, com os mesmos três nomes da trilha desenhada.

Nada foi inventado para agradar buscador. Ficaram de fora, de propósito, `learningResourceType` (seria classificação chutada) e `SearchAction` no `WebSite` (a busca do site é filtro no cliente, não tem URL de resultado). A regra que decide o desenho é a do Google: a marcação reflete o que está na tela.

**4. A trilha do tópico virou navegação.** Eram três `<span>`. Agora "Início" leva a `/`, o grupo leva a `/roadmap/`, o tópico corrente tem `aria-current="page"`, tudo num `<nav aria-label>`.

**5. `/apoie` parou de pular nível de título.** Os dois `h3` viraram `h2`.

**6. O índice "Nesta página" ganhou nome.** Achado do agente que integrou os 13 PRs e mediu o conjunto: com a trilha nomeada, o `<nav className="toc">` ficou o **único** landmark de navegação anônimo das 47 páginas de tópico. Ele já era anônimo na `main`; a diferença é que agora fica isolado, e quem usa leitor de tela ouve uma navegação com nome e outra dizendo só "navegação".

Optei por `aria-labelledby` apontando para o `.toc-title` em vez de um `aria-label` novo: **o rótulo visível já existe**, e apontar para ele faz o nome anunciado ser o MESMO texto do nome lido, para sempre. Um `aria-label` seria uma segunda cópia da string, livre para divergir sem quebrar nada — exatamente a armadilha que este PR fecha no sitemap. O teste confere que o nome acessível é igual ao rótulo visível, e o detalhe que isso revelou vale a escolha: o `.toc-title` é escrito em versalete pelo CSS, então o texto renderizado é "NESTA PÁGINA" e o nome acessível é "Nesta página", que é o certo para quem ouve.

**7. Dado estruturado saiu das 11 páginas `noindex`.** Este era o item que veio da integração com a pergunta "decida você". **Decidi que entra**, e o argumento é o do próprio PR: `noindex`, filtro do sitemap e agora a marcação saem todos da **mesma** `isEmptyTopic`. Faltava o terceiro. Uma página que declara ser um recurso de aprendizado e, duas tags adiante, pede para não ser indexada é a mesma contradição que abriu o buraco do sitemap. O `noindex` vence no Google, então não é defeito de ranking; mas quem lê JSON-LD sem olhar `robots` (agregador, rastreador de modelo) recebia a promessa. `Organization` e `WebSite` seguem em toda rota, porque descrevem o site e quem o publica, não a página. A trilha **desenhada** também continua nas 47.

**8. O contorno da `og:image` saiu da rota de tópico.** O `ogImage: "raiz"` nasceu **aqui, durante a revisão**, quando medi que definir `openGraph` na página corta a herança da imagem da raiz e deixava as 47 páginas de tópico sem `og:image`. Na época o card da raiz era o único que existia. Agora o #64 traz o conserto de verdade, um card por tópico, e o contorno **anula** o conserto: o `images` explícito vence o arquivo do segmento. A linha saiu **só da rota de tópico**; o `/apoie/` continua com `"raiz"`, que é o caso legítimo do parâmetro (fala do projeto inteiro, não tem conteúdo próprio para estampar, e não vai ganhar card de segmento). O `PageSeo` ganhou o aviso escrito no lugar onde alguém erraria de novo.

## A dependência com o #64

Medido em três estados, todos com `npm run build` conferido:

| estado | `og:image` das 47 páginas de tópico | `/apoie/` | `/`, `/roadmap/`, `/introducao/` |
|---|---|---|---|
| `main` de hoje | 1 card, o da raiz, igual para as 47 | raiz | card próprio |
| **só este PR**, antes do #64 mergear | **nenhum card** (47 nulos) | raiz ✅ | card próprio ✅ |
| **só o #64** (com a linha que este PR tira) | 47 cards gerados, **1 usado** | raiz | card próprio |
| **os dois juntos** (estado atual desta branch) | **47 cards distintos** ✅ | raiz ✅ | card próprio ✅ |

Com os dois na branch, a suíte inteira passa: **587 testes**.

O risco de merge que existia era dos dois lados, e o pior seria esta linha entrar sozinha: 47 páginas sem imagem de card é pior que 47 páginas com a mesma imagem. Com o #64 na `main`, ele deixou de existir.

## Prova de quebra

O teste novo foi escrito **antes** do conserto e rodado contra o build da `main`. Saída real:

```
Error: 48 de 51 rotas não declaram a própria URL
Error: 11 URLs do sitemap apontam para páginas com noindex (cada uma vira um erro permanente no Search Console)
Error: 51 URLs sem lastmod com o histórico do Git disponível
Error: 51 de 51 rotas sem Organization/WebSite
Error: 47 de 47 tópicos sem LearningResource
Error: 47 de 47 tópicos sem BreadcrumbList
Error: /roadmap/ sem ItemList
Error: hierarquia de títulos quebrada
+   "/apoie/ → 1,3,3,2,2",
Error: element(s) not found        (a âncora "Início" da trilha)

11 failed
3 passed (11.7s)
```

Os dois itens da integração ganharam prova própria, cada uma com o **build conferido linha a linha** em vez de silenciado, e com a confirmação de que a quebra chegou ao artefato antes de o teste rodar (a primeira tentativa da prova do item 6 teve o build reprovado por um comentário JSX mal colocado; sem conferir a saída do build, o teste teria reprovado contra o `out/` velho e eu concluiria que a prova valia):

```
A) quebra: aria-labelledby removido do <nav className="toc">
   ✓ Compiled successfully
   -> a quebra chegou ao artefato? 0 ocorrências de aria-labelledby
   Error: big-o: 1 de 2 landmarks de navegação têm nome; sem nome: .toc
   1 failed
   (restaurado, build ok, 1 ocorrência no artefato) -> 1 passed

B) quebra: guarda isEmptyTopic removida do JsonLd
   ✓ Compiled successfully
   -> a quebra chegou ao artefato? LearningResource em página noindex: 11 de 11
   Error: /topico/trie/ é noindex e não pode declarar LearningResource
   Error: /topico/trie/ é noindex e não pode declarar BreadcrumbList
   2 failed
   (restaurado, build ok, 0 de 11) -> passa
```

```
C) quebra: ogImage "raiz" devolvido ao generateMetadata do tópico
   ✓ Compiled successfully
   -> chegou ao artefato? og:image em out/topico/big-o/ = https://dsa.craftcodeclub.io/opengraph-image
   seo-estrutura.spec.ts:141  Error: 47 páginas de tópico usam o card da raiz em vez do próprio
   seo-estrutura.spec.ts:178  Error: card apontando para um segmento que não é o do tópico
                              + "/topico/big-o/ → https://dsa.craftcodeclub.io/opengraph-image"
   2 failed
   (restaurado, build ok) -> 2 passed
```

As duas reprovações são em linhas **deste** spec, com o valor antigo no `Received`. O teste enuncia o defeito e não o mecanismo: *nenhuma página de tópico usa o card da raiz* e *duas páginas de tópico nunca dividem a mesma imagem*. As duas afirmações são verdadeiras antes e depois de o #64 entrar, então o teste não se adapta ao que estiver no lugar — o que ele nunca aceita é a volta do card compartilhado. Um terceiro teste mede a própria dependência: os tópicos com card têm que ser **0** (o #64 ainda não entrou) ou **47** (entrou e está valendo); qualquer número no meio reprova.

Depois de tudo, a suíte inteira em **587 passed (1.6m)**, com a `main` nova (incluindo #50, #52 e #64) já mesclada. `npm run lint`: **6 problemas, 0 erros**, o mesmo baseline da `main`.

Três coisas que o teste faz de propósito, e que o `tests/seo.spec.ts` não fazia:

- **itera `ALL_TOPICS`**, nunca uma lista escrita à mão. A lista à mão do `seo.spec.ts:16-20` é o motivo de o buraco parecer coberto: ela chega a **visitar** `/topico/big-o/` e `/apoie/` para conferir `og:locale` e `twitter:card`, e nunca olhou o canonical. Tópico novo entra na cobertura sozinho;
- **cruza os dois artefatos do build**: para cada `<loc>` do `sitemap.xml`, abre o `index.html` de destino e falha se ele tiver `noindex`. É o teste que teria pego o defeito;
- **cobre os dois lados de cada condicional**: tópico indexável tem a marcação com todos os campos, tópico `noindex` não tem nenhuma. Só a primeira metade deixaria a marcação voltar sem ninguém ver;
- para o JSON-LD, faz `JSON.parse` e confere **campo por nome**. Contar `<script>` não prova nada. E o teste dos landmarks **conta todos os `<nav>` de `.topic-layout` e exige nome em cada um**, em vez de conferir o atributo de um elemento escolhido a dedo: foi asserção estreita demais que deixou o `.toc` passar, e o nome do teste diz exatamente o que ele mede.

## A decisão sobre o `lastModified`, com a checagem do ambiente de build

O campo é derivado do Git, e **não** de um `updatedAt` preenchido à mão: data que depende de disciplina humana em PR envelhece errado e passa a mentir.

Conferi o ambiente em vez de presumir. Os dois workflows relevantes (`cloudflare-pages-deploy.yml:19` e `tests.yml:18`) usam `actions/checkout@v7` **sem `fetch-depth`**, ou seja, clone raso de profundidade 1. Medido num `git clone --depth 1` deste repositório:

```
commits na história: 1
git log arrays.mdx  -> [2026-08-05T21:40:47-03:00]
git log roadmap.ts  -> [2026-08-05T21:40:47-03:00]
```

O `git log` **não falha** no clone raso: ele devolve a data do HEAD para **qualquer** caminho. Se eu confiasse nele, as 40 URLs sairiam com a data do último deploy, que é exatamente o `lastmod` que o Google aprendeu a ignorar. É pior que não ter o campo.

Então o `sitemap.ts` checa `git rev-parse --is-shallow-repository` e, sendo raso, **não emite `lastmod` nenhum**. Verificado com um build de verdade dentro de um clone raso desta branch:

```
shallow=true commits=1
✓ Compiled successfully
urls=40 lastmod=0   canonical=51   ldjson=53
14 passed
```

**O que falta para o campo valer em produção:** `fetch-depth: 0` no checkout do `.github/workflows/cloudflare-pages-deploy.yml`, que vem no **#54**. Não mexi nele porque `.github/` está fora do escopo desta frente. Com o #54 mergeado antes deste PR, os 40 `lastmod` aparecem sozinhos, sem tocar em código; sem ele, a detecção de clone raso é o que impede as URLs de saírem com a data do deploy.

## O `lastmod` na CI: três tentativas erradas, e o que a medição ensinou

Depois de mesclar a `main` (com o `fetch-depth: 0` do #54), a suíte reprovou **quatro vezes** neste guarda, sempre com o sitemap **certo**. Fica registrado porque a conclusão contraria o que este PR afirmava:

1. **`git rev-parse --is-shallow-repository`** dizia "raso" num job com histórico de sobra. Atribuí a EAGAIN sob carga (o job cuspia `BrokenPipeError` o tempo todo) e troquei por leitura do arquivo `.git/shallow`. **Era palpite, e estava errado.**
2. Com o arquivo, reprovou igual. Aí embuti o diagnóstico na mensagem, e ele fechou a primeira questão numa linha: **o `actions/checkout` deixa o marcador `.git/shallow` para trás mesmo com `fetch-depth: 0`.** Não existe pergunta sobre profundidade que responda o que este código precisa.
3. Troquei por uma **capacidade** medida nas próprias datas coletadas. Reprovou de novo, e revelou o fundo do poço:

   > **No mesmo job, os dois processos veem históricos diferentes.** O build resolveu 17 datas distintas e corretas (`big-o` em `2026-08-03T03:08:41Z`, idêntico ao build local); o processo do teste, no passo seguinte, resolveu `2026-08-07T12:10:17Z` para os **41** caminhos.

4. A quarta reprovação foi o erro simétrico do primeiro: eu cobrava a **ausência** do campo com base na capacidade do processo que mede, que não representa a do processo que constrói.

**A forma final não pergunta nada sobre o ambiente.** As invariantes do artefato valem sempre; a conferência contra o Git só roda onde este processo enxerga o histórico, e quando não enxerga o teste é pulado com a razão escrita (é o `1 skipped` da CI) em vez de acusar o build de um limite que é de quem mede.

| conferido sempre, só com o artefato | conferido só onde o git deste processo enxerga |
|---|---|
| todas as URLs têm `lastmod`, ou nenhuma tem | presença do campo |
| toda data é válida e nenhuma está no futuro | a data de cada rota, arquivo a arquivo |
| **há mais de um valor distinto** | |

A última linha é o guarda que importa: 40 URLs com o mesmo carimbo são a data do último commit repetida 40 vezes, que é o `lastmod` que o Google aprendeu a ignorar.

Conferido em quatro ambientes, com o mesmo código:

| ambiente | `lastmod` | testes do arquivo |
|---|---|---|
| worktree, histórico completo | 40, **17 distintas** | 17 passed |
| `git clone --depth 1` | **0** (o campo some sozinho) | 16 passed, 1 skipped |
| `git clone --depth 40` (marcador de raso presente, histórico bom) | 40, **16 distintas** | 17 passed |
| artefato bom + git do teste truncado (o caso da CI) | 40 | skipped, com a razão |

E a prova de quebra: tirando o guarda do `sitemap.ts` no clone raso, saem **40 `lastmod` com 1 data distinta** e o teste reprova com *"as 40 URLs saíram com o mesmo lastmod (2026-08-07T13:47:23.000Z)"*.

**Na prática:** o `fetch-depth: 0` do #54 é suficiente para o **build**, que é quem produz o `lastmod` que vai ao ar. As datas no `sitemap.xml` do artefato desta branch estão corretas e variadas.

## O que NÃO mudou

- **Texto na tela:** diffei o texto renderizado das 53 páginas contra o build da `main`. O delta inteiro é `Início` mais um separador `/` nas 47 páginas de tópico, e nada mais — reconferido depois dos dois commits novos. O `/apoie` não teve **nenhuma** linha de texto alterada (mudou a tag dos títulos, não o conteúdo).
- **Metadata:** as mesmas 53 páginas, tag a tag. Só três campos mudam, e nas mesmas 48 rotas: `canonical` (não existia), `og:url` (não existia) e a URL de `og:image`/`twitter:image`, que perdeu a query de cache. Título, descrição, `og:title`, `og:description`, `twitter:*`, `robots`, `alt` e as dimensões da imagem seguem idênticos.
- **Pixels do `/apoie`:** medido em 1512x900 e 390x844, antes e depois. `654x26` e `662x20` no desktop, `296x26` e `304x40` no celular, mesma posição (`top=411` e `top=641`), mesmo `22px/600` e `16px/600`, mesmo `letter-spacing`, mesmas margens, página com a mesma altura (1636px e 2216px). Os valores das regras `.cta-card h3` e `.feature-card h3` foram repostos inline porque o estilo vinha por **tag** e o `globals.css` pertence a outra frente nesta rodada.
- **Aparência da trilha:** os 47 tópicos, nos dois viewports. Mesma cor (`rgb(139, 160, 187)`), mesma altura de 15px. O `color: "inherit"` nas âncoras é o que neutraliza o `a { color: var(--ccc-accent) }` do `globals.css:37`.
- **Aparência do índice:** `aria-labelledby` e um `id` não desenham nada; o `.toc-title` segue com a mesma classe e o mesmo texto.
- **JavaScript no cliente:** nenhum byte novo. `application/ld+json` não é executado.
- **Arquivos:** só os 8 do diff. Nada de `globals.css`, `Shell.tsx`, `RoadmapGroups.tsx`, `visualizer.tsx`, `mdx-components.tsx`, `content/`, `.github/`, `playwright.config.ts`, `next.config.ts` nem spec que já existia.

## O que achei e não consertei

1. **(resolvido)** A varredura de landmarks tinha escopo `.topic-layout` porque os dois `.topnav` da casca eram anônimos e nomeá-los era do #50. Com o #50 na `main`, o escopo caiu e o teste cobre a **página inteira**: 5 landmarks num tópico `ready`, 4 num `soon`, todos com nome. A prova de quebra passou a reprovar com **`4 de 5`**, o mesmo número do censo da integração.
2. **`RoadmapGroups.tsx:16` usa `key={g.id}`, e `key` é prop do React, não vira atributo.** Não existe `#<id>` no `/roadmap`, então o nível do meio da trilha aponta para `/roadmap/`. Quando a `<section>` ganhar `id`, muda só o destino em `src/lib/jsonld.ts` e no `<Link>` do `topico/[slug]/page.tsx`; a marcação já sai com os três níveis. Confirmado pela integração que isto **não** cria dependência entre os PRs.
3. **A trilha ficou sem afirmação visual de link.** Uma regra `.breadcrumb a { ... }` no `globals.css` (sublinhado no hover, por exemplo) resolve, e aquele arquivo é de outra frente. Hoje as âncoras funcionam e são anunciadas como link, mas não parecem clicáveis.
4. **`busca-binaria-avancada` em 390px:** com o item novo, a trilha passa de 15px para 30px, em duas linhas. Nada é cortado e a página não estoura (medido nos 47 tópicos: é o único). É uma página `noindex`, das "em breve".
5. **O `og:image:alt` é o mesmo texto nas 47 páginas, e eu decidi NÃO consertar aqui.** Não é escolha do #64: o Next lê `imageModule.alt` uma vez por segmento, e `generateImageMetadata` é incompatível com `output: "export"`. Quem alcançaria os dois é o `generateMetadata` deste arquivo, então testei, na branch com os dois PRs:

   ```
   com images explícito por tópico:  47 imagens distintas, 47 alts distintos, 0 com hash de cache
   com o arquivo do segmento:        47 imagens distintas,  1 alt,           47 com hash de cache
   ```

   Funciona, e cobra o preço exato que este PR acabou de recusar em outro lugar: para variar o `alt` é obrigatório declarar `images`, e **o `images` explícito é o mecanismo que anula o arquivo do segmento** — o mesmo que fez o `ogImage: "raiz"` engolir o #64. Além de perder o cache-busting nos 47 cards, o que significa card velho no LinkedIn quando o desenho mudar. Trocar cache-busting de 47 imagens por 47 alts, e reintroduzir o mecanismo que este PR está removendo, não cabe num PR sobre canonical e dados estruturados. **Vira o próximo**, com a escolha declarada em vez de embutida.

6. **`og:image` do `/apoie/` perdeu a query de cache** (`?e42ae7e…`), porque a imagem é nomeada em vez de herdada. A imagem, o `alt` e as dimensões são os mesmos; perde-se o cache-busting quando o desenho do card mudar. O conserto é um `opengraph-image.tsx` no segmento do `/apoie/`, fora deste escopo.
7. **`VideoObject` fica para um PR seguinte.** Ele exige `uploadDate`, que não existe no type `Topic` (`content/roadmap.ts:36-60`) — e 34 tópicos têm `youtube`. O PR seguinte acrescenta o campo, preenche a data de publicação de cada vídeo e marca `VideoObject` com `name`, `description`, `thumbnailUrl`, `uploadDate` e `embedUrl`. Há teste aqui garantindo que hoje **não** existe `VideoObject`, para a marcação não nascer inválida.
8. **`tests/seo.spec.ts:16-20` continua com a lista de rotas escrita à mão.** Não toquei: o arquivo é de outra frente nesta rodada. Vale trocar a lista por `ALL_TOPICS` quando ele estiver livre.




