### PR TITLE
fix(viz): duas frases quebradas no comparador de três vias do quick sort

### DIFF
--- a/content/visualizers/QuickSortTresVias.tsx
+++ b/content/visualizers/QuickSortTresVias.tsx
@@ -158,6 +158,11 @@ function tresVias(valores: number[]): Resultado {
 }
 
 function Painel({ titulo, r, n, selo }: { titulo: string; r: Resultado; n: number; selo: string }) {
+  // Quantos elementos sobraram ao todo. É ele que rege o verbo e o plural: a
+  // moldura "sobram ... para a recursão resolver" só faz sentido quando existe
+  // o que sobrar, e no preset "Todos iguais" a partição de três vias não deixa
+  // nada — daí a frase inteira ser condicional, e não só o miolo dela.
+  const sobraram = r.restantes.reduce((soma, x) => soma + x, 0);
   return (
     <div className="ms-op">
       <div className="bb-formula-cab">
@@ -183,13 +188,20 @@ function Painel({ titulo, r, n, selo }: { titulo: string; r: Resultado; n: numbe
         })}
       </div>
       <p className="bb-formula-fim">
-        Depois da primeira partição sobram{" "}
         {r.restantes.length === 0 ? (
-          <strong>nenhum subproblema: acabou aqui</strong>
+          <>
+            A primeira partição resolveu o array inteiro:{" "}
+            <strong>não sobrou nada para a recursão</strong>.
+          </>
         ) : (
-          <strong>{r.restantes.join(" e ")} elementos</strong>
-        )}{" "}
-        para a recursão resolver.
+          <>
+            Depois da primeira partição {sobraram === 1 ? "sobra" : "sobram"}{" "}
+            <strong>
+              {r.restantes.join(" e ")} elemento{sobraram === 1 ? "" : "s"}
+            </strong>{" "}
+            para a recursão resolver.
+          </>
+        )}
       </p>
     </div>
   );

--- a/content/visualizers/QuickSortTresVias.tsx
+++ b/content/visualizers/QuickSortTresVias.tsx
@@ -145,7 +145,16 @@ function tresVias(valores: number[]): Resultado {
       primeira = [...a];
       regioes = [];
       if (lt > lo) regioes.push({ de: lo, ate: lt - 1, cls: "menor", txt: "< pivô, volta para a recursão" });
-      regioes.push({ de: lt, ate: gt, cls: "pivo", txt: `= pivô, ${gt - lt + 1} já resolvidos` });
+      // A faixa do meio tem um elemento só quando não há repetidos do pivô, que
+      // é justamente o preset "Sem repetição": sem a concordância, a tela dizia
+      // "1 já resolvidos" bem no exemplo que existe para mostrar o contraponto.
+      const iguais = gt - lt + 1;
+      regioes.push({
+        de: lt,
+        ate: gt,
+        cls: "pivo",
+        txt: `= pivô, ${iguais} já resolvido${iguais === 1 ? "" : "s"}`,
+      });
       if (hi > gt) regioes.push({ de: gt + 1, ate: hi, cls: "maior", txt: "> pivô, volta para a recursão" });
       restantes = [lt - lo, hi - gt].filter((x) => x > 0);
     }

--- a/content/visualizers/QuickSortTresVias.tsx
+++ b/content/visualizers/QuickSortTresVias.tsx
@@ -148,12 +148,12 @@ function tresVias(valores: number[]): Resultado {
       // A faixa do meio tem um elemento só quando não há repetidos do pivô, que
       // é justamente o preset "Sem repetição": sem a concordância, a tela dizia
       // "1 já resolvidos" bem no exemplo que existe para mostrar o contraponto.
-      const iguais = gt - lt + 1;
+      const equalCount = gt - lt + 1;
       regioes.push({
         de: lt,
         ate: gt,
         cls: "pivo",
-        txt: `= pivô, ${iguais} já resolvido${iguais === 1 ? "" : "s"}`,
+        txt: `= pivô, ${equalCount} já resolvido${equalCount === 1 ? "" : "s"}`,
       });
       if (hi > gt) regioes.push({ de: gt + 1, ate: hi, cls: "maior", txt: "> pivô, volta para a recursão" });
       restantes = [lt - lo, hi - gt].filter((x) => x > 0);
@@ -171,7 +171,7 @@ function Painel({ titulo, r, n, selo }: { titulo: string; r: Resultado; n: numbe
   // moldura "sobram ... para a recursão resolver" só faz sentido quando existe
   // o que sobrar, e no preset "Todos iguais" a partição de três vias não deixa
   // nada — daí a frase inteira ser condicional, e não só o miolo dela.
-  const sobraram = r.restantes.reduce((soma, x) => soma + x, 0);
+  const remainingTotal = r.restantes.reduce((sum, x) => sum + x, 0);
   return (
     <div className="ms-op">
       <div className="bb-formula-cab">
@@ -204,9 +204,9 @@ function Painel({ titulo, r, n, selo }: { titulo: string; r: Resultado; n: numbe
           </>
         ) : (
           <>
-            Depois da primeira partição {sobraram === 1 ? "sobra" : "sobram"}{" "}
+            Depois da primeira partição {remainingTotal === 1 ? "sobra" : "sobram"}{" "}
             <strong>
-              {r.restantes.join(" e ")} elemento{sobraram === 1 ? "" : "s"}
+              {r.restantes.join(" e ")} elemento{remainingTotal === 1 ? "" : "s"}
             </strong>{" "}
             para a recursão resolver.
           </>

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -1484,7 +1484,12 @@ test("quick sort: o pior caso mora nas entradas mais comuns", async ({ page }) =
   const vias = page.locator("figure.viz").filter({ hasText: "o que fazer com os iguais" });
   await expect(vias.locator(".ms-op").nth(0)).toContainText("28 comparações · profundidade 8");
   await expect(vias.locator(".ms-op").nth(1)).toContainText("16 comparações · profundidade 1");
-  await expect(vias.locator(".ms-op").nth(1)).toContainText("nenhum subproblema");
+  // A frase inteira, no nó dela: o ramo sem subproblema deixou de entrar no
+  // meio de uma moldura fixa, e a asserção antiga (`toContainText("nenhum
+  // subproblema")`) gravava justamente o texto quebrado.
+  await expect(vias.locator(".ms-op").nth(1).locator(".bb-formula-fim")).toHaveText(
+    "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."
+  );
   // sem repetidos ela não é melhor: mesma profundidade e o dobro de comparações
   await vias.getByRole("button", { name: /Sem repetição/ }).click();
   await expect(vias.locator(".ms-op").nth(0)).toContainText("18 comparações · profundidade 5");

--- a/tests/viz-quick-sort.spec.ts
+++ b/tests/viz-quick-sort.spec.ts
@@ -328,6 +328,26 @@ test.describe("quick sort", () => {
     await expect(painelTres(fig).locator(".ms-seg.pivo")).toHaveText("= pivô, 8 já resolvidos");
   });
 
+  test("três vias: sem repetição a faixa do meio tem um elemento só, e a frase concorda", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1512, 900);
+    const fig = figTresVias(page);
+    await fig.getByRole("button", { name: /Sem repetição/ }).click();
+
+    // Sem repetidos, a faixa dos iguais é só o pivô: singular, no rótulo que
+    // existe justamente para mostrar o contraponto honesto da técnica.
+    await expect(painelTres(fig).locator(".ms-seg.pivo")).toHaveText("= pivô, 1 já resolvido");
+    // A moldura volta a valer, com os dois subproblemas que de fato sobraram.
+    await expect(painelTres(fig).locator(".bb-formula-fim")).toHaveText(
+      "Depois da primeira partição sobram 1 e 6 elementos para a recursão resolver."
+    );
+    // E a de duas vias, na mesma tela, com a mesma moldura e outros números.
+    await expect(painelDuas(fig).locator(".bb-formula-fim")).toHaveText(
+      "Depois da primeira partição sobram 1 e 6 elementos para a recursão resolver."
+    );
+  });
+
   test("no artigo a peça recolhida cabe no orçamento de uma tela", async ({ page }) => {
     await abrirPagina(page, 1512, 900);
     const fig = figArtigo(page);

--- a/tests/viz-quick-sort.spec.ts
+++ b/tests/viz-quick-sort.spec.ts
@@ -278,6 +278,56 @@ test.describe("quick sort", () => {
     expect(await cartao("comparações")).toEqual({ rotulo: "comparações", valor: "28" });
   });
 
+  // -------------------------------------------------------------------------
+  // As frases do comparador de três vias.
+  //
+  // Estas asserções são de TEXTO INTEIRO, com `toHaveText`, e isso é o ponto:
+  // as duas frases consertadas aqui passaram anos por uma suíte verde porque
+  // ninguém lia a frase, só pedaços dela. `toContainText("já resolvido")` casa
+  // com "1 já resolvidos", e `toContainText("elementos")` casa com a moldura
+  // engolindo o próprio miolo. Ler a frase inteira é o que separa uma coisa da
+  // outra.
+  //
+  // Cada condicional é conferida DOS DOIS LADOS: o preset em que o ramo dispara
+  // e o preset em que ele não dispara. Um ramo só testado onde ele vale não
+  // prova que o outro existe.
+  // -------------------------------------------------------------------------
+
+  /** O comparador de três vias é a 3ª figura da página, e não tem casca. */
+  const figTresVias = (page: Page) => page.locator("article figure.viz").nth(2);
+  /** Os dois painéis lado a lado, na ordem em que a peça os monta. */
+  const painelDuas = (fig: Locator) => fig.locator(".ms-op").nth(0);
+  const painelTres = (fig: Locator) => fig.locator(".ms-op").nth(1);
+
+  test("três vias: quando a partição resolve tudo, a frase não promete subproblema nenhum", async ({
+    page,
+  }) => {
+    await abrirPagina(page, 1512, 900);
+    const fig = figTresVias(page);
+    // A figura certa, antes de qualquer asserção: os três irmãos compartilham
+    // as classes, e medir o painel errado passaria despercebido.
+    await expect(fig.locator(".viz-head-title")).toHaveText(
+      "Visualizador · o que fazer com os iguais ao pivô"
+    );
+    await expect(painelTres(fig).locator(".bb-formula-tit")).toHaveText(
+      "Três vias (bandeira holandesa)"
+    );
+
+    // Preset "Todos iguais", o padrão: a partição de três vias resolve as oito
+    // posições de uma vez e NÃO sobra subproblema. É o ramo em que a moldura
+    // "sobram ... para a recursão resolver" não tem o que enquadrar.
+    await expect(painelTres(fig).locator(".bb-formula-fim")).toHaveText(
+      "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."
+    );
+    // O outro lado da MESMA condicional, na mesma tela: a de duas vias devolve
+    // sete elementos para a recursão, e aí a moldura vale inteira.
+    await expect(painelDuas(fig).locator(".bb-formula-fim")).toHaveText(
+      "Depois da primeira partição sobram 7 elementos para a recursão resolver."
+    );
+    // E a faixa do meio no plural, que é o lado em que a concordância acerta.
+    await expect(painelTres(fig).locator(".ms-seg.pivo")).toHaveText("= pivô, 8 já resolvidos");
+  });
+
   test("no artigo a peça recolhida cabe no orçamento de uma tela", async ({ page }) => {
     await abrirPagina(page, 1512, 900);
     const fig = figArtigo(page);


### PR DESCRIPTION
## O que estava errado

Dois defeitos de texto em `content/visualizers/QuickSortTresVias.tsx`, os dois na tela, os dois achados pela lane de testes.

### 1. A moldura engolindo o próprio miolo (`:185-192`)

A frase era fixa e só o miolo condicional. No preset **"Todos iguais"** a partição de três vias resolve as oito posições de uma vez e não sobra subproblema, então o aluno lia:

> "Depois da primeira partição sobram **nenhum subproblema: acabou aqui** para a recursão resolver."

O conserto é a **frase inteira condicional**, não o miolo: "sobram ... para a recursão resolver" só faz sentido quando existe o que sobrar. O ramo vazio virou:

> "A primeira partição resolveu o array inteiro: **não sobrou nada para a recursão**."

### 2. Plural que não concorda (`:148`)

`` `= pivô, ${gt - lt + 1} já resolvidos` `` sem plural condicional. Sem repetidos do pivô a faixa do meio tem um elemento só, e no preset **"Sem repetição"** a tela dizia **"= pivô, 1 já resolvidos"** — justamente no exemplo que existe para mostrar o contraponto honesto da técnica.

## A varredura da classe

Rodei os dois geradores em Node sobre os **quatro presets** e imprimi cada string renderizada, em vez de conferir de olho. Todo número interpolado seguido de substantivo no arquivo:

| onde | texto | menor valor real | situação |
|---|---|---|---|
| `:148` | `${n} já resolvidos` | **1** (Sem repetição) | ✗ **quebrado, consertado aqui** |
| `:190` | `{restantes.join(" e ")} elementos` | 7 (entrada única) | ✓ hoje; a lista `[1]` diria "1 elementos" — passou a concordar pelo total, já que a frase estava sendo reescrita |
| `:217`, `:257` | `{n} valor/valores distinto/distintos` | 1 | ✓ já condicional |
| `:243`, `:249`, `:270` | `${n} comparações` | 14 | ✓ |
| `:260` | `{duas.prof} níveis` | 4 | ✓ hoje; latente se um preset novo descer 1 nível com repetidos |

Nenhuma outra ocorrência reproduz com os presets de hoje. **Nenhum outro arquivo de `content/visualizers/` foi tocado** — a varredura da mesma classe fora deste arquivo é reporte, não conserto (ver o fim).

## A prova

**Testes que leem a frase INTEIRA**, com `toHaveText` e não `toContainText` — foi exatamente a asserção por substring que deixou as duas passarem por anos. Cada condicional é conferida **dos dois lados**, incluindo o ramo "não aconteceu":

- preset "Todos iguais": o painel de três vias que **não deixa nada**, o de duas vias que deixa sete, e a faixa no plural (`= pivô, 8 já resolvidos`)
- preset "Sem repetição": a faixa no **singular** (`= pivô, 1 já resolvido`) e a moldura de volta, com os dois subproblemas reais

**Prova de quebra** (texto antigo restaurado, `npm run build` entre cada uma, nunca silenciado):

| quebra | resultado |
|---|---|
| A) `já resolvidos` sem condicional | ✗ `Expected: "= pivô, 1 já resolvido"` / `Received: "= pivô, 1 já resolvidos"` |
| B) a moldura antiga | ✗ `Expected: "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."` / `Received: "Depois da primeira partição sobram nenhum subproblema: acabou aqui para a recursão resolver."` |

**Diff de literais de tela** (`scripts/guarda-idioma.py`, antes contra depois) — só as duas frases se mexeram:

```
SUMIRAM:      '= pivô, § já resolvidos'   'nenhum subproblema: acabou aqui'
APARECERAM:   '= pivô, § já resolvido§'   'não sobrou nada para a recursão'   's'  'sobra'  'sobram'
```

**Conferência de viewport reaberta**, porque os dois consertos mudam string renderizada:

| | 390x844 | 1512x900 |
|---|---|---|
| overflow da página | não | não |
| frase (`.bb-formula-fim`) | 274/274, sem corte | 361/361, sem corte |
| faixa (`.ms-seg.pivo`), preset Todos iguais | 272/272, 9px, sem corte | 359/359, sem corte |

`npx tsc --noEmit` limpo. `npm run build` ✓.

## O que NÃO mudou

- Três arquivos, e só: `QuickSortTresVias.tsx`, `tests/viz-quick-sort.spec.ts` e **uma única asserção**
  de `tests/navegacao.spec.ts` (ver a seção abaixo).
- Os números da peça: comparações, profundidade e os tamanhos dos subproblemas saem dos mesmos geradores, intocados.
- Nenhum outro visualizador, nenhum `.mdx`, nenhum CSS, nenhuma config.

## A asserção que afirmava o texto quebrado veio junto

`tests/navegacao.spec.ts:1487` gravava o defeito no lugar:

```js
await expect(vias.locator(".ms-op").nth(1)).toContainText("nenhum subproblema");
```

Ela reprovava por **efeito direto deste conserto**, então veio no PR que a causou, em **commit separado** (`test(nav)`), e só ela mudou no arquivo. A forma nova lê a frase inteira no nó dela, que é o que a asserção antiga não fazia:

```js
await expect(vias.locator(".ms-op").nth(1).locator(".bb-formula-fim")).toHaveText(
  "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."
);
```

**Prova de quebra:** com a frase antiga de volta no componente (build refeito no meio), reprovam **os dois** specs — `navegacao.spec.ts:1490` e `viz-quick-sort.spec.ts:319`. A asserção está mesmo presa ao texto.

Suíte: **461 passed / 0 failed**.
## ✅ O conflito com o #48 foi resolvido (a `main` está mesclada)

O **#48 mergeou primeiro**, e o conflito previsto aqui virou real: `git merge-tree` acusava
`CONFLICT (content): Merge conflict in tests/navegacao.spec.ts`, no hunk que os dois PRs disputavam.

Seguido o caminho **"se o #48 mergear primeiro"**, escrito nesta descrição antes de alguém topar com ele.
A `main` (`899e38c`, que já traz o #48, o #50 e o #56) está mesclada na branch em `208d67e`.

**A resolução, e ela é uma linha e um comentário:**

- **Ficou a estrutura do #48**, por ser estritamente melhor *e* por ser necessária: o helper
  `const selo = (i) => vias.locator(".ms-op").nth(i).locator(".bb-formula-selo")` é usado
  **fora do hunk em conflito**, nas linhas 1626-1627 do preset "Sem repetição". Dropá-lo não
  compilaria, e os quatro `toHaveText` de comparações/profundidade que ele carrega seguem de pé
  — nenhuma asserção do #48 foi enfraquecida.
- **Trocou só a string da frase**, para o texto que este PR conserta.
- **Saiu o comentário `BUG DE PRODUTO`**, porque ele deixou de ser verdade: mandaria o próximo
  leitor procurar em `QuickSortTresVias.tsx:186-192` um defeito que este PR remove. No lugar
  dele ficou a nota que explica *por que a asserção lê a frase inteira*.

O diff da resolução contra a `main`, inteiro:

```diff
@@ -1614,12 +1614,11 @@ test("quick sort: o pior caso mora nas entradas mais comuns", ...
   const selo = (i: number) => vias.locator(".ms-op").nth(i).locator(".bb-formula-selo");
   await expect(selo(0)).toHaveText("28 comparações · profundidade 8");
   await expect(selo(1)).toHaveText("16 comparações · profundidade 1");
-  // BUG DE PRODUTO (não é desta lane): o ramo sem subproblema entra no meio da
-  // frase e produz "sobram nenhum subproblema: acabou aqui para a recursão
-  // resolver" — QuickSortTresVias.tsx:186-192. A asserção grava o texto ATUAL,
-  // para que o conserto seja um diff visível em vez de passar despercebido.
+  // A frase inteira, no nó dela: o ramo sem subproblema deixou de entrar no
+  // meio de uma moldura fixa, e a asserção antiga (`toContainText("nenhum
+  // subproblema")`) gravava justamente o texto quebrado.
   await expect(vias.locator(".ms-op").nth(1).locator(".bb-formula-fim")).toHaveText(
-    "Depois da primeira partição sobram nenhum subproblema: acabou aqui para a recursão resolver."
+    "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."
   );
```

`tests/viz-quick-sort.spec.ts` mesclou sozinho: a `main` mexeu no `figArtigo` (o comparador de
pivôs entrou na casca pelo #56 e `figure.viz-fit` deixou de identificar uma peça só), e este PR
mexe no `figTresVias`, que é outro bloco. As três figuras da página continuam três, e o
`figTresVias` confere o título antes de medir, em vez de confiar no `.nth(2)`.

### A prova de quebra, refeita sobre a `main` nova

Com a moldura antiga de volta em `QuickSortTresVias.tsx` (build refeito, nunca silenciado; o
arquivo restaurado de cópia em diretório temporário, não com `git checkout --`), **os dois specs
reprovam na linha da asserção, com o texto antigo no `Received`** — não por timeout de locator:

```
1) tests/navegacao.spec.ts:1561 › quick sort: o pior caso mora nas entradas mais comuns
   Expected: "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."
   Received: "Depois da primeira partição sobram nenhum subproblema: acabou aqui para a recursão resolver."
     at tests/navegacao.spec.ts:1620:74

2) tests/viz-quick-sort.spec.ts:310 › três vias: quando a partição resolve tudo, a frase não
   promete subproblema nenhum
   Expected: "A primeira partição resolveu o array inteiro: não sobrou nada para a recursão."
   Received: "Depois da primeira partição sobram nenhum subproblema: acabou aqui para a recursão resolver."
     at tests/viz-quick-sort.spec.ts:327:62

2 failed · 113 passed
```

O log do Playwright mostra `24 × locator resolved to <p class="bb-formula-fim">` com o valor
errado: o elemento estava lá e o texto é que não batia, que é o critério.

### Depois do merge

| | resultado |
|---|---|
| suíte inteira (`npm run test:build`, `PORT=4461`) | **556 passed / 0 failed**, 1,5 min |
| `npx tsc --noEmit` | limpo |
| `npx eslint .` | **6 avisos, 0 erros** — os 6 em `Shell.tsx`, `visualizer.tsx` e `ProgressProvider.tsx`, todos `react-hooks/set-state-in-effect` e **nenhum em arquivo deste PR** |
| guarda de commit | 4 commits, 4 `✓` (o commit de merge fica de fora: `@commitlint/config-conventional` ignora merges por padrão) |

Nenhum flake apareceu, inclusive na primeira rodada depois do build — nem o de
`viz-strings.spec.ts`, o que é coerente com o #53 já estar na `main`.

**Conferência de viewport reaberta** contra o build novo, medindo o elemento e comparando com
`documentElement.clientWidth`:

| | 390x844 | 1512x900 |
|---|---|---|
| rolagem horizontal da página | não | não |
| frase, preset "Todos iguais" | 274/274, inteira | 361/361, inteira |
| frase, preset "Sem repetição" | 274/274, inteira | 361/361, inteira |
| faixa `= pivô, 8 já resolvidos` | 272/272, inteira | 359/359, inteira |
| faixa `= pivô, 1 já resolvido` | **123 em 30px, cortada** | **140 em 41px, cortada** |

A última linha é o defeito de CSS já descrito abaixo, anterior a este PR e fora dele.

## O que ficou de fora, e por quê

**A faixa de um elemento só é cortada, e isso é anterior a este PR.** No preset "Sem repetição" o rótulo do meio ocupa uma coluna do grid: precisa de **140px e recebe 41px** no desktop (**123px em 30px** no celular). Com `.ms-seg { white-space: nowrap; overflow: hidden }` (`globals.css:1620`), o aluno vê o rótulo cortado, inclusive a concordância que este PR arruma. O texto do DOM está certo (é o que o leitor de tela lê). Fica como PR próprio: o `globals.css` tem dois PRs abertos em cima.


