### PR TITLE
test(strings): a sobra da rolagem lida no mesmo instante do scrollTop

### DIFF
--- a/tests/viz-strings.spec.ts
+++ b/tests/viz-strings.spec.ts
@@ -64,13 +64,24 @@ async function medicaoTerminou(alvo: Locator) {
  * mais cedo, e a sobra congelada saiu 6, 19 e 20 (e 0) contra os 22 reais.
  *
  * O critério de parada é o valor repetido em quadros consecutivos, e não uma
- * espera fixa, que erra dos dois lados. O teto de quadros está aí para o teste
- * reprovar na asserção, com número na mão, em vez de estourar o timeout mudo.
+ * espera fixa, que erra dos dois lados.
+ *
+ * O teto de quadros **reprova**, e não devolve o que leu por último. Devolver
+ * seria entregar ao teste um número ainda em movimento — exatamente o defeito
+ * que esta função existe para fechar —, e o teste seguinte reprovaria (ou
+ * passaria) por um motivo que não é o dele. Reprovando aqui, a mensagem já traz
+ * a última sobra observada e diz que ela não assentou.
+ *
+ * O teto é folgado de propósito: medido em 24 execuções sob carga (12
+ * repetições dos dois testes, 6 workers), a sobra assentou entre 5 e 10
+ * quadros — 18x abaixo do teto. Ele é rede de segurança, não caminho normal.
  */
+const TETO_DE_QUADROS = 180;
+
 async function sobraAssentada(miolo: Locator): Promise<number> {
   return miolo.evaluate(
-    (el) =>
-      new Promise<number>((resolve) => {
+    (el, teto) =>
+      new Promise<number>((resolve, reject) => {
         let anterior = -1;
         let repetidos = 0;
         let quadros = 0;
@@ -78,11 +89,19 @@ async function sobraAssentada(miolo: Locator): Promise<number> {
           const sobra = el.scrollHeight - el.clientHeight;
           repetidos = sobra === anterior ? repetidos + 1 : 0;
           anterior = sobra;
-          if (repetidos >= 5 || ++quadros > 180) resolve(sobra);
+          if (repetidos >= 5) resolve(sobra);
+          else if (++quadros > teto)
+            reject(
+              new Error(
+                `a sobra de rolagem do miolo não assentou em ${teto} quadros; ` +
+                  `última leitura: ${sobra}px (scrollHeight ${el.scrollHeight}, clientHeight ${el.clientHeight})`
+              )
+            );
           else requestAnimationFrame(olhar);
         };
         requestAnimationFrame(olhar);
-      })
+      }),
+    TETO_DE_QUADROS
   );
 }
 

--- a/tests/viz-strings.spec.ts
+++ b/tests/viz-strings.spec.ts
@@ -50,23 +50,85 @@ async function medicaoTerminou(alvo: Locator) {
 }
 
 /**
+ * Sobra de rolagem do miolo (`scrollHeight - clientHeight`) medida depois de ela
+ * PARAR de mudar.
+ *
+ * O bloco recolhível abre com transição — `grid-template-rows` em 0.32s no
+ * `.viz-code-slot` (`globals.css`) —, e o `expect.poll` de altura que vem antes
+ * devolve assim que o conteúdo cruza o limiar, ou seja no MEIO da transição.
+ * Amostrada quadro a quadro a partir desse instante, a sobra deste painel sobe
+ * 14 → 19 → 20 → 22 e só assenta ~145ms depois.
+ *
+ * Ler ali congela um número que a rolagem seguinte já não obedece, e era daí que
+ * vinha a reprovação intermitente: com a máquina carregada o `poll` volta ainda
+ * mais cedo, e a sobra congelada saiu 6, 19 e 20 (e 0) contra os 22 reais.
+ *
+ * O critério de parada é o valor repetido em quadros consecutivos, e não uma
+ * espera fixa, que erra dos dois lados. O teto de quadros está aí para o teste
+ * reprovar na asserção, com número na mão, em vez de estourar o timeout mudo.
+ */
+async function sobraAssentada(miolo: Locator): Promise<number> {
+  return miolo.evaluate(
+    (el) =>
+      new Promise<number>((resolve) => {
+        let anterior = -1;
+        let repetidos = 0;
+        let quadros = 0;
+        const olhar = () => {
+          const sobra = el.scrollHeight - el.clientHeight;
+          repetidos = sobra === anterior ? repetidos + 1 : 0;
+          anterior = sobra;
+          if (repetidos >= 5 || ++quadros > 180) resolve(sobra);
+          else requestAnimationFrame(olhar);
+        };
+        requestAnimationFrame(olhar);
+      })
+  );
+}
+
+/**
  * Rola o miolo até uma fração da sobra e só volta quando o navegador aplicou a
  * rolagem e pintou o quadro seguinte. Espera fixa aqui erra dos dois lados: é
  * lenta quando a máquina está livre e insuficiente quando ela está carregada.
  *
- * O retorno é o `scrollTop` REAL, e conferi-lo não é preciosismo: se a rolagem
- * não acontecer, "o cabeçalho não se mexeu" vira verdade à toa e o teste passa
- * sem ter testado nada.
+ * Devolve o alvo E o `scrollTop` real, os dois do MESMO instante: o alvo sai da
+ * sobra lida na linha que aplica a rolagem, não de uma medição anterior. É a
+ * mesma forma que o `viz-intervals.spec.ts` já usa, e pelo mesmo motivo — quem
+ * compara o real contra uma sobra medida antes do laço mede outra coisa, porque
+ * a sobra muda entre as duas leituras.
+ *
+ * O real continua sendo o que importa: se a rolagem não acontecer, "o cabeçalho
+ * não se mexeu" vira verdade à toa e o teste passa sem ter testado nada.
  */
-async function rolarMiolo(miolo: Locator, fracao: number): Promise<number> {
+async function rolarMiolo(miolo: Locator, fracao: number): Promise<{ alvo: number; real: number }> {
   return miolo.evaluate(
     (el, f) =>
-      new Promise<number>((resolve) => {
-        el.scrollTop = (el.scrollHeight - el.clientHeight) * f;
-        requestAnimationFrame(() => requestAnimationFrame(() => resolve(el.scrollTop)));
+      new Promise<{ alvo: number; real: number }>((resolve) => {
+        const alvo = (el.scrollHeight - el.clientHeight) * f;
+        el.scrollTop = alvo;
+        requestAnimationFrame(() =>
+          requestAnimationFrame(() => resolve({ alvo, real: el.scrollTop }))
+        );
       }),
     fracao
   );
+}
+
+/**
+ * A rolagem chegou onde foi pedida, e aconteceu de verdade.
+ *
+ * O 1px de folga é para o arredondamento sub-pixel do `scrollTop`, não para a
+ * sobra ter mudado no meio do caminho — medido em 120 rolagens, o desvio entre
+ * alvo e real foi 0 ou 0,5px, nunca mais que isso. Afrouxar este número seria
+ * justamente parar de pegar o defeito que o teste existe para pegar.
+ *
+ * A segunda asserção é a que fecha a porta do verde à toa: num miolo parado no
+ * topo, "o cabeçalho não se mexeu" é verdade sem rolagem nenhuma. A metade da
+ * proporção é folga de sobra, para ela não virar a mesma armadilha do alvo.
+ */
+function conferirRolagem(rolagem: { alvo: number; real: number }, sobra: number, destino: number) {
+  expect(Math.abs(rolagem.real - rolagem.alvo)).toBeLessThanOrEqual(1);
+  expect(rolagem.real).toBeGreaterThan(sobra * destino * 0.5);
 }
 
 async function expandir(page: Page, n: number) {
@@ -94,8 +156,11 @@ test("rotate expandido: cabeçalho e rodapé não se mexem quando o miolo rola a
   await expect.poll(() => altura(p.locator(".viz-code"))).toBeGreaterThan(100);
 
   const miolo = p.locator(".viz-body");
-  const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
-  // Sem sobra o teste não prova nada: ele precisa de conteúdo para rolar.
+  // Sem sobra o teste não prova nada: ele precisa de conteúdo para rolar. E a
+  // medição espera a transição do bloco de código terminar, senão ela lê o meio
+  // do caminho — inclusive o zero, que já reprovou aqui com o painel inteiro em
+  // ordem.
+  const sobra = await sobraAssentada(miolo);
   expect(sobra).toBeGreaterThan(0);
 
   const cabeca = p.locator(".viz-head");
@@ -112,8 +177,7 @@ test("rotate expandido: cabeçalho e rodapé não se mexem quando o miolo rola a
   // em vez de olhar só o instante depois de uma espera fixa.
   const desvios: number[] = [];
   for (const destino of [0.25, 0.5, 0.75, 1]) {
-    const real = await rolarMiolo(miolo, destino);
-    expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
+    conferirRolagem(await rolarMiolo(miolo, destino), sobra, destino);
     desvios.push(
       Math.abs((await cabeca.boundingBox())!.y - antes.cabeca),
       Math.abs((await rodape.boundingBox())!.y - antes.rodape),
@@ -337,15 +401,16 @@ test("bytes expandido: o cabeçalho fica parado enquanto a tabela aberta rola", 
   await expect.poll(() => altura(p.locator(".str-scroll"))).toBeGreaterThan(400);
 
   const miolo = p.locator(".viz-body");
-  const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
+  // Mesma armadilha do teste do rotate: a tabela também abre com transição, e
+  // ler a sobra antes de ela assentar congela um número do meio do caminho.
+  const sobra = await sobraAssentada(miolo);
   expect(sobra).toBeGreaterThan(0);
 
   const cabeca = p.locator(".viz-head");
   const antes = (await cabeca.boundingBox())!.y;
   const desvios: number[] = [];
   for (const destino of [0.34, 0.67, 1]) {
-    const real = await rolarMiolo(miolo, destino);
-    expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
+    conferirRolagem(await rolarMiolo(miolo, destino), sobra, destino);
     desvios.push(Math.abs((await cabeca.boundingBox())!.y - antes));
   }
   expect(Math.max(...desvios)).toBeLessThanOrEqual(1);

--- a/tests/viz-strings.spec.ts
+++ b/tests/viz-strings.spec.ts
@@ -90,10 +90,12 @@ async function sobraAssentada(miolo: Locator): Promise<number> {
           repetidos = sobra === anterior ? repetidos + 1 : 0;
           anterior = sobra;
           if (repetidos >= 5) resolve(sobra);
-          else if (++quadros > teto)
+          else if (++quadros >= teto)
             reject(
               new Error(
-                `a sobra de rolagem do miolo não assentou em ${teto} quadros; ` +
+                // O número sai do próprio contador, não do teto: assim ele não
+                // pode divergir da condição que o produziu.
+                `a sobra de rolagem do miolo não assentou em ${quadros} quadros; ` +
                   `última leitura: ${sobra}px (scrollHeight ${el.scrollHeight}, clientHeight ${el.clientHeight})`
               )
             );


### PR DESCRIPTION
## O que estava errado

`tests/viz-strings.spec.ts` tinha **dois** testes de rolagem com o mesmo defeito, não um:

- `:82` — *rotate expandido: cabeçalho e rodapé não se mexem quando o miolo rola até o fim*, asserção em `:116`
- `:326` — *bytes expandido: o cabeçalho fica parado enquanto a tabela aberta rola*, asserção em `:348`

Os dois mediam a sobra de rolagem (`scrollHeight - clientHeight`) **uma vez, antes do laço**, e comparavam as quatro (e três) rolagens contra esse valor congelado:

```js
const sobra = await miolo.evaluate((el) => el.scrollHeight - el.clientHeight);
...
for (const destino of [0.25, 0.5, 0.75, 1]) {
  const real = await rolarMiolo(miolo, destino);
  expect(Math.abs(real - sobra * destino)).toBeLessThanOrEqual(1);
```

**A causa raiz, medida.** O bloco recolhível abre com transição de 0.32s (`grid-template-rows` no `.viz-code-slot`), e o `expect.poll` de altura que vem logo antes devolve assim que o conteúdo cruza o limiar, ou seja **no meio da transição**. Amostrada quadro a quadro a partir desse instante, a sobra do painel do rotate é:

```
 45ms sobra=14   74ms sobra=20   152ms sobra=22
 47ms sobra=19  145ms sobra=22   (assentada)
```

A sobra congelada é lida em algum ponto dessa subida. Com a máquina carregada o `poll` volta ainda mais cedo, e ela saiu **6, 19 e 20** contra os 22 reais — e **0**, que reprovava a própria pré-condição `expect(sobra).toBeGreaterThan(0)`.

Daí a intermitência: reprovou o CI do #46 (460 passed / 1 failed), **passou no re-run do mesmo commit**, passa isolado, e os runs anteriores da `main` estão verdes.

> Correção de um número que circulava: o CI do #46 recebeu **1,5 e 2,5px** (log do run `31132824636`), não 10,4. A ordem de grandeza pequena é o que se espera de uma sobra de 22px que ainda está crescendo.

## O que mudou

Só `tests/viz-strings.spec.ts`.

1. **`rolarMiolo` devolve alvo e real do mesmo instante.** O alvo sai da sobra lida na própria linha que aplica a rolagem, então a comparação é contra o estado daquele momento. É a forma que o **`tests/viz-intervals.spec.ts:64-90` já adotou para este mesmo flake** — o `viz-strings` tinha ficado para trás.
2. **`sobraAssentada` espera a sobra parar de mudar** antes da pré-condição, por valor repetido em quadros consecutivos (com teto de quadros, para reprovar na asserção em vez de estourar o timeout mudo). É o que fecha o modo de falha `expect(sobra).toBeGreaterThan(0)` recebendo 0.
3. **Asserção nova de que a rolagem aconteceu** (`real > sobra * destino * 0.5`). Sem ela, num miolo parado no topo "o cabeçalho não se mexeu" é verdade à toa.

**A tolerância de 1px continua 1px, de propósito.** Ela é o arredondamento sub-pixel do `scrollTop` — medido em 120 rolagens, o desvio entre alvo e real foi 0 ou 0,5px, nunca mais que isso —, e não licença para o layout mexer no meio do caminho. Afrouxá-la até parar de reclamar seria justamente parar de pegar o defeito que o teste existe para pegar (cabeçalho e rodapé se mexendo).

## A prova

**Flake reproduzido**, com 30 repetições e 12 workers numa máquina de 12 núcleos:

| teste | antes (main) | depois |
|---|---|---|
| `:82` rotate | **3 reprovações na tolerância** em 30 | **0 em 60** |
| `:326` bytes | **11 reprovações na tolerância** em 30 | **0 em 60** |

Isoladamente, com `--workers=1`, as 20 repetições passam nos dois estados: a carga é parte da condição, e é por isso que ele só aparece na suíte cheia do CI.

As demais reprovações das rodadas (timeout de 30s em `click()` e `fill()`) são saturação da máquina, aparecem **antes e depois** e não têm relação com a mudança.

**Prova de quebra** — as asserções novas continuam pegando defeito de verdade:

| quebra | resultado |
|---|---|
| A) a rolagem não é aplicada (`el.scrollTop = alvo` removido) | ✗ reprova: `\|real - alvo\|` = 5,5 |
| B) `.viz-body` deixa de ser quem rola (`overflow-y: visible`) | ✗ reprova: `\|real - alvo\|` = 2 |
| C) o painel deixa de caber na janela (`max-height: none`) | ✗ reprova: sobra = 0 |

**Verificação:** `npm run test:build` → **459 passed**, `npx tsc --noEmit` limpo.

## O que NÃO mudou

- Nenhum arquivo de produto: zero linhas em `src/`, `content/` ou config. É mudança só de teste.
- A intenção do laço, que é boa e está preservada: *"«Está parado agora» não é «continua parado»: amostra ao longo da rolagem"*. As quatro (e três) frações continuam lá.
- A tolerância de 1px, pelo motivo acima.
- Nenhum outro `tests/*.spec.ts`.

## Varredura, e o que fica de fora

Varri `tests/` inteiro pelo idioma "sobra medida uma vez, comparada contra fração":

- **`tests/viz-strings.spec.ts`: duas ocorrências, as duas neste PR.** Não há terceira.
- **`tests/viz-intervals.spec.ts`** já tem a forma corrigida (`:64-90`), e foi de onde veio o padrão adotado aqui.
- Os outros ~30 specs usam um idioma diferente e imune: rolam até o fim (`scrollTop = scrollHeight`) e afirmam `scrollTop > 0`, sem fração de sobra congelada.

Fora do escopo, reportado e **não** consertado:

- `tests/viz-strings.spec.ts:394` (`expect(f).toHaveAttribute("data-codigo", "off")`) reprovou 1 vez em 30 com 16 workers, recebendo `"on"`. É outra classe (corrida da decisão por medição, não sobra congelada), não reproduz com 12 workers e nunca reprovou no CI. Deixei de fora para o PR não misturar dois assuntos.

## Os números batem com os que outras lanes viram

A reprodução local não só falhou nos mesmos lugares, ela produziu os **mesmos valores** que já tinham sido relatados por observadores independentes — o que fecha a dúvida de ser coincidência:

| desvio recebido | onde | quem já tinha visto |
|---|---|---|
| **11,08** | `:326` bytes | relatado por outra lane |
| 1,5 e 2,5 | `:82` rotate | o CI do #46, log do run `31132824636` |
| 2, 2,5 e 3 | `:82` rotate | esta reprodução |
| 2,24 a **56,64** | `:326` bytes | esta reprodução |

A dispersão explica por que o mesmo defeito aparecia com magnitudes tão diferentes: o desvio é o quanto a sobra **cresceu** entre a medição congelada e a rolagem, então ele escala com o tamanho do bloco que está abrindo. No rotate abre o bloco de código (sobra final de 22px) e o desvio fica na casa de 1 a 3px; no bytes abre a tabela de 20 code points e ele chega a 56px.

Isso também corrige a leitura de que o `:82` teria recebido 10,4: o valor dessa ordem é do `:326`.


## O flake reapareceu no CI enquanto este PR esperava, e no OUTRO modo de falha

Confirmação independente, e ela chegou sozinha: o CI do **#55** (outro PR, ramificado da `main`, **sem** este conserto) marcou `tests/viz-strings.spec.ts:82` como **flaky** — reprovou e passou no retry, no run `31139159280`. O valor recebido:

```
Expected: > 0
Received:   0
```

Não é a asserção de tolerância: é a **pré-condição** `expect(sobra).toBeGreaterThan(0)`, a sobra lida como **zero** porque a transição do bloco de código ainda não tinha começado a crescer o conteúdo.

Isso importa para revisar este PR, porque separa os dois modos de falha e mostra que **remedir a sobra dentro do laço não bastaria**:

| modo | o que reprova | o que conserta |
|---|---|---|
| sobra congelada no meio da transição | `\|real - sobra × fração\| <= 1` | alvo e real do mesmo instante (`rolarMiolo`) |
| sobra lida antes de existir | `sobra > 0` recebendo **0** | esperar assentar (`sobraAssentada`) |

O segundo é o que o CI acabou de exibir, e é exatamente o que o `sobraAssentada` existe para cobrir. Um conserto que só mexesse na tolerância deixaria essa reprovação de pé.
