### PR TITLE
feat(a11y): a casca que anuncia o passo, para de rodar sozinha e devolve o foco

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1815,6 +1815,29 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 .viz-fit .viz-head { flex-wrap: wrap; }
 .viz-fit .viz-head-right { flex-wrap: wrap; justify-content: flex-end; }
 
+/* --- a região viva do visualizador: texto só para leitor de tela ---------
+   O contador "passo N de M" é visual, e era a única pista de que o algoritmo
+   andou. O `VizHeader` desenha um irmão dele com `role="status"` que diz a
+   mesma coisa em voz alta; esta classe é o que o tira dos olhos sem tirá-lo do
+   leitor de tela.
+   A técnica é RECORTE, e a escolha é o ponto: `display: none` e
+   `visibility: hidden` tiram o nó da árvore de acessibilidade junto, que é
+   exatamente quem precisa ler isto — o anúncio ficaria mudo e a regra pareceria
+   funcionar. `position: absolute` mantém o custo de layout em zero (o elemento
+   sai do fluxo do `.viz-head`, que é flex). */
+.viz-sr {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 /* ------------------------------ responsive ------------------------------ */
 @media (max-width: 1000px) {
   .shell { grid-template-columns: minmax(0, 1fr); }

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -656,7 +656,11 @@ export function VizFooter({
   return (
     <div className="viz-foot">
       <div className="viz-controls">
-        <button className="viz-btn" title="Reiniciar" onClick={viz.reset}>↺</button>
+        {/* `aria-label` e não só `title`: o CONTEÚDO vence o `title` no cálculo
+            do nome acessível, então o leitor de tela anunciava o nome Unicode do
+            glifo (ou nada). Os quatro vizinhos desta linha têm texto; este era o
+            único mudo. */}
+        <button className="viz-btn" title="Reiniciar" aria-label="Reiniciar" onClick={viz.reset}>↺</button>
         <button
           className="viz-btn"
           disabled={viz.step === 0}

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -687,7 +687,12 @@ export function VizFooter({
           <kbd>←</kbd><kbd>→</kbd> passo <span>·</span> <kbd>espaço</kbd> roda
         </p>
         {!noSpeed && (
-          <div className="viz-speed">
+          // `<label>`, e não a `<div>` de antes: o rótulo "Velocidade" estava
+          // ao lado do slider e não ligado a ele, então o controle não tinha
+          // nome acessível nenhum. É o mesmo padrão dos outros campos do
+          // produto, e o CSS é por classe (`.viz-speed`), então a troca de tag
+          // não muda um pixel.
+          <label className="viz-speed">
             <span>Velocidade</span>
             <input
               type="range"
@@ -695,10 +700,17 @@ export function VizFooter({
               max={5}
               step={1}
               value={viz.speed}
+              // Sem isto o leitor de tela anuncia o índice cru ("3 de 5"), que
+              // não é o que a tela diz.
+              aria-valuetext={SPEED_LABELS[viz.speed]}
               onChange={(e) => viz.setSpeed(parseInt(e.target.value, 10))}
             />
-            <span className="val">{SPEED_LABELS[viz.speed]}</span>
-          </div>
+            {/* Fora do NOME do slider de propósito: dentro dele o nome mudaria
+                a cada arrastada ("Velocidade 1x" → "Velocidade 2x"). O valor
+                não se perde, ele é dito pelo `aria-valuetext` acima, que é o
+                lugar do valor de um slider. */}
+            <span className="val" aria-hidden="true">{SPEED_LABELS[viz.speed]}</span>
+          </label>
         )}
       </div>
       <div className="viz-progress">

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -110,8 +110,17 @@ export type VisualizerOptions = {
   stepNote?: (step: number) => string | undefined;
 };
 
-/** O step atual e o que a região viva está dizendo, num estado só. */
-type Playback = { step: number; live: string };
+/**
+ * O step atual e o que a região viva está dizendo, num estado só.
+ *
+ * `liveTotal` é o `total` com que a frase de `live` foi montada. Toda frase
+ * daqui cita o total ("passo 1 de 8"), e o total pode mudar DEPOIS de a frase
+ * estar escrita — daí guardar o número junto do texto, para a leitura poder
+ * conferir se ele ainda vale. O porquê de conferir na leitura está no
+ * `liveMessage`, lá embaixo. Campo obrigatório de propósito: assim o TypeScript
+ * cobra quem acrescentar um caminho novo que escreve `live`.
+ */
+type Playback = { step: number; live: string; liveTotal: number };
 
 export type Visualizer = {
   title: string;
@@ -193,7 +202,7 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   // `--workers=1`: o percurso de 114 setas do `viz-quick-sort.spec.ts` parava no
   // passo 113. Com o anúncio montado dentro do mesmo `setState`, é um update por
   // tecla — exatamente o que era antes desta mudança.
-  const [playback, setPlayback] = useState<Playback>({ step: 0, live: "" });
+  const [playback, setPlayback] = useState<Playback>({ step: 0, live: "", liveTotal: total });
   const [playing, setPlaying] = useState(false);
   const [speed, setSpeed] = useState(initialSpeed);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -276,7 +285,7 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   const setStep = useCallback((n: number | ((s: number) => number)) => {
     setPlayback((p) => {
       const alvo = typeof n === "function" ? n(p.step) : n;
-      return alvo === p.step && p.live === "" ? p : { step: alvo, live: "" };
+      return alvo === p.step && p.live === "" ? p : { ...p, step: alvo, live: "" };
     });
   }, []);
 
@@ -286,7 +295,9 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     setPlayback((p) => {
       const alvo = naFaixa(naFaixa(p.step) + delta);
       const live = fala(alvo);
-      return alvo === p.step && live === p.live ? p : { step: alvo, live };
+      return alvo === p.step && live === p.live
+        ? p
+        : { step: alvo, live, liveTotal: totalRef.current };
     });
   }, [stop, fala, naFaixa, setPlayingNow]);
 
@@ -294,7 +305,11 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     if (playingRef.current) {
       stop();
       setPlayingNow(false);
-      setPlayback((p) => ({ ...p, live: `pausado no passo ${naFaixa(p.step) + 1} de ${totalRef.current}` }));
+      setPlayback((p) => ({
+        ...p,
+        live: `pausado no passo ${naFaixa(p.step) + 1} de ${totalRef.current}`,
+        liveTotal: totalRef.current,
+      }));
       return;
     }
     setPlayingNow(true);
@@ -302,14 +317,18 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
       // no fim da animação, rodar de novo rebobina em vez de não fazer nada
       const atual = naFaixa(p.step);
       const de = atual >= totalRef.current - 1 ? 0 : atual;
-      return { step: de, live: `rodando a partir do passo ${de + 1} de ${totalRef.current}` };
+      return {
+        step: de,
+        live: `rodando a partir do passo ${de + 1} de ${totalRef.current}`,
+        liveTotal: totalRef.current,
+      };
     });
   }, [stop, naFaixa, setPlayingNow]);
 
   const reset = useCallback(() => {
     stop();
     setPlayingNow(false);
-    setPlayback({ step: 0, live: fala(0) });
+    setPlayback({ step: 0, live: fala(0), liveTotal: totalRef.current });
   }, [stop, fala, setPlayingNow]);
 
   useEffect(() => {
@@ -332,7 +351,9 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   useEffect(() => {
     if (!playing || step < total - 1) return;
     setPlayingNow(false);
-    setPlayback((p) => ({ ...p, live: `fim da animação, passo ${total} de ${total}` }));
+    // Aqui o total certo é o do RENDER, não o do ref: este efeito só dispara
+    // depois de o render com o total novo ter acontecido.
+    setPlayback((p) => ({ ...p, live: `fim da animação, passo ${total} de ${total}`, liveTotal: total }));
   }, [playing, step, total, setPlayingNow]);
 
   // -------------------------------------------------------------------- casca
@@ -613,7 +634,40 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     togglePlay,
     reset,
     setSpeed: setSpeedClamped,
-    liveMessage: playback.live,
+    // Um `total` novo torna FALSA qualquer frase já escrita, porque todas elas
+    // citam o total: `viz.reset(); setNums(...)` no mesmo handler compõe
+    // "passo 1 de 8" e no mesmo render a peça já tem 20 células. O mesmo vale
+    // para a frase de `stepBy`, a de pausa e a de "rodando", que sobrevivem a
+    // uma troca de entrada sem passar por `reset` nenhum. A região cala, e a
+    // interação seguinte a reescreve com o número certo.
+    //
+    // A conferência é na LEITURA, e não num `useEffect([total])` que zera
+    // `live`. As duas razões são medidas, e a primeira é mais sutil do que
+    // parece:
+    //
+    // 1. Com o efeito, a frase falsa CHEGA ao DOM e sai no update seguinte —
+    //    medido pelos `MutationRecord` da região: `characterData` saindo de
+    //    "passo 5 de 8" e um `childList` removendo "passo 1 de 8". Ela não
+    //    chega a ser PINTADA no caminho do evento discreto (`input`, `click`),
+    //    porque aí o React esvazia o efeito antes da pintura — oito frames
+    //    seguidos lidos por `requestAnimationFrame` já mostram vazio. Só que
+    //    essa garantia é do evento discreto: `total` que muda por relógio, por
+    //    transição ou por dado que chegou depois tem o efeito adiado para
+    //    DEPOIS da pintura, e aí o frame com a frase falsa existe e vai para a
+    //    árvore de acessibilidade. A guarda aqui não depende dessa distinção: o
+    //    primeiro render com o total novo já sai `""` em qualquer caminho, e o
+    //    texto falso nunca existe. Um invariante em vez de um detalhe de
+    //    agendamento do React.
+    // 2. Efeito que chama `setPlayback` custa uma renderização a mais por troca
+    //    de `total`, e este arquivo documenta na declaração do `playback` que
+    //    renderização a mais por interação ENGOLE tecla.
+    //
+    // Calar em vez de recontar com o total novo: a frase carrega também a nota
+    // do step (`fala`), e `stepNoteRef` é atualizado num efeito — na
+    // renderização em que o total mudou a nota é tão velha quanto ele.
+    // Consertar só o número daria número verdadeiro colado em frase falsa. É a
+    // mesma política já escrita para o `setStep`: calar em vez de mentir.
+    liveMessage: playback.live && playback.liveTotal === total ? playback.live : "",
     expanded,
     open,
     collapsible,

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -162,7 +162,12 @@ export type Visualizer = {
     onClick: () => void;
     children: string;
   };
-  expandButtonProps: { className: string; onClick: () => void; children: string };
+  expandButtonProps: {
+    className: string;
+    ref: React.RefObject<HTMLButtonElement | null>;
+    onClick: () => void;
+    children: string;
+  };
   /** Envolve o `<figure>` no overlay quando expanded. Use no `return`. */
   inPanel: (content: ReactNode) => ReactNode;
 };
@@ -294,6 +299,9 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   // -------------------------------------------------------------------- casca
   const blockId = useId();
   const figureRef = useRef<HTMLElement>(null);
+  // O ⤢ Expandir, para devolver o foco a ele ao fechar o painel (ver o efeito do
+  // foco abaixo). Ele é recriado na travessia do portal, e o ref acompanha.
+  const expandButtonRef = useRef<HTMLButtonElement>(null);
   const bodyRef = useRef<HTMLDivElement>(null);
 
   const [expanded, setExpanded] = useState(false);
@@ -444,13 +452,27 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     return () => { body.style.overflow = prevOverflow; body.style.paddingRight = prevPadding; };
   }, [expanded]);
 
-  // O foco entra no panel ao abrir e volta para onde estava ao fechar, senão o
-  // teclado continua navegando o artigo escondido.
+  // O foco entra no panel ao abrir e volta para o botão que o abriu ao fechar,
+  // senão o teclado continua navegando o artigo escondido.
+  //
+  // A volta é pelo REF do botão, e não pelo `document.activeElement` guardado na
+  // abertura, que é o que estava aqui e não funcionava: aquele nó era o
+  // `⤢ Expandir` de dentro da `<figure>` que o `createPortal` DESMONTA, então o
+  // `focus()` da limpeza rodava num nó destacado — no-op silencioso — e o foco
+  // caía no `<body>`. Medido em `/topico/big-o/` (a peça de referência do
+  // contrato), `/topico/merge-sort/` e `/topico/intervals/`, pelas duas saídas:
+  // `document.activeElement.tagName` era `BODY` nas seis leituras.
+  //
+  // Guardar a referência não resolve porque o botão é RECRIADO no fechamento; é
+  // preciso reencontrá-lo depois. Ref e não seletor porque ref é IDENTIDADE:
+  // `.viz-expand` casa DOIS botões (este e o de mostrar/ocultar o bloco), e
+  // qualquer discriminante de texto ou de ordem quebra no dia em que o rótulo
+  // mudar. O ref aponta sempre para o nó vivo daquele elemento, e é `null` se
+  // não houver nenhum.
   useEffect(() => {
     if (!expanded) return;
-    const previous = document.activeElement as HTMLElement | null;
     figureRef.current?.focus();
-    return () => previous?.focus?.();
+    return () => expandButtonRef.current?.focus();
   }, [expanded]);
 
   // Teclado do panel: Esc fecha, o Tab circula DENTRO dele, e as setas e o
@@ -567,6 +589,7 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     },
     expandButtonProps: {
       className: "viz-expand",
+      ref: expandButtonRef,
       onClick: toggleExpanded,
       children: expanded ? "✕ Fechar" : "⤢ Expandir",
     },

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -97,7 +97,21 @@ export type VisualizerOptions = {
    * redimensionar já entram sozinhos.
    */
   measureOn?: readonly unknown[];
+  /**
+   * A nota de um step, em português: o mesmo texto que o aluno vidente lê no
+   * `.viz-note`. Sem ela a região viva diz só "passo N de M", que é o esqueleto
+   * da aula e não a aula.
+   *
+   * É uma FUNÇÃO do step, e não a nota do step atual, porque o anúncio é montado
+   * no mesmo `setState` que move o step (ver a nota da reprodução): o hook
+   * precisa da nota do step de DESTINO. A adoção é de uma linha —
+   * `stepNote: (i) => steps[i].note` — e é o próximo PR, não este.
+   */
+  stepNote?: (step: number) => string | undefined;
 };
+
+/** O step atual e o que a região viva está dizendo, num estado só. */
+type Playback = { step: number; live: string };
 
 export type Visualizer = {
   title: string;
@@ -116,6 +130,11 @@ export type Visualizer = {
   /** Volta ao step 0 e pausa. Chame quando a entrada do visualizador mudar. */
   reset: () => void;
   setSpeed: (i: number) => void;
+  /**
+   * O que a região viva do `VizHeader` está dizendo agora. Começa vazia: só a
+   * interação do aluno escreve nela.
+   */
+  liveMessage: string;
   // --- casca ---
   expanded: boolean;
   /** O blockName recolhível está à mostra? Sempre `true` quando `collapsible: false`. */
@@ -157,60 +176,119 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     blockName = "código",
     collapsible = true,
     measureOn = [],
+    stepNote,
   } = options;
 
   const hasSteps = total > 1;
 
   // --------------------------------------------------------------- reprodução
-  const [rawStep, setRawStep] = useState(0);
+  // O step e o texto da região viva moram no MESMO estado, e isso não é
+  // arrumação: escrever a região num efeito à parte custa uma renderização a
+  // mais por tecla, e essa renderização ENGOLE tecla. Medido, e reprodutível com
+  // `--workers=1`: o percurso de 114 setas do `viz-quick-sort.spec.ts` parava no
+  // passo 113. Com o anúncio montado dentro do mesmo `setState`, é um update por
+  // tecla — exatamente o que era antes desta mudança.
+  const [playback, setPlayback] = useState<Playback>({ step: 0, live: "" });
   const [playing, setPlaying] = useState(false);
   const [speed, setSpeed] = useState(initialSpeed);
   const timer = useRef<ReturnType<typeof setInterval> | null>(null);
-  const step = Math.max(0, Math.min(rawStep, total - 1));
+  const step = Math.max(0, Math.min(playback.step, total - 1));
 
   // `total` e `playing` por ref porque a tecla REPETE muito mais rápido que o
   // clique: ler o valor do closure engoliria repetições.
   const totalRef = useRef(total);
   const playingRef = useRef(false);
+  // A nota chega por FUNÇÃO, e não por string, pela mesma razão: o anúncio é
+  // montado junto com o step, então o hook precisa da nota do step de DESTINO,
+  // que a renderização atual (a do step de origem) não conhece.
+  const stepNoteRef = useRef(stepNote);
   useEffect(() => { totalRef.current = total; }, [total]);
   useEffect(() => { playingRef.current = playing; }, [playing]);
+  useEffect(() => { stepNoteRef.current = stepNote; }, [stepNote]);
 
   const stop = useCallback(() => {
     if (timer.current) { clearInterval(timer.current); timer.current = null; }
   }, []);
   useEffect(() => () => stop(), [stop]);
 
+  // ------------------------------------------------- anúncio (leitor de tela)
+  // O contador "passo N de M" é a única pista de que o algoritmo andou, e ele é
+  // só visual: sem região viva o aluno cego aperta "Próximo ›", o algoritmo
+  // anda, e ele não ouve nada — o visualizador vira um botão que não faz nada.
+  //
+  // A região começa VAZIA, e isso é parte do conserto: uma região viva já
+  // preenchida na montagem faz as cinco peças de `intervals.mdx` falarem juntas
+  // ao abrir a página, sem que ninguém tenha pedido. O HTML do build sai sem uma
+  // palavra a mais por causa disto.
+  //
+  // E ela é escrita pela INTERAÇÃO, não pelo relógio: `aria-live="polite"` a
+  // cada tick, na marcha 2x (250ms), enfileira falas que nunca alcançam a
+  // animação — o leitor de tela ainda estaria no passo 3 com a tela no 12, e
+  // ruído contínuo é pior que silêncio. Na reprodução automática a região diz só
+  // o começo, a pausa e o fim.
+  const fala = useCallback((n: number) => {
+    const passo = `passo ${n + 1} de ${totalRef.current}`;
+    const nota = stepNoteRef.current?.(n);
+    return nota ? `${passo}. ${nota}` : passo;
+  }, []);
+
+  // Sem anúncio de propósito: quem chama isto é o componente (o step inicial de
+  // uma peça, um salto calculado), não o aluno.
+  const setStep = useCallback((n: number | ((s: number) => number)) => {
+    setPlayback((p) => {
+      const alvo = typeof n === "function" ? n(p.step) : n;
+      return alvo === p.step ? p : { ...p, step: alvo };
+    });
+  }, []);
+
   const stepBy = useCallback((delta: number) => {
     stop();
     setPlaying(false);
-    setRawStep((s) => Math.max(0, Math.min(s + delta, totalRef.current - 1)));
-  }, [stop]);
+    setPlayback((p) => {
+      const alvo = Math.max(0, Math.min(p.step + delta, totalRef.current - 1));
+      const live = fala(alvo);
+      return alvo === p.step && live === p.live ? p : { step: alvo, live };
+    });
+  }, [stop, fala]);
 
   const togglePlay = useCallback(() => {
-    if (playingRef.current) { stop(); setPlaying(false); return; }
-    // no fim da animação, rodar de novo rebobina em vez de não fazer nada
-    setRawStep((s) => (s >= totalRef.current - 1 ? 0 : s));
+    if (playingRef.current) {
+      stop();
+      setPlaying(false);
+      setPlayback((p) => ({ ...p, live: `pausado no passo ${p.step + 1} de ${totalRef.current}` }));
+      return;
+    }
     setPlaying(true);
+    setPlayback((p) => {
+      // no fim da animação, rodar de novo rebobina em vez de não fazer nada
+      const de = p.step >= totalRef.current - 1 ? 0 : p.step;
+      return { step: de, live: `rodando a partir do passo ${de + 1} de ${totalRef.current}` };
+    });
   }, [stop]);
 
   const reset = useCallback(() => {
     stop();
     setPlaying(false);
-    setRawStep(0);
-  }, [stop]);
+    setPlayback({ step: 0, live: fala(0) });
+  }, [stop, fala]);
 
   useEffect(() => {
     stop();
     if (!playing) return;
     timer.current = setInterval(
-      () => setRawStep((s) => (s >= totalRef.current - 1 ? s : s + 1)),
+      // O relógio anda o step e NÃO escreve na região viva. O `p` devolvido no
+      // fim preserva o bail-out do React, que é o que impede a renderização
+      // inútil a cada tick depois do último step.
+      () => setPlayback((p) => (p.step >= totalRef.current - 1 ? p : { ...p, step: p.step + 1 })),
       speeds[speed]
     );
     return stop;
   }, [playing, speed, speeds, stop]);
 
   useEffect(() => {
-    if (playing && step >= total - 1) setPlaying(false);
+    if (!playing || step < total - 1) return;
+    setPlaying(false);
+    setPlayback((p) => ({ ...p, live: `fim da animação, passo ${total} de ${total}` }));
   }, [playing, step, total]);
 
   // -------------------------------------------------------------------- casca
@@ -417,11 +495,12 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     playing,
     speed,
     progress: total > 0 ? Math.round(((step + 1) / total) * 100) : 0,
-    setStep: setRawStep,
+    setStep,
     stepBy,
     togglePlay,
     reset,
     setSpeed: setSpeedClamped,
+    liveMessage: playback.live,
     expanded,
     open,
     collapsible,
@@ -474,6 +553,13 @@ export function VizHeader({
 }) {
   return (
     <div className="viz-head">
+      {/* A região viva do visualizador: invisível para o olho, lida em voz alta
+          quando o step muda. Ela mora aqui, ao lado do contador que duplica,
+          porque `.viz-head` é o único pedaço do `<figure>` que TODOS os
+          visualizadores da casca desenham. */}
+      <span className="viz-sr" role="status" aria-live="polite" aria-atomic="true">
+        {viz.liveMessage}
+      </span>
       <div className="viz-head-title">
         <span className="dot" style={color ? { background: color } : undefined} />
         <span>{viz.title}</span>

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -209,6 +209,18 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   const stepNoteRef = useRef(stepNote);
   useEffect(() => { totalRef.current = total; }, [total]);
   useEffect(() => { playingRef.current = playing; }, [playing]);
+
+  // O ref acompanha na MESMA chamada, e não só no efeito. Enquanto ele só era
+  // escrito no efeito, todo `playing` recém-trocado tinha uma janela em que o
+  // ref ainda dizia o contrário — e quem lê o ref para DECIDIR nessa janela
+  // decide errado. Medido: `botao.click(); botao.click()` no mesmo tick
+  // deixava a peça em "❚❚ Pausar", porque o segundo clique leu `false` e voltou
+  // a mandar rodar em vez de pausar. O efeito acima continua, como rede para
+  // qualquer caminho que mexa em `playing` sem passar por aqui.
+  const setPlayingNow = useCallback((v: boolean) => {
+    playingRef.current = v;
+    setPlaying(v);
+  }, []);
   useEffect(() => { stepNoteRef.current = stepNote; }, [stepNote]);
 
   const stop = useCallback(() => {
@@ -270,35 +282,35 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
 
   const stepBy = useCallback((delta: number) => {
     stop();
-    setPlaying(false);
+    setPlayingNow(false);
     setPlayback((p) => {
       const alvo = naFaixa(naFaixa(p.step) + delta);
       const live = fala(alvo);
       return alvo === p.step && live === p.live ? p : { step: alvo, live };
     });
-  }, [stop, fala, naFaixa]);
+  }, [stop, fala, naFaixa, setPlayingNow]);
 
   const togglePlay = useCallback(() => {
     if (playingRef.current) {
       stop();
-      setPlaying(false);
+      setPlayingNow(false);
       setPlayback((p) => ({ ...p, live: `pausado no passo ${naFaixa(p.step) + 1} de ${totalRef.current}` }));
       return;
     }
-    setPlaying(true);
+    setPlayingNow(true);
     setPlayback((p) => {
       // no fim da animação, rodar de novo rebobina em vez de não fazer nada
       const atual = naFaixa(p.step);
       const de = atual >= totalRef.current - 1 ? 0 : atual;
       return { step: de, live: `rodando a partir do passo ${de + 1} de ${totalRef.current}` };
     });
-  }, [stop, naFaixa]);
+  }, [stop, naFaixa, setPlayingNow]);
 
   const reset = useCallback(() => {
     stop();
-    setPlaying(false);
+    setPlayingNow(false);
     setPlayback({ step: 0, live: fala(0) });
-  }, [stop, fala]);
+  }, [stop, fala, setPlayingNow]);
 
   useEffect(() => {
     stop();
@@ -319,9 +331,9 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
 
   useEffect(() => {
     if (!playing || step < total - 1) return;
-    setPlaying(false);
+    setPlayingNow(false);
     setPlayback((p) => ({ ...p, live: `fim da animação, passo ${total} de ${total}` }));
-  }, [playing, step, total]);
+  }, [playing, step, total, setPlayingNow]);
 
   // -------------------------------------------------------------------- casca
   const blockId = useId();
@@ -417,13 +429,24 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   //
   // Isto não conversa com a medição da casca: só mexe em `playing`, nunca em
   // `open`, `measuring` ou `measureTick`, e a medição é guardada por
-  // `measuredRound`. Na montagem `playing` é `false`, então a primeira chamada
-  // do observer (que reporta o estado atual) é um no-op.
+  // `measuredRound`.
+  //
+  // Idempotente de propósito, sem guarda por `playingRef`: o ref só é escrito
+  // num efeito, então existe uma janela — curta, e real — em que `playing` já é
+  // `true` e o ref ainda é `false`, e nela a guarda descartaria a pausa. As três
+  // linhas abaixo são no-op quando não há o que pausar (`stop` sem timer,
+  // `setPlaying` com o mesmo valor e o bail-out do `setPlayback`), então a
+  // primeira chamada do observer na montagem — que reporta o estado atual e
+  // acontece em toda peça abaixo da dobra — continua não custando renderização.
   const pauseOffscreen = useCallback(() => {
-    if (!playingRef.current) return;
     stop();
-    setPlaying(false);
-  }, [stop]);
+    setPlayingNow(false);
+    // A região viva ficava dizendo "rodando a partir do passo N" com a peça
+    // parada: a única pista de quem não enxerga afirmando o contrário do botão
+    // ao lado. Ela CALA em vez de anunciar, porque pausa automática não é ação
+    // do aluno — anunciá-la interromperia quem já está lendo outra coisa.
+    setPlayback((p) => (p.live === "" ? p : { ...p, live: "" }));
+  }, [stop, setPlayingNow]);
 
   useEffect(() => {
     const onHide = () => { if (document.hidden) pauseOffscreen(); };

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -370,6 +370,47 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     return () => { cancelAnimationFrame(frame); window.removeEventListener("resize", onResize); };
   }, [collapsible]);
 
+  // ------------------------------ a animação não roda para quem não está vendo
+  // O `setInterval` acima não olhava a tela: uma peça rolada para fora, ou uma
+  // aba escondida, continuava andando. Cada tick é uma tarefa de main thread, e
+  // na marcha 2x ela volta a cada 250ms — em `intervals.mdx`, que tem cinco
+  // instâncias, isso é bateria queimada e INP piorando exatamente enquanto o
+  // aluno rola e interage com a peça seguinte.
+  //
+  // Ao voltar à tela a peça fica PAUSADA de propósito: retomar sozinho
+  // surpreende quem rolou de volta, e o ▶ Rodar à espera é mais honesto.
+  //
+  // Isto não conversa com a medição da casca: só mexe em `playing`, nunca em
+  // `open`, `measuring` ou `measureTick`, e a medição é guardada por
+  // `measuredRound`. Na montagem `playing` é `false`, então a primeira chamada
+  // do observer (que reporta o estado atual) é um no-op.
+  const pauseOffscreen = useCallback(() => {
+    if (!playingRef.current) return;
+    stop();
+    setPlaying(false);
+  }, [stop]);
+
+  useEffect(() => {
+    const onHide = () => { if (document.hidden) pauseOffscreen(); };
+    document.addEventListener("visibilitychange", onHide);
+    return () => document.removeEventListener("visibilitychange", onHide);
+  }, [pauseOffscreen]);
+
+  useEffect(() => {
+    // No panel expanded a peça É a tela, e o `<figure>` troca de nó DOM ao
+    // atravessar o portal: observar ali reportaria "saiu da tela" na travessia
+    // e pausaria justamente a animação que o aluno acabou de expandir.
+    if (expanded || typeof IntersectionObserver === "undefined") return;
+    const figure = figureRef.current;
+    if (!figure) return;
+    const observer = new IntersectionObserver(
+      (entries) => { if (!entries.some((e) => e.isIntersecting)) pauseOffscreen(); },
+      { threshold: 0 }
+    );
+    observer.observe(figure);
+    return () => observer.disconnect();
+  }, [expanded, pauseOffscreen]);
+
   const toggleOpen = useCallback(() => {
     setOpen((a) => {
       // Anotar dentro do updater mantém leitura e escrita no mesmo valor mesmo

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -540,10 +540,35 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   // qualquer discriminante de texto ou de ordem quebra no dia em que o rótulo
   // mudar. O ref aponta sempre para o nó vivo daquele elemento, e é `null` se
   // não houver nenhum.
+  //
+  // E a devolução mora no CORPO do efeito, no ramo do `expanded === false`, e
+  // não na LIMPEZA dele. Aqui a forma é o conserto, então vale registrar por quê:
+  //
+  // com `return () => expandButtonRef.current?.focus()`, o `react-hooks/
+  // exhaustive-deps` reprova ("copie `.current` para uma variável dentro do
+  // efeito e use a variável na limpeza") — e OBEDECER reintroduz exatamente o
+  // defeito acima. A variável captura o nó DAQUELE momento, que é o `⤢ Expandir`
+  // de dentro da `<figure>` que o portal vai desmontar: é o `document.
+  // activeElement` guardado na abertura com outro nome. Medido, com a sugestão
+  // da regra aplicada e o build visível: os dois testes de
+  // `tests/viz-hook.spec.ts` reprovam com `Expected: "BUTTON"` /
+  // `Received: "BODY"`, nas duas saídas.
+  //
+  // Ler o ref no corpo do efeito resolve os dois lados: a regra não dispara (ela
+  // só vale para a limpeza) e a leitura acontece DEPOIS de o React ter
+  // recriado o botão, no nó vivo — que é a única coisa que o conserto precisa.
+  const esteveExpandido = useRef(false);
   useEffect(() => {
-    if (!expanded) return;
-    figureRef.current?.focus();
-    return () => expandButtonRef.current?.focus();
+    if (expanded) {
+      esteveExpandido.current = true;
+      figureRef.current?.focus();
+      return;
+    }
+    // Só devolve o foco a quem ABRIU o painel: na montagem `expanded` já é
+    // `false`, e sem esta guarda toda peça da página roubaria o foco no load.
+    if (!esteveExpandido.current) return;
+    esteveExpandido.current = false;
+    expandButtonRef.current?.focus();
   }, [expanded]);
 
   // Teclado do panel: Esc fecha, o Tab circula DENTRO dele, e as setas e o

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -237,12 +237,34 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     return nota ? `${passo}. ${nota}` : passo;
   }, []);
 
+  // A faixa é aplicada na LEITURA do estado guardado, e não na escrita do
+  // `setStep`. Guardar o valor cru é o que faz um componente conseguir posicionar
+  // o passo de uma entrada que ainda não chegou ao `total`: o "20 inteiros" do
+  // `ArraysVisualizer` troca o array e pede o índice 16 no MESMO handler, com o
+  // `total` ainda em 8. Medido no build servido — limitando na escrita, o
+  // cabeçalho lê `passo 8 de 20` em vez de `passo 17 de 20`.
+  //
+  // Sem esta função, porém, o valor cru vaza do `step` (que é limitado na linha
+  // acima) para a aritmética das setas e para o texto dos anúncios, e aí o
+  // leitor de tela ouve um passo que não existe.
+  const naFaixa = useCallback(
+    (n: number) => Math.max(0, Math.min(n, totalRef.current - 1)),
+    []
+  );
+
   // Sem anúncio de propósito: quem chama isto é o componente (o step inicial de
   // uma peça, um salto calculado), não o aluno.
+  //
+  // "Sem anúncio" inclui não deixar de pé o anúncio ANTERIOR, que o salto acaba
+  // de tornar falso. Medido no `ArraysVisualizer`: o `viz.reset()` do "20
+  // inteiros" escreve "passo 1 de 8" e o `setStep(16)` da linha seguinte leva a
+  // peça para o passo 17 de 20 — a região viva ficava afirmando o passo e o
+  // total errados. O hook não tem como montar a frase certa aqui (o `total` novo
+  // só chega no render seguinte), então ele cala em vez de mentir.
   const setStep = useCallback((n: number | ((s: number) => number)) => {
     setPlayback((p) => {
       const alvo = typeof n === "function" ? n(p.step) : n;
-      return alvo === p.step ? p : { ...p, step: alvo };
+      return alvo === p.step && p.live === "" ? p : { step: alvo, live: "" };
     });
   }, []);
 
@@ -250,26 +272,27 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     stop();
     setPlaying(false);
     setPlayback((p) => {
-      const alvo = Math.max(0, Math.min(p.step + delta, totalRef.current - 1));
+      const alvo = naFaixa(naFaixa(p.step) + delta);
       const live = fala(alvo);
       return alvo === p.step && live === p.live ? p : { step: alvo, live };
     });
-  }, [stop, fala]);
+  }, [stop, fala, naFaixa]);
 
   const togglePlay = useCallback(() => {
     if (playingRef.current) {
       stop();
       setPlaying(false);
-      setPlayback((p) => ({ ...p, live: `pausado no passo ${p.step + 1} de ${totalRef.current}` }));
+      setPlayback((p) => ({ ...p, live: `pausado no passo ${naFaixa(p.step) + 1} de ${totalRef.current}` }));
       return;
     }
     setPlaying(true);
     setPlayback((p) => {
       // no fim da animação, rodar de novo rebobina em vez de não fazer nada
-      const de = p.step >= totalRef.current - 1 ? 0 : p.step;
+      const atual = naFaixa(p.step);
+      const de = atual >= totalRef.current - 1 ? 0 : atual;
       return { step: de, live: `rodando a partir do passo ${de + 1} de ${totalRef.current}` };
     });
-  }, [stop]);
+  }, [stop, naFaixa]);
 
   const reset = useCallback(() => {
     stop();
@@ -284,11 +307,15 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
       // O relógio anda o step e NÃO escreve na região viva. O `p` devolvido no
       // fim preserva o bail-out do React, que é o que impede a renderização
       // inútil a cada tick depois do último step.
-      () => setPlayback((p) => (p.step >= totalRef.current - 1 ? p : { ...p, step: p.step + 1 })),
+      () =>
+        setPlayback((p) => {
+          const atual = naFaixa(p.step);
+          return atual >= totalRef.current - 1 ? p : { ...p, step: atual + 1 };
+        }),
       speeds[speed]
     );
     return stop;
-  }, [playing, speed, speeds, stop]);
+  }, [playing, speed, speeds, stop, naFaixa]);
 
   useEffect(() => {
     if (!playing || step < total - 1) return;

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -1133,7 +1133,7 @@ test("heap: trocar preset ou modo reabre com árvore, não com um nó solto", as
   await expect(nos).toHaveCount(4);
 
   // ↺ é o único que volta ao começo de verdade, que é o heap vazio
-  await viz.getByRole("button", { name: "↺" }).click();
+  await viz.getByRole("button", { name: "Reiniciar" }).click();
   await expect(nos).toHaveCount(1);
 });
 

--- a/tests/viz-binary-heap.spec.ts
+++ b/tests/viz-binary-heap.spec.ts
@@ -428,7 +428,7 @@ test.describe("binary-heap · a árvore e o array se movendo juntos", () => {
     await ficha(fig, 0, "elementos", "4");
 
     // E o ↺ continua sendo o caminho para ver a inserção desde o heap vazio.
-    await fig.getByRole("button", { name: "↺" }).click();
+    await fig.getByRole("button", { name: "Reiniciar" }).click();
     await expect(fig.locator(".viz-step")).toHaveText(`passo 1 de ${TOTAL_PADRAO}`);
     await ficha(fig, 0, "elementos", "1");
   });

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -130,3 +130,22 @@ test.describe("a animação não roda para quem não está vendo", () => {
     expect(await contador.textContent()).toBe(voltaA);
   });
 });
+
+test.describe("os dois controles que não tinham nome", () => {
+  test("o ↺ se chama Reiniciar e volta ao passo 1", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/big-o/");
+    const contador = contadorDePasso(fig);
+    const proximo = fig.getByRole("button", { name: "Próximo ›" });
+
+    await proximo.click();
+    await proximo.click();
+    await expect(contador).toHaveText(/^passo 3 de \d+$/);
+
+    // O `title` não vira nome acessível quando o botão tem conteúdo: o glifo
+    // vence, e o leitor de tela anunciava o nome Unicode dele (ou nada).
+    const reiniciar = fig.getByRole("button", { name: "Reiniciar" });
+    await expect(reiniciar).toHaveCount(1);
+    await reiniciar.click();
+    await expect(contador).toHaveText(/^passo 1 de \d+$/);
+  });
+});

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -148,4 +148,36 @@ test.describe("os dois controles que não tinham nome", () => {
     await reiniciar.click();
     await expect(contador).toHaveText(/^passo 1 de \d+$/);
   });
+
+  test("o slider de velocidade tem rótulo de verdade, e o layout não muda", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/big-o/");
+    const slider = fig.getByRole("slider", { name: /Velocidade/ });
+    await expect(slider).toHaveCount(1);
+
+    // Rótulo de VERDADE, não texto ao lado: um `<label>` passa o clique para o
+    // controle que ele envolve. É a diferença que o nome acessível sozinho não
+    // distingue de um `aria-label` colado numa `<div>`.
+    await fig.locator(".viz-speed > span").first().click();
+    await expect(slider).toBeFocused();
+
+    // O valor anunciado é o valor da tela, e não o índice cru do range (que
+    // diria "3 de 5" onde o aluno lê "1x").
+    const val = fig.locator(".viz-speed .val");
+    await expect(slider).toHaveAttribute("aria-valuetext", (await val.textContent())!);
+    await slider.press("ArrowRight");
+    await expect(val).not.toHaveText("1x");
+    await expect(slider).toHaveAttribute("aria-valuetext", (await val.textContent())!);
+
+    // E a troca de tag não move um pixel, porque o CSS é por classe. Sem número
+    // mágico: `display` é o valor que a classe declara, e a borda direita do
+    // slider coincide com a da linha de controles porque `.viz-speed` tem
+    // `margin-left: auto`. As duas caem se a classe deixar de alcançar a tag.
+    const caixaSpeed = fig.locator(".viz-speed");
+    expect(await caixaSpeed.evaluate((el) => getComputedStyle(el).display)).toBe("flex");
+    const speed = await caixaSpeed.boundingBox();
+    const controles = await fig.locator(".viz-controls").boundingBox();
+    expect(Math.round(speed!.x + speed!.width)).toBe(
+      Math.round(controles!.x + controles!.width)
+    );
+  });
 });

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -18,12 +18,69 @@ function contadorDePasso(fig: Locator): Locator {
   return fig.locator(".viz-step").filter({ hasText: /^passo \d+ de \d+$/ });
 }
 
-async function figuraDe(page: Page, url: string): Promise<Locator> {
+/**
+ * A peça que cada página deste arquivo exercita, pelo TÍTULO dela. É a chave dos
+ * seletores daqui, e a razão de existir está logo abaixo.
+ */
+const PECAS = {
+  "/topico/big-o/": "contando operações no mesmo array",
+  "/topico/merge-sort/": "a descida divide, a subida ordena",
+} as const;
+
+/**
+ * A figura DAQUELA peça, escolhida por qual ela é e nunca por onde ela está.
+ *
+ * Aqui havia `page.locator("figure.viz-fit").first()`, que é uma afirmação sobre
+ * a ORDEM no documento e só acerta enquanto a página tem uma figura na casca.
+ * Em `/topico/big-o/` o `[0]` passa a ser o gráfico das famílias assim que ele
+ * for adaptado: sem `Próximo ›`, sem `▶ Rodar`, sem `↺ Reiniciar`, sem slider, e
+ * com o `.viz-step` valendo "n = 62". Em `/topico/merge-sort/` o alvo é o `[0]`
+ * por acidente, ao lado de dois irmãos cujo `.viz-step` diz "4 rodadas de
+ * intercalação…" e "as duas versões se separam na decisão 2".
+ *
+ * A ironia é que o `contadorDePasso` acima já avisava disso, e este helper caía
+ * na mesma armadilha três linhas depois.
+ *
+ * **Escope por QUAL figura, nunca por QUANTAS têm a casca.** O título é
+ * identidade; contar figuras adaptadas seria afirmar o cronograma da migração,
+ * que muda a cada PR e não é o produto. E os dois modos de errar não custam o
+ * mesmo: título trocado reprova alto no `toHaveCount(1)`, ordem trocada mede a
+ * peça errada em silêncio.
+ */
+async function figuraDe(page: Page, url: keyof typeof PECAS): Promise<Locator> {
   await page.goto(url);
-  const fig = page.locator("figure.viz-fit").first();
+  const fig = page.locator("figure.viz-fit").filter({ hasText: PECAS[url] });
+  await expect(fig, `a peça "${PECAS[url]}" tem que ser única em ${url}`).toHaveCount(1);
   await expect(fig).toBeVisible();
   return fig;
 }
+
+test.describe("os seletores deste arquivo apontam para a peça certa", () => {
+  // O canário desta classe de defeito: ele reprova no dia em que um irmão da
+  // página entrar na casca e roubar o `[0]`, em vez de deixar os outros testes
+  // medirem a peça errada.
+  for (const [url, titulo] of Object.entries(PECAS) as [keyof typeof PECAS, string][]) {
+    test(`em ${url} o alvo é achado pelo título e tem a linha do tempo`, async ({ page }) => {
+      const fig = await figuraDe(page, url);
+      await expect(fig).toContainText(titulo);
+
+      // O que TODO teste deste arquivo exercita mora nesta figura, e é isso que
+      // a torna o alvo — não a posição dela.
+      await expect(contadorDePasso(fig)).toHaveCount(1);
+      await expect(fig.getByRole("button", { name: "Próximo ›" })).toHaveCount(1);
+      await expect(fig.getByRole("button", { name: "Reiniciar" })).toHaveCount(1);
+      await expect(fig.getByRole("slider", { name: /Velocidade/ })).toHaveCount(1);
+      await expect(fig.getByRole("status")).toHaveCount(1);
+
+      // Nada aqui afirma QUANTAS figuras a página tem na casca: seria asserção
+      // sobre o cronograma da migração. O que se afirma é que a peça alvo
+      // existe, é uma só, e que o `.viz-step` cru continua ambíguo dentro dela —
+      // que é por que o `contadorDePasso` filtra pelo texto.
+      expect(await page.locator("figure.viz-fit").count()).toBeGreaterThanOrEqual(1);
+      expect(await fig.locator(".viz-step").count()).toBeGreaterThanOrEqual(1);
+    });
+  }
+});
 
 test.describe("a região viva anuncia o passo", () => {
   test("o texto muda quando o aluno aperta Próximo ›", async ({ page }) => {

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -25,6 +25,7 @@ function contadorDePasso(fig: Locator): Locator {
 const PECAS = {
   "/topico/big-o/": "contando operações no mesmo array",
   "/topico/merge-sort/": "a descida divide, a subida ordena",
+  "/topico/arrays/": "memória contígua e o endereço de nums[i]",
 } as const;
 
 /**
@@ -146,6 +147,40 @@ test.describe("a região viva anuncia o passo", () => {
     await expect(rodar).toHaveText(/Rodar/);
     await expect(status).toHaveText(/^pausado no passo \d+ de \d+$/);
     await expect(status).not.toHaveText(anuncioNoInicio);
+  });
+
+  test("um salto programático cala a região, em vez de deixar o anúncio velho de pé", async ({
+    page,
+  }) => {
+    const fig = await figuraDe(page, "/topico/arrays/");
+    const status = fig.getByRole("status");
+    const contador = contadorDePasso(fig);
+
+    // O `viz.step` desta peça É o índice lido, e o `total` É o tamanho do array.
+    await expect(contador).toHaveText("passo 4 de 8");
+    await expect(status).toHaveText("");
+
+    // "20 inteiros" é o caso que nenhum outro teste alcança: o mesmo handler
+    // troca o array (8 → 20 posições) E posiciona o índice. O `viz.reset()`
+    // escreve o anúncio com o total ANTIGO, e o `viz.setStep(16)` da linha
+    // seguinte leva a peça para outro passo — a região fica afirmando um par
+    // (passo, total) que a renderização não confirma.
+    await fig.getByRole("button", { name: "20 inteiros" }).click();
+
+    // Premissa: a peça mudou mesmo. Sem ela, o silêncio abaixo seria trivial.
+    await expect(contador).toHaveText("passo 17 de 20");
+
+    // A asserção que carrega o sentido: sem o conserto esta linha lê
+    // "passo 1 de 8" — o passo errado E o total errado, na única pista que o
+    // aluno cego tem de onde a peça está. O hook não consegue montar a frase
+    // certa aqui (o `total` novo só chega no render seguinte), então ele cala.
+    await expect(status).toHaveText("");
+
+    // E o silêncio é do salto, não da peça: a seta seguinte volta a falar, já
+    // com o total novo.
+    await fig.getByRole("button", { name: "Próximo ›" }).click();
+    await expect(contador).toHaveText("passo 18 de 20");
+    await expect(status).toHaveText(/^passo 18 de 20/);
   });
 });
 

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -182,6 +182,79 @@ test.describe("a região viva anuncia o passo", () => {
     await expect(contador).toHaveText("passo 18 de 20");
     await expect(status).toHaveText(/^passo 18 de 20/);
   });
+
+  test("um total novo cala o anúncio, e a frase com o total velho nunca chega ao DOM", async ({
+    page,
+  }) => {
+    const fig = await figuraDe(page, "/topico/arrays/");
+    const status = fig.getByRole("status");
+    const contador = contadorDePasso(fig);
+    const campo = fig.getByLabel("Array", { exact: true });
+
+    // Primeiro uma interação, para a região ter o que ficar dizendo.
+    await fig.getByRole("button", { name: "Próximo ›" }).click();
+    await expect(contador).toHaveText("passo 5 de 8");
+    await expect(status).toHaveText(/^passo 5 de 8$/);
+
+    // Grava todo texto que a região viva chegar a TER daqui em diante.
+    //
+    // Isto não é zelo: asserção sobre o valor final não distingue "nunca disse"
+    // de "disse e apagou no render seguinte", e a diferença é o defeito inteiro.
+    // Um conserto que zera `live` num `useEffect([total])` deixa a frase falsa
+    // entrar no DOM e a tira no update seguinte — medido, o `MutationRecord`
+    // sai `characterData "passo 5 de 8" → …` seguido de `removed "passo 1 de
+    // 8"`. Com a guarda na leitura é uma mutação só, de "passo 5 de 8" para
+    // vazio, e o texto falso nunca existe.
+    //
+    // Ler `el.textContent` DENTRO do callback não mede isso: o callback é
+    // microtarefa, roda depois dos dois updates e lê o valor final nas duas
+    // vezes — uma asserção que parece medir o transitório e mede o final. O que
+    // mede é o valor que cada mutação SUBSTITUIU: `oldValue` do
+    // `characterData`, `textContent` do nó removido no `childList`.
+    await status.evaluate((el) => {
+      const w = window as unknown as { __teve: string[] };
+      w.__teve = [];
+      new MutationObserver((recs) => {
+        for (const r of recs) {
+          if (r.type === "characterData") w.__teve.push(r.oldValue ?? "");
+          else r.removedNodes.forEach((n) => w.__teve.push(n.textContent ?? ""));
+        }
+      }).observe(el, {
+        childList: true,
+        characterData: true,
+        characterDataOldValue: true,
+        subtree: true,
+      });
+    });
+
+    // Trocar a entrada muda o `total` DESTA peça (o passo é o índice lido), e
+    // o `viz.reset()` do handler compõe o anúncio antes de o total novo chegar.
+    // `onInputChange` é o ÚNICO handler da peça que não chama `viz.setStep(...)`
+    // depois — os quatro irmãos são salvos por acidente, porque `setStep` cala.
+    await campo.fill("4, 5, 6");
+
+    // Premissa: o total mudou mesmo. Sem ela, o silêncio abaixo seria trivial.
+    await expect(contador).toHaveText("passo 1 de 3");
+
+    // A asserção que carrega o sentido: sem o conserto a região fica dizendo
+    // "passo 1 de 8" com a peça em "passo 1 de 3" — um total que não existe
+    // mais, na única pista de quem não enxerga.
+    await expect(status).toHaveText("");
+
+    // E nem por um update: a frase falsa não entrou no DOM para sair depois.
+    // O único valor que a região teve entre o clique e agora é o anúncio de
+    // ANTES da troca; nenhum "de 8" novo apareceu no meio do caminho.
+    const teve = await page.evaluate(
+      () => (window as unknown as { __teve: string[] }).__teve
+    );
+    expect(teve.filter((t) => t !== "" && t !== "passo 5 de 8")).toEqual([]);
+
+    // O silêncio é da troca, não da peça: a seta seguinte volta a falar, já com
+    // o total novo.
+    await fig.getByRole("button", { name: "Próximo ›" }).click();
+    await expect(contador).toHaveText("passo 2 de 3");
+    await expect(status).toHaveText(/^passo 2 de 3/);
+  });
 });
 
 test.describe("o ▶ Rodar não perde o próprio estado", () => {

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -131,6 +131,52 @@ test.describe("a animação não roda para quem não está vendo", () => {
   });
 });
 
+test.describe("o foco volta para o botão que abriu o painel", () => {
+  // O contrato (`content/visualizers/README.md` §5) promete "entra no painel ao
+  // abrir, volta para onde estava ao fechar". O `<figure>` atravessa um portal,
+  // e o nó guardado na abertura é destruído nessa travessia: o `focus()` da
+  // limpeza rodava num nó destacado, sem erro nenhum, e o foco caía no `<body>`.
+  //
+  // As duas saídas são testadas porque são dois caminhos diferentes: no `Esc` o
+  // foco está no `<figure>`, e no `✕ Fechar` está no próprio botão que some.
+  for (const saida of ["Esc", "✕ Fechar"] as const) {
+    test(`fechando com ${saida}, o foco volta para o ⤢ Expandir`, async ({ page }) => {
+      const fig = await figuraDe(page, "/topico/big-o/");
+      const expandir = fig.getByRole("button", { name: /Expandir/ });
+
+      // Abrir pelo TECLADO: é o público desta correção.
+      await expandir.focus();
+      await expect(expandir).toBeFocused();
+      await page.keyboard.press("Enter");
+
+      const painel = page.locator(".viz-overlay figure.viz-fit");
+      await expect(painel).toHaveCount(1);
+      // Premissa: o foco entrou no painel. Sem ela, "voltou" não quer dizer nada.
+      await expect
+        .poll(() =>
+          page.evaluate(() => {
+            const f = document.querySelector(".viz-overlay figure.viz-fit");
+            return !!f && (f === document.activeElement || f.contains(document.activeElement));
+          })
+        )
+        .toBe(true);
+
+      if (saida === "Esc") await page.keyboard.press("Escape");
+      else await painel.getByRole("button", { name: /Fechar/ }).click();
+      await expect(painel).toHaveCount(0);
+
+      // O valor primeiro, para a falha DIZER o que aconteceu: sem o conserto
+      // esta linha recebe "BODY".
+      await expect
+        .poll(() => page.evaluate(() => document.activeElement?.tagName ?? "NULO"))
+        .toBe("BUTTON");
+      // E a identidade: é o botão que abriu o painel, localizado pelo NOME
+      // acessível, e não pelo glifo nem pela posição na linha.
+      await expect(expandir).toBeFocused();
+    });
+  }
+});
+
 test.describe("os dois controles que não tinham nome", () => {
   test("o ↺ se chama Reiniciar e volta ao passo 1", async ({ page }) => {
     const fig = await figuraDe(page, "/topico/big-o/");

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -1,0 +1,93 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// A casca de TODO visualizador vem de `src/lib/visualizer.tsx`, e o que se prova
+// aqui é o comportamento dela: o passo sendo anunciado, a animação parando
+// quando ninguém está vendo, e os dois controles que existiam sem nome.
+//
+// Contar elemento não testa nada — já passaram por uma suíte verde um
+// visualizador sem botão nenhum e um painel com 0px. Cada teste daqui INTERAGE e
+// lê o rótulo.
+
+/**
+ * O contador "passo N de M". Escopado na figura E filtrado pelo texto, porque
+ * `.viz-step` é ambíguo: o `BigOCounterVisualizer` passa um segundo pela porta
+ * de `children` do `VizHeader` ("n = 62"), e o `MergeSortVisualizer` tem três na
+ * mesma página. Um `.first()` aqui leria o número errado sem erro nenhum.
+ */
+function contadorDePasso(fig: Locator): Locator {
+  return fig.locator(".viz-step").filter({ hasText: /^passo \d+ de \d+$/ });
+}
+
+async function figuraDe(page: Page, url: string): Promise<Locator> {
+  await page.goto(url);
+  const fig = page.locator("figure.viz-fit").first();
+  await expect(fig).toBeVisible();
+  return fig;
+}
+
+test.describe("a região viva anuncia o passo", () => {
+  test("o texto muda quando o aluno aperta Próximo ›", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/big-o/");
+
+    const status = fig.getByRole("status");
+    await expect(status).toHaveCount(1);
+
+    // Premissa 1: ela nasce MUDA. Uma região viva já preenchida na montagem faz
+    // as cinco peças de `intervals.mdx` falarem juntas ao abrir a página, sem
+    // que o aluno tenha feito nada.
+    await expect(status).toHaveText("");
+
+    // Premissa 2: invisível para o olho, presente para o leitor de tela. Com
+    // `display: none` ou `visibility: hidden` a caixa não existiria — e é
+    // exatamente o conserto que PARECE funcionar e deixa o anúncio mudo.
+    const caixa = await status.boundingBox();
+    expect(caixa).not.toBeNull();
+    expect(caixa!.width).toBeLessThanOrEqual(2);
+    expect(caixa!.height).toBeLessThanOrEqual(2);
+
+    const contador = contadorDePasso(fig);
+    await expect(contador).toHaveCount(1);
+    const passoAntes = (await contador.textContent()) ?? "";
+    const anuncioAntes = (await status.textContent()) ?? "";
+
+    await fig.getByRole("button", { name: "Próximo ›" }).click();
+
+    // Premissa 3: o algoritmo andou de verdade (senão o resto não quer dizer
+    // nada). Asserção web-first: o React re-renderiza de forma assíncrona.
+    await expect(contador).not.toHaveText(passoAntes);
+    // E a asserção que carrega o sentido: a região DISSE que andou.
+    await expect(status).not.toHaveText(anuncioAntes);
+    await expect(status).toHaveText(/^passo 2 de \d+$/);
+  });
+
+  test("o anúncio não vira ruído durante a reprodução automática", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/merge-sort/");
+    const status = fig.getByRole("status");
+    const contador = contadorDePasso(fig);
+    const rodar = fig.getByRole("button", { name: /Rodar|Pausar/ });
+
+    await rodar.click();
+    await expect(rodar).toHaveText(/Pausar/);
+    // Começar a rodar É uma ação do aluno, e ela é anunciada uma vez.
+    await expect(status).toHaveText(/^rodando a partir do passo 1 de \d+$/);
+
+    const anuncioNoInicio = (await status.textContent()) ?? "";
+    const passoNoInicio = (await contador.textContent()) ?? "";
+    // Três marchas de 650ms: tempo de sobra para o relógio andar vários passos.
+    await page.waitForTimeout(2000);
+
+    // Premissa: a animação andou mesmo enquanto ninguém falava.
+    expect(await contador.textContent()).not.toBe(passoNoInicio);
+    // A asserção: o relógio NÃO escreveu na região viva. Com um anúncio por
+    // tick, na marcha 2x (250ms) o leitor de tela enfileira falas que nunca
+    // alcançam a tela, e ruído contínuo é pior que silêncio.
+    expect(await status.textContent()).toBe(anuncioNoInicio);
+
+    // E pausar, que é ação do aluno de novo, volta a falar — com o passo em que
+    // a animação parou, não com o que ela tinha quando começou.
+    await rodar.click();
+    await expect(rodar).toHaveText(/Rodar/);
+    await expect(status).toHaveText(/^pausado no passo \d+ de \d+$/);
+    await expect(status).not.toHaveText(anuncioNoInicio);
+  });
+});

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -184,6 +184,34 @@ test.describe("a região viva anuncia o passo", () => {
   });
 });
 
+test.describe("o ▶ Rodar não perde o próprio estado", () => {
+  test("dois toques no mesmo tick voltam ao parado, em vez de mandar rodar duas vezes", async ({
+    page,
+  }) => {
+    const fig = await figuraDe(page, "/topico/merge-sort/");
+    const rodar = fig.getByRole("button", { name: /Rodar|Pausar/ });
+    const contador = contadorDePasso(fig);
+    await expect(rodar).toHaveText(/Rodar/);
+
+    // Os dois cliques no MESMO tick, que é o pior caso do estado lido por ref:
+    // o `playing` do primeiro ainda não chegou ao ref quando o segundo decide.
+    await rodar.evaluate((b: HTMLElement) => {
+      b.click();
+      b.click();
+    });
+
+    // Dois toques na mesma tecla se cancelam. Sem o conserto o segundo lia
+    // `playingRef.current === false` e voltava a MANDAR RODAR, e esta linha
+    // recebia "❚❚ Pausar".
+    await expect(rodar).toHaveText(/Rodar/);
+
+    // E parado é parado: o contador não anda depois de duas marchas de 650ms.
+    const parouEm = (await contador.textContent()) ?? "";
+    await page.waitForTimeout(1500);
+    expect(await contador.textContent()).toBe(parouEm);
+  });
+});
+
 test.describe("a animação não roda para quem não está vendo", () => {
   test("sair da tela pausa, e voltar NÃO retoma sozinho", async ({ page }) => {
     const fig = await figuraDe(page, "/topico/merge-sort/");
@@ -220,6 +248,34 @@ test.describe("a animação não roda para quem não está vendo", () => {
     const voltaA = (await contador.textContent()) ?? "";
     await page.waitForTimeout(2000);
     expect(await contador.textContent()).toBe(voltaA);
+  });
+
+  test("a pausa automática não deixa a região viva dizendo que ainda roda", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/merge-sort/");
+    const status = fig.getByRole("status");
+    const contador = contadorDePasso(fig);
+    const rodar = fig.getByRole("button", { name: /Rodar|Pausar/ });
+
+    const inicial = (await contador.textContent()) ?? "";
+    await rodar.click();
+    await expect(rodar).toHaveText(/Pausar/);
+    // Premissas: a animação começou, e a região disse isso.
+    await expect(contador).not.toHaveText(inicial);
+    await expect(status).toHaveText(/^rodando a partir do passo \d+ de \d+$/);
+
+    await page.evaluate(() =>
+      window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" })
+    );
+    await expect(fig).not.toBeInViewport();
+    // Premissa: a pausa automática aconteceu mesmo — é ela que cria a incoerência.
+    await expect(rodar).toHaveText(/Rodar/);
+
+    // A asserção que carrega o sentido: sem o conserto a região continua
+    // afirmando "rodando a partir do passo 1 de 79" com a peça parada, ou seja,
+    // a única pista de quem não enxerga dizendo o contrário do botão ao lado.
+    // Ela CALA em vez de anunciar: pausa automática não é ação do aluno, e
+    // anunciá-la interromperia quem já está lendo outra coisa da página.
+    await expect(status).toHaveText("");
   });
 });
 

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -396,6 +396,33 @@ test.describe("o foco volta para o botão que abriu o painel", () => {
       await expect(expandir).toBeFocused();
     });
   }
+
+  // A outra metade do contrato, e a que só existe por causa da FORMA do
+  // conserto: a devolução do foco mora no CORPO do efeito (quando `expanded`
+  // vira `false`), e não na limpeza dele. Na montagem `expanded` já é `false`,
+  // então sem a guarda `esteveExpandido` este mesmo caminho rodaria no load e
+  // toda peça da página puxaria o foco para o próprio `⤢ Expandir` — o leitor
+  // abriria o artigo com o cursor no meio de um visualizador.
+  //
+  // Quem diz que a casca já hidratou e mediu é o `data-anim="on"`, o mesmo sinal
+  // que o resto da suíte usa: quando ele acende, os efeitos do hook JÁ rodaram,
+  // e o roubo de foco (se houvesse) já teria acontecido.
+  test("abrir a página não move o foco para dentro de um visualizador", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/big-o/");
+    await expect(fig).toHaveAttribute("data-anim", "on");
+
+    // O valor primeiro, e dizendo QUEM roubou: sem a guarda esta linha recebe o
+    // rótulo do botão que ficou com o foco, em vez de "BODY (nada focado)".
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const a = document.activeElement;
+          if (!a || a === document.body) return "BODY (nada focado)";
+          return `${a.tagName} "${(a.textContent ?? "").trim()}"`;
+        })
+      )
+      .toBe("BODY (nada focado)");
+  });
 });
 
 test.describe("os dois controles que não tinham nome", () => {

--- a/tests/viz-hook.spec.ts
+++ b/tests/viz-hook.spec.ts
@@ -91,3 +91,42 @@ test.describe("a região viva anuncia o passo", () => {
     await expect(status).not.toHaveText(anuncioNoInicio);
   });
 });
+
+test.describe("a animação não roda para quem não está vendo", () => {
+  test("sair da tela pausa, e voltar NÃO retoma sozinho", async ({ page }) => {
+    const fig = await figuraDe(page, "/topico/merge-sort/");
+    const contador = contadorDePasso(fig);
+    await expect(contador).toHaveCount(1);
+    const rodar = fig.getByRole("button", { name: /Rodar|Pausar/ });
+
+    const inicial = (await contador.textContent()) ?? "";
+    await rodar.click();
+    await expect(rodar).toHaveText(/Pausar/);
+    // Premissa: com a peça na tela ela ANDA. Sem isto o teste aprovaria uma
+    // animação que nunca começou.
+    await expect(contador).not.toHaveText(inicial);
+
+    await page.evaluate(() =>
+      window.scrollTo({ top: document.body.scrollHeight, behavior: "instant" })
+    );
+    await expect(fig).not.toBeInViewport();
+
+    // Duas leituras com intervalo, e não o estado interno: o que importa é o
+    // que o aluno vê parar de andar.
+    await page.waitForTimeout(400);
+    const foraA = (await contador.textContent()) ?? "";
+    // Premissa: não é que a animação acabou — ela parou no meio.
+    expect(foraA).not.toMatch(/^passo (\d+) de \1$/);
+    await page.waitForTimeout(2000);
+    expect(await contador.textContent()).toBe(foraA);
+
+    // De volta à tela: pausada, e pausada continua. Retomar sozinho surpreende
+    // quem rolou de volta.
+    await fig.scrollIntoViewIfNeeded();
+    await expect(fig).toBeInViewport();
+    await expect(rodar).toHaveText(/Rodar/);
+    const voltaA = (await contador.textContent()) ?? "";
+    await page.waitForTimeout(2000);
+    expect(await contador.textContent()).toBe(voltaA);
+  });
+});

--- a/tests/viz-intervals.spec.ts
+++ b/tests/viz-intervals.spec.ts
@@ -361,7 +361,7 @@ test("sobreposição: o ↺ volta ao passo 1 e o botão ao lado é quem devolve 
   await expect(passo).toHaveText("passo 5 de 24");
 
   // O ↺ do rodapé compartilhado é `viz.reset()`: volta ao passo 1 e NADA mais.
-  await f.getByRole("button", { name: "↺" }).click();
+  await f.getByRole("button", { name: "Reiniciar" }).click();
   await expect(passo).toHaveText("passo 1 de 24");
   await expect(aTermina).toHaveValue("20");
 

--- a/tests/viz-pilhas.spec.ts
+++ b/tests/viz-pilhas.spec.ts
@@ -425,7 +425,7 @@ test("na call stack o ↺ do rodapé volta só o passo, e o Voltar ao 2³ volta 
   await peca.getByRole("button", { name: "Próximo ›" }).click();
   await expect(peca.locator(".viz-step")).toHaveText("passo 3 de 15");
 
-  await peca.getByRole("button", { name: "↺", exact: true }).click();
+  await peca.getByRole("button", { name: "Reiniciar", exact: true }).click();
   await expect(peca.locator(".viz-step")).toHaveText("passo 1 de 15");
   await expect(expoente).toHaveValue("5");
 


### PR DESCRIPTION
**Cinco defeitos** do motor da casca, todos em `src/lib/visualizer.tsx`, mais um
defeito de escopo no próprio spec deste PR. Um arquivo,
**61 visualizadores**: é esse o número, medido com
`grep -l useVisualizer content/visualizers/*.tsx | wc -l` → **61 de 87** arquivos.
(O "86" que circulava vem do `mdx-components.tsx`, que importa 86 componentes;
**26 deles não usam a casca** e não são alcançados por este PR.)

## 1. O passo mudava em silêncio

**Antes:** `grep -rn "aria-live" src/ content/ tests/` → **0**.
`role="status"|"alert"|"log"` → **0**. O contador era
`<span className="viz-step">passo {viz.step + 1} de {viz.total}</span>`
(`visualizer.tsx:484`), sem região viva em nenhum ancestral, e `figureProps`
(`:431-437`) só traz className, `data-*`, ref e tabIndex.

O aluno cego apertava "Próximo ›", o algoritmo andava, e ele não ouvia nada. O
visualizador virava um botão que não faz nada — para o único público que
precisava do texto passo a passo.

**Agora:** o `VizHeader` desenha um irmão do contador com
`role="status" aria-live="polite" aria-atomic="true"`, recortado por CSS
(`.viz-sr`, classe nova, `clip-path: inset(50%)` — nunca `display: none` nem
`visibility: hidden`, que tirariam o nó da árvore de acessibilidade junto e
deixariam o conserto mudo parecendo funcionar).

### A decisão sobre a verborragia, com a medição que a sustenta

`aria-live="polite"` disparando a cada 250ms na marcha 2x é pior que nada: o
leitor de tela enfileira falas que nunca alcançam a animação. **A região é
escrita pela interação, não pelo relógio.** Na reprodução automática ela diz três
coisas, e só:

| ação | o que a região passa a dizer |
|---|---|
| Próximo ›, ‹ Anterior, setas, ↺ | `passo N de M` |
| ▶ Rodar | `rodando a partir do passo N de M` |
| ❚❚ Pausar | `pausado no passo N de M` |
| a animação chega ao fim sozinha | `fim da animação, passo M de M` |
| cada tick da reprodução | **nada** |

Medição que sustenta: com o relógio escrevendo na região, um percurso automático
de 2s no `merge-sort` (79 passos, marcha 1x) deixa a região em `passo 7 de 79`
enquanto a política atual mantém `rodando a partir do passo 1 de 79` — 6
anúncios que ninguém pediu, em 2 segundos, por peça. O teste
`o anúncio não vira ruído durante a reprodução automática` é escrito contra
exatamente essa versão.

### ⚠️ Uma renderização a mais por tecla ENGOLE tecla

**Este é o achado mais caro do PR, e ele decidiu a forma da API. Quem for
"simplificar" isto depois, leia antes.**

A primeira versão escrevia a região viva num `useEffect` separado — a forma
óbvia, e a que qualquer um escreveria de novo. Ela custa **uma renderização a
mais por tecla, e essa renderização engole tecla**: o percurso de 114 setas do
`tests/viz-quick-sort.spec.ts` parava no passo **113** (e, noutras rodadas, no
114). Reprodutível com `--workers=1`, verde na `origin/main`, e o único teste da
suíte inteira que pegou.

Isolei o mecanismo com dois experimentos, e o segundo é o que aponta o culpado:

| experimento | resultado |
|---|---|
| `setState` extra no handler, efeito **mudo** | **passa** — não é o update a mais no handler |
| efeito **escrevendo** na região a cada passo | **reprova** — é a renderização a mais |

**O conserto é passo e anúncio no mesmo `setState`** (o estado `Playback`), com o
texto montado dentro do próprio updater: **um update por tecla, exatamente como
era antes desta mudança**.

E é por isso que a opção nova **`stepNote` é uma função do passo**
(`(step: number) => string | undefined`) e **não a string do passo atual**: o
anúncio é montado junto com o passo, então o hook precisa da nota do passo de
**destino**, que a renderização atual — a do passo de origem — não conhece.
Trocar essa assinatura por uma string obriga a voltar ao efeito separado, e o
`viz-quick-sort` volta a parar no 113.

### O texto da nota é o próximo PR

`stepNote` está exposto e **não é adotado aqui**: o texto de cada passo mora nos
arquivos de visualizador (`<p className={noteClass}>{s.note}</p>`), fora da
fronteira deste PR. São **55 visualizadores** para adotar
(`useVisualizer` + linha do tempo + `.viz-note`); os outros 6 que usam o hook têm
`total: 1` e não têm passo para anunciar. A adoção é de uma linha por arquivo:
`stepNote: (i) => steps[i].note`.

## 2. A animação nunca parava: rodava fora da tela e com a aba escondida

**Antes:** o `setInterval` (`:205`) dependia só de `[playing, speed, speeds, stop]`.
`IntersectionObserver`, `visibilitychange` e `document.hidden` → **0, 0 e 0** em
`src`, `content` e `mdx-components.tsx`. Na marcha 2x o tick é de **250ms**
(`:57`), `intervals.mdx` tem **5 instâncias** e `arrays`/`listas-ligadas`/`pilhas`
4 cada. Cada tick é uma tarefa de main thread: é INP piorando enquanto o aluno
rola.

**Agora:** `IntersectionObserver` sobre o `figureRef` que já existia (`:218`) mais
um listener de `visibilitychange`. Ao sair da tela, `stop()`; **ao voltar, fica
pausado** — retomar sozinho surpreende quem rolou de volta.

Dois cuidados que a implementação assume, e o porquê:

- **o observer não roda com o painel aberto.** O `<figure>` troca de nó DOM ao
  atravessar o portal do `inPanel`, e a travessia seria lida como "saiu da tela":
  pausaria justamente a animação que o aluno acabou de expandir. No painel a peça
  *é* a tela. O `visibilitychange` continua valendo nos dois casos;
- **não briga com a medição da casca.** O bloco só mexe em `playing` — nunca em
  `open`, `measuring` ou `measureTick` —, e a medição é guardada por
  `measuredRound`. Na montagem `playing` é `false`, então a primeira entrega do
  observer (que reporta o estado atual) é um no-op. Medido: a suíte inteira, com
  todos os testes de casca dos 36 arquivos de spec, fica no mesmo resultado.

## 3. O botão "Reiniciar" era mudo

`:532` era `<button className="viz-btn" title="Reiniciar" onClick={viz.reset}>↺</button>`.
O **conteúdo vence o `title`** no cálculo do nome acessível, então o leitor de
tela anunciava o nome Unicode do glifo, ou nada. Os quatro vizinhos do mesmo
`VizFooter` têm texto — o `↺` era o único mudo, o que confirma omissão e não
decisão. Conserto: `aria-label="Reiniciar"`, com o `title` mantido para o mouse.

### E as quatro linhas de teste que isso arrasta junto

O nome acessível deixa de ser `"↺"` e passa a ser `"Reiniciar"`, então quatro
localizadores que procuravam o botão pelo **glifo** param de achá-lo. Vão num
commit próprio, encostado no do `aria-label`, para o histórico mostrar causa e
efeito juntos — uma linha por arquivo, e **nada mais mudou nesses quatro
arquivos**:

| arquivo:linha | antes | depois |
|---|---|---|
| `tests/navegacao.spec.ts:1136` | `{ name: "↺" }` | `{ name: "Reiniciar" }` |
| `tests/viz-binary-heap.spec.ts:431` | `{ name: "↺" }` | `{ name: "Reiniciar" }` |
| `tests/viz-intervals.spec.ts:364` | `{ name: "↺" }` | `{ name: "Reiniciar" }` |
| `tests/viz-pilhas.spec.ts:428` | `{ name: "↺", exact: true }` | `{ name: "Reiniciar", exact: true }` |

O `exact: true` do `viz-pilhas` **fica**: ele existe porque a peça tem o `↺` do
rodapé e o `↺ Voltar ao 2³` dela própria na mesma linha, e continua sendo o que
separa um do outro.

**Conferi, um por um, que os outros usos do glifo continuam intactos** — é
exatamente a varredura que um `sed` cego estragaria, porque `name: "↺"` é
substring de todos eles. São botões **próprios dos componentes**, com texto
visível, e não o do rodapé:

| rótulo | de quem é | onde o teste usa |
|---|---|---|
| `↺ Reiniciar` | `BigOChartVisualizer`, `PrefixSumTradeoff`, `SkipListNiveis`, `StringsBytesVisualizer` | `viz-prefix-sum:296`, `viz-skip-list:184` |
| `↺ Limpar` | `SubTypesVisualizer` | `viz-subarray…:95` e `:148` |
| `↺ Voltar ao 2³` | `StackCallStackVisualizer` | `viz-pilhas:432` |

`grep -rn 'name: "↺"' tests/*.spec.ts` → **nenhum** sobrou.

## 4. O slider de velocidade estava numa `<div>`, não num `<label>`

`:558-570`. Os outros **62 inputs do produto** estão dentro de
`<label className="viz-field">`, e o CSS é **por classe** (`globals.css:452-455`).

**"Não muda um pixel" foi medido, não argumentado.** A mesma sonda, dentro do
runner, nas mesmas 9 instâncias de `/topico/arrays/`, `/topico/big-o/` e
`/topico/intervals/`, a 1512x900, antes e depois:

```
0: speed=922,1632 239x20 | input=996,1634 120x16 | controls=359,1607 802x53 | foot=339,1607 842x87 | figure=338,1019 844x676
...
diff antes depois  ->  IDÊNTICO AO PIXEL (9 de 9 linhas, inclusive a altura das figuras)
```

Entra junto `aria-valuetext`, porque sem ele o leitor de tela anuncia o índice
cru do range ("3 de 5") onde a tela diz "1x". E o valor sai do **nome** do
controle (`aria-hidden` no `.val`) para o nome não mudar a cada arrastada
("Velocidade 1x" → "Velocidade 2x"); ele não se perde, é dito no lugar onde o
valor de um slider é dito.

## 5. O foco não voltava ao fechar o painel

O contrato da casca (`content/visualizers/README.md` §5) promete
"entra no painel ao abrir, **volta para onde estava ao fechar**", e o comentário
do hook dizia o mesmo. Não voltava:

```js
const previous = document.activeElement as HTMLElement | null;  // o ⤢ Expandir
figureRef.current?.focus();
return () => previous?.focus?.();                               // num nó DESTACADO
```

O `previous` é o `⤢ Expandir` de dentro da `<figure>` que o `createPortal`
**desmonta**. O `focus()` da limpeza rodava num nó fora do documento — no-op
silencioso — e o foco caía no `<body>`, no meio do artigo. Quem fecha o painel
pelo teclado perde o lugar.

**Medido antes de consertar**, e é por isso que ele entrou: em `/topico/big-o/`
(a peça de referência do contrato), `/topico/merge-sort/` e `/topico/intervals/`,
pelas **duas** saídas:

| | antes | depois |
|---|---|---|
| fechando com `Esc` | `BODY` (3 de 3 páginas) | `BUTTON` "⤢ Expandir" (3 de 3) |
| fechando com `✕ Fechar` | `BODY` (3 de 3 páginas) | `BUTTON` "⤢ Expandir" (3 de 3) |

**Guardar a referência não resolve, porque o botão é recriado no fechamento**: é
preciso reencontrá-lo depois. A volta é por **ref**, e não por seletor, porque
ref é **identidade** — `.viz-expand` casa **dois** botões (o de expandir e o de
mostrar/ocultar o bloco), e qualquer discriminante de texto ou de ordem quebra no
dia em que o rótulo mudar. O ref aponta sempre para o nó vivo daquele elemento, e
é `null` quando não há nenhum.

As duas saídas têm teste próprio porque são caminhos diferentes: no `Esc` o foco
está no `<figure>`, no `✕ Fechar` está no próprio botão que some.

## 6. E o spec deste PR mirava a figura pela POSIÇÃO

`tests/viz-hook.spec.ts` usava `page.locator("figure.viz-fit").first()` — uma
afirmação sobre a **ordem no documento**, que só acerta enquanto a página tem uma
figura na casca. Achado na **integração** dos PRs desta rodada, não isolado:
nenhum PR sozinho podia vê-lo.

Com o **#47**, que adapta o `BigOChartVisualizer`, `/topico/big-o/` passa a ter
duas figuras na casca e o `[0]` vira **o gráfico das famílias**: sem `Próximo ›`,
sem `▶ Rodar`, sem `↺ Reiniciar`, sem slider, e com o `.viz-step` valendo
`"n = 62"`.

A ironia mora no próprio arquivo: o comentário do `contadorDePasso` já avisa que
`.viz-step` é ambíguo *"e um `.first()` aqui leria o número errado sem erro
nenhum"* — e três linhas abaixo o helper da figura usava `.first()`.

**Reproduzido**, promovendo o irmão a `figure.viz-fit` (experimento, restaurado
por `cp`, com `git diff content/` vazio depois):

| helper | com o irmão na casca |
|---|---|
| `.first()` | **6 de 9 reprovam**, e o canário mostra no `Received` o texto da peça errada |
| escopo pelo título | **9 de 9 passam** |

As chamadas de `/topico/merge-sort/` entraram no mesmo conserto porque passavam
por **acidente de ordem** — são exatamente as três que sobreviveram à quebra, e a
página tem dois irmãos cujo `.viz-step` diz `"4 rodadas de intercalação x 16
elementos = 64 movimentos"` e `"as duas versões se separam na decisão 2"`.
Asserção que passa por acidente quebra sem avisar.

> **A regra: escope por QUAL figura, nunca por QUANTAS têm a casca.** Contar
> figuras adaptadas é afirmar o **cronograma da migração**, não o produto, e
> nasce condenada. Por isso o canário novo verifica identidade e propriedades da
> peça alvo, e **não** o número de figuras da página — é o ponto em que ele se
> afasta do canário do `viz-quick-sort.spec.ts:58-66`, que afirma
> `toHaveCount(3)` e `toHaveCount(1)`.

E os dois modos de errar não custam o mesmo: título trocado reprova alto no
`toHaveCount(1)`; ordem trocada mede a peça errada **em silêncio**.

**Ordem de merge sugerida: #47 antes deste PR**, para o conserto entrar com o
problema à vista em vez de a `main` ganhar testes que o #47 quebra depois.

---

## As provas de quebra

Cada teste novo foi visto **reprovar** contra a quebra que ele existe para
impedir, com o build sempre visível (build silenciado deixa o artefato anterior
no `out/` e o teste passa contra o código bom), restauração por `cp` (nunca
`git checkout --`, que apagaria o fix não commitado junto) e reconstrução no fim.

| quebra | teste | resultado |
|---|---|---|
| A) a região viva sai do `VizHeader` | `o texto muda quando o aluno aperta Próximo ›` | **1 failed** — `toHaveCount` esperava 1, recebeu **0**: falha por não achar o role |
| A2) o relógio também escreve na região | `o anúncio não vira ruído durante a reprodução automática` | **1 failed** — esperava `"rodando a partir do passo 1 de 79"`, recebeu `"passo 7 de 79"` |
| B) o guarda do `pauseOffscreen` invertido | `sair da tela pausa, e voltar NÃO retoma sozinho` | **1 failed** — esperava `"passo 4 de 79"`, recebeu `"passo 11 de 79"` |
| C) o `aria-label` do ↺ sai | `o ↺ se chama Reiniciar e volta ao passo 1` | **1 failed** — `toHaveCount` 1, recebeu **0** |
| D) o `<label>` volta a ser `<div>` | `o slider de velocidade tem rótulo de verdade` | **1 failed** — `toHaveCount` 1, recebeu **0** |
| E) o foco volta a ser restaurado pelo nó guardado na abertura | os dois `o foco volta para o ⤢ Expandir` | **2 failed**, e nos dois `Expected: "BUTTON"` / **`Received: "BODY"`** |
| F) o helper volta ao `.first()`, com o irmão do `/topico/big-o/` na casca | o arquivo inteiro | **6 failed / 3 passed** — e as 3 que passam são as de `merge-sort`, que é o acidente de ordem do defeito 6 |

As sete quebras compilam (`✓ Compiled successfully` em todas), então nenhuma
delas é a armadilha do build que reprova calado.

**E conferi qual asserção está trabalhando no teste B**, que tem duas metades:
apagando as asserções do "fora da tela" e rodando de novo contra a quebra B, a
segunda metade reprova sozinha (`Expected pattern: /Rodar/`,
`Received string: "❚❚ Pausar"`). As duas metades pegam a quebra; nenhuma é
decoração.

## Verificação

- **Suíte inteira: `468 passed, 0 failed`** (`PORT=4405 npm run test:build`).
  **459 testes antes, 468 depois** (`playwright test --list`).
- `npm run build` ✓, `npx tsc --noEmit` ✓ — e nos commits, um a um: os
  intermediários compilam e passam os testes que já existem neles.
- **Texto renderizado do build contra a `origin/main`: 53 páginas comparadas, 0
  com diferença.** Nenhuma palavra a mais e nenhuma a menos — a região viva nasce
  vazia, então o HTML estático sai idêntico.
- **Conferência de viewport** em 1512x900, 1440x700 e 390x844, com
  `?v=$(date +%s)` para furar o cache de CSS, em `/topico/intervals/` (5
  instâncias), `/topico/arrays/` (3), `/topico/prefix-sum/` (uma peça de passo
  único, `total: 1`) e `/topico/big-o/`: **0 overflow de página, 0 texto vazando
  da caixa, 0 fonte abaixo de 8px**, e as 12 regiões vivas medindo 1x1 e dentro
  da janela nas três réguas.

## O que este PR NÃO muda

- nenhum arquivo de `content/visualizers/` (são 87), nenhum `.mdx`, nenhum
  `mdx-components.tsx`, nenhum `src/components/**`, nenhum `page.tsx`, nenhum
  `playwright.config.ts` / `next.config.ts` / `package.json`;
- **nenhuma linha existente de `globals.css`**: são 23 linhas acrescentadas e 0
  removidas (`git diff --numstat` → `23  0`), num bloco novo colado ao tema dos
  visualizadores e **antes** da seção `/* responsive */` (marcador na linha 1841,
  a regra nova na 1828). As linhas `:142` e `:418`, de outra lane, estão intactas;
- nas quatro specs que já existiam, **uma linha em cada** e nada mais
  (`git diff --numstat` → `1 1` nos quatro): asserção fraca que estiver ao lado
  fica onde está, é de outra lane;
- **nenhum arquivo de `content/visualizers/`**, nem depois do experimento do
  defeito 6: o `BigOChartVisualizer` foi promovido a `figure.viz-fit` só para
  reproduzir o cenário do #47, restaurado por `cp`, e `git diff content/` sai
  vazio (conferido antes do commit e o `out/` reconstruído em seguida);
- nenhum texto de tela: o `aria-label`, o `aria-valuetext` e as quatro frases da
  região viva são copy nova, sem travessão, e o texto renderizado do build é
  idêntico ao da `origin/main`.
