### PR TITLE
feat(a11y): casca de navegação acessível e busca que acha

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -277,7 +277,9 @@ html { scroll-behavior: smooth; }
    primeiro grupo para fora da tela. Título curto não sente diferença. */
 .roadmap-wrap h1 { margin: 10px 0 8px; font-size: clamp(28px, 7vw, 40px); font-weight: 600; letter-spacing: -0.03em; }
 .roadmap-intro { margin: 0 0 36px; max-width: 62ch; font-size: 16px; line-height: 1.6; color: #a3b6cf; }
-.rgroup { margin-bottom: 34px; }
+/* O grupo agora tem `id` (âncora de destino), e o cabeçalho é fixo: sem a folga
+   o título do grupo pararia debaixo dele. */
+.rgroup { margin-bottom: 34px; scroll-margin-top: 80px; }
 .rgroup-head { display: flex; align-items: baseline; gap: 12px; margin-bottom: 14px; }
 .rgroup-head h2 { margin: 0; font-size: 20px; font-weight: 600; letter-spacing: -0.015em; }
 .rgroup-count { font-size: 12.5px; color: var(--ccc-muted); font-family: var(--mono); }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,6 +174,11 @@ html { scroll-behavior: smooth; }
 .side-caret.open { transform: rotate(90deg); }
 .side-count { font-size: 11px; font-weight: 500; color: var(--ccc-muted); font-family: var(--mono); }
 .side-items { display: flex; flex-direction: column; gap: 1px; padding: 2px 0 6px 19px; }
+/* Obrigatória, e não redundante: o `display: flex` da regra acima vence o
+   `display: none` que o navegador aplica ao atributo `hidden` (folha do usuário
+   contra folha do autor), e sem esta linha o grupo "fechado" apareceria aberto.
+   Ela também é o que tira os itens ocultos da ordem de tabulação. */
+.side-items[hidden] { display: none; }
 .side-item {
   display: flex; align-items: center; gap: 9px; width: 100%; padding: 7px 9px;
   border: none; border-radius: 7px; background: transparent; color: #a7bad2;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -62,6 +62,18 @@ html { scroll-behavior: smooth; }
 /* ------------------------------- shell ---------------------------------- */
 .shell { display: grid; grid-template-columns: 290px minmax(0, 1fr); align-items: start; }
 
+/* Link de pular para o conteúdo (WCAG 2.4.1). Fica FORA da tela em vez de
+   `display: none`, que o tiraria da ordem de tabulação junto e o deixaria
+   inalcançável — que é o mesmo que não existir. `fixed` porque o `.shell` é
+   grid: em fluxo, ele ocuparia a primeira célula e empurraria o menu lateral. */
+.skip-link {
+  position: fixed; top: -100px; left: 12px; z-index: 60;
+  padding: 10px 16px; border-radius: 0 0 9px 9px;
+  background: var(--ccc-accent); color: #fff; font-size: 13.5px; font-weight: 600;
+  transition: top 0.15s;
+}
+.skip-link:focus { top: 0; color: #fff; }
+
 .header {
   position: sticky; top: 0; z-index: 40; grid-column: 1 / -1;
   display: flex; align-items: center; justify-content: space-between; gap: 24px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -74,6 +74,13 @@ html { scroll-behavior: smooth; }
 }
 .skip-link:focus { top: 0; color: #fff; }
 
+/* Texto só para leitor de tela: sai da tela sem sair da árvore de acessibilidade
+   (`display: none` e `visibility: hidden` somem das duas). */
+.sr-only {
+  position: absolute; width: 1px; height: 1px; margin: -1px; padding: 0;
+  overflow: hidden; clip-path: inset(50%); white-space: nowrap; border: 0;
+}
+
 .header {
   position: sticky; top: 0; z-index: 40; grid-column: 1 / -1;
   display: flex; align-items: center; justify-content: space-between; gap: 24px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -199,6 +199,9 @@ html { scroll-behavior: smooth; }
 .side-row:hover .side-item { color: #fff; }
 .side-row.on { background: var(--ccc-accent-soft); box-shadow: inset 2px 0 0 var(--ccc-accent); }
 .side-row .side-item { flex: 1; min-width: 0; padding-left: 0; background: none; box-shadow: none; }
+/* Busca sem resultado: coluna vazia não diz nada a ninguém. */
+.side-vazio { margin: 10px; font-size: 12.5px; line-height: 1.55; color: var(--ccc-muted); }
+.side-vazio strong { color: var(--ccc-text); font-weight: 600; }
 .side-intro-ico { display: grid; place-items: center; width: 16px; flex: none; font-size: 11px; color: var(--ccc-muted); }
 .badge-novo { padding: 1px 6px; border-radius: 5px; background: rgba(124, 58, 237, 0.2); color: #c4b5fd; font-size: 9.5px; font-weight: 700; letter-spacing: 0.06em; }
 .badge-soon { padding: 1px 6px; border-radius: 5px; background: rgba(255, 255, 255, 0.06); color: #7f93ad; font-size: 9px; font-weight: 600; letter-spacing: 0.04em; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -151,7 +151,10 @@ html { scroll-behavior: smooth; }
   width: 100%; margin-top: 12px; padding: 8px 10px; border: 1px solid var(--ccc-line);
   border-radius: 8px; background: #101a27; color: var(--ccc-text); font: inherit; font-size: 13px;
 }
-.side-search:focus { border-color: var(--ccc-accent); outline: none; }
+/* Sem `outline: none`: a regra usava `:focus` (vale para o teclado) e tinha
+   especificidade maior que o `:focus-visible` global, então apagava justamente
+   o anel de quem navega sem mouse. A borda azul continua, somada ao anel. */
+.side-search:focus { border-color: var(--ccc-accent); }
 .side-scroll { flex: 1; overflow-y: auto; padding: 10px 10px 4px; }
 .side-group { margin-bottom: 2px; }
 .side-group-btn {
@@ -427,7 +430,9 @@ html { scroll-behavior: smooth; }
 .viz-field.grow { flex: 1; min-width: 240px; }
 .viz-field span { font-size: 11.5px; font-weight: 600; letter-spacing: 0.06em; text-transform: uppercase; color: var(--ccc-muted); }
 .viz-input { padding: 8px 11px; border: 1px solid var(--ccc-line); border-radius: 8px; background: #0e1725; color: var(--ccc-text); font-family: var(--mono); font-size: 13px; }
-.viz-input:focus { border-color: var(--ccc-accent); outline: none; }
+/* Mesmo motivo do `.side-search:focus`: o `outline: none` daqui apagava o anel
+   de foco dos campos de 41 visualizadores. */
+.viz-input:focus { border-color: var(--ccc-accent); }
 .viz-input.k { width: 74px; }
 .viz-btn { padding: 9px 13px; border: 1px solid var(--ccc-line); border-radius: 8px; background: transparent; color: #a9bcd4; font: inherit; font-size: 13px; cursor: pointer; }
 .viz-btn:hover:not(:disabled) { background: rgba(255, 255, 255, 0.05); color: #fff; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,6 +189,16 @@ html { scroll-behavior: smooth; }
 }
 .side-check.done { border-color: rgba(52, 211, 153, 0.6); background: rgba(52, 211, 153, 0.18); color: var(--ccc-green); }
 .side-item-name { flex: 1; }
+/* A linha do tópico: o ✓ é irmão do link (ver Shell.tsx), então quem pinta
+   hover e "você está aqui" passa a ser a linha, e não o link — senão o realce
+   começaria depois do ✓. A geometria é a mesma de antes: 9px de recuo, ✓ de
+   16px, 9px de intervalo, nome. Estas regras vêm DEPOIS de `.side-item.on` de
+   propósito: mesma especificidade, e quem vence é a última. */
+.side-row { display: flex; align-items: center; gap: 9px; padding-left: 9px; border-radius: 7px; }
+.side-row:hover { background: rgba(255, 255, 255, 0.05); }
+.side-row:hover .side-item { color: #fff; }
+.side-row.on { background: var(--ccc-accent-soft); box-shadow: inset 2px 0 0 var(--ccc-accent); }
+.side-row .side-item { flex: 1; min-width: 0; padding-left: 0; background: none; box-shadow: none; }
 .side-intro-ico { display: grid; place-items: center; width: 16px; flex: none; font-size: 11px; color: var(--ccc-muted); }
 .badge-novo { padding: 1px 6px; border-radius: 5px; background: rgba(124, 58, 237, 0.2); color: #c4b5fd; font-size: 9.5px; font-weight: 700; letter-spacing: 0.06em; }
 .badge-soon { padding: 1px 6px; border-radius: 5px; background: rgba(255, 255, 255, 0.06); color: #7f93ad; font-size: 9px; font-weight: 600; letter-spacing: 0.04em; }
@@ -274,6 +284,15 @@ html { scroll-behavior: smooth; }
 .topic-card.done { background: rgba(52, 211, 153, 0.05); }
 .topic-card-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .topic-card-name { font-size: 15px; font-weight: 600; }
+/* O ✓ do card saiu de dentro do link (ver RoadmapGroups.tsx) e passou a irmão
+   dele. Sai do fluxo para o card continuar sendo um alvo de clique inteiro, nas
+   coordenadas medidas do arranjo antigo (17,5px do topo, 17px da direita, com o
+   1px de borda do card já contado); o título reserva a faixa dele para não
+   passar por baixo. `grid` no invólucro faz o card ocupar a linha toda da
+   grade, como ocupava quando era ele o item da grade. */
+.topic-card-wrap { position: relative; display: grid; }
+.topic-card-wrap .topic-card-top { padding-right: 25px; }
+.tcard-check { position: absolute; top: 17.5px; right: 17px; }
 .topic-card p { margin: 7px 0 0; font-size: 12.5px; line-height: 1.5; color: #8ea3bd; }
 .tcard-tags { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 11px; }
 .ttag { display: inline-flex; align-items: center; gap: 5px; font-size: 10.5px; font-weight: 600; letter-spacing: 0.02em; padding: 3px 8px; border-radius: 6px; border: 1px solid var(--ccc-line); color: var(--ccc-muted); }

--- a/src/components/RoadmapGroups.tsx
+++ b/src/components/RoadmapGroups.tsx
@@ -38,6 +38,23 @@ export function RoadmapGroups() {
                   // Ela sai do fluxo (o CSS a posiciona) para o card inteiro
                   // continuar sendo um alvo de clique só.
                   <div className="topic-card-wrap" key={t.slug}>
+                    {/* A marca vem ANTES do link no DOM, como na trilha lateral
+                        e no `ProblemList`. Ela é a primeira coisa do card em
+                        todas as outras listas, e aqui era a última: o teclado
+                        chegava ao card, entrava no tópico, e só encontrava o
+                        "marcar como concluído" na volta. `position: absolute`
+                        mantém o ✓ no mesmo canto — medido, 18px do topo e 17px
+                        da direita antes e depois. */}
+                    <button
+                      type="button"
+                      className={`side-check tcard-check${feito ? " done" : ""}`}
+                      role="checkbox"
+                      aria-checked={feito}
+                      aria-label={`Marcar ${t.name} como concluído`}
+                      onClick={() => toggleTopico(t.slug)}
+                    >
+                      {feito ? "✓" : ""}
+                    </button>
                     <Link href={`/topico/${t.slug}`} className={`topic-card${feito ? " done" : ""}`}>
                       <div className="topic-card-top">
                         <span className="topic-card-name">{t.name}</span>
@@ -50,16 +67,6 @@ export function RoadmapGroups() {
                         ))}
                       </div>
                     </Link>
-                    <button
-                      type="button"
-                      className={`side-check tcard-check${feito ? " done" : ""}`}
-                      role="checkbox"
-                      aria-checked={feito}
-                      aria-label={`Marcar ${t.name} como concluído`}
-                      onClick={() => toggleTopico(t.slug)}
-                    >
-                      {feito ? "✓" : ""}
-                    </button>
                   </div>
                 );
               })}

--- a/src/components/RoadmapGroups.tsx
+++ b/src/components/RoadmapGroups.tsx
@@ -13,7 +13,9 @@ export function RoadmapGroups() {
       {GROUPS.map((g) => {
         const feitos = contarTopicos(g.topics.map((t) => t.slug));
         return (
-          <section className="rgroup" key={g.id}>
+          // `key` é prop do React e não vira atributo: sem o `id`, nenhuma
+          // âncora do site conseguia apontar para um grupo do roadmap.
+          <section className="rgroup" id={g.id} key={g.id}>
             <div className="rgroup-head">
               <h2>{g.name}</h2>
               <span className="rgroup-count">{feitos}/{g.topics.length}</span>

--- a/src/components/RoadmapGroups.tsx
+++ b/src/components/RoadmapGroups.tsx
@@ -31,29 +31,34 @@ export function RoadmapGroups() {
               {g.topics.map((t) => {
                 const feito = isTopico(t.slug);
                 return (
-                  <Link key={t.slug} href={`/topico/${t.slug}`} className={`topic-card${feito ? " done" : ""}`}>
-                    <div className="topic-card-top">
-                      <span className="topic-card-name">{t.name}</span>
-                      <span
-                        className={`side-check${feito ? " done" : ""}`}
-                        role="checkbox"
-                        aria-checked={feito}
-                        tabIndex={0}
-                        aria-label={`Marcar ${t.name} como concluído`}
-                        onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleTopico(t.slug); }}
-                        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); toggleTopico(t.slug); } }}
-                      >
-                        {feito ? "✓" : ""}
-                      </span>
-                    </div>
-                    <p>{t.description}</p>
-                    <div className="tcard-tags">
-                      <span className={`level ${levelClass(t.level)}`}>{t.level}</span>
-                      {topicTags(t).map((tag) => (
-                        <span key={tag.kind} className={`ttag ttag-${tag.kind}`}>{tag.label}</span>
-                      ))}
-                    </div>
-                  </Link>
+                  // A marca de concluído é IRMÃ do link, como no `ProblemList`:
+                  // widget focável dentro de `<a>` é estado inválido pela ARIA.
+                  // Ela sai do fluxo (o CSS a posiciona) para o card inteiro
+                  // continuar sendo um alvo de clique só.
+                  <div className="topic-card-wrap" key={t.slug}>
+                    <Link href={`/topico/${t.slug}`} className={`topic-card${feito ? " done" : ""}`}>
+                      <div className="topic-card-top">
+                        <span className="topic-card-name">{t.name}</span>
+                      </div>
+                      <p>{t.description}</p>
+                      <div className="tcard-tags">
+                        <span className={`level ${levelClass(t.level)}`}>{t.level}</span>
+                        {topicTags(t).map((tag) => (
+                          <span key={tag.kind} className={`ttag ttag-${tag.kind}`}>{tag.label}</span>
+                        ))}
+                      </div>
+                    </Link>
+                    <button
+                      type="button"
+                      className={`side-check tcard-check${feito ? " done" : ""}`}
+                      role="checkbox"
+                      aria-checked={feito}
+                      aria-label={`Marcar ${t.name} como concluído`}
+                      onClick={() => toggleTopico(t.slug)}
+                    >
+                      {feito ? "✓" : ""}
+                    </button>
+                  </div>
                 );
               })}
             </div>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -311,27 +311,33 @@ export function Shell({ children }: { children: React.ReactNode }) {
                       // artigo ou visualização, o tópico é navegável como qualquer outro.
                       const vazio = isEmptyTopic(t);
                       return (
-                        <Link
-                          key={t.slug}
-                          href={`/topico/${t.slug}`}
-                          className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}
-                          aria-current={ativo ? "page" : undefined}
-                        >
-                          <span
+                        // A marca de concluído é IRMÃ do link, não filha: widget
+                        // focável dentro de `<a>` é estado inválido pela ARIA, e
+                        // dava dois destinos para o mesmo Tab. É o arranjo que o
+                        // `ProblemList` já usa. Quem pinta o estado da linha
+                        // passa a ser a `.side-row`, para o ✓ continuar dentro
+                        // do realce de "você está aqui".
+                        <div className={`side-row${ativo ? " on" : ""}`} key={t.slug}>
+                          <button
+                            type="button"
                             className={`side-check${feito ? " done" : ""}`}
                             role="checkbox"
                             aria-checked={feito}
-                            tabIndex={0}
                             aria-label={`Marcar ${t.name} como concluído`}
-                            onClick={(e) => { e.preventDefault(); e.stopPropagation(); toggleTopico(t.slug); }}
-                            onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); e.stopPropagation(); toggleTopico(t.slug); } }}
+                            onClick={() => toggleTopico(t.slug)}
                           >
                             {feito ? "✓" : ""}
-                          </span>
-                          <span className="side-item-name">{t.name}</span>
-                          {t.isNew && <span className="badge-novo">NOVO</span>}
-                          {vazio && <span className="badge-soon">em breve</span>}
-                        </Link>
+                          </button>
+                          <Link
+                            href={`/topico/${t.slug}`}
+                            className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}
+                            aria-current={ativo ? "page" : undefined}
+                          >
+                            <span className="side-item-name">{t.name}</span>
+                            {t.isNew && <span className="badge-novo">NOVO</span>}
+                            {vazio && <span className="badge-soon">em breve</span>}
+                          </Link>
+                        </div>
                       );
                     })}
                   </div>

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -128,7 +128,10 @@ export function Shell({ children }: { children: React.ReactNode }) {
   // precisa. `block: nearest` na mão: distância mínima, sem centralizar nada.
   useEffect(() => {
     const lista = listaRef.current;
-    const atual = lista?.querySelector<HTMLElement>(".side-item.on");
+    // `:not([hidden])` porque o item do grupo fechado agora existe no DOM: sem o
+    // filtro, o `getBoundingClientRect` de um elemento oculto devolve zeros e a
+    // conta abaixo rolaria o menu para o topo sem motivo.
+    const atual = lista?.querySelector<HTMLElement>(".side-items:not([hidden]) .side-item.on");
     if (!lista || !atual) return;
     const item = atual.getBoundingClientRect();
     const caixa = lista.getBoundingClientRect();
@@ -309,56 +312,60 @@ export function Shell({ children }: { children: React.ReactNode }) {
                   <span style={{ flex: 1 }}>{g.name}</span>
                   <span className="side-count">{feitos}/{g.topics.length}</span>
                 </button>
-                {g.aberto && (
-                  <div className="side-items">
-                    {g.intro && (
-                      <Link
-                        href={g.intro.href}
-                        className={`side-item${navOn(g.intro.href) ? " on" : ""}`}
-                        aria-current={navOn(g.intro.href) ? "page" : undefined}
-                      >
-                        <span className="side-intro-ico" aria-hidden="true">✦</span>
-                        <span className="side-item-name">{g.intro.name}</span>
-                      </Link>
-                    )}
-                    {g.itens.map((t) => {
-                      const feito = isTopico(t.slug);
-                      const ativo = slugAtivo === t.slug;
-                      // "Em breve" é só para quem ainda não tem nada: se já existe vídeo,
-                      // artigo ou visualização, o tópico é navegável como qualquer outro.
-                      const vazio = isEmptyTopic(t);
-                      return (
-                        // A marca de concluído é IRMÃ do link, não filha: widget
-                        // focável dentro de `<a>` é estado inválido pela ARIA, e
-                        // dava dois destinos para o mesmo Tab. É o arranjo que o
-                        // `ProblemList` já usa. Quem pinta o estado da linha
-                        // passa a ser a `.side-row`, para o ✓ continuar dentro
-                        // do realce de "você está aqui".
-                        <div className={`side-row${ativo ? " on" : ""}`} key={t.slug}>
-                          <button
-                            type="button"
-                            className={`side-check${feito ? " done" : ""}`}
-                            role="checkbox"
-                            aria-checked={feito}
-                            aria-label={`Marcar ${t.name} como concluído`}
-                            onClick={() => toggleTopico(t.slug)}
-                          >
-                            {feito ? "✓" : ""}
-                          </button>
-                          <Link
-                            href={`/topico/${t.slug}`}
-                            className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}
-                            aria-current={ativo ? "page" : undefined}
-                          >
-                            <span className="side-item-name">{t.name}</span>
-                            {t.isNew && <span className="badge-novo">NOVO</span>}
-                            {vazio && <span className="badge-soon">em breve</span>}
-                          </Link>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
+                {/* O grupo fechado esconde os itens, e não deixa de renderizá-los:
+                    o menu era a única lista de tópicos de toda página, e com
+                    `{g.aberto && ...}` ela chegava ao rastreador com 1 link no pior
+                    caso. `hidden` (mais a regra que vence o `display: flex` no CSS)
+                    dá o mesmo visual, tira os itens ocultos da ordem de foco e
+                    entrega os 47 tópicos em toda página. */}
+                <div className="side-items" hidden={!g.aberto}>
+                  {g.intro && (
+                    <Link
+                      href={g.intro.href}
+                      className={`side-item${navOn(g.intro.href) ? " on" : ""}`}
+                      aria-current={navOn(g.intro.href) ? "page" : undefined}
+                    >
+                      <span className="side-intro-ico" aria-hidden="true">✦</span>
+                      <span className="side-item-name">{g.intro.name}</span>
+                    </Link>
+                  )}
+                  {g.itens.map((t) => {
+                    const feito = isTopico(t.slug);
+                    const ativo = slugAtivo === t.slug;
+                    // "Em breve" é só para quem ainda não tem nada: se já existe vídeo,
+                    // artigo ou visualização, o tópico é navegável como qualquer outro.
+                    const vazio = isEmptyTopic(t);
+                    return (
+                      // A marca de concluído é IRMÃ do link, não filha: widget
+                      // focável dentro de `<a>` é estado inválido pela ARIA, e
+                      // dava dois destinos para o mesmo Tab. É o arranjo que o
+                      // `ProblemList` já usa. Quem pinta o estado da linha
+                      // passa a ser a `.side-row`, para o ✓ continuar dentro
+                      // do realce de "você está aqui".
+                      <div className={`side-row${ativo ? " on" : ""}`} key={t.slug}>
+                        <button
+                          type="button"
+                          className={`side-check${feito ? " done" : ""}`}
+                          role="checkbox"
+                          aria-checked={feito}
+                          aria-label={`Marcar ${t.name} como concluído`}
+                          onClick={() => toggleTopico(t.slug)}
+                        >
+                          {feito ? "✓" : ""}
+                        </button>
+                        <Link
+                          href={`/topico/${t.slug}`}
+                          className={`side-item${ativo ? " on" : ""}${vazio ? " soon" : ""}`}
+                          aria-current={ativo ? "page" : undefined}
+                        >
+                          <span className="side-item-name">{t.name}</span>
+                          {t.isNew && <span className="badge-novo">NOVO</span>}
+                          {vazio && <span className="badge-soon">em breve</span>}
+                        </Link>
+                      </div>
+                    );
+                  })}
+                </div>
               </div>
             );
           })}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -56,6 +56,13 @@ function gravarAbertos(abertos: Record<string, boolean>) {
 const mesmaRota = (a: string | null | undefined, b: string) =>
   !!a && a.replace(/\/+$/, "") === b.replace(/\/+$/, "");
 
+// Minúsculas e sem acento. NFD separa a letra da marca de acento em pontos de
+// código diferentes, e o `replace` joga fora só a marca: com isso "recursao"
+// acha "Recursão" e "memoizacao" acha "memoização". Fica fora do componente
+// para não virar dependência nova do `useMemo` a cada renderização.
+const semAcento = (s: string) =>
+  s.normalize("NFD").replace(/[\u0300-\u036f]/g, "").toLowerCase();
+
 export function Shell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { hydrated, isTopico, toggleTopico, contarTopicos } = useProgress();
@@ -141,12 +148,22 @@ export function Shell({ children }: { children: React.ReactNode }) {
   const feitosTotal = contarTopicos(GROUPS.flatMap((g) => g.topics.map((t) => t.slug)));
   const pct = hydrated && TOTAL_TOPICS ? Math.round((feitosTotal / TOTAL_TOPICS) * 100) : 0;
 
-  const b = busca.trim().toLowerCase();
+  const b = semAcento(busca.trim());
 
+  // A busca casa nome, descrição e nome do grupo. Só pelo nome ela mentia sobre
+  // o guia: "janela" (Sliding Window), "memoização" (Programação Dinâmica) e
+  // "ponteiro" (Listas Encadeadas) aparecem em `description` e em zero `name`,
+  // e quem digitava concluía que o tópico não existe aqui. Custo de bundle zero:
+  // as descrições já vêm no mesmo chunk que os nomes.
   const grupos = useMemo(
     () =>
       GROUPS.map((g) => {
-        const itens = g.topics.filter((t) => !b || t.name.toLowerCase().includes(b));
+        // Grupo que casa pelo nome entrega a lista inteira dele: quem digita
+        // "grafos" quer o grupo, não o subconjunto que repete a palavra.
+        const grupoCasa = !!b && semAcento(g.name).includes(b);
+        const itens = g.topics.filter(
+          (t) => !b || grupoCasa || semAcento(`${t.name} ${t.description}`).includes(b)
+        );
         return { ...g, itens, aberto: b ? itens.length > 0 : !!abertos[g.id] };
       }).filter((g) => !b || g.itens.length > 0),
     [b, abertos]
@@ -345,6 +362,14 @@ export function Shell({ children }: { children: React.ReactNode }) {
               </div>
             );
           })}
+          {/* Sem isto, busca sem resultado devolvia uma coluna vazia, e a tela
+              não dizia se o guia não tem o assunto ou se o menu quebrou. */}
+          {b && grupos.length === 0 && (
+            <p className="side-vazio" role="status">
+              Nenhum tópico com <strong>{busca.trim()}</strong>. Tente outra palavra, como
+              &ldquo;janela&rdquo;, &ldquo;árvore&rdquo; ou &ldquo;ordenação&rdquo;.
+            </p>
+          )}
         </div>
 
         <div className="side-apoio">

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -158,6 +158,13 @@ export function Shell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="shell">
+      {/* WCAG 2.4.1: antes desta linha eram 44 paradas de tabulação até o
+          primeiro parágrafo em /topico/dijkstra/, em toda página aberta. Ele é o
+          primeiro filho do shell de propósito, e some da tela sem sair da ordem
+          de foco (por isso não é `display: none`). */}
+      <a className="skip-link" href="#conteudo">
+        Ir para o conteúdo
+      </a>
       <header className="header">
         <div className="header-left">
           <button
@@ -327,7 +334,12 @@ export function Shell({ children }: { children: React.ReactNode }) {
         </div>
       </aside>
 
-      <main className="main">{children}</main>
+      {/* `tabIndex={-1}` para o link de pular ter onde pousar o foco: sem ele o
+          navegador rola até o conteúdo e deixa o foco no começo da página, e o
+          Tab seguinte volta para o menu. */}
+      <main className="main" id="conteudo" tabIndex={-1}>
+        {children}
+      </main>
     </div>
   );
 }

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -169,7 +169,9 @@ export function Shell({ children }: { children: React.ReactNode }) {
         <div className="header-left">
           <button
             className="header-menu-toggle nav-icon"
-            aria-label="Abrir menu de tópicos"
+            aria-label="Menu de tópicos"
+            aria-expanded={mobileNav}
+            aria-controls="menu-lateral"
             onClick={() => setMobileNav((v) => !v)}
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
@@ -183,13 +185,15 @@ export function Shell({ children }: { children: React.ReactNode }) {
               <span className="brand-sub">por Craft &amp; Code Club</span>
             </span>
           </Link>
-          <nav className="topnav nav-left">
+          {/* Cada landmark com nome próprio: são três `nav` na página, e sem
+              rótulo o leitor de tela anuncia "navegação" três vezes. */}
+          <nav className="topnav nav-left" aria-label="Principal">
             <Link href="/" className={`nav-hide-sm${navOn("/") ? " on" : ""}`}>Início</Link>
             <Link href="/roadmap" className={`nav-hide-sm${navOn("/roadmap") ? " on" : ""}`}>Roadmap</Link>
           </nav>
         </div>
 
-        <nav className="topnav nav-right">
+        <nav className="topnav nav-right" aria-label="Comunidade e apoio">
           <a href={LINKS.youtube} className="nav-yt nav-hide-sm ext" target="_blank" rel="noopener noreferrer">
             <span className="dot" />YouTube<span className="ext-arrow" aria-hidden="true">↗</span>
           </a>
@@ -239,7 +243,14 @@ export function Shell({ children }: { children: React.ReactNode }) {
         </nav>
       </header>
 
-      <aside className={`sidebar${mobileNav ? " open" : ""}`}>
+      {/* `nav`, e não `aside`: a trilha inteira é navegação, e o landmark
+          "complementar" do `aside` mandava o leitor de tela procurar o menu de
+          tópicos fora da lista de navegação da página. */}
+      <nav
+        id="menu-lateral"
+        className={`sidebar${mobileNav ? " open" : ""}`}
+        aria-label="Trilha de estudos"
+      >
         <div className="side-head">
           <div className="side-head-row">
             <span className="side-label">Sua trilha</span>
@@ -248,8 +259,16 @@ export function Shell({ children }: { children: React.ReactNode }) {
           <div className="progress-track">
             <div className="progress-fill" style={{ width: `${pct}%` }} />
           </div>
+          {/* O `placeholder` era o único nome do campo, e ele some na primeira
+              letra digitada: a partir daí quem usa leitor de tela ouvia só
+              "caixa de edição". O rótulo fica fora da tela, e não escondido. */}
+          <label className="sr-only" htmlFor="busca-topico">
+            Buscar tópico
+          </label>
           <input
+            id="busca-topico"
             className="side-search"
+            type="search"
             value={busca}
             onChange={(e) => setBusca(e.target.value)}
             placeholder="Buscar tópico…"
@@ -332,7 +351,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
             <p>Ajude a manter a comunidade e o conteúdo livres, para todo mundo.</p>
           </Link>
         </div>
-      </aside>
+      </nav>
 
       {/* `tabIndex={-1}` para o link de pular ter onde pousar o foco: sem ele o
           navegador rola até o conteúdo e deixa o foco no começo da página, e o

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
-import { GROUPS } from "../content/roadmap";
+import { ALL_TOPICS, GROUPS } from "../content/roadmap";
 
 // Acessibilidade da casca de navegação: link de pular, anel de foco, nome dos
 // campos e dos landmarks, e a marca de progresso fora do link.
@@ -121,10 +121,13 @@ test("a busca acha pelo que o aluno digita, e avisa quando não acha", async ({ 
   await expect(page.locator(".side-vazio")).toContainText("xilofone");
   await expect(page.locator(".side-scroll .side-item")).toHaveCount(0);
 
-  // E o menu volta inteiro quando o campo esvazia.
+  // E o menu volta inteiro quando o campo esvazia: os 47 tópicos de volta ao
+  // DOM, com o grupo da página aberto. (O primeiro `.side-item` da lista é o do
+  // grupo de cima, que está fechado — daí a asserção ser sobre o item da rota.)
   await campo.fill("");
   await expect(page.locator(".side-vazio")).toHaveCount(0);
-  await expect(page.locator(".side-scroll .side-item").first()).toBeVisible();
+  await expect(page.locator('.sidebar a[href^="/topico/"]')).toHaveCount(ALL_TOPICS.length);
+  await expect(page.locator('.side-item[href="/topico/arrays/"]')).toBeVisible();
 });
 
 test("a marca de progresso não mora dentro do link, e o progresso sobrevive à recarga", async ({
@@ -206,6 +209,79 @@ test("o botão do menu diz se o menu está aberto", async ({ page }) => {
   await botao.click();
   await expect(botao).toHaveAttribute("aria-expanded", "false");
   await expect(page.locator("#menu-lateral")).toBeHidden();
+});
+
+test("o menu leva os 47 tópicos em toda página, com o grupo fechado ou aberto", async ({ page }) => {
+  // Antes, o menu era `{g.aberto && ...}`: os itens do grupo fechado não
+  // existiam no DOM. Medido no build, nas 47 páginas de tópico: MÍNIMO 1 link
+  // (programacao-dinamica, backtracking, big-o, greedy, matematica, hash-table),
+  // mediana 5, máximo 9, e 24 páginas com 5 ou menos. O menu é a única lista de
+  // tópicos que a página carrega.
+  const total = ALL_TOPICS.length;
+
+  for (const rota of ["/topico/matematica/", "/topico/big-o/", "/", "/roadmap/"]) {
+    await page.goto(rota);
+    await expect(page.locator('.sidebar a[href^="/topico/"]'), rota).toHaveCount(total);
+  }
+
+  // E continua sendo uma lista COM grupos fechados: o visual não mudou.
+  await page.goto("/topico/big-o/");
+  const ocultos = page.locator(".side-items[hidden]");
+  expect(await ocultos.count()).toBeGreaterThan(0);
+  await expect(page.locator('.sidebar a[href="/topico/dijkstra/"]')).toBeHidden();
+  await expect(page.locator('.sidebar a[href="/topico/big-o/"]')).toBeVisible();
+});
+
+test("o item do grupo fechado não é pintado nem alcançado pelo teclado", async ({ page }) => {
+  // As duas armadilhas do `hidden`: uma regra de `display` no seletor do item
+  // derruba o atributo (e aí o menu "fechado" aparece aberto), e item oculto que
+  // continua focável transforma o conserto do rastreador em regressão do link de
+  // pular que este PR acabou de entregar.
+  for (const [w, h] of [
+    [1512, 900],
+    [1440, 700],
+    [390, 844],
+  ]) {
+    await page.setViewportSize({ width: w, height: h });
+    await page.goto("/topico/big-o/");
+    if (w < 1000) await page.locator(".header-menu-toggle").click();
+    await expect(page.locator(".sidebar")).toBeVisible();
+
+    const medida = await page.evaluate(() => {
+      const oculto = document.querySelector<HTMLElement>(".side-items[hidden]")!;
+      const link = oculto.querySelector<HTMLElement>(".side-item")!;
+      link.focus();
+      const r = oculto.getBoundingClientRect();
+      return {
+        display: getComputedStyle(oculto).display,
+        altura: r.height,
+        largura: r.width,
+        recebeuFoco: document.activeElement === link,
+      };
+    });
+    expect(medida.display, `${w}x${h}: o CSS sobrepôs o atributo hidden`).toBe("none");
+    expect(medida.altura, `${w}x${h}: o grupo fechado ainda ocupa altura`).toBe(0);
+    expect(medida.largura).toBe(0);
+    expect(medida.recebeuFoco, `${w}x${h}: item oculto recebeu foco`).toBe(false);
+  }
+
+  // A prova de comportamento: tabulando desde o começo, o foco nunca cai dentro
+  // de um grupo fechado, e sair do menu inteiro continua custando o que custava.
+  await page.setViewportSize({ width: 1512, height: 900 });
+  await page.goto("/topico/big-o/");
+  const visitados: string[] = [];
+  for (let i = 0; i < 45; i++) {
+    await page.keyboard.press("Tab");
+    const onde = await page.evaluate(() => {
+      const a = document.activeElement;
+      if (!a || a === document.body) return "corpo";
+      return a.closest(".side-items[hidden]") ? "OCULTO" : a.closest("main") ? "conteudo" : "casca";
+    });
+    visitados.push(onde);
+    if (onde === "conteudo") break;
+  }
+  expect(visitados.filter((v) => v === "OCULTO"), "o teclado entrou num grupo fechado").toEqual([]);
+  expect(visitados.at(-1), "o foco não chegou ao conteúdo em 45 tabulações").toBe("conteudo");
 });
 
 test("cada grupo do roadmap tem âncora própria, e ela para abaixo do cabeçalho", async ({

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -180,6 +180,46 @@ test("a marca de progresso não mora dentro do link, e o progresso sobrevive à 
   ).toHaveAttribute("aria-checked", "false");
 });
 
+// As TRÊS listas com marca de progresso são a mesma ideia repetida, e o teclado
+// só aprende o padrão se elas concordarem. O card do /roadmap era a única em que
+// a marca vinha DEPOIS do link: quem tabulava chegava ao card, entrava no
+// tópico, e só encontrava o "marcar como concluído" na volta. Como o ✓ é
+// `position: absolute` no canto superior direito, a ordem do DOM era também a
+// única coisa que dizia onde ele está — e ela dizia "no fim".
+//
+// O teste olha as três de uma vez porque a próxima lista com ✓ vai nascer
+// copiando uma delas, e copiando a errada se ninguém comparar.
+test("a marca de progresso vem antes do link nas três listas", async ({ page }) => {
+  const ordemEm = (seletor: string) =>
+    page.evaluate((sel) => {
+      const cont = document.querySelector(sel);
+      if (!cont) return ["SEM CONTAINER"];
+      return Array.from(cont.querySelectorAll("a,button")).map((e) => e.tagName);
+    }, seletor);
+
+  await page.goto("/roadmap/");
+  expect(await ordemEm(".topic-card-wrap"), "card do /roadmap").toEqual(["BUTTON", "A"]);
+
+  await page.goto("/topico/two-pointers/");
+  // Na trilha, o par é `button` + `a` dentro do item; o primeiro focável tem que
+  // ser o checkbox.
+  const naTrilha = await page.evaluate(() => {
+    const btn = document.querySelector('.sidebar [role="checkbox"]')!;
+    const link = btn.parentElement!.querySelector("a")!;
+    // `compareDocumentPosition` responde a pergunta certa: quem vem antes no DOM.
+    return (btn.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+  });
+  expect(naTrilha, "na trilha lateral a marca tem que vir antes do link").toBe(true);
+
+  const naListaDeProblemas = await page.evaluate(() => {
+    const btn = document.querySelector('.problem-row [role="checkbox"], .problem-row button');
+    if (!btn) return "SEM LISTA DE PROBLEMAS";
+    const link = btn.closest("li,div")!.querySelector("a")!;
+    return (btn.compareDocumentPosition(link) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+  });
+  expect(naListaDeProblemas, "na lista de problemas a marca tem que vir antes do link").toBe(true);
+});
+
 test("todo landmark de navegação tem nome próprio", async ({ page }) => {
   // Na home só existem os três da casca. Sem nome, o leitor de tela anuncia
   // "navegação" três vezes e o aluno não sabe qual é o menu de tópicos.

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -90,6 +90,42 @@ test("o anel de foco sobrevive nos campos de busca e de visualizador", async ({ 
   expect(parseFloat(viz.largura)).toBeGreaterThan(0);
 });
 
+test("a busca acha pelo que o aluno digita, e avisa quando não acha", async ({ page }) => {
+  await page.goto("/topico/arrays/");
+  const campo = page.getByLabel("Buscar tópico");
+
+  // Nenhuma destas três palavras aparece em `name` nenhum: sem casar descrição,
+  // a busca devolvia vazio e o aluno concluía que o guia não tem o assunto.
+  await campo.fill("janela");
+  await expect(page.locator('.side-item[href="/topico/sliding-window/"]')).toBeVisible();
+
+  await campo.fill("ponteiro");
+  await expect(page.locator('.side-item[href="/topico/listas-ligadas/"]')).toBeVisible();
+
+  await campo.fill("memoização");
+  await expect(page.locator('.side-item[href="/topico/programacao-dinamica/"]')).toBeVisible();
+
+  // Sem acento acha com acento: quem digita rápido não põe til.
+  await campo.fill("recursao");
+  await expect(page.locator('.side-item[href="/topico/recursao/"]')).toBeVisible();
+
+  // Nome do grupo traz a lista dele inteira.
+  await campo.fill("manipulacao");
+  await expect(page.locator('.side-item[href="/topico/operacoes-bitwise/"]')).toBeVisible();
+
+  // Sem resultado, a mensagem — e não a coluna vazia, que não diz se o guia não
+  // tem o assunto ou se o menu quebrou.
+  await campo.fill("xilofone");
+  await expect(page.locator(".side-vazio")).toContainText("Nenhum tópico");
+  await expect(page.locator(".side-vazio")).toContainText("xilofone");
+  await expect(page.locator(".side-scroll .side-item")).toHaveCount(0);
+
+  // E o menu volta inteiro quando o campo esvazia.
+  await campo.fill("");
+  await expect(page.locator(".side-vazio")).toHaveCount(0);
+  await expect(page.locator(".side-scroll .side-item").first()).toBeVisible();
+});
+
 test("a marca de progresso não mora dentro do link, e o progresso sobrevive à recarga", async ({
   page,
 }) => {

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// Acessibilidade da casca de navegação: link de pular, anel de foco, nome dos
+// campos e dos landmarks, e a marca de progresso fora do link.
+//
+// Todo teste daqui INTERAGE. Contar elemento não prova nada neste repositório:
+// já passou por suíte verde um visualizador sem botão nenhum e um painel de 0px.
+// "O link de pular existe" é exatamente esse tipo de asserção — o que importa é
+// se um Tab e um Enter levam o foco para dentro do `<main>`.
+
+/** Tabula até o elemento pedido e devolve quantos Tabs custou. Falha alto se
+ *  não chegar: laço que sai calado deixa a asserção seguinte medir outra coisa. */
+async function tabularAte(page: Page, seletor: string, limite = 80) {
+  for (let i = 1; i <= limite; i++) {
+    await page.keyboard.press("Tab");
+    const chegou = await page.evaluate(
+      (s) => document.activeElement?.matches(s) ?? false,
+      seletor
+    );
+    if (chegou) return i;
+  }
+  throw new Error(`o foco não alcançou ${seletor} em ${limite} tabulações`);
+}
+
+/** O foco está no `<main>` ou dentro dele? */
+const focoNoConteudo = (page: Page) =>
+  page.evaluate(() => {
+    const main = document.querySelector("main");
+    const alvo = document.activeElement;
+    return !!main && !!alvo && (alvo === main || main.contains(alvo));
+  });
+
+test("um Tab e um Enter levam o foco para dentro do conteúdo", async ({ page }) => {
+  // Antes do link de pular, o teclado atravessava a barra do topo e o menu
+  // lateral inteiros: 44 paradas até o primeiro elemento do `<main>` em
+  // /topico/dijkstra/, 40 em /topico/arrays/ e 29 na home, em TODA página
+  // aberta. E 44 é piso, porque o menu não renderiza grupo fechado.
+  for (const rota of ["/topico/dijkstra/", "/topico/arrays/", "/", "/roadmap/"]) {
+    await page.goto(rota);
+
+    // Fora da tela para quem usa mouse: o link é uma saída de teclado, não um
+    // elemento de página.
+    const escondido = await page
+      .locator(".skip-link")
+      .evaluate((e) => e.getBoundingClientRect().bottom < 0);
+    expect(escondido, `o link de pular aparece sem foco em ${rota}`).toBe(true);
+
+    const tabs = await tabularAte(page, ".skip-link");
+    expect(tabs, `o link de pular não é a primeira parada em ${rota}`).toBe(1);
+    await expect(page.locator(".skip-link")).toBeInViewport();
+
+    await page.keyboard.press("Enter");
+    await expect
+      .poll(() => focoNoConteudo(page), { message: `o foco não entrou no <main> em ${rota}` })
+      .toBe(true);
+
+    // E o Tab seguinte continua DENTRO do conteúdo, em vez de voltar ao menu:
+    // é isso que o `tabIndex={-1}` no `<main>` compra.
+    await page.keyboard.press("Tab");
+    expect(await focoNoConteudo(page), `o Tab depois do pulo saiu do <main> em ${rota}`).toBe(true);
+  }
+});

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -89,3 +89,34 @@ test("o anel de foco sobrevive nos campos de busca e de visualizador", async ({ 
   expect(viz.estilo, "o campo do visualizador ficou sem anel de foco").not.toBe("none");
   expect(parseFloat(viz.largura)).toBeGreaterThan(0);
 });
+
+test("todo landmark de navegação tem nome próprio", async ({ page }) => {
+  // Na home só existem os três da casca. Sem nome, o leitor de tela anuncia
+  // "navegação" três vezes e o aluno não sabe qual é o menu de tópicos.
+  await page.goto("/");
+  await expect(page.getByRole("navigation")).toHaveCount(3);
+  for (const nome of ["Principal", "Comunidade e apoio", "Trilha de estudos"]) {
+    await expect(page.getByRole("navigation", { name: nome })).toHaveCount(1);
+  }
+
+  // A trilha é navegação, e não `aside` (landmark "complementar").
+  await expect(page.locator("nav#menu-lateral.sidebar")).toHaveCount(1);
+});
+
+test("o botão do menu diz se o menu está aberto", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/topico/arrays/");
+
+  const botao = page.getByRole("button", { name: "Menu de tópicos" });
+  await expect(botao).toHaveAttribute("aria-expanded", "false");
+  await expect(botao).toHaveAttribute("aria-controls", "menu-lateral");
+  await expect(page.locator("#menu-lateral")).toBeHidden();
+
+  await botao.click();
+  await expect(botao).toHaveAttribute("aria-expanded", "true");
+  await expect(page.locator("#menu-lateral")).toBeVisible();
+
+  await botao.click();
+  await expect(botao).toHaveAttribute("aria-expanded", "false");
+  await expect(page.locator("#menu-lateral")).toBeHidden();
+});

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -60,3 +60,32 @@ test("um Tab e um Enter levam o foco para dentro do conteúdo", async ({ page })
     expect(await focoNoConteudo(page), `o Tab depois do pulo saiu do <main> em ${rota}`).toBe(true);
   }
 });
+
+test("o anel de foco sobrevive nos campos de busca e de visualizador", async ({ page }) => {
+  await page.goto("/topico/arrays/");
+
+  // Chegando pelo teclado, como o aluno que não usa mouse chega.
+  await tabularAte(page, ".side-search");
+  const busca = await page.evaluate(() => {
+    const s = getComputedStyle(document.activeElement as Element);
+    return { estilo: s.outlineStyle, largura: s.outlineWidth };
+  });
+  // `outlineWidth` sozinho NÃO serve de prova: com `outline: none` o Chrome
+  // devolve `3px` (a largura `medium` do padrão) e só o estilo vira `none`.
+  // Medido nesta branch, antes da correção: `{ largura: "3px", estilo: "none" }`.
+  expect(busca.estilo, "a busca da trilha ficou sem anel de foco").not.toBe("none");
+  expect(parseFloat(busca.largura)).toBeGreaterThan(0);
+
+  // Campo de visualizador: mesma regra, e é o campo de 41 páginas. Ele fica no
+  // meio do artigo, longe demais para tabular desde o topo; campo de texto casa
+  // `:focus-visible` em qualquer modalidade, então focar direto mede o mesmo.
+  const campo = page.locator(".viz-input").first();
+  await expect(campo).toBeVisible();
+  const viz = await campo.evaluate((e) => {
+    (e as HTMLElement).focus();
+    const s = getComputedStyle(e);
+    return { estilo: s.outlineStyle, largura: s.outlineWidth };
+  });
+  expect(viz.estilo, "o campo do visualizador ficou sem anel de foco").not.toBe("none");
+  expect(parseFloat(viz.largura)).toBeGreaterThan(0);
+});

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect, type Page } from "@playwright/test";
+import { GROUPS } from "../content/roadmap";
 
 // Acessibilidade da casca de navegação: link de pular, anel de foco, nome dos
 // campos e dos landmarks, e a marca de progresso fora do link.
@@ -205,4 +206,26 @@ test("o botão do menu diz se o menu está aberto", async ({ page }) => {
   await botao.click();
   await expect(botao).toHaveAttribute("aria-expanded", "false");
   await expect(page.locator("#menu-lateral")).toBeHidden();
+});
+
+test("cada grupo do roadmap tem âncora própria, e ela para abaixo do cabeçalho", async ({
+  page,
+}) => {
+  await page.goto("/roadmap/");
+  for (const g of GROUPS) {
+    await expect(page.locator(`section.rgroup[id="${g.id}"]`), `sem âncora para ${g.name}`).toHaveCount(1);
+  }
+
+  // Âncora que existe e para debaixo do cabeçalho fixo não serve de destino.
+  await page.goto("/roadmap/#grafos");
+  const alturaHeader = await page.evaluate(
+    () => document.querySelector(".header")!.getBoundingClientRect().height
+  );
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.querySelector("#grafos .rgroup-head h2")!.getBoundingClientRect().top
+      )
+    )
+    .toBeGreaterThanOrEqual(alturaHeader);
 });

--- a/tests/navegacao-a11y.spec.ts
+++ b/tests/navegacao-a11y.spec.ts
@@ -90,6 +90,56 @@ test("o anel de foco sobrevive nos campos de busca e de visualizador", async ({ 
   expect(parseFloat(viz.largura)).toBeGreaterThan(0);
 });
 
+test("a marca de progresso não mora dentro do link, e o progresso sobrevive à recarga", async ({
+  page,
+}) => {
+  // Widget focável dentro de `<a>` é estado inválido pela ARIA (`nested-interactive`
+  // do axe). Medido no build anterior: 7 em /topico/arrays/ e 48 em /roadmap/.
+  const aninhados = 'a button, a input, a [role="checkbox"], a [tabindex="0"]';
+
+  for (const rota of ["/topico/arrays/", "/roadmap/"]) {
+    await page.goto(rota);
+    await expect(page.locator(aninhados), `${rota} tem widget focável dentro de link`).toHaveCount(0);
+  }
+
+  // O progresso é dado que já está no navegador do aluno: a mudança é só de
+  // estrutura do DOM, e marcar continua marcando depois do F5.
+  await page.goto("/roadmap/");
+  // Escopo no card: o menu lateral do /roadmap pode estar mostrando o mesmo
+  // tópico (ele lembra o grupo aberto da visita anterior), e aí o mesmo nome
+  // acessível casa duas vezes.
+  const noCard = page
+    .locator(".topic-card-wrap")
+    .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+  await expect(noCard).toHaveAttribute("aria-checked", "false");
+  await noCard.click();
+  await expect(noCard).toHaveAttribute("aria-checked", "true");
+  await page.reload();
+  await expect(
+    page.locator(".topic-card-wrap").getByRole("checkbox", { name: "Marcar Two Pointers como concluído" })
+  ).toHaveAttribute("aria-checked", "true");
+
+  // O mesmo tópico, marcado no /roadmap, aparece marcado no menu lateral: é o
+  // mesmo dado, e o card e a trilha continuam falando a mesma língua.
+  await page.goto("/topico/two-pointers/");
+  const noMenu = page
+    .locator(".sidebar")
+    .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+  await expect(noMenu).toHaveAttribute("aria-checked", "true");
+
+  // Pelo teclado, e sem navegar junto: a barra de espaço marca o ✓ e a rota
+  // continua a mesma (o ✓ era filho do link, e o clique nele disputava com a
+  // navegação).
+  await noMenu.focus();
+  await page.keyboard.press(" ");
+  await expect(noMenu).toHaveAttribute("aria-checked", "false");
+  await expect(page).toHaveURL(/topico\/two-pointers/);
+  await page.reload();
+  await expect(
+    page.locator(".sidebar").getByRole("checkbox", { name: "Marcar Two Pointers como concluído" })
+  ).toHaveAttribute("aria-checked", "false");
+});
+
 test("todo landmark de navegação tem nome próprio", async ({ page }) => {
   // Na home só existem os três da casca. Sem nome, o leitor de tela anuncia
   // "navegação" três vezes e o aluno não sabe qual é o menu de tópicos.

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -1694,7 +1694,11 @@ test("binários negativos: complemento de dois, zero único e o padrão sem sina
 // Vídeo extra é link para resolução de exercício, não material do tópico, e um
 // tópico que só tem isso continua sem aula, sem texto e sem visualização.
 test("o selo em breve aparece em quem não tem vídeo, artigo nem visualização", async ({ page }) => {
-  // O menu lateral só renderiza o grupo aberto, então a conferência é por grupo.
+  // A conferência é por grupo, então o locator olha só o grupo ABERTO. Ele já foi
+  // `.sidebar .badge-soon`, sem o filtro, e isso funcionava por acidente: o menu
+  // não renderizava o grupo fechado, e por isso escondia 46 dos 47 tópicos do
+  // rastreador no pior caso. Corrigido aquilo, os 11 selos do site inteiro
+  // passaram a estar no DOM, e o que contava o grupo passou a contar o site.
   // Ler de ALL_TOPICS em vez de fixar uma lista faz o teste sobreviver ao dia
   // em que qualquer um destes tópicos for publicado.
   //
@@ -1709,7 +1713,9 @@ test("o selo em breve aparece em quem não tem vídeo, artigo nem visualização
     const grupo = ALL_TOPICS.find((t) => t.slug === slug)!.group;
     const doGrupo = ALL_TOPICS.filter((t) => t.group === grupo);
     const vazios = doGrupo.filter((t) => isEmptyTopic(t));
-    await expect(page.locator(".sidebar .badge-soon")).toHaveCount(vazios.length);
+    await expect(page.locator(".sidebar .side-items:not([hidden]) .badge-soon")).toHaveCount(
+      vazios.length
+    );
     for (const t of doGrupo) {
       const item = page.locator(`.sidebar a[href="/topico/${t.slug}/"]`);
       if (isEmptyTopic(t)) await expect(item, `${t.slug} devia estar em breve`).toHaveClass(/\bsoon\b/);


### PR DESCRIPTION
Oito defeitos da casca de navegação, todos em `Shell.tsx` e `RoadmapGroups.tsx`.

## O que muda para o aluno

| | antes (medido) | depois (medido) |
|---|---|---|
| tabulações até o `<main>` | **44** em `/topico/dijkstra/`, 40 em `/topico/arrays/`, 29 na home e no `/roadmap` | **1 Tab + Enter**, em qualquer página |
| anel de foco dos campos | `outline-style: none` (a busca das 47 páginas e os campos dos visualizadores) | `solid`, 2px |
| nome acessível da busca | nenhum (só `placeholder`, que some na primeira letra) | `Buscar tópico`, com `<label>` e `type="search"` |
| botão do menu no celular | `aria-label` fixo, sem estado | `aria-expanded` + `aria-controls` |
| landmarks de navegação | três `nav` sem nome, e a trilha num `<aside>` | três `nav` com nome próprio, trilha como `nav` |
| widget focável dentro de `<a>` | **7** em `/topico/arrays/`, **48** em `/roadmap/` | **0** nos dois |
| links de tópico no menu | **mínimo 1**, mediana 5, máximo 9, e **24 das 47 páginas com 5 ou menos** | **47** em toda página, home e `/roadmap` inclusive |
| busca por "janela" | nada | Sliding Window |
| busca sem resultado | coluna vazia, sem mensagem | mensagem dizendo o que aconteceu |
| âncora de grupo no `/roadmap` | **0** | **16** |

## Os consertos

**1. Link de pular (WCAG 2.4.1, nível A).** O `<main>` vinha depois do cabeçalho
e do menu lateral inteiros. O link é o primeiro filho do `.shell`, sai da tela em
vez de `display: none` (que o tiraria da ordem de foco junto), e o `<main>` ganhou
`id` e `tabIndex={-1}` para o foco ter onde pousar. `position: fixed` porque o
`.shell` é grid: em fluxo ele ocuparia a primeira célula e empurraria o menu.

**2. `outline: none` no foco.** As duas regras usavam `:focus` (vale para o
teclado) com especificidade 0-2-0, derrubando o `:focus-visible` global de 0-1-0.

**3. Nome acessível da busca.** Sem `aria-label`, `id`, `<label>` nem
`type="search"` (`grep -rn htmlFor src/ content/` devolvia 0 no repositório
inteiro). O `placeholder` era o único nome, e ele some na primeira letra digitada.

**4. Botão do menu com estado.** `aria-expanded` e `aria-controls`, como o mesmo
arquivo já fazia em outros dois botões.

**5. Landmarks com nome.** A trilha era um `<aside>` (landmark "complementar") e
os dois `nav` do topo não tinham nome: o leitor de tela anunciava "navegação"
três vezes.

**6. Marca de progresso fora do link.** `role="checkbox"` com `tabIndex={0}`
dentro de `<a>` é estado inválido pela ARIA (`nested-interactive` do axe). O
arranjo novo é o que o `ProblemList.tsx` já usava: botão **irmão** do link.

**7. O menu leva os 47 tópicos em toda página.** Era `{g.aberto && ...}`: os
itens do grupo fechado não existiam no DOM, e o menu é a única lista de tópicos
que a página carrega. Medido em `out/`, nas 47 páginas de tópico: **mínimo 1
link** (`programacao-dinamica`, `backtracking`, `big-o`, `greedy`, `matematica`,
`hash-table`), mediana 5, máximo 9, e **24 páginas com 5 ou menos**. Agora 47 em
todas.

A regra `.side-items[hidden] { display: none }` não é enfeite: o `display: flex`
do seletor vence o `display: none` que o navegador dá ao atributo `hidden`, e sem
ela o grupo "fechado" apareceria aberto. As duas conferências que o conserto
exige, feitas nas três viewports e testadas (não deduzidas):

- o grupo fechado computa `display: none`, com **0px de altura e 0px de largura**;
- o item oculto **não recebe foco**: `focus()` não move o `activeElement`, e
  tabulando desde o começo nenhuma parada cai dentro de um grupo fechado. O link
  de pular deste mesmo PR continua custando um Tab.

**8. A busca acha o que o aluno procura.** Filtrava só `t.name`, sem normalizar
acento, e descartava o grupo sem casamento. "janela", "memoização" e "ponteiro"
existem em `description` e em **zero** `name`; "recursao" sem acento não achava
"Recursão". Agora casa nome, descrição e nome do grupo, por NFD, e diz quando não
acha nada. Custo de bundle zero: as descrições já iam no mesmo chunk.

**9. `id` na seção do grupo do `/roadmap`.** `key={g.id}` é prop do React e não
vira atributo. **Isso destrava o `BreadcrumbList` de três níveis da lane de SEO**,
que hoje só consegue dois porque o nível do meio não tinha destino. O
`scroll-margin-top` vai junto: âncora que para debaixo do cabeçalho fixo não serve
de destino, e o teste mede isso.

## A asserção que mudou em `navegacao.spec.ts`, e por quê

`tests/navegacao.spec.ts:1712` contava `.sidebar .badge-soon` e comparava com os
tópicos vazios do grupo da rota. Ela passava **por acidente**: dependia de o menu
não renderizar o grupo fechado, que é exatamente o defeito do item 7. Com os 47
tópicos no DOM, os 11 selos "em breve" do site inteiro passam a estar lá, e o que
media o grupo passou a medir o site (esperava 1, recebia 11). O comentário acima
dela descrevia esse defeito como se fosse contrato.

O locator agora diz o que o teste sempre quis dizer: os selos do grupo **aberto**
(`.side-items:not([hidden]) .badge-soon`). E ele não perdeu força: forçando o selo
em todo tópico, reprova. **Nada mais daquele arquivo foi tocado** — a asserção
fraca ao lado é de outra lane.

## O que o layout NÃO mudou

O item 6 mexe na estrutura de toda linha do menu e de todos os 47 cards do
roadmap; o item 7 põe até 46 itens a mais no DOM da barra. Medido em 1512x900,
1440x700 e 390x844, com `?v=` para furar o cache:

```
linha do menu   antes: left 29px  altura 30px  ✓ em 38px  nome em 63px
                depois: left 29px  altura 30px  ✓ em 38px  nome em 63px
                (mesmo fundo rgba(59,130,246,.14) e o mesmo inset 2px do "você está aqui")
✓ do card       antes: 17,5px do topo, 17px da direita, 16px
                depois: 17,5px do topo, 17px da direita, 16px
card            antes: 312px (3 colunas) · 350px a 390px
                depois: 312px (3 colunas) · 350px a 390px
menu lateral    scrollHeight em /topico/dijkstra/: 876px antes, 876px depois
                (os grupos ocultos somam 0px), largura 290px / 390px na gaveta,
                links visíveis 9 antes e 9 depois
```

Zero overflow horizontal de página e da barra nas três larguras, nenhum rótulo
cortado (`scrollWidth > clientWidth` em `.side-item-name`, `.topic-card-name`,
`.side-vazio` e `.skip-link`: nenhum), e o link de pular **fora da tela** sem foco
(`bottom: -64px`) nas três. Ele só aparece ao receber foco, e aí cobre o
cabeçalho, com o anel de foco visível.

## O progresso do aluno sobrevive

A mudança do item 6 é só de **estrutura do DOM**: nada mudou na chave
(`ccc-dsa-progresso`), no formato nem na semântica do que é gravado, e
`ProgressProvider` não foi tocado. O teste marca no card do `/roadmap`,
**recarrega**, exige o ✓ de volta, confere que o mesmo tópico aparece marcado no
menu lateral de outra página, desmarca **pelo teclado** e recarrega de novo.

## A propriedade medida também precisa ser a que carrega o defeito

Vale registrar, porque é a lição mais barata deste PR. A prova do anel de foco ia
ser `getComputedStyle().outlineWidth !== "0px"`. Medido: com `outline: none`, o
Chrome devolve `outline-width: **3px**` (a largura `medium` do padrão) e só o
**estilo** vira `none`. Aquela asserção teria passado **verde no código
quebrado**, e o PR sairia com um guarda decorativo.

É a armadilha de "verificar comportamento, não existência" numa camada mais fina:
não basta trocar contagem por medição, a **propriedade** medida precisa ser a que
carrega o defeito. O teste olha o estilo (e o commit registra os dois números).

## As provas de quebra

Todo teste novo foi visto reprovando contra o código quebrado, com build de
verdade a cada rodada. Sem `git checkout --` em momento nenhum: cópia em
diretório temporário e restauração por `cp`.

```
A) os três arquivos como estão na origin/main ......... 7 failed
B) <main> sem id e sem tabIndex ....................... 1 failed
C) outline: none de volta nos dois campos ............. 1 failed
D) busca só por t.name (sem descrição) ................ 1 failed
E) busca sem normalizar acento ........................ 1 failed
F) sem mensagem de resultado vazio .................... 1 failed
G) <section> do roadmap sem id ........................ 1 failed
H) grupo fechado de volta a não existir no DOM ........ 1 failed (esperava 47, recebeu 1)
I) sem .side-items[hidden] { display: none } .......... 1 failed
J) selo "em breve" em todo tópico ..................... 1 failed (a asserção escopada ainda mede)
```

A quebra H foi refeita: a primeira tentativa **não compilou**, e o teste passou
verde contra o `out/` do build anterior. É o alerta do runbook em ação (build que
falha deixa o artefato bom no lugar); a segunda versão compila e reprova.
`git diff --stat` depois de restaurar mostrou só o fix.

## Verificação

- `npm run build` ✓ · `npx tsc --noEmit` ✓
- `npm run test:build` com a suíte inteira: **459 testes antes, 468 depois**
  (9 novos), **466 passando**. As duas reprovações são
  `tests/viz-strings.spec.ts:82` e `:326`, o flake conhecido de tolerância de
  rolagem: as duas passam quando o arquivo roda sozinho, e nenhuma tem relação
  com esta branch (não toco em visualizador).
- conferência visual em 1512x900, 1440x700 e 390x844.

## Achado que não é desta lane

`src/app/topico/[slug]/page.tsx:227` — o índice "Nesta página" é um quarto
`<nav>`, e é o único que continua sem nome. Nas páginas de tópico o leitor de
tela ouve três nomes e uma "navegação" solta. O arquivo é da lane de SEO.
