### PR TITLE
perf: corta o JS de visualizador por rota, com teto de bytes e links

### DIFF
--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -223,8 +223,16 @@ function Ancora({ href, className, children, ...props }: ComponentPropsWithoutRe
     );
   }
   if (link.tipo === "externo") {
+    // O `{...props}` vinha DEPOIS de `target`/`rel`, e em JSX quem vem depois
+    // vence: um `rel` escrito no MDX substituía "noopener noreferrer" inteiro e
+    // reabria o tabnabbing na aba nova. Agora o spread vem antes, e o `rel`
+    // final é a UNIÃO — o que o autor pediu mais as duas palavras que não são
+    // negociáveis quando a aba abre com `target="_blank"`.
+    const rel = new Set((props.rel ?? "").split(/\s+/).filter(Boolean));
+    rel.add("noopener");
+    rel.add("noreferrer");
     return (
-      <a className={classe} href={link.href} target="_blank" rel="noopener noreferrer" {...props}>
+      <a {...props} className={classe} href={link.href} target="_blank" rel={[...rel].join(" ")}>
         {children}
       </a>
     );

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,4 +1,5 @@
 import type { MDXComponents } from "mdx/types";
+import Link from "next/link";
 import { isValidElement, type ComponentPropsWithoutRef, type ReactNode } from "react";
 import { SlidingWindowVisualizer } from "@content/visualizers/SlidingWindowVisualizer";
 import { SubTypesVisualizer } from "@content/visualizers/SubTypesVisualizer";
@@ -156,6 +157,79 @@ function Pre({ children, className, style, ...props }: ComponentPropsWithoutRef<
   );
 }
 
+export type TipoDeLink = "interno" | "externo" | "cru";
+
+// `mailto:`, `tel:`, `ftp:` — qualquer coisa com esquema que não seja http(s).
+const TEM_ESQUEMA = /^[a-z][a-z0-9+.-]*:/i;
+
+/**
+ * Decide o que fazer com o `href` de um link escrito no artigo.
+ *
+ * Este é o ponto único: os `.mdx` escrevem `[Dijkstra](/topico/dijkstra)`, no
+ * formato mais natural de digitar, e a normalização acontece aqui. Consertar nos
+ * 251 links dos 36 artigos seria conserto de sintoma, e o 252º nasceria errado
+ * de novo.
+ *
+ * Três destinos, e a fronteira entre eles é o que morde:
+ *
+ * - **interno** (`/topico/arrays`) vira `next/link` com a barra final. O
+ *   `next.config.ts` tem `trailingSlash: true`, então a URL canônica termina em
+ *   barra e a sem barra devolve **308** em produção (medido:
+ *   `curl -o /dev/null -w '%{http_code}' https://dsa.craftcodeclub.io/topico/arrays`).
+ *   Cada clique pagava o redirecionamento e depois recarregava a aplicação
+ *   inteira, porque `<a>` cru sai do router.
+ * - **externo** (`https://`, `//cdn…`) continua `<a>`, e ganha o
+ *   `target="_blank" rel="noopener noreferrer"` que os 12 links de problema do
+ *   LeetCode não tinham.
+ * - **cru**: tudo que só PARECE interno. Âncora da própria página (`#secao`)
+ *   não é navegação de rota; `mailto:` e `tel:` não são caminho; e caminho que
+ *   termina em nome de arquivo (`/imagens/x.png`, `/sitemap.xml`) quebraria se
+ *   ganhasse barra no fim. Caminho relativo também fica de fora: sem saber a
+ *   rota de origem não dá para normalizar sem chutar.
+ *
+ * A query e o fragmento sobrevivem à normalização: a barra entra no caminho,
+ * não no fim da string (`/roadmap?g=1#x` -> `/roadmap/?g=1#x`).
+ */
+export function classificarLink(href?: string): { tipo: TipoDeLink; href: string } {
+  if (!href) return { tipo: "cru", href: "" };
+  if (href.startsWith("//") || /^https?:\/\//i.test(href)) return { tipo: "externo", href };
+  if (TEM_ESQUEMA.test(href)) return { tipo: "cru", href };
+  if (!href.startsWith("/")) return { tipo: "cru", href };
+
+  const corte = href.search(/[?#]/);
+  const caminho = corte === -1 ? href : href.slice(0, corte);
+  const sufixo = corte === -1 ? "" : href.slice(corte);
+  const ultimoSegmento = caminho.slice(caminho.lastIndexOf("/") + 1);
+  if (ultimoSegmento.includes(".")) return { tipo: "cru", href };
+
+  return { tipo: "interno", href: (caminho.endsWith("/") ? caminho : `${caminho}/`) + sufixo };
+}
+
+function Ancora({ href, className, children, ...props }: ComponentPropsWithoutRef<"a">) {
+  const link = classificarLink(href);
+  const classe = cx("prose-a", className);
+
+  if (link.tipo === "interno") {
+    return (
+      <Link href={link.href} className={classe} {...props}>
+        {children}
+      </Link>
+    );
+  }
+  if (link.tipo === "externo") {
+    return (
+      <a className={classe} href={link.href} target="_blank" rel="noopener noreferrer" {...props}>
+        {children}
+      </a>
+    );
+  }
+  return (
+    <a className={classe} href={link.href || undefined} {...props}>
+      {children}
+    </a>
+  );
+}
+
 function Colunas({ children }: { children: ReactNode }) {
   return <div className="mdx-colunas">{children}</div>;
 }
@@ -181,7 +255,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
     ul: (props) => <ul className="prose-ul" {...props} />,
     ol: (props) => <ol className="prose-ol" {...props} />,
     li: (props) => <li className="prose-li" {...props} />,
-    a: (props) => <a className="prose-a" {...props} />,
+    a: Ancora,
     code: ({ className, ...props }) => <code className={cx("prose-code", className)} {...props} />,
     pre: Pre,
     strong: (props) => <strong className="prose-strong" {...props} />,

--- a/mdx-components.tsx
+++ b/mdx-components.tsx
@@ -1,92 +1,98 @@
 import type { MDXComponents } from "mdx/types";
 import Link from "next/link";
 import { isValidElement, type ComponentPropsWithoutRef, type ReactNode } from "react";
-import { SlidingWindowVisualizer } from "@content/visualizers/SlidingWindowVisualizer";
-import { SubTypesVisualizer } from "@content/visualizers/SubTypesVisualizer";
-import { TwoPointersVisualizer } from "@content/visualizers/TwoPointersVisualizer";
-import { TwoPointersPalindromo } from "@content/visualizers/TwoPointersPalindromo";
-import { TwoPointersCiclo } from "@content/visualizers/TwoPointersCiclo";
-import { StringsVisualizer } from "@content/visualizers/StringsVisualizer";
-import { StringsBytesVisualizer } from "@content/visualizers/StringsBytesVisualizer";
-import { StringsRotateVisualizer } from "@content/visualizers/StringsRotateVisualizer";
-import { HashTableVisualizer } from "@content/visualizers/HashTableVisualizer";
-import { HashTableBuscaVisualizer } from "@content/visualizers/HashTableBuscaVisualizer";
-import { HashTableOperacoes } from "@content/visualizers/HashTableOperacoes";
-import { BigOChartVisualizer } from "@content/visualizers/BigOChartVisualizer";
-import { BigOCounterVisualizer } from "@content/visualizers/BigOCounterVisualizer";
-import { BigOFamilias } from "@content/visualizers/BigOFamilias";
-import { ArraysVisualizer } from "@content/visualizers/ArraysVisualizer";
-import { ArraysOperacoes } from "@content/visualizers/ArraysOperacoes";
-import { ArraysCrescimento } from "@content/visualizers/ArraysCrescimento";
-import { ArraysMatrizes } from "@content/visualizers/ArraysMatrizes";
-import { PrefixSumVisualizer } from "@content/visualizers/PrefixSumVisualizer";
-import { PrefixSumTradeoff } from "@content/visualizers/PrefixSumTradeoff";
-import { PrefixSumGrade2D } from "@content/visualizers/PrefixSumGrade2D";
-import { IntervalsSobreposicaoVisualizer } from "@content/visualizers/IntervalsSobreposicaoVisualizer";
-import { IntervalsVisualizer } from "@content/visualizers/IntervalsVisualizer";
-import { IntervalsSweepVisualizer } from "@content/visualizers/IntervalsSweepVisualizer";
-import { SlidingWindowForcaBruta } from "@content/visualizers/SlidingWindowForcaBruta";
-import { RecursionVisualizer } from "@content/visualizers/RecursionVisualizer";
-import { RecursionArvoreVisualizer } from "@content/visualizers/RecursionArvoreVisualizer";
-import { RecursionTipos } from "@content/visualizers/RecursionTipos";
-import { LinkedListVisualizer } from "@content/visualizers/LinkedListVisualizer";
-import { LinkedListOperacoes } from "@content/visualizers/LinkedListOperacoes";
-import { LinkedListReversao } from "@content/visualizers/LinkedListReversao";
-import { LinkedListFloyd } from "@content/visualizers/LinkedListFloyd";
-import { SkipListVisualizer } from "@content/visualizers/SkipListVisualizer";
-import { SkipListInsercao } from "@content/visualizers/SkipListInsercao";
-import { SkipListNiveis } from "@content/visualizers/SkipListNiveis";
-import { StackVisualizer } from "@content/visualizers/StackVisualizer";
-import { StackCallStackVisualizer } from "@content/visualizers/StackCallStackVisualizer";
-import { StackMonotonicaVisualizer } from "@content/visualizers/StackMonotonicaVisualizer";
-import { StackImplementacoes } from "@content/visualizers/StackImplementacoes";
-import { QueueVisualizer } from "@content/visualizers/QueueVisualizer";
-import { QueueDuasPilhas } from "@content/visualizers/QueueDuasPilhas";
-import { QueueDequeMonotonico } from "@content/visualizers/QueueDequeMonotonico";
-import { TailRecursionVisualizer } from "@content/visualizers/TailRecursionVisualizer";
-import { TailRecursionForma } from "@content/visualizers/TailRecursionForma";
-import { TailRecursionTrampolim } from "@content/visualizers/TailRecursionTrampolim";
-import { TreeTraversalVisualizer } from "@content/visualizers/TreeTraversalVisualizer";
-import { BinaryTreeFormatos } from "@content/visualizers/BinaryTreeFormatos";
-import { NAryTreeVisualizer } from "@content/visualizers/NAryTreeVisualizer";
-import { BSTVisualizer } from "@content/visualizers/BSTVisualizer";
-import { GrafoRepresentacao } from "@content/visualizers/GrafoRepresentacao";
-import { GrafoDfsBfs } from "@content/visualizers/GrafoDfsBfs";
-import { DijkstraVisualizer } from "@content/visualizers/DijkstraVisualizer";
-import { BellmanFordVisualizer } from "@content/visualizers/BellmanFordVisualizer";
-import { AStarVisualizer } from "@content/visualizers/AStarVisualizer";
-import { TopoSortVisualizer } from "@content/visualizers/TopoSortVisualizer";
-import { MstVisualizer } from "@content/visualizers/MstVisualizer";
-import { BinaryHeapVisualizer } from "@content/visualizers/BinaryHeapVisualizer";
-import { HeapIndicesVisualizer } from "@content/visualizers/HeapIndicesVisualizer";
-import { HeapEstruturas } from "@content/visualizers/HeapEstruturas";
-import { HeapSortVisualizer } from "@content/visualizers/HeapSortVisualizer";
-import { HeapSortEstabilidade } from "@content/visualizers/HeapSortEstabilidade";
-import { HeapSortComparativo } from "@content/visualizers/HeapSortComparativo";
-import { BuscaBinariaVisualizer } from "@content/visualizers/BuscaBinariaVisualizer";
-import { BuscaBinariaOverflow } from "@content/visualizers/BuscaBinariaOverflow";
-import { BuscaBinariaFronteira } from "@content/visualizers/BuscaBinariaFronteira";
-import { OrdenacaoBasicaVisualizer } from "@content/visualizers/OrdenacaoBasicaVisualizer";
-import { OrdenacaoBasicaCorrida } from "@content/visualizers/OrdenacaoBasicaCorrida";
-import { OrdenacaoBasicaEstabilidade } from "@content/visualizers/OrdenacaoBasicaEstabilidade";
-import { MergeSortVisualizer } from "@content/visualizers/MergeSortVisualizer";
-import { MergeSortNiveis } from "@content/visualizers/MergeSortNiveis";
-import { MergeEmpate } from "@content/visualizers/MergeEmpate";
-import { QuickSortVisualizer } from "@content/visualizers/QuickSortVisualizer";
-import { QuickSortPivo } from "@content/visualizers/QuickSortPivo";
-import { QuickSortTresVias } from "@content/visualizers/QuickSortTresVias";
-import { ShellSortVisualizer } from "@content/visualizers/ShellSortVisualizer";
-import { ShellSortSubsequencias } from "@content/visualizers/ShellSortSubsequencias";
-import { ShellSortGaps } from "@content/visualizers/ShellSortGaps";
-import { BacktrackingVisualizer } from "@content/visualizers/BacktrackingVisualizer";
-import { BacktrackingSudoku } from "@content/visualizers/BacktrackingSudoku";
-import { BacktrackingPoda } from "@content/visualizers/BacktrackingPoda";
-import { BinarioConversor } from "@content/visualizers/BinarioConversor";
-import { BinarioDivisoes } from "@content/visualizers/BinarioDivisoes";
-import { BinarioBases } from "@content/visualizers/BinarioBases";
-import { BinarioComplemento } from "@content/visualizers/BinarioComplemento";
-import { BinarioTresFormas } from "@content/visualizers/BinarioTresFormas";
-import { BinarioFaixa } from "@content/visualizers/BinarioFaixa";
+// Os 86 visualizadores entram por aqui, e não por import direto: o
+// `VizLazy` é `"use client"` e faz o `import()` do lado do cliente, que é o
+// único lado onde ele vira chunk assíncrono de verdade. O porquê, com os
+// números da tentativa que não funcionou, está no cabeçalho daquele arquivo.
+import {
+  SlidingWindowVisualizer,
+  SubTypesVisualizer,
+  TwoPointersVisualizer,
+  TwoPointersPalindromo,
+  TwoPointersCiclo,
+  StringsVisualizer,
+  StringsBytesVisualizer,
+  StringsRotateVisualizer,
+  HashTableVisualizer,
+  HashTableBuscaVisualizer,
+  HashTableOperacoes,
+  BigOChartVisualizer,
+  BigOCounterVisualizer,
+  BigOFamilias,
+  ArraysVisualizer,
+  ArraysOperacoes,
+  ArraysCrescimento,
+  ArraysMatrizes,
+  PrefixSumVisualizer,
+  PrefixSumTradeoff,
+  PrefixSumGrade2D,
+  IntervalsSobreposicaoVisualizer,
+  IntervalsVisualizer,
+  IntervalsSweepVisualizer,
+  SlidingWindowForcaBruta,
+  RecursionVisualizer,
+  RecursionArvoreVisualizer,
+  RecursionTipos,
+  LinkedListVisualizer,
+  LinkedListOperacoes,
+  LinkedListReversao,
+  LinkedListFloyd,
+  SkipListVisualizer,
+  SkipListInsercao,
+  SkipListNiveis,
+  StackVisualizer,
+  StackCallStackVisualizer,
+  StackMonotonicaVisualizer,
+  StackImplementacoes,
+  QueueVisualizer,
+  QueueDuasPilhas,
+  QueueDequeMonotonico,
+  TailRecursionVisualizer,
+  TailRecursionForma,
+  TailRecursionTrampolim,
+  TreeTraversalVisualizer,
+  BinaryTreeFormatos,
+  NAryTreeVisualizer,
+  BSTVisualizer,
+  GrafoRepresentacao,
+  GrafoDfsBfs,
+  DijkstraVisualizer,
+  BellmanFordVisualizer,
+  AStarVisualizer,
+  TopoSortVisualizer,
+  MstVisualizer,
+  BinaryHeapVisualizer,
+  HeapIndicesVisualizer,
+  HeapEstruturas,
+  HeapSortVisualizer,
+  HeapSortEstabilidade,
+  HeapSortComparativo,
+  BuscaBinariaVisualizer,
+  BuscaBinariaOverflow,
+  BuscaBinariaFronteira,
+  OrdenacaoBasicaVisualizer,
+  OrdenacaoBasicaCorrida,
+  OrdenacaoBasicaEstabilidade,
+  MergeSortVisualizer,
+  MergeSortNiveis,
+  MergeEmpate,
+  QuickSortVisualizer,
+  QuickSortPivo,
+  QuickSortTresVias,
+  ShellSortVisualizer,
+  ShellSortSubsequencias,
+  ShellSortGaps,
+  BacktrackingVisualizer,
+  BacktrackingSudoku,
+  BacktrackingPoda,
+  BinarioConversor,
+  BinarioDivisoes,
+  BinarioBases,
+  BinarioComplemento,
+  BinarioTresFormas,
+  BinarioFaixa,
+} from "@/components/VizLazy";
 import { slugify, textOf } from "@/lib/slug";
 
 /**

--- a/src/components/VizLazy.tsx
+++ b/src/components/VizLazy.tsx
@@ -1,0 +1,379 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+/**
+ * Os 86 visualizadores, carregados sob demanda.
+ *
+ * POR QUE ESTE ARQUIVO EXISTE, E POR QUE ELE É `"use client"`
+ *
+ * O `mdx-components.tsx` é a única porta de entrada dos componentes do MDX, e
+ * nenhum artigo importa nada por conta própria. Enquanto ele importava os 86
+ * direto, o bundler não tinha por onde cortar: os 86 viravam UM chunk de
+ * 692.459 B (175,1 KB gzip) no `<head>` das 47 rotas de tópico, inclusive nas
+ * 11 páginas "em breve", que não usam nenhum.
+ *
+ * A tentativa óbvia não funciona, e isso está medido: pôr `next/dynamic` no
+ * `mdx-components.tsx` não corta um byte. Ele é um Server Component, e ali o
+ * `import()` de um componente `"use client"` não é um import de verdade, é uma
+ * REFERÊNCIA DE CLIENTE. Todas as referências alcançáveis pelo grafo de servidor
+ * da rota entram no entry dela, dinâmicas ou não: no
+ * `page_client-reference-manifest.js` os 86 apontavam para os mesmos 3 chunks do
+ * entry. A preguiça do `next/dynamic` ficava só do lado do servidor, e ainda
+ * custava 12.309 B gzip por rota.
+ *
+ * Deste lado da fronteira o `import()` é import de verdade. O grafo é o do
+ * cliente, o Turbopack emite chunk assíncrono por visualizador, e cada página
+ * baixa só os que usa.
+ *
+ * `ssr: false` É PROIBIDO AQUI, e não é preferência: o HTML pré-renderizado é o
+ * ativo de SEO do projeto, e o Google indexa o que está no arquivo, não o que a
+ * hidratação monta depois. Com o padrão (`ssr: true`), o servidor continua
+ * renderizando o visualizador inteiro para dentro do HTML; o que passa a ser sob
+ * demanda é só o JS da INTERATIVIDADE. Há teste guardando isso, contando por
+ * figura quantas trazem contador de passo e controles no HTML estático.
+ */
+
+export const SlidingWindowVisualizer = dynamic(() =>
+  import("@content/visualizers/SlidingWindowVisualizer").then((m) => m.SlidingWindowVisualizer)
+);
+
+export const SubTypesVisualizer = dynamic(() =>
+  import("@content/visualizers/SubTypesVisualizer").then((m) => m.SubTypesVisualizer)
+);
+
+export const TwoPointersVisualizer = dynamic(() =>
+  import("@content/visualizers/TwoPointersVisualizer").then((m) => m.TwoPointersVisualizer)
+);
+
+export const TwoPointersPalindromo = dynamic(() =>
+  import("@content/visualizers/TwoPointersPalindromo").then((m) => m.TwoPointersPalindromo)
+);
+
+export const TwoPointersCiclo = dynamic(() =>
+  import("@content/visualizers/TwoPointersCiclo").then((m) => m.TwoPointersCiclo)
+);
+
+export const StringsVisualizer = dynamic(() =>
+  import("@content/visualizers/StringsVisualizer").then((m) => m.StringsVisualizer)
+);
+
+export const StringsBytesVisualizer = dynamic(() =>
+  import("@content/visualizers/StringsBytesVisualizer").then((m) => m.StringsBytesVisualizer)
+);
+
+export const StringsRotateVisualizer = dynamic(() =>
+  import("@content/visualizers/StringsRotateVisualizer").then((m) => m.StringsRotateVisualizer)
+);
+
+export const HashTableVisualizer = dynamic(() =>
+  import("@content/visualizers/HashTableVisualizer").then((m) => m.HashTableVisualizer)
+);
+
+export const HashTableBuscaVisualizer = dynamic(() =>
+  import("@content/visualizers/HashTableBuscaVisualizer").then((m) => m.HashTableBuscaVisualizer)
+);
+
+export const HashTableOperacoes = dynamic(() =>
+  import("@content/visualizers/HashTableOperacoes").then((m) => m.HashTableOperacoes)
+);
+
+export const BigOChartVisualizer = dynamic(() =>
+  import("@content/visualizers/BigOChartVisualizer").then((m) => m.BigOChartVisualizer)
+);
+
+export const BigOCounterVisualizer = dynamic(() =>
+  import("@content/visualizers/BigOCounterVisualizer").then((m) => m.BigOCounterVisualizer)
+);
+
+export const BigOFamilias = dynamic(() =>
+  import("@content/visualizers/BigOFamilias").then((m) => m.BigOFamilias)
+);
+
+export const ArraysVisualizer = dynamic(() =>
+  import("@content/visualizers/ArraysVisualizer").then((m) => m.ArraysVisualizer)
+);
+
+export const ArraysOperacoes = dynamic(() =>
+  import("@content/visualizers/ArraysOperacoes").then((m) => m.ArraysOperacoes)
+);
+
+export const ArraysCrescimento = dynamic(() =>
+  import("@content/visualizers/ArraysCrescimento").then((m) => m.ArraysCrescimento)
+);
+
+export const ArraysMatrizes = dynamic(() =>
+  import("@content/visualizers/ArraysMatrizes").then((m) => m.ArraysMatrizes)
+);
+
+export const PrefixSumVisualizer = dynamic(() =>
+  import("@content/visualizers/PrefixSumVisualizer").then((m) => m.PrefixSumVisualizer)
+);
+
+export const PrefixSumTradeoff = dynamic(() =>
+  import("@content/visualizers/PrefixSumTradeoff").then((m) => m.PrefixSumTradeoff)
+);
+
+export const PrefixSumGrade2D = dynamic(() =>
+  import("@content/visualizers/PrefixSumGrade2D").then((m) => m.PrefixSumGrade2D)
+);
+
+export const IntervalsSobreposicaoVisualizer = dynamic(() =>
+  import("@content/visualizers/IntervalsSobreposicaoVisualizer").then((m) => m.IntervalsSobreposicaoVisualizer)
+);
+
+export const IntervalsVisualizer = dynamic(() =>
+  import("@content/visualizers/IntervalsVisualizer").then((m) => m.IntervalsVisualizer)
+);
+
+export const IntervalsSweepVisualizer = dynamic(() =>
+  import("@content/visualizers/IntervalsSweepVisualizer").then((m) => m.IntervalsSweepVisualizer)
+);
+
+export const SlidingWindowForcaBruta = dynamic(() =>
+  import("@content/visualizers/SlidingWindowForcaBruta").then((m) => m.SlidingWindowForcaBruta)
+);
+
+export const RecursionVisualizer = dynamic(() =>
+  import("@content/visualizers/RecursionVisualizer").then((m) => m.RecursionVisualizer)
+);
+
+export const RecursionArvoreVisualizer = dynamic(() =>
+  import("@content/visualizers/RecursionArvoreVisualizer").then((m) => m.RecursionArvoreVisualizer)
+);
+
+export const RecursionTipos = dynamic(() =>
+  import("@content/visualizers/RecursionTipos").then((m) => m.RecursionTipos)
+);
+
+export const LinkedListVisualizer = dynamic(() =>
+  import("@content/visualizers/LinkedListVisualizer").then((m) => m.LinkedListVisualizer)
+);
+
+export const LinkedListOperacoes = dynamic(() =>
+  import("@content/visualizers/LinkedListOperacoes").then((m) => m.LinkedListOperacoes)
+);
+
+export const LinkedListReversao = dynamic(() =>
+  import("@content/visualizers/LinkedListReversao").then((m) => m.LinkedListReversao)
+);
+
+export const LinkedListFloyd = dynamic(() =>
+  import("@content/visualizers/LinkedListFloyd").then((m) => m.LinkedListFloyd)
+);
+
+export const SkipListVisualizer = dynamic(() =>
+  import("@content/visualizers/SkipListVisualizer").then((m) => m.SkipListVisualizer)
+);
+
+export const SkipListInsercao = dynamic(() =>
+  import("@content/visualizers/SkipListInsercao").then((m) => m.SkipListInsercao)
+);
+
+export const SkipListNiveis = dynamic(() =>
+  import("@content/visualizers/SkipListNiveis").then((m) => m.SkipListNiveis)
+);
+
+export const StackVisualizer = dynamic(() =>
+  import("@content/visualizers/StackVisualizer").then((m) => m.StackVisualizer)
+);
+
+export const StackCallStackVisualizer = dynamic(() =>
+  import("@content/visualizers/StackCallStackVisualizer").then((m) => m.StackCallStackVisualizer)
+);
+
+export const StackMonotonicaVisualizer = dynamic(() =>
+  import("@content/visualizers/StackMonotonicaVisualizer").then((m) => m.StackMonotonicaVisualizer)
+);
+
+export const StackImplementacoes = dynamic(() =>
+  import("@content/visualizers/StackImplementacoes").then((m) => m.StackImplementacoes)
+);
+
+export const QueueVisualizer = dynamic(() =>
+  import("@content/visualizers/QueueVisualizer").then((m) => m.QueueVisualizer)
+);
+
+export const QueueDuasPilhas = dynamic(() =>
+  import("@content/visualizers/QueueDuasPilhas").then((m) => m.QueueDuasPilhas)
+);
+
+export const QueueDequeMonotonico = dynamic(() =>
+  import("@content/visualizers/QueueDequeMonotonico").then((m) => m.QueueDequeMonotonico)
+);
+
+export const TailRecursionVisualizer = dynamic(() =>
+  import("@content/visualizers/TailRecursionVisualizer").then((m) => m.TailRecursionVisualizer)
+);
+
+export const TailRecursionForma = dynamic(() =>
+  import("@content/visualizers/TailRecursionForma").then((m) => m.TailRecursionForma)
+);
+
+export const TailRecursionTrampolim = dynamic(() =>
+  import("@content/visualizers/TailRecursionTrampolim").then((m) => m.TailRecursionTrampolim)
+);
+
+export const TreeTraversalVisualizer = dynamic(() =>
+  import("@content/visualizers/TreeTraversalVisualizer").then((m) => m.TreeTraversalVisualizer)
+);
+
+export const BinaryTreeFormatos = dynamic(() =>
+  import("@content/visualizers/BinaryTreeFormatos").then((m) => m.BinaryTreeFormatos)
+);
+
+export const NAryTreeVisualizer = dynamic(() =>
+  import("@content/visualizers/NAryTreeVisualizer").then((m) => m.NAryTreeVisualizer)
+);
+
+export const BSTVisualizer = dynamic(() =>
+  import("@content/visualizers/BSTVisualizer").then((m) => m.BSTVisualizer)
+);
+
+export const GrafoRepresentacao = dynamic(() =>
+  import("@content/visualizers/GrafoRepresentacao").then((m) => m.GrafoRepresentacao)
+);
+
+export const GrafoDfsBfs = dynamic(() =>
+  import("@content/visualizers/GrafoDfsBfs").then((m) => m.GrafoDfsBfs)
+);
+
+export const DijkstraVisualizer = dynamic(() =>
+  import("@content/visualizers/DijkstraVisualizer").then((m) => m.DijkstraVisualizer)
+);
+
+export const BellmanFordVisualizer = dynamic(() =>
+  import("@content/visualizers/BellmanFordVisualizer").then((m) => m.BellmanFordVisualizer)
+);
+
+export const AStarVisualizer = dynamic(() =>
+  import("@content/visualizers/AStarVisualizer").then((m) => m.AStarVisualizer)
+);
+
+export const TopoSortVisualizer = dynamic(() =>
+  import("@content/visualizers/TopoSortVisualizer").then((m) => m.TopoSortVisualizer)
+);
+
+export const MstVisualizer = dynamic(() =>
+  import("@content/visualizers/MstVisualizer").then((m) => m.MstVisualizer)
+);
+
+export const BinaryHeapVisualizer = dynamic(() =>
+  import("@content/visualizers/BinaryHeapVisualizer").then((m) => m.BinaryHeapVisualizer)
+);
+
+export const HeapIndicesVisualizer = dynamic(() =>
+  import("@content/visualizers/HeapIndicesVisualizer").then((m) => m.HeapIndicesVisualizer)
+);
+
+export const HeapEstruturas = dynamic(() =>
+  import("@content/visualizers/HeapEstruturas").then((m) => m.HeapEstruturas)
+);
+
+export const HeapSortVisualizer = dynamic(() =>
+  import("@content/visualizers/HeapSortVisualizer").then((m) => m.HeapSortVisualizer)
+);
+
+export const HeapSortEstabilidade = dynamic(() =>
+  import("@content/visualizers/HeapSortEstabilidade").then((m) => m.HeapSortEstabilidade)
+);
+
+export const HeapSortComparativo = dynamic(() =>
+  import("@content/visualizers/HeapSortComparativo").then((m) => m.HeapSortComparativo)
+);
+
+export const BuscaBinariaVisualizer = dynamic(() =>
+  import("@content/visualizers/BuscaBinariaVisualizer").then((m) => m.BuscaBinariaVisualizer)
+);
+
+export const BuscaBinariaOverflow = dynamic(() =>
+  import("@content/visualizers/BuscaBinariaOverflow").then((m) => m.BuscaBinariaOverflow)
+);
+
+export const BuscaBinariaFronteira = dynamic(() =>
+  import("@content/visualizers/BuscaBinariaFronteira").then((m) => m.BuscaBinariaFronteira)
+);
+
+export const OrdenacaoBasicaVisualizer = dynamic(() =>
+  import("@content/visualizers/OrdenacaoBasicaVisualizer").then((m) => m.OrdenacaoBasicaVisualizer)
+);
+
+export const OrdenacaoBasicaCorrida = dynamic(() =>
+  import("@content/visualizers/OrdenacaoBasicaCorrida").then((m) => m.OrdenacaoBasicaCorrida)
+);
+
+export const OrdenacaoBasicaEstabilidade = dynamic(() =>
+  import("@content/visualizers/OrdenacaoBasicaEstabilidade").then((m) => m.OrdenacaoBasicaEstabilidade)
+);
+
+export const MergeSortVisualizer = dynamic(() =>
+  import("@content/visualizers/MergeSortVisualizer").then((m) => m.MergeSortVisualizer)
+);
+
+export const MergeSortNiveis = dynamic(() =>
+  import("@content/visualizers/MergeSortNiveis").then((m) => m.MergeSortNiveis)
+);
+
+export const MergeEmpate = dynamic(() =>
+  import("@content/visualizers/MergeEmpate").then((m) => m.MergeEmpate)
+);
+
+export const QuickSortVisualizer = dynamic(() =>
+  import("@content/visualizers/QuickSortVisualizer").then((m) => m.QuickSortVisualizer)
+);
+
+export const QuickSortPivo = dynamic(() =>
+  import("@content/visualizers/QuickSortPivo").then((m) => m.QuickSortPivo)
+);
+
+export const QuickSortTresVias = dynamic(() =>
+  import("@content/visualizers/QuickSortTresVias").then((m) => m.QuickSortTresVias)
+);
+
+export const ShellSortVisualizer = dynamic(() =>
+  import("@content/visualizers/ShellSortVisualizer").then((m) => m.ShellSortVisualizer)
+);
+
+export const ShellSortSubsequencias = dynamic(() =>
+  import("@content/visualizers/ShellSortSubsequencias").then((m) => m.ShellSortSubsequencias)
+);
+
+export const ShellSortGaps = dynamic(() =>
+  import("@content/visualizers/ShellSortGaps").then((m) => m.ShellSortGaps)
+);
+
+export const BacktrackingVisualizer = dynamic(() =>
+  import("@content/visualizers/BacktrackingVisualizer").then((m) => m.BacktrackingVisualizer)
+);
+
+export const BacktrackingSudoku = dynamic(() =>
+  import("@content/visualizers/BacktrackingSudoku").then((m) => m.BacktrackingSudoku)
+);
+
+export const BacktrackingPoda = dynamic(() =>
+  import("@content/visualizers/BacktrackingPoda").then((m) => m.BacktrackingPoda)
+);
+
+export const BinarioConversor = dynamic(() =>
+  import("@content/visualizers/BinarioConversor").then((m) => m.BinarioConversor)
+);
+
+export const BinarioDivisoes = dynamic(() =>
+  import("@content/visualizers/BinarioDivisoes").then((m) => m.BinarioDivisoes)
+);
+
+export const BinarioBases = dynamic(() =>
+  import("@content/visualizers/BinarioBases").then((m) => m.BinarioBases)
+);
+
+export const BinarioComplemento = dynamic(() =>
+  import("@content/visualizers/BinarioComplemento").then((m) => m.BinarioComplemento)
+);
+
+export const BinarioTresFormas = dynamic(() =>
+  import("@content/visualizers/BinarioTresFormas").then((m) => m.BinarioTresFormas)
+);
+
+export const BinarioFaixa = dynamic(() =>
+  import("@content/visualizers/BinarioFaixa").then((m) => m.BinarioFaixa)
+);

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -262,7 +262,13 @@ test("todo link interno de artigo já sai com a barra final", () => {
   const ancoras = ancorasDosArtigos();
   expect(ancoras.length, "nenhuma âncora de prosa no build").toBeGreaterThan(200);
 
-  const internos = ancoras.filter((a) => a.href.startsWith("/"));
+  // Quem decide o que é "interno" é a MESMA função que o renderer usa, e não um
+  // `startsWith("/")` paralelo. O atalho divergia dela em dois pontos:
+  // `//cdn...` começa com "/" e é EXTERNO, e `/imagens/x.png` é `cru` — que de
+  // propósito não ganha barra final, então cobrar barra dele reprovaria um
+  // artigo legítimo. Teste e implementação com modelos diferentes é o defeito
+  // que este arquivo existe para não ter.
+  const internos = ancoras.filter((a) => classificarLink(a.href).tipo === "interno");
   expect(internos.length, "nenhum link interno de artigo no build").toBeGreaterThan(200);
 
   const semBarra = internos.filter((a) => !a.href.split(/[?#]/)[0].endsWith("/"));
@@ -274,7 +280,11 @@ test("todo link interno de artigo já sai com a barra final", () => {
 });
 
 test("todo link externo de artigo abre em nova aba com rel seguro", () => {
-  const externos = ancorasDosArtigos().filter((a) => /^https?:\/\//.test(a.href));
+  // Idem: `/^https?:\/\//` deixava `//cdn...` de fora, e `classificarLink`
+  // manda protocol-relative para o ramo externo — ou seja, um link desses
+  // ganharia `target="_blank"` e escaparia do guarda de `rel` por um buraco
+  // entre os dois modelos.
+  const externos = ancorasDosArtigos().filter((a) => classificarLink(a.href).tipo === "externo");
   expect(externos.length, "nenhum link externo de artigo no build").toBeGreaterThan(5);
 
   const frouxos = externos.filter(

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect } from "@playwright/test";
+import { gzipSync } from "node:zlib";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+/**
+ * Orçamento de bytes do build.
+ *
+ * POR QUE ESTE ARQUIVO EXISTE
+ *
+ * Um chunk de 692.459 B (175,1 KB gzip) chegou até a produção no `<head>` das 47
+ * rotas de tópico, inclusive nas 11 que não têm artigo nem visualizador. Nada
+ * reprovou, porque não havia nada medindo:
+ *
+ *     grep -rniE "budget|lighthouse|bundle" tests .github/workflows package.json  ->  0
+ *
+ * Este arquivo é esse guarda. Ele não abre navegador para medir peso: lê o HTML
+ * exportado em `out/`, resolve cada `<script src>` (e cada `<link rel=preload
+ * as=script>`, que o navegador baixa do mesmo jeito) no arquivo correspondente
+ * de `out/_next/`, e soma. Roda em segundos.
+ *
+ * O QUE ELE CONTA: só o JS **inicial** — o que o navegador baixa para a página
+ * ficar de pé. Chunk buscado sob demanda depois da hidratação não entra. Script
+ * de terceiro (Analytics) não tem arquivo local para medir e fica de fora.
+ */
+
+const OUT = path.join(process.cwd(), "out");
+const KB = 1024;
+
+/**
+ * Teto por rota, em bytes gzipados do JS inicial. É o piso da casca do site
+ * (207,4 KB, o que a home custa sem visualizador nenhum) mais ~20% de folga.
+ */
+const TETO_ROTA = 250 * KB;
+
+/**
+ * Nenhum chunk sozinho passa disso, em bytes crus. O maior de hoje tem 692.459 B
+ * e é o dos 86 visualizadores; o segundo, que é o do framework, tem 226.344.
+ * Este é o guarda mais direto do defeito: é ESTE chunk que engorda a cada
+ * tópico publicado.
+ */
+const TETO_MAIOR_CHUNK = 250 * KB;
+
+/**
+ * O que uma página de tópico `soon` baixa **a mais** que a home, em gzip. As
+ * duas mostram um parágrafo e nenhum visualizador, então a diferença deveria
+ * ser ~0. Medido hoje: 179.286 B (175,1 KB), que é exatamente o chunk dos
+ * visualizadores.
+ */
+const TETO_EXCEDENTE_SEM_VIZ = 10 * KB;
+
+/** Rota `soon` sem artigo e sem visualizador (ver `isEmptyTopic`). */
+const ROTA_SEM_VIZ = "topico/trie/index.html";
+
+// ---------------------------------------------------------------------------
+// leitura do build
+// ---------------------------------------------------------------------------
+
+function rotasDoBuild(): string[] {
+  const entradas = readdirSync(OUT, { recursive: true, withFileTypes: true });
+  return entradas
+    .filter((e) => e.isFile() && e.name === "index.html")
+    .map((e) => path.relative(OUT, path.join(e.parentPath, e.name)))
+    .sort();
+}
+
+const gzipPorArquivo = new Map<string, number>();
+function gzipDe(rel: string): number {
+  const cache = gzipPorArquivo.get(rel);
+  if (cache !== undefined) return cache;
+  const n = gzipSync(readFileSync(path.join(OUT, rel)), { level: 9 }).length;
+  gzipPorArquivo.set(rel, n);
+  return n;
+}
+
+const SCRIPT_SRC = /<script\b[^>]*\bsrc="([^"]+)"/g;
+const PRELOAD_SCRIPT = /<link\b[^>]*\bas="script"[^>]*>/g;
+const HREF = /\bhref="([^"]+)"/;
+
+/** Os arquivos de JS que o navegador baixa só para montar a página. */
+function jsInicial(rota: string) {
+  const html = readFileSync(path.join(OUT, rota), "utf8");
+  const urls = new Set<string>();
+  for (const m of html.matchAll(SCRIPT_SRC)) urls.add(m[1]);
+  for (const m of html.matchAll(PRELOAD_SCRIPT)) {
+    const href = m[0].match(HREF)?.[1];
+    if (href) urls.add(href);
+  }
+  const arquivos = [...urls]
+    .filter((u) => u.startsWith("/_next/"))
+    .map((u) => u.slice(1))
+    .sort()
+    .map((rel) => ({ rel, raw: statSync(path.join(OUT, rel)).size, gzip: gzipDe(rel) }));
+  return {
+    arquivos,
+    raw: arquivos.reduce((a, f) => a + f.raw, 0),
+    gzip: arquivos.reduce((a, f) => a + f.gzip, 0),
+  };
+}
+
+const kb = (n: number) => `${(n / KB).toFixed(1)} KB`;
+
+// ---------------------------------------------------------------------------
+// orçamento
+// ---------------------------------------------------------------------------
+
+test("nenhuma rota estoura o teto de JS inicial", () => {
+  const rotas = rotasDoBuild();
+  expect(rotas.length, "build vazio: rode `npm run build` antes").toBeGreaterThan(40);
+
+  const medidas = rotas.map((r) => ({ rota: r, ...jsInicial(r) }));
+  const acima = medidas.filter((m) => m.gzip > TETO_ROTA).sort((a, b) => b.gzip - a.gzip);
+
+  const relatorio = acima
+    .slice(0, 5)
+    .map((m) => {
+      const maiores = [...m.arquivos]
+        .sort((a, b) => b.gzip - a.gzip)
+        .slice(0, 3)
+        .map((f) => `${f.rel} ${kb(f.gzip)}`)
+        .join(", ");
+      return `  /${m.rota.replace(/index\.html$/, "")} -> ${kb(m.gzip)} gzip em ${m.arquivos.length} chunks. Maiores: ${maiores}`;
+    })
+    .join("\n");
+
+  expect(
+    acima.length,
+    `${acima.length} de ${medidas.length} rotas acima do teto de ${kb(TETO_ROTA)} gzip ` +
+      `de JS inicial:\n${relatorio}`
+  ).toBe(0);
+});
+
+test("nenhum chunk sozinho passa do teto", () => {
+  const chunks = readdirSync(path.join(OUT, "_next/static/chunks"))
+    .filter((n) => n.endsWith(".js"))
+    .map((n) => ({ n, raw: statSync(path.join(OUT, "_next/static/chunks", n)).size }))
+    .sort((a, b) => b.raw - a.raw);
+
+  const gordos = chunks.filter((c) => c.raw > TETO_MAIOR_CHUNK);
+  expect(
+    gordos.map((c) => `${c.n} ${c.raw.toLocaleString()} B`),
+    `chunk único acima de ${kb(TETO_MAIOR_CHUNK)}. Ele vai para o <head> de toda rota ` +
+      `que o referencia, e é o que engorda a cada tópico publicado.`
+  ).toEqual([]);
+});
+
+test("página de tópico sem visualizador quase não paga a mais que a home", () => {
+  // A home e uma página "em breve" mostram a mesma coisa em termos de JS:
+  // a casca do site. Tudo que a segunda baixa a mais é desperdício, e o número
+  // dessa diferença é o tamanho exato do problema.
+  const semViz = jsInicial(ROTA_SEM_VIZ);
+  const home = jsInicial("index.html");
+  const excedente = semViz.gzip - home.gzip;
+
+  const soDela = semViz.arquivos
+    .filter((f) => !home.arquivos.some((h) => h.rel === f.rel))
+    .sort((a, b) => b.gzip - a.gzip)
+    .map((f) => `    ${kb(f.gzip)} gzip / ${f.raw.toLocaleString()} B  ${f.rel}`)
+    .join("\n");
+
+  expect(
+    excedente,
+    `/${ROTA_SEM_VIZ.replace(/index\.html$/, "")} é uma página "em breve", sem artigo e sem ` +
+      `visualizador, e baixa ${kb(excedente)} gzip a mais que a home (${kb(semViz.gzip)} contra ` +
+      `${kb(home.gzip)}). Chunks que só ela tem:\n${soDela}`
+  ).toBeLessThanOrEqual(TETO_EXCEDENTE_SEM_VIZ);
+});
+
+// ---------------------------------------------------------------------------
+// o HTML estático continua completo (nada de `ssr: false`)
+// ---------------------------------------------------------------------------
+
+test("os visualizadores continuam renderizados no HTML estático", () => {
+  // O HTML pré-renderizado é o ativo de SEO do projeto: o Google indexa o que
+  // está no arquivo, não o que a hidratação monta depois. Quem for cortar o
+  // chunk dos visualizadores pode adiar a INTERATIVIDADE; não pode adiar o
+  // conteúdo. Em `next/dynamic`, isso quer dizer: `ssr: false` é proibido.
+  //
+  // E a conta é POR FIGURA, não por página: cinco visualizadores neste
+  // repositório já passaram por uma suíte verde sem um botão renderizado,
+  // justamente porque a asserção era "existe um `figure.viz` na página".
+  // Contar figura deixa passar figura oca.
+  const esperado: Record<string, number> = {
+    "topico/arrays/index.html": 3,
+    "topico/intervals/index.html": 5,
+  };
+  for (const [rota, quantos] of Object.entries(esperado)) {
+    const html = readFileSync(path.join(OUT, rota), "utf8");
+    const figuras = html.split(/(?=<figure class="viz\b)/).slice(1);
+    const completas = figuras.filter(
+      // O contador e os controles só existem no HTML se o componente rodou no
+      // servidor: os dois vêm do estado do visualizador, não da casca.
+      (f) => f.includes('class="viz-step">passo ') && f.includes("Próximo ›")
+    );
+    expect(
+      completas.length,
+      `${rota}: ${completas.length} de ${figuras.length} visualizadores renderizaram ` +
+        `contador e controles no HTML estático (esperado ${quantos})`
+    ).toBe(quantos);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// comportamento
+// ---------------------------------------------------------------------------
+
+test("o visualizador continua interativo, e o passo anda nos dois sentidos", async ({ page }) => {
+  await page.goto("/topico/arrays/");
+  const viz = page.locator("figure.viz").first();
+  const passo = viz.locator(".viz-step");
+  const antes = await passo.textContent();
+  expect(antes, "o contador de passo não renderizou").toBeTruthy();
+
+  const proximo = viz.getByRole("button", { name: "Próximo ›" });
+  await expect(proximo).toBeEnabled();
+  await proximo.click();
+  await expect(passo).not.toHaveText(antes ?? "");
+
+  await viz.getByRole("button", { name: "‹ Anterior" }).click();
+  await expect(passo).toHaveText(antes ?? "");
+});

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -22,32 +22,50 @@ import path from "node:path";
  * O QUE ELE CONTA: só o JS **inicial** — o que o navegador baixa para a página
  * ficar de pé. Chunk buscado sob demanda depois da hidratação não entra. Script
  * de terceiro (Analytics) não tem arquivo local para medir e fica de fora.
+ *
+ * OS TETOS SÃO CATRACA, NÃO ALVO
+ *
+ * O alvo é `TETO_ALVO`, 250 KB gzip por rota: o piso da casca do site (~207 KB,
+ * o que a home custa) com folga. Nenhuma rota de tópico chega perto hoje, e o
+ * corte que faltava não cabe neste arquivo — está medido em `mdx-components.tsx`,
+ * no bloco sobre os 86 visualizadores. Enquanto ele não vem, os tetos abaixo
+ * estão logo acima do número de hoje, para que o problema **pare de crescer**:
+ * cada tópico publicado engorda o mesmo chunk que TODAS as 47 rotas baixam, e
+ * ainda faltam 11 tópicos para publicar.
  */
 
 const OUT = path.join(process.cwd(), "out");
 const KB = 1024;
 
 /**
- * Teto por rota, em bytes gzipados do JS inicial. É o piso da casca do site
- * (207,4 KB, o que a home custa sem visualizador nenhum) mais ~20% de folga.
+ * Teto por rota, em bytes gzipados do JS inicial. Medido em 2026-08-06: as 47
+ * rotas de tópico estão em 391.698 B (382,5 KB) e as 6 rotas fixas em 212.412 B
+ * (207,4 KB). 400 KB é 4,6% acima do pior caso de hoje — não passa a próxima
+ * leva de visualizadores.
  */
-const TETO_ROTA = 250 * KB;
+const TETO_ROTA = 400 * KB;
+
+/**
+ * Onde o projeto quer chegar. É o piso da casca (207,4 KB, o custo da home, que
+ * não tem visualizador nenhum) mais ~20% de folga. Não é o teto ativo porque o
+ * corte por rota ainda não foi feito; quando for, este vira `TETO_ROTA`.
+ */
+const TETO_ALVO = 250 * KB;
 
 /**
  * Nenhum chunk sozinho passa disso, em bytes crus. O maior de hoje tem 692.459 B
- * e é o dos 86 visualizadores; o segundo, que é o do framework, tem 226.344.
- * Este é o guarda mais direto do defeito: é ESTE chunk que engorda a cada
- * tópico publicado.
+ * e é o dos 86 visualizadores; o segundo tem 226.344. Este é o guarda mais
+ * direto do defeito: é ESTE chunk que engorda a cada tópico publicado.
  */
-const TETO_MAIOR_CHUNK = 250 * KB;
+const TETO_MAIOR_CHUNK = 700 * KB;
 
 /**
  * O que uma página de tópico `soon` baixa **a mais** que a home, em gzip. As
- * duas mostram um parágrafo e nenhum visualizador, então a diferença deveria
- * ser ~0. Medido hoje: 179.286 B (175,1 KB), que é exatamente o chunk dos
- * visualizadores.
+ * duas mostram um parágrafo e nenhum visualizador, então a diferença é
+ * desperdício puro. Medido hoje: 179.286 B (175,1 KB) — exatamente o chunk dos
+ * visualizadores. O teto trava esse número; o conserto o leva a ~0.
  */
-const TETO_EXCEDENTE_SEM_VIZ = 10 * KB;
+const TETO_EXCEDENTE_SEM_VIZ = 180 * KB;
 
 /** Rota `soon` sem artigo e sem visualizador (ver `isEmptyTopic`). */
 const ROTA_SEM_VIZ = "topico/trie/index.html";
@@ -125,8 +143,8 @@ test("nenhuma rota estoura o teto de JS inicial", () => {
 
   expect(
     acima.length,
-    `${acima.length} de ${medidas.length} rotas acima do teto de ${kb(TETO_ROTA)} gzip ` +
-      `de JS inicial:\n${relatorio}`
+    `${acima.length} de ${medidas.length} rotas acima do teto de ${kb(TETO_ROTA)} gzip de JS inicial ` +
+      `(o alvo do projeto é ${kb(TETO_ALVO)}):\n${relatorio}`
   ).toBe(0);
 });
 

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -2,9 +2,10 @@ import { test, expect } from "@playwright/test";
 import { gzipSync } from "node:zlib";
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import path from "node:path";
+import { classificarLink } from "../mdx-components";
 
 /**
- * Orçamento de bytes do build.
+ * Orçamento de bytes do build, e o comportamento dos links do artigo.
  *
  * POR QUE ESTE ARQUIVO EXISTE
  *
@@ -219,8 +220,114 @@ test("os visualizadores continuam renderizados no HTML estático", () => {
 });
 
 // ---------------------------------------------------------------------------
-// comportamento
+// links do artigo
 // ---------------------------------------------------------------------------
+
+/** Todas as âncoras de prosa (`className="prose-a"`) do build, com os atributos. */
+function ancorasDosArtigos() {
+  const achadas: { rota: string; tag: string; href: string }[] = [];
+  for (const rota of rotasDoBuild()) {
+    const html = readFileSync(path.join(OUT, rota), "utf8");
+    for (const m of html.matchAll(/<a\s[^>]*>/g)) {
+      const tag = m[0];
+      if (!/\bclass="[^"]*\bprose-a\b/.test(tag)) continue;
+      achadas.push({ rota, tag, href: tag.match(HREF)?.[1] ?? "" });
+    }
+  }
+  return achadas;
+}
+
+test("todo link interno de artigo já sai com a barra final", () => {
+  // `next.config.ts` tem `trailingSlash: true`. Link sem a barra toma 308 em
+  // produção (medido: `curl -o /dev/null -w '%{http_code}'
+  // https://dsa.craftcodeclub.io/topico/arrays` -> 308) antes de carregar
+  // qualquer byte útil.
+  const ancoras = ancorasDosArtigos();
+  expect(ancoras.length, "nenhuma âncora de prosa no build").toBeGreaterThan(200);
+
+  const internos = ancoras.filter((a) => a.href.startsWith("/"));
+  expect(internos.length, "nenhum link interno de artigo no build").toBeGreaterThan(200);
+
+  const semBarra = internos.filter((a) => !a.href.split(/[?#]/)[0].endsWith("/"));
+  const amostra = semBarra.slice(0, 5).map((a) => `  ${a.rota}: ${a.href}`).join("\n");
+  expect(
+    semBarra.length,
+    `${semBarra.length} de ${internos.length} links internos sem barra final (cada clique = um 308):\n${amostra}`
+  ).toBe(0);
+});
+
+test("todo link externo de artigo abre em nova aba com rel seguro", () => {
+  const externos = ancorasDosArtigos().filter((a) => /^https?:\/\//.test(a.href));
+  expect(externos.length, "nenhum link externo de artigo no build").toBeGreaterThan(5);
+
+  const frouxos = externos.filter(
+    (a) =>
+      !/\btarget="_blank"/.test(a.tag) ||
+      !/\brel="[^"]*\bnoopener\b/.test(a.tag) ||
+      !/\brel="[^"]*\bnoreferrer\b/.test(a.tag)
+  );
+  const amostra = frouxos.slice(0, 5).map((a) => `  ${a.rota}: ${a.tag}`).join("\n");
+  expect(
+    frouxos.length,
+    `${frouxos.length} de ${externos.length} links externos sem target/rel:\n${amostra}`
+  ).toBe(0);
+});
+
+test("classificarLink separa interno, externo e o que fica como <a> cru", () => {
+  // Os artigos de hoje só têm dois casos (251 links `/topico/...` e 12 `https://`),
+  // mas a condição precisa estar certa para os que ainda vão aparecer: âncora da
+  // própria página, `mailto:`, arquivo estático com extensão, caminho relativo.
+  const casos: [string | undefined, ReturnType<typeof classificarLink>][] = [
+    ["/topico/arrays", { tipo: "interno", href: "/topico/arrays/" }],
+    ["/topico/arrays/", { tipo: "interno", href: "/topico/arrays/" }],
+    ["/topico/arrays#quando-usar", { tipo: "interno", href: "/topico/arrays/#quando-usar" }],
+    ["/roadmap?g=1#x", { tipo: "interno", href: "/roadmap/?g=1#x" }],
+    ["/", { tipo: "interno", href: "/" }],
+    ["#nesta-pagina", { tipo: "cru", href: "#nesta-pagina" }],
+    ["mailto:oi@craftcodeclub.io", { tipo: "cru", href: "mailto:oi@craftcodeclub.io" }],
+    ["tel:+5511999999999", { tipo: "cru", href: "tel:+5511999999999" }],
+    ["/imagens/arvore.png", { tipo: "cru", href: "/imagens/arvore.png" }],
+    ["/sitemap.xml", { tipo: "cru", href: "/sitemap.xml" }],
+    ["./vizinho", { tipo: "cru", href: "./vizinho" }],
+    [
+      "https://leetcode.com/problems/two-sum/",
+      { tipo: "externo", href: "https://leetcode.com/problems/two-sum/" },
+    ],
+    ["http://exemplo.com", { tipo: "externo", href: "http://exemplo.com" }],
+    ["//cdn.exemplo.com/x.js", { tipo: "externo", href: "//cdn.exemplo.com/x.js" }],
+    [undefined, { tipo: "cru", href: "" }],
+  ];
+  for (const [entrada, esperado] of casos) {
+    expect(classificarLink(entrada), `href ${JSON.stringify(entrada)}`).toEqual(esperado);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// comportamento: o ganho do next/link
+// ---------------------------------------------------------------------------
+
+test("clicar num link do artigo não recarrega o documento", async ({ page }) => {
+  await page.goto("/topico/a-star/");
+  // A marca morre em qualquer navegação de documento. Se ela sobreviver, a
+  // troca de página foi do router, sem recarregar a aplicação inteira.
+  await page.evaluate(() => {
+    (window as unknown as { __semRecarga?: boolean }).__semRecarga = true;
+  });
+
+  const link = page.locator("article a.prose-a[href^='/topico/']").first();
+  const destino = await link.getAttribute("href");
+  expect(destino, "o link do artigo precisa apontar para a URL final, sem 308").toMatch(/\/$/);
+
+  await link.click();
+  await expect(page).toHaveURL(new RegExp(`${destino}$`));
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  expect(
+    await page.evaluate(
+      () => (window as unknown as { __semRecarga?: boolean }).__semRecarga === true
+    ),
+    "o documento recarregou: a navegação não passou pelo router"
+  ).toBe(true);
+});
 
 test("o visualizador continua interativo, e o passo anda nos dois sentidos", async ({ page }) => {
   await page.goto("/topico/arrays/");

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -343,14 +343,23 @@ test("clicar num link do artigo não recarrega o documento", async ({ page }) =>
 
   const link = page.locator("article a.prose-a[href^='/topico/']").first();
   const destino = await link.getAttribute("href");
-  expect(destino, "o link do artigo precisa apontar para a URL final, sem 308").toMatch(/\/$/);
+  // A barra final é do CAMINHO, não do href inteiro: `classificarLink` produz
+  // `/topico/arrays/#quando-usar`, que é correto e não termina em "/". Afirmar
+  // sobre o href cru contradiria o contrato da própria função no dia em que um
+  // artigo linkar tópico com âncora (hoje: 0 dos 251 links `/topico/`).
+  const alvo = new URL(destino ?? "", "http://local");
+  expect(alvo.pathname, "o link do artigo precisa apontar para a URL final, sem 308").toMatch(
+    /\/$/
+  );
 
   await link.click();
-  // Comparação de caminho, não regex montada com a URL: `new RegExp(destino)`
-  // trataria `.`, `?` e `(` como metacaractere, e um href com query ou ponto
-  // casaria de menos (ou de mais) sem ninguém perceber. O predicado compara o
-  // `pathname` inteiro, que é exatamente o que se quer afirmar aqui.
-  await expect(page).toHaveURL((u) => u.pathname === destino);
+  // Comparação de URL destrinchada, não regex montada com ela: `new
+  // RegExp(destino)` trataria `.`, `?` e `(` como metacaractere. E compara as
+  // TRÊS partes, não só o `pathname`: com `/topico/x/#ancora` o caminho sozinho
+  // casaria mesmo se a âncora se perdesse na navegação.
+  await expect(page).toHaveURL(
+    (u) => u.pathname === alvo.pathname && u.search === alvo.search && u.hash === alvo.hash
+  );
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   expect(
     await page.evaluate(

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -24,49 +24,55 @@ import { classificarLink } from "../mdx-components";
  * ficar de pé. Chunk buscado sob demanda depois da hidratação não entra. Script
  * de terceiro (Analytics) não tem arquivo local para medir e fica de fora.
  *
- * OS TETOS SÃO CATRACA, NÃO ALVO
+ * OS TETOS ACOMPANHAM O GANHO
  *
- * O alvo é `TETO_ALVO`, 250 KB gzip por rota: o piso da casca do site (~207 KB,
- * o que a home custa) com folga. Nenhuma rota de tópico chega perto hoje, e o
- * corte que faltava não cabe neste arquivo — está medido em `mdx-components.tsx`,
- * no bloco sobre os 86 visualizadores. Enquanto ele não vem, os tetos abaixo
- * estão logo acima do número de hoje, para que o problema **pare de crescer**:
- * cada tópico publicado engorda o mesmo chunk que TODAS as 47 rotas baixam, e
- * ainda faltam 11 tópicos para publicar.
+ * Eles foram baixados junto com o corte por rota (`src/components/VizLazy.tsx`).
+ * Teto escolhido para o estado anterior é teto que só guarda uma vez: depois de
+ * o pior caso cair de 382,5 KB para 235,7 KB, um teto de 400 KB deixaria caber
+ * de volta tudo o que acabou de sair. Quem melhorar estes números de novo desce
+ * os tetos no mesmo PR.
  */
 
 const OUT = path.join(process.cwd(), "out");
 const KB = 1024;
 
 /**
- * Teto por rota, em bytes gzipados do JS inicial. Medido em 2026-08-06: as 47
- * rotas de tópico estão em 391.698 B (382,5 KB) e as 6 rotas fixas em 212.412 B
- * (207,4 KB). 400 KB é 4,6% acima do pior caso de hoje — não passa a próxima
- * leva de visualizadores.
+ * Teto por rota, em bytes gzipados do JS inicial.
+ *
+ * A régua é o piso da casca do site mais ~20%: 207,4 KB é o que a home custa, e
+ * ela não tem visualizador nenhum. Medido depois do corte por rota: a pior das
+ * 53 rotas é `/topico/listas-ligadas/`, com 235,7 KB (folga de 6,1%), a mediana
+ * das rotas de tópico fica perto de 224 KB, e as 11 páginas "em breve" custam
+ * 213,3 KB. Antes do corte eram 382,5 KB em todas as 47 rotas de tópico.
+ *
+ * Este teto não atrapalha publicar tópico novo, e é de propósito: agora um
+ * visualizador só pesa na rota que o usa. O que ele barra é uma PÁGINA ficar
+ * pesada demais sozinha, que é o sinal certo para pedir medição.
  */
-const TETO_ROTA = 400 * KB;
+const TETO_ROTA = 250 * KB;
 
 /**
- * Onde o projeto quer chegar. É o piso da casca (207,4 KB, o custo da home, que
- * não tem visualizador nenhum) mais ~20% de folga. Não é o teto ativo porque o
- * corte por rota ainda não foi feito; quando for, este vira `TETO_ROTA`.
+ * Nenhum chunk sozinho passa disso, em bytes crus. O maior de hoje tem 226.344 B
+ * e é o do framework; os 86 chunks de visualizador ficam todos bem abaixo. 265 KB
+ * é esse maior mais ~20%.
+ *
+ * É o guarda contra a volta do defeito que motivou este arquivo: se alguém puser
+ * os visualizadores de volta no grafo de servidor, eles voltam a virar UM chunk,
+ * e o número dele era 692.459 B.
  */
-const TETO_ALVO = 250 * KB;
-
-/**
- * Nenhum chunk sozinho passa disso, em bytes crus. O maior de hoje tem 692.459 B
- * e é o dos 86 visualizadores; o segundo tem 226.344. Este é o guarda mais
- * direto do defeito: é ESTE chunk que engorda a cada tópico publicado.
- */
-const TETO_MAIOR_CHUNK = 700 * KB;
+const TETO_MAIOR_CHUNK = 265 * KB;
 
 /**
  * O que uma página de tópico `soon` baixa **a mais** que a home, em gzip. As
  * duas mostram um parágrafo e nenhum visualizador, então a diferença é
- * desperdício puro. Medido hoje: 179.286 B (175,1 KB) — exatamente o chunk dos
- * visualizadores. O teto trava esse número; o conserto o leva a ~0.
+ * desperdício puro. Era 179.286 B (175,1 KB), o chunk inteiro dos 86
+ * visualizadores; depois do corte é **5.997 B**, um chunk só, que é o da rota
+ * `/topico/[slug]` e carrega os 86 invólucros do `VizLazy`.
+ *
+ * O teto de 8 KB é esse número com folga para o mapa crescer: ele ganha uma
+ * linha por visualizador novo, o que dá alguns bytes gzipados cada.
  */
-const TETO_EXCEDENTE_SEM_VIZ = 180 * KB;
+const TETO_EXCEDENTE_SEM_VIZ = 8 * KB;
 
 /** Rota `soon` sem artigo e sem visualizador (ver `isEmptyTopic`). */
 const ROTA_SEM_VIZ = "topico/trie/index.html";
@@ -145,7 +151,7 @@ test("nenhuma rota estoura o teto de JS inicial", () => {
   expect(
     acima.length,
     `${acima.length} de ${medidas.length} rotas acima do teto de ${kb(TETO_ROTA)} gzip de JS inicial ` +
-      `(o alvo do projeto é ${kb(TETO_ALVO)}):\n${relatorio}`
+      `(a casca do site sozinha custa 207,4 KB):\n${relatorio}`
   ).toBe(0);
 });
 
@@ -191,17 +197,22 @@ test("página de tópico sem visualizador quase não paga a mais que a home", ()
 
 test("os visualizadores continuam renderizados no HTML estático", () => {
   // O HTML pré-renderizado é o ativo de SEO do projeto: o Google indexa o que
-  // está no arquivo, não o que a hidratação monta depois. Quem for cortar o
-  // chunk dos visualizadores pode adiar a INTERATIVIDADE; não pode adiar o
+  // está no arquivo, não o que a hidratação monta depois. O corte por rota
+  // (`src/components/VizLazy.tsx`) adia a INTERATIVIDADE, e não pode adiar o
   // conteúdo. Em `next/dynamic`, isso quer dizer: `ssr: false` é proibido.
   //
   // E a conta é POR FIGURA, não por página: cinco visualizadores neste
   // repositório já passaram por uma suíte verde sem um botão renderizado,
   // justamente porque a asserção era "existe um `figure.viz` na página".
   // Contar figura deixa passar figura oca.
+  //
+  // Perfis diferentes de propósito: cinco visualizadores num artigo denso, três
+  // num artigo comum, um só numa página de grafo, e dois num artigo do meio.
   const esperado: Record<string, number> = {
-    "topico/arrays/index.html": 3,
     "topico/intervals/index.html": 5,
+    "topico/arrays/index.html": 3,
+    "topico/hash-table/index.html": 2,
+    "topico/dijkstra/index.html": 1,
   };
   for (const [rota, quantos] of Object.entries(esperado)) {
     const html = readFileSync(path.join(OUT, rota), "utf8");
@@ -329,18 +340,25 @@ test("clicar num link do artigo não recarrega o documento", async ({ page }) =>
   ).toBe(true);
 });
 
-test("o visualizador continua interativo, e o passo anda nos dois sentidos", async ({ page }) => {
-  await page.goto("/topico/arrays/");
-  const viz = page.locator("figure.viz").first();
-  const passo = viz.locator(".viz-step");
-  const antes = await passo.textContent();
-  expect(antes, "o contador de passo não renderizou").toBeTruthy();
+// O visualizador agora chega ao navegador por um `import()` que só acontece
+// depois da hidratação. Renderizar no HTML é metade: o teste tem que CLICAR e
+// ver o passo mudar, senão ele só provou que a casca está lá. Três perfis, pelo
+// mesmo motivo de sempre — o que quebra num artigo denso não é o que quebra
+// numa página de um visualizador só.
+for (const rota of ["/topico/arrays/", "/topico/dijkstra/", "/topico/hash-table/"]) {
+  test(`${rota} continua interativo, e o passo anda nos dois sentidos`, async ({ page }) => {
+    await page.goto(rota);
+    const viz = page.locator("figure.viz").first();
+    const passo = viz.locator(".viz-step");
+    const antes = await passo.textContent();
+    expect(antes, "o contador de passo não renderizou").toBeTruthy();
 
-  const proximo = viz.getByRole("button", { name: "Próximo ›" });
-  await expect(proximo).toBeEnabled();
-  await proximo.click();
-  await expect(passo).not.toHaveText(antes ?? "");
+    const proximo = viz.getByRole("button", { name: "Próximo ›" });
+    await expect(proximo).toBeEnabled();
+    await proximo.click();
+    await expect(passo).not.toHaveText(antes ?? "");
 
-  await viz.getByRole("button", { name: "‹ Anterior" }).click();
-  await expect(passo).toHaveText(antes ?? "");
-});
+    await viz.getByRole("button", { name: "‹ Anterior" }).click();
+    await expect(passo).toHaveText(antes ?? "");
+  });
+}

--- a/tests/orcamento-bundle.spec.ts
+++ b/tests/orcamento-bundle.spec.ts
@@ -156,9 +156,15 @@ test("nenhuma rota estoura o teto de JS inicial", () => {
 });
 
 test("nenhum chunk sozinho passa do teto", () => {
-  const chunks = readdirSync(path.join(OUT, "_next/static/chunks"))
+  // `recursive: true` não é detalhe: sem ele a listagem pega só o primeiro
+  // nível e um chunk emitido em `chunks/app/...` passaria pelo teto sem
+  // reprovar — um guarda que parece varredura e não é. Hoje o build põe os 98
+  // chunks no nível 1 e nenhum em subpasta, então isto não muda o resultado;
+  // muda o que acontece no dia em que o Next mudar o layout de saída.
+  const base = path.join(OUT, "_next/static/chunks");
+  const chunks = readdirSync(base, { recursive: true, encoding: "utf-8" })
     .filter((n) => n.endsWith(".js"))
-    .map((n) => ({ n, raw: statSync(path.join(OUT, "_next/static/chunks", n)).size }))
+    .map((n) => ({ n, raw: statSync(path.join(base, n)).size }))
     .sort((a, b) => b.raw - a.raw);
 
   const gordos = chunks.filter((c) => c.raw > TETO_MAIOR_CHUNK);
@@ -330,7 +336,11 @@ test("clicar num link do artigo não recarrega o documento", async ({ page }) =>
   expect(destino, "o link do artigo precisa apontar para a URL final, sem 308").toMatch(/\/$/);
 
   await link.click();
-  await expect(page).toHaveURL(new RegExp(`${destino}$`));
+  // Comparação de caminho, não regex montada com a URL: `new RegExp(destino)`
+  // trataria `.`, `?` e `(` como metacaractere, e um href com query ou ponto
+  // casaria de menos (ou de mais) sem ninguém perceber. O predicado compara o
+  // `pathname` inteiro, que é exatamente o que se quer afirmar aqui.
+  await expect(page).toHaveURL((u) => u.pathname === destino);
   await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
   expect(
     await page.evaluate(


### PR DESCRIPTION
## O que este PR entrega

1. **O corte por rota.** Uma página de tópico deixa de baixar os 86 visualizadores
   e passa a baixar só os que usa. O chunk de 692.459 B que ia no `<head>` de
   todas as 47 rotas, inclusive nas 11 páginas "em breve", deixa de existir.
2. **Guarda de orçamento de bytes** (`tests/orcamento-bundle.spec.ts`, novo). Não
   existia nada medindo o peso do build, e foi por esse buraco que aquele chunk
   chegou até a produção.
3. **Link interno do artigo pelo `next/link`, com a barra final**
   (`mdx-components.tsx`). 251 links deixam de tomar 308 e de recarregar a
   aplicação a cada clique; 12 links externos ganham `target`/`rel`.

Arquivos: `src/components/VizLazy.tsx` (novo), `mdx-components.tsx`,
`tests/orcamento-bundle.spec.ts` (novo). Mais nada.

---

## Antes e depois

Build da `main` (`e35c1b2`) contra esta branch, medido no `out/`:

| | main | esta branch | |
|---|---:|---:|---:|
| **maior chunk** | 692.459 B | **226.344 B** | **-67%** |
| **pior rota** (JS inicial gzip) | 382,5 KB | **235,7 KB** | **-38%** |
| **página "em breve"** | 382,5 KB | **213,3 KB** | **-44%** |
| **`/topico/trie/` menos a home** | 179.286 B | **5.997 B** | **-96,6%** |
| JS total em disco | 1.429.649 B | 1.939.658 B | +36% |
| arquivos JS emitidos | 15 | 101 | |

Por rota, JS inicial gzipado (`<script src>` mais `<link rel=preload as=script>`,
que o navegador baixa do mesmo jeito):

| rota | main | branch | | chunks | HTML gzip |
|---|---:|---:|---:|---:|---:|
| `/` | 212.412 | 212.396 | -0,0% | 10 → 10 | 6.392 → 6.391 |
| `/topico/arrays/` | 391.698 | **236.254** | **-39,7%** | 11 → 15 | 40.317 → 39.631 |
| `/topico/intervals/` (5 visualizadores) | 391.698 | **239.242** | **-38,9%** | 11 → 14 | 41.316 → 41.371 |
| `/topico/listas-ligadas/` (a pior rota) | 391.698 | **241.384** | **-38,4%** | 11 → 15 | 52.257 → 50.748 |
| `/topico/trie/` (`soon`, sem viz) | 391.698 | **218.393** | **-44,2%** | 11 → 11 | 4.838 → 4.837 |

**O que o navegador baixa de verdade**, medido com Chrome em 390x844, contando
todo JS que chega pela rede:

| rota | main | branch | |
|---|---:|---:|---:|
| `/topico/arrays/` | 1.314.642 B | **696.245 B** | **-47%** |
| `/topico/intervals/` | 1.314.642 B | **705.670 B** | **-46%** |
| `/topico/trie/` | 1.314.642 B | **646.136 B** | **-51%** |

O `+36%` de JS total em disco é o preço da divisão: módulos compartilhados
aparecem em mais de um dos 86 chunks. Ele só apareceria para quem visitasse
**todos** os 47 tópicos na mesma sessão; qualquer visita real baixa ~metade.

O HTML de `/topico/arrays/` **encolheu** 686 B gzipados, e não cresceu: o payload
RSC embutido ficou menor (111.838 → 106.523 B crus) porque as referências de
cliente agora apontam para um módulo só em vez de 86. Onde o HTML cresceu
(`intervals`, +55 B gzip) foi pelas barras finais dos links.

---

## Como o corte foi feito, e por que a primeira tentativa não serviu

`next/dynamic` nos 86 imports do `mdx-components.tsx`, que era o caminho óbvio,
**não corta um byte** (commit `81ddc36` tem a medição inteira): maior chunk
692.459 → 693.903 B, JS do `<head>` 383.933 → 396.242 B gzip, nenhum chunk novo
emitido. Ou seja: custava 12 KB gzip por rota e cortava zero.

A causa está no manifesto. Em
`.next/server/app/topico/[slug]/page_client-reference-manifest.js` os 86
visualizadores apontavam para os **mesmos 3 chunks** do entry da página. Num
Server Component, o `import()` de um componente `"use client"` não é um import,
é uma **referência de cliente**, e toda referência alcançável pelo grafo de
servidor da rota entra no entry dela, dinâmica ou não. A preguiça do
`next/dynamic` ficava só do lado do servidor.

`src/components/VizLazy.tsx` é `"use client"`. Deste lado da fronteira o
`import()` é import de verdade: o grafo é o do cliente, o Turbopack emite um
chunk assíncrono por visualizador (12 → 98 chunks), e cada página baixa só os
que usa. O `mdx-components.tsx` passou a importar os 86 de lá, e nada mais mudou
nele.

O `content/topics/index.ts:2-36` (os 36 artigos importados estaticamente numa
rota só) **não bloqueou** o ganho: ele mantém os artigos no mesmo entry, e o que
pesava eram os visualizadores, que agora saem por outro caminho. Ele continua
fora da fronteira desta lane e não foi tocado.

---

## O que NÃO mudou

- **O texto renderizado é idêntico ao da `main`.** Comparação das **53 páginas**
  do build, com `<script>`/`<style>`/comentários removidos, tags removidas,
  entidades resolvidas e espaços colapsados:

  ```
  páginas comparadas: 53
  páginas com texto diferente: NENHUMA (diff vazio)
  ```

- **Os visualizadores continuam no HTML estático**, e a conta é **por figura**:
  **58 → 58** figuras com contador de passo e controles renderizados pelo
  servidor, e **nenhuma página** mudou de contagem. `ssr: false` continua
  proibido, agora com guarda executável (ver prova de quebra F).

- **O markup que mudou é só de âncora:** 263 âncoras, 251 ganhando a barra final
  e 12 ganhando `target="_blank" rel="noopener noreferrer"`. A contagem de `<a>`
  por página não mudou em nenhuma das 53.

  ```
  antes : <a class="prose-a" href="/topico/big-o">
  depois: <a class="prose-a" href="/topico/big-o/">                        (x251)

  antes : <a class="prose-a" href="https://leetcode.com/problems/design-linked-list/">
  depois: ... target="_blank" rel="noopener noreferrer">                    (x12)
  ```

---

## O preço, dito com número

**O primeiro visualizador da página fica interativo ~15 ms mais tarde**, porque a
hidratação daquele pedaço espera o módulo chegar. Medido com polling por frame,
sete amostras, máquina ociosa:

| rota | main (mediana) | branch (mediana) | pedidos/página |
|---|---:|---:|---:|
| `/topico/arrays/` | 3,8 ms | **18,3 ms** | 19 → 24 |
| `/topico/intervals/` | 2,7 ms | **17,7 ms** | 17 → 20 |

O HTML já está pintado bem antes disso, e o visualizador não é o LCP de nenhuma
página. Contra os 618 KB de JS que saem da rede, a troca é boa.

**Efeito colateral na suíte, e é honesto declarar:** essa janela de 15 ms mais os
~4 pedidos a mais por página deixam a família de testes de rolagem e cabeçalho
parado (`viz-strings`, `viz-a-star`, `viz-recursao-funcional`,
`viz-arvores-binarias`) mais sensível quando 6 workers disputam o
`ThreadingHTTPServer` de teste. A/B na mesma máquina, só com os specs que já
existiam:

| build | 3 rodadas completas |
|---|---|
| antes do corte | 459 passed, 459 passed, 459 passed |
| depois do corte | 457 passed / 2 failed (`viz-strings` x2), 459 passed, 459 passed |

As falhas são sempre de tolerância de 1px em posição de rolagem
(`expect(1.25).toBeLessThanOrEqual(1)`), sempre passam isoladas, e nunca são as
mesmas duas vezes. Não é regressão de comportamento, é margem de medição
apertada; e é a mesma família que já tem alguém atacando a causa raiz.

---

## Os tetos, e por que estes números

Os três desceram junto com o ganho, no mesmo commit. Teto escolhido para o estado
anterior guarda uma vez só: com o pior caso caindo para 235,7 KB, um teto de
400 KB deixaria caber de volta tudo o que acabou de sair.

A régua é a mesma de antes: o **piso da casca do site** (207,4 KB gzip, o que a
home custa sem visualizador nenhum) mais **~20%**.

| teto | antes | agora | valor medido hoje | folga |
|---|---:|---:|---:|---:|
| JS inicial por rota (gzip) | 400 KB | **250 KB** | 235,7 KB na pior rota | 6,1% |
| chunk único (cru) | 700 KB | **265 KB** | 226.344 B (o do framework) | 20% |
| excedente da página `soon` (gzip) | 180 KB | **8 KB** | 5.997 B | 33% |

O terceiro é o que mede o corte de verdade: ele compara `/topico/trie/` (página
"em breve") com a home (também sem visualizador). Era o chunk inteiro dos 86;
agora é um chunk só, o da rota `/topico/[slug]`, que carrega os invólucros do
`VizLazy` e cresce uma linha por visualizador novo.

O teto por rota **não atrapalha publicar tópico**, e isso mudou de sentido com o
corte: agora um visualizador só pesa na rota que o usa, então o que o teto barra
é uma **página** ficar pesada sozinha, que é exatamente o sinal certo para pedir
medição. O guarda percorre **as 53 rotas do build**, não uma lista escrita à mão.

---

## Provas de quebra

Cada teste novo foi visto falhar. O fix foi copiado antes de cada quebra e
restaurado por `cp` (nunca `git checkout --`), e o build **nunca** foi silenciado.

**E) Desfaz o corte** (o `mdx-components.tsx` volta a importar os 86 direto, que é
o estado da `main`) — os três tetos pegam:

```
✓ Compiled successfully in 2.6s
    Error: 47 de 53 rotas acima do teto de 250.0 KB gzip de JS inicial
    Error: chunk único acima de 265.0 KB.
    Error: /topico/trie/ ... baixa 175.3 KB gzip a mais que a home
           (382.9 KB contra 207.6 KB)
  3 failed
```

**F) `ssr: false` nos 86** (que só compila porque o `VizLazy` é componente
cliente) — o guarda do HTML estático pega, e o mais instrutivo é o que passa:

```
✓ Compiled successfully in 2.1s
    Error: topico/intervals/index.html: 0 de 0 visualizadores renderizaram
           contador e controles no HTML estático (esperado 5)
  1 failed
  3 passed        <- os TRÊS testes de clique continuam verdes
```

Com `ssr: false` a página funciona no navegador e o HTML sai vazio para o
rastreador. É por isso que a asserção precisa ler o arquivo, e não só clicar.

**A) Volta o `<a>` cru no lugar do componente de link:**

```
    Error: 251 de 251 links internos sem barra final (cada clique = um 308):
    Error: 12 de 14 links externos sem target/rel:
    Error: o link do artigo precisa apontar para a URL final, sem 308
  3 failed
```

**B) Um visualizador vira casca vazia** (`() => <figure className="viz" />`), que é
o bug já vivido aqui de `figure.viz` sem botão nenhum:

```
    Error: topico/arrays/index.html: 2 de 3 visualizadores renderizaram contador
           e controles no HTML estático (esperado 3)
  1 failed
```

> Esta quebra derrubou a **primeira** versão do teste, que contava
> `<figure class="viz">` por página e passava verde com a figura oca. Foi
> reescrito para olhar dentro de cada figura, e só então reprovou.

**C) A âncora da própria página (`#secao`) tratada como rota interna:**

```
    Error: href "#nesta-pagina"
  1 failed
```

---

## Verificação

- `npm run build` ✓ · `npx tsc --noEmit` ✓
- **Suíte inteira: 459 → 470 testes, três rodadas completas verdes** (`470 passed`
  x3). A sensibilidade extra descrita acima está declarada com o A/B, sem
  maquiagem.
- **Interatividade, com clique, em três perfis x três viewports** (1512x900,
  1440x700, 390x844), com `?v=<timestamp>` para furar cache:

  ```
  /topico/arrays/      3 figuras  passo 4 de 8  -> passo 5 de 8   overflow=false erros=0
  /topico/dijkstra/    1 figura   passo 1 de 17 -> passo 2 de 17  overflow=false erros=0
  /topico/hash-table/  2 figuras  passo 1 de 18 -> passo 2 de 18  overflow=false erros=0
  /topico/trie/        sem visualizador (soon)                    overflow=false erros=0
  ```

  Zero erro de console, zero overflow horizontal, e o passo volta ao clicar em
  `‹ Anterior` (o teste cobre os dois sentidos). Os mesmos três perfis viraram
  teste, junto com quatro no guarda de HTML estático (5, 3, 2 e 1 visualizador).

- Prefetch dos 251 `<Link>` novos, medido rolando o artigo inteiro: 712.267 →
  712.289 B em 1512x900. Praticamente zero, porque o menu lateral já prefetchava
  os mesmos destinos.

## Fronteira

Tocados: `src/components/VizLazy.tsx` (novo), `mdx-components.tsx`,
`tests/orcamento-bundle.spec.ts` (novo). Não toquei em `content/topics/**`
(inclusive o `index.ts`), `src/lib/**`, `src/app/**`, `content/visualizers/**`,
`content/roadmap.ts`, nenhum spec que já existia, `next.config.ts`,
`playwright.config.ts` nem `package.json`.
