### PR TITLE
Casca adaptativa nas cinco peças mudas do grupo Ordenação

### DIFF
--- a/content/visualizers/HeapSortEstabilidade.tsx
+++ b/content/visualizers/HeapSortEstabilidade.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // HeapSortEstabilidade, o preço que o heap sort cobra e quase ninguém enxerga.
@@ -18,17 +19,23 @@ import { useMemo, useState } from "react";
 //
 // Os dois algoritmos rodam de verdade no componente (nada de resultado fixo),
 // e as inversões são detectadas comparando a posição ORIGINAL de cada empate.
+//
+// Sobre a casca: `total: 1` e `collapsible: false`. Não há passo a passo nem
+// bloco dispensável — as três filas e a explicação SÃO o conteúdo. Esta é a
+// peça mais baixa da rodada, e mesmo assim precisa do painel: cabe a 1512x900
+// (712px de 816) e passa do orçamento a 1440x700 (712 de 616) e a 390x844
+// (1.240 de 760).
 // ---------------------------------------------------------------------------
 
-type Reg = { chave: number; nome: string; orig: number };
+type Rec = { key: number; name: string; orig: number };
 
-type Preset = { key: string; rotulo: string; dados: [number, string][]; dica: string };
+type Preset = { key: string; label: string; data: [number, string][]; hint: string };
 
 const PRESETS: Preset[] = [
   {
     key: "nomes",
-    rotulo: "Lista ordenada por nome, reordenando por idade",
-    dados: [
+    label: "Lista ordenada por nome, reordenando por idade",
+    data: [
       [3, "Ana"],
       [5, "Bia"],
       [3, "Caio"],
@@ -36,104 +43,104 @@ const PRESETS: Preset[] = [
       [5, "Enzo"],
       [2, "Fran"],
     ],
-    dica: "A entrada está em ordem alfabética. Ordenando por idade, o esperado é que dentro de cada idade os nomes continuem alfabéticos, e é isso que o sort estável entrega.",
+    hint: "A entrada está em ordem alfabética. Ordenando por idade, o esperado é que dentro de cada idade os nomes continuem alfabéticos, e é isso que o sort estável entrega.",
   },
   {
     key: "empate",
-    rotulo: "Um empate que sobrevive por sorte",
-    dados: [
+    label: "Um empate que sobrevive por sorte",
+    data: [
       [7, "sete"],
       [4, "quatro-a"],
       [9, "nove"],
       [4, "quatro-b"],
       [1, "um"],
     ],
-    dica: "Aqui o heap sort devolve o mesmo resultado do estável, e é justamente esse o perigo: instável não quer dizer sempre errado, quer dizer sem garantia. Um código apoiado neste comportamento passa nos testes e quebra quando um dado muda.",
+    hint: "Aqui o heap sort devolve o mesmo resultado do estável, e é justamente esse o perigo: instável não quer dizer sempre errado, quer dizer sem garantia. Um código apoiado neste comportamento passa nos testes e quebra quando um dado muda.",
   },
   {
     key: "iguais",
-    rotulo: "Chaves todas iguais",
-    dados: [
+    label: "Chaves todas iguais",
+    data: [
       [4, "p"],
       [4, "q"],
       [4, "r"],
       [4, "s"],
       [4, "t"],
     ],
-    dica: "Caso extremo: como toda comparação empata, o sort estável não move ninguém e o heap sort embaralha à vontade. Os dois resultados estão corretos pela chave.",
+    hint: "Caso extremo: como toda comparação empata, o sort estável não move ninguém e o heap sort embaralha à vontade. Os dois resultados estão corretos pela chave.",
   },
 ];
 
 // Insertion sort: estável por construção, porque só desloca enquanto o de trás
 // for ESTRITAMENTE maior. Empate nunca provoca troca.
-function ordenacaoEstavel(reg: Reg[]): Reg[] {
-  const a = reg.map((r) => ({ ...r }));
+function stableSort(recs: Rec[]): Rec[] {
+  const a = recs.map((r) => ({ ...r }));
   for (let i = 1; i < a.length; i++) {
-    const atual = a[i];
+    const current = a[i];
     let j = i - 1;
-    while (j >= 0 && a[j].chave > atual.chave) {
+    while (j >= 0 && a[j].key > current.key) {
       a[j + 1] = a[j];
       j--;
     }
-    a[j + 1] = atual;
+    a[j + 1] = current;
   }
   return a;
 }
 
 // Heap sort, exatamente o mesmo algoritmo da outra visualização, só que
-// comparando o campo `chave` de um registro em vez de um número solto.
-function heapSort(reg: Reg[]): Reg[] {
-  const a = reg.map((r) => ({ ...r }));
+// comparando o campo `key` de um registro em vez de um número solto.
+function heapSort(recs: Rec[]): Rec[] {
+  const a = recs.map((r) => ({ ...r }));
   const n = a.length;
-  const desce = (i: number, limite: number) => {
-    let guarda = 0;
-    while (guarda++ < 200) {
-      let maior = i;
-      const e = 2 * i + 1;
-      const d = 2 * i + 2;
-      if (e < limite && a[e].chave > a[maior].chave) maior = e;
-      if (d < limite && a[d].chave > a[maior].chave) maior = d;
-      if (maior === i) return;
-      [a[i], a[maior]] = [a[maior], a[i]];
-      i = maior;
+  const siftDown = (i: number, limit: number) => {
+    let guard = 0;
+    while (guard++ < 200) {
+      let largest = i;
+      const l = 2 * i + 1;
+      const r = 2 * i + 2;
+      if (l < limit && a[l].key > a[largest].key) largest = l;
+      if (r < limit && a[r].key > a[largest].key) largest = r;
+      if (largest === i) return;
+      [a[i], a[largest]] = [a[largest], a[i]];
+      i = largest;
     }
   };
-  for (let i = Math.floor(n / 2) - 1; i >= 0; i--) desce(i, n);
-  for (let fim = n - 1; fim > 0; fim--) {
-    [a[0], a[fim]] = [a[fim], a[0]];
-    desce(0, fim);
+  for (let i = Math.floor(n / 2) - 1; i >= 0; i--) siftDown(i, n);
+  for (let end = n - 1; end > 0; end--) {
+    [a[0], a[end]] = [a[end], a[0]];
+    siftDown(0, end);
   }
   return a;
 }
 
 // Um empate inverteu se, entre dois registros de mesma chave, o que veio depois
 // na entrada aparece antes na saída.
-function invertidos(saida: Reg[]): Set<number> {
-  const marcados = new Set<number>();
-  for (let i = 0; i < saida.length; i++) {
-    for (let j = i + 1; j < saida.length; j++) {
-      if (saida[i].chave === saida[j].chave && saida[i].orig > saida[j].orig) {
-        marcados.add(saida[i].orig);
-        marcados.add(saida[j].orig);
+function inverted(output: Rec[]): Set<number> {
+  const marked = new Set<number>();
+  for (let i = 0; i < output.length; i++) {
+    for (let j = i + 1; j < output.length; j++) {
+      if (output[i].key === output[j].key && output[i].orig > output[j].orig) {
+        marked.add(output[i].orig);
+        marked.add(output[j].orig);
       }
     }
   }
-  return marcados;
+  return marked;
 }
 
-function Fila({ regs, marcados, titulo, selo }: { regs: Reg[]; marcados: Set<number>; titulo: string; selo: string }) {
+function Fila({ recs, marked, title, badge }: { recs: Rec[]; marked: Set<number>; title: string; badge: string }) {
   return (
     <div className="hs-fila">
       <div className="hs-fila-cab">
-        <span className="hs-fila-tit">{titulo}</span>
-        <span className={`hs-fila-selo${marcados.size > 0 ? " quebrou" : ""}`}>{selo}</span>
+        <span className="hs-fila-tit">{title}</span>
+        <span className={`hs-fila-selo${marked.size > 0 ? " quebrou" : ""}`}>{badge}</span>
       </div>
       <div className="hp-arr">
-        {regs.map((r) => (
-          <span key={r.orig} className={`hp-cel reg${marcados.has(r.orig) ? " inverteu" : ""}`}>
+        {recs.map((r) => (
+          <span key={r.orig} className={`hp-cel reg${marked.has(r.orig) ? " inverteu" : ""}`}>
             <i>entrou em {r.orig}</i>
-            <b>{r.chave}</b>
-            <em>{r.nome}</em>
+            <b>{r.key}</b>
+            <em>{r.name}</em>
           </span>
         ))}
       </div>
@@ -145,45 +152,49 @@ export function HeapSortEstabilidade() {
   const [presetKey, setPresetKey] = useState("nomes");
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
 
-  const entrada: Reg[] = useMemo(
-    () => preset.dados.map(([chave, nome], orig) => ({ chave, nome, orig })),
+  const input: Rec[] = useMemo(
+    () => preset.data.map(([key, name], orig) => ({ key, name, orig })),
     [preset]
   );
-  const estavel = useMemo(() => ordenacaoEstavel(entrada), [entrada]);
-  const doHeap = useMemo(() => heapSort(entrada), [entrada]);
-  const marcasHeap = useMemo(() => invertidos(doHeap), [doHeap]);
-  const marcasEstavel = useMemo(() => invertidos(estavel), [estavel]);
+  const stable = useMemo(() => stableSort(input), [input]);
+  const fromHeap = useMemo(() => heapSort(input), [input]);
+  const tiesHeap = useMemo(() => inverted(fromHeap), [fromHeap]);
+  const tiesStable = useMemo(() => inverted(stable), [stable]);
 
-  const chavesOk = useMemo(
-    () => doHeap.map((r) => r.chave).join(",") === estavel.map((r) => r.chave).join(","),
-    [doHeap, estavel]
+  const sameKeys = useMemo(
+    () => fromHeap.map((r) => r.key).join(",") === stable.map((r) => r.key).join(","),
+    [fromHeap, stable]
   );
 
   // O primeiro par que trocou de lugar, para a explicação citar nomes de verdade.
-  const parTrocado = useMemo(() => {
-    for (let i = 0; i < doHeap.length; i++) {
-      for (let j = i + 1; j < doHeap.length; j++) {
-        if (doHeap[i].chave === doHeap[j].chave && doHeap[i].orig > doHeap[j].orig) {
-          return { antes: doHeap[j], depois: doHeap[i] };
+  const swappedPair = useMemo(() => {
+    for (let i = 0; i < fromHeap.length; i++) {
+      for (let j = i + 1; j < fromHeap.length; j++) {
+        if (fromHeap[i].key === fromHeap[j].key && fromHeap[i].orig > fromHeap[j].orig) {
+          return { before: fromHeap[j], after: fromHeap[i] };
         }
       }
     }
     return null;
-  }, [doHeap]);
+  }, [fromHeap]);
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o que &quot;instável&quot; significa na prática</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">{marcasHeap.size > 0 ? `${marcasHeap.size} registros fora da ordem original` : "nenhum empate trocou desta vez"}</span>
-        </div>
-      </div>
+  const viz = useVisualizer({
+    title: 'Visualizador · o que "instável" significa na prática',
+    // Sem linha do tempo: a variável é o preset, não o tempo.
+    total: 1,
+    // Sem bloco dispensável: as três filas e a explicação são o conteúdo.
+    collapsible: false,
+  });
 
-      <div className="viz-body">
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem "passo N de M": entra o número que resume o estado, com o rótulo
+          junto, como manda a §6 do contrato. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">{tiesHeap.size > 0 ? `${tiesHeap.size} registros fora da ordem original` : "nenhum empate trocou desta vez"}</span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
@@ -192,27 +203,27 @@ export function HeapSortEstabilidade() {
               onClick={() => setPresetKey(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="hs-filas">
-          <Fila regs={entrada} marcados={new Set()} titulo="Entrada" selo="como chegou" />
-          <Fila regs={estavel} marcados={marcasEstavel} titulo="Ordenação estável (insertion sort)" selo={marcasEstavel.size > 0 ? "quebrou" : "empates preservados"} />
-          <Fila regs={doHeap} marcados={marcasHeap} titulo="Heap sort" selo={marcasHeap.size > 0 ? "empates trocados" : "empates preservados"} />
+          <Fila recs={input} marked={new Set()} title="Entrada" badge="como chegou" />
+          <Fila recs={stable} marked={tiesStable} title="Ordenação estável (insertion sort)" badge={tiesStable.size > 0 ? "quebrou" : "empates preservados"} />
+          <Fila recs={fromHeap} marked={tiesHeap} title="Heap sort" badge={tiesHeap.size > 0 ? "empates trocados" : "empates preservados"} />
         </div>
 
-        <p className={`viz-note${marcasHeap.size > 0 ? " invalid" : " ok"}`}>
-          {parTrocado ? (
+        <p className={`viz-note${tiesHeap.size > 0 ? " invalid" : " ok"}`}>
+          {swappedPair ? (
             <>
-              As duas saídas estão <strong>corretas pela chave</strong>: {chavesOk ? "a sequência de chaves é idêntica nas duas" : "as chaves saem em ordem crescente nas duas"}. O que mudou foi o
-              desempate. <strong>{parTrocado.depois.nome}</strong> entrou na posição {parTrocado.depois.orig} e{" "}
-              <strong>{parTrocado.antes.nome}</strong> na posição {parTrocado.antes.orig}, os dois com chave{" "}
-              {parTrocado.antes.chave}. O sort estável manteve essa ordem; o heap sort devolveu{" "}
-              {parTrocado.depois.nome} na frente. Ninguém errou uma comparação: é que o heap arranca o último
+              As duas saídas estão <strong>corretas pela chave</strong>: {sameKeys ? "a sequência de chaves é idêntica nas duas" : "as chaves saem em ordem crescente nas duas"}. O que mudou foi o
+              desempate. <strong>{swappedPair.after.name}</strong> entrou na posição {swappedPair.after.orig} e{" "}
+              <strong>{swappedPair.before.name}</strong> na posição {swappedPair.before.orig}, os dois com chave{" "}
+              {swappedPair.before.key}. O sort estável manteve essa ordem; o heap sort devolveu{" "}
+              {swappedPair.after.name} na frente. Ninguém errou uma comparação: é que o heap arranca o último
               elemento do array e joga na raiz, e esse salto não tem como respeitar de onde o registro veio.
             </>
           ) : (
@@ -228,6 +239,9 @@ export function HeapSortEstabilidade() {
           duas chaves de uma vez, na mesma função de comparação, em vez de ordenar duas vezes.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o rodapé não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/HeapSortVisualizer.tsx
+++ b/content/visualizers/HeapSortVisualizer.tsx
@@ -269,6 +269,14 @@ export function HeapSortVisualizer() {
   const phaseLabel =
     s.phase === "build" ? "fase 1 · virando max-heap" : s.phase === "sort" ? "fase 2 · arrancando o maior" : "pronto";
 
+  // Com o heap vazio não existe faixa de posições a nomear. O `Math.max(n-1,0)`
+  // que estava aqui fabricava um "posições 0 a 0" no último passo, afirmando
+  // que a posição 0 ainda está no heap: exatamente o que o desenho ao lado nega
+  // ("heap vazio: tudo virou resultado"). E o pior é que essa frase é a MESMA
+  // do passo com n = 1, onde ela é verdadeira: dois estados diferentes com o
+  // mesmo texto, e um deles mentindo.
+  const heapRange = s.n > 0 ? `heap ativo: posições 0 a ${s.n - 1}` : "heap vazio";
+
   return viz.inPanel(
     <figure {...viz.figureProps} style={{ margin: 0 }}>
       <VizHeader viz={viz} />
@@ -295,7 +303,7 @@ export function HeapSortVisualizer() {
         <div className={`hs-fase f-${PHASE_CLASS[s.phase]}`}>
           <span className="hs-fase-selo">{phaseLabel}</span>
           <span className="hs-fase-txt">
-            heap ativo: posições 0 a {Math.max(s.n - 1, 0)} · já ordenado: {sortedCount} de {s.arr.length}
+            {heapRange} · já ordenado: {sortedCount} de {s.arr.length}
           </span>
         </div>
 

--- a/content/visualizers/MergeEmpate.tsx
+++ b/content/visualizers/MergeEmpate.tsx
@@ -30,7 +30,7 @@ import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 type Rec = { key: number; tag: string; orig: number };
 
-type Decision = { left: Rec | null; right: Rec | null; tie: boolean; chosen: Rec; side: "left" | "right" };
+type Decision = { left: Rec | null; right: Rec | null; tie: boolean; chosen: Rec };
 
 type Preset = { key: string; label: string; data: [number, string][]; hint: string };
 
@@ -89,7 +89,6 @@ function merge(left: Rec[], right: Rec[], strict: boolean): { output: Rec[]; dec
       right: hasRight ? right[j] : null,
       tie: hasLeft && hasRight && left[i].key === right[j].key,
       chosen,
-      side: takeLeft ? "left" : "right",
     });
     output.push(chosen);
     if (takeLeft) i++;

--- a/content/visualizers/MergeEmpate.tsx
+++ b/content/visualizers/MergeEmpate.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // MergeEmpate, o caractere que decide a estabilidade do merge sort.
@@ -19,19 +20,25 @@ import { useMemo, useState } from "react";
 // Interativo sem linha do tempo de propósito. A variável aqui é o OPERADOR, e
 // dar um botão de play sobre uma intercalação de seis elementos empurraria a
 // atenção para o passo a passo, que é assunto do visualizador principal.
+//
+// Sobre a casca: `total: 1` e `collapsible: false`. Não há passo a passo nem
+// bloco dispensável — as duas colunas e a lista de decisões SÃO o conteúdo. O
+// que a peça ganha é o painel expandido com o cabeçalho parado enquanto o miolo
+// rola, e ela precisa: o preset das linhas de log pede 1.205px de um orçamento
+// de 816 a 1512x900, e 2.185 de 760 a 390x844.
 // ---------------------------------------------------------------------------
 
-type Reg = { chave: number; etiq: string; orig: number };
+type Rec = { key: number; tag: string; orig: number };
 
-type Decisao = { esq: Reg | null; dir: Reg | null; empate: boolean; escolhido: Reg; lado: "esq" | "dir" };
+type Decision = { left: Rec | null; right: Rec | null; tie: boolean; chosen: Rec; side: "left" | "right" };
 
-type Preset = { key: string; rotulo: string; dados: [number, string][]; dica: string };
+type Preset = { key: string; label: string; data: [number, string][]; hint: string };
 
 const PRESETS: Preset[] = [
   {
     key: "logs",
-    rotulo: "Linhas de log com o mesmo segundo",
-    dados: [
+    label: "Linhas de log com o mesmo segundo",
+    data: [
       [12, "erro-A"],
       [9, "info-B"],
       [12, "erro-C"],
@@ -39,82 +46,82 @@ const PRESETS: Preset[] = [
       [9, "warn-E"],
       [12, "erro-F"],
     ],
-    dica: "Três linhas caíram no segundo 12 e duas no segundo 9. Ordenar por horário não pode embaralhar a ordem em que elas foram escritas, senão a leitura do incidente conta a história errada.",
+    hint: "Três linhas caíram no segundo 12 e duas no segundo 9. Ordenar por horário não pode embaralhar a ordem em que elas foram escritas, senão a leitura do incidente conta a história errada.",
   },
   {
     key: "um",
-    rotulo: "Um único empate, no fim da intercalação",
-    dados: [
+    label: "Um único empate, no fim da intercalação",
+    data: [
       [3, "a"],
       [5, "b"],
       [1, "c"],
       [5, "d"],
     ],
-    dica: "O menor exemplo que quebra: duas chaves 5, uma em cada metade. Repare que as duas versões tomam decisões idênticas até chegar nesse empate, e só ali se separam.",
+    hint: "O menor exemplo que quebra: duas chaves 5, uma em cada metade. Repare que as duas versões tomam decisões idênticas até chegar nesse empate, e só ali se separam.",
   },
   {
     key: "todos",
-    rotulo: "Chaves todas iguais",
-    dados: [
+    label: "Chaves todas iguais",
+    data: [
       [4, "p"],
       [4, "q"],
       [4, "r"],
       [4, "s"],
     ],
-    dica: "Caso extremo: como toda comparação é um empate, o operador decide tudo. Com <= a saída é idêntica à entrada; com < as duas metades trocam de lugar inteiras.",
+    hint: "Caso extremo: como toda comparação é um empate, o operador decide tudo. Com <= a saída é idêntica à entrada; com < as duas metades trocam de lugar inteiras.",
   },
 ];
 
 // Merge de duas metades já ordenadas, com o operador escolhido. É a única
 // diferença entre as duas colunas: o resto do algoritmo é idêntico.
-function intercalar(esq: Reg[], dir: Reg[], estrito: boolean): { saida: Reg[]; decisoes: Decisao[] } {
-  const saida: Reg[] = [];
-  const decisoes: Decisao[] = [];
+function merge(left: Rec[], right: Rec[], strict: boolean): { output: Rec[]; decisions: Decision[] } {
+  const output: Rec[] = [];
+  const decisions: Decision[] = [];
   let i = 0;
   let j = 0;
-  while (i < esq.length || j < dir.length) {
-    const temE = i < esq.length;
-    const temD = j < dir.length;
-    const pegaEsq = !temD || (temE && (estrito ? esq[i].chave < dir[j].chave : esq[i].chave <= dir[j].chave));
-    const escolhido = pegaEsq ? esq[i] : dir[j];
-    decisoes.push({
-      esq: temE ? esq[i] : null,
-      dir: temD ? dir[j] : null,
-      empate: temE && temD && esq[i].chave === dir[j].chave,
-      escolhido,
-      lado: pegaEsq ? "esq" : "dir",
+  while (i < left.length || j < right.length) {
+    const hasLeft = i < left.length;
+    const hasRight = j < right.length;
+    const takeLeft = !hasRight || (hasLeft && (strict ? left[i].key < right[j].key : left[i].key <= right[j].key));
+    const chosen = takeLeft ? left[i] : right[j];
+    decisions.push({
+      left: hasLeft ? left[i] : null,
+      right: hasRight ? right[j] : null,
+      tie: hasLeft && hasRight && left[i].key === right[j].key,
+      chosen,
+      side: takeLeft ? "left" : "right",
     });
-    saida.push(escolhido);
-    if (pegaEsq) i++;
+    output.push(chosen);
+    if (takeLeft) i++;
     else j++;
   }
-  return { saida, decisoes };
+  return { output, decisions };
 }
 
-function invertidos(saida: Reg[]): Set<number> {
-  const marcados = new Set<number>();
-  for (let i = 0; i < saida.length; i++)
-    for (let j = i + 1; j < saida.length; j++)
-      if (saida[i].chave === saida[j].chave && saida[i].orig > saida[j].orig) {
-        marcados.add(saida[i].orig);
-        marcados.add(saida[j].orig);
+function inverted(output: Rec[]): Set<number> {
+  const marked = new Set<number>();
+  for (let i = 0; i < output.length; i++)
+    for (let j = i + 1; j < output.length; j++)
+      if (output[i].key === output[j].key && output[i].orig > output[j].orig) {
+        marked.add(output[i].orig);
+        marked.add(output[j].orig);
       }
-  return marcados;
+  return marked;
 }
 
-function Fila({ regs, marcados, titulo, selo }: { regs: Reg[]; marcados: Set<number>; titulo: string; selo?: string }) {
+function Fila({ recs, marked, title, badge }: { recs: Rec[]; marked: Set<number>; title: string; badge?: string }) {
   return (
     <div className="hs-fila">
       <div className="hs-fila-cab">
-        <span className="hs-fila-tit">{titulo}</span>
-        {selo ? <span className={`hs-fila-selo${marcados.size > 0 ? " quebrou" : ""}`}>{selo}</span> : null}
+        <span className="hs-fila-tit">{title}</span>
+        {badge ? <span className={`hs-fila-selo${marked.size > 0 ? " quebrou" : ""}`}>{badge}</span> : null}
       </div>
       <div className="hp-arr">
-        {regs.map((r) => (
-          <span key={r.orig} className={`hp-cel reg${marcados.has(r.orig) ? " inverteu" : ""}`}>
+        {recs.map((r) => (
+          <span key={r.orig} className={`hp-cel reg${marked.has(r.orig) ? " inverteu" : ""}`}>
             <i>entrou em {r.orig}</i>
-            <b>{r.chave}</b>
-            <em>{r.etiq}</em>
+            <b>{r.key}</b>
+            <em>{r.tag}</em>
           </span>
         ))}
       </div>
@@ -126,52 +133,56 @@ export function MergeEmpate() {
   const [presetKey, setPresetKey] = useState("logs");
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
 
-  const entrada: Reg[] = useMemo(
-    () => preset.dados.map(([chave, etiq], orig) => ({ chave, etiq, orig })),
+  const input: Rec[] = useMemo(
+    () => preset.data.map(([key, tag], orig) => ({ key, tag, orig })),
     [preset]
   );
 
   // As duas metades chegam à intercalação final já ordenadas, exatamente como a
   // recursão as devolveria. Ordenar cada uma de forma estável aqui é o que
   // reproduz esse estado sem precisar rodar a recursão inteira.
-  const [esq, dir] = useMemo(() => {
-    const meio = Math.ceil(entrada.length / 2);
-    const estavel = (v: Reg[]) => [...v].sort((x, y) => x.chave - y.chave || x.orig - y.orig);
-    return [estavel(entrada.slice(0, meio)), estavel(entrada.slice(meio))];
-  }, [entrada]);
+  const [left, right] = useMemo(() => {
+    const mid = Math.ceil(input.length / 2);
+    const stable = (v: Rec[]) => [...v].sort((x, y) => x.key - y.key || x.orig - y.orig);
+    return [stable(input.slice(0, mid)), stable(input.slice(mid))];
+  }, [input]);
 
-  const comIgual = useMemo(() => intercalar(esq, dir, false), [esq, dir]);
-  const comEstrito = useMemo(() => intercalar(esq, dir, true), [esq, dir]);
-  const mIgual = useMemo(() => invertidos(comIgual.saida), [comIgual]);
-  const mEstrito = useMemo(() => invertidos(comEstrito.saida), [comEstrito]);
+  const withLte = useMemo(() => merge(left, right, false), [left, right]);
+  const withLt = useMemo(() => merge(left, right, true), [left, right]);
+  const tiesLte = useMemo(() => inverted(withLte.output), [withLte]);
+  const tiesLt = useMemo(() => inverted(withLt.output), [withLt]);
 
   // O primeiro passo em que as duas versões escolhem lados diferentes.
-  const divergencia = useMemo(() => {
-    for (let k = 0; k < comIgual.decisoes.length; k++)
-      if (comIgual.decisoes[k].escolhido.orig !== comEstrito.decisoes[k].escolhido.orig) return k;
+  const divergence = useMemo(() => {
+    for (let k = 0; k < withLte.decisions.length; k++)
+      if (withLte.decisions[k].chosen.orig !== withLt.decisions[k].chosen.orig) return k;
     return -1;
-  }, [comIgual, comEstrito]);
+  }, [withLte, withLt]);
 
-  const chavesIguais =
-    comIgual.saida.map((r) => r.chave).join(",") === comEstrito.saida.map((r) => r.chave).join(",");
+  const sameKeys =
+    withLte.output.map((r) => r.key).join(",") === withLt.output.map((r) => r.key).join(",");
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o sinal que decide a estabilidade</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {divergencia >= 0
-              ? `as duas versões se separam na decisão ${divergencia + 1}`
-              : "nenhum empate nesta entrada: as duas versões coincidem"}
-          </span>
-        </div>
-      </div>
+  const viz = useVisualizer({
+    title: "Visualizador · o sinal que decide a estabilidade",
+    // Sem linha do tempo: a variável é o operador, não o tempo.
+    total: 1,
+    // Sem bloco dispensável: as duas colunas e a lista de decisões são o conteúdo.
+    collapsible: false,
+  });
 
-      <div className="viz-body">
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem "passo N de M": entra o número que resume o estado, com o rótulo
+          junto, como manda a §6 do contrato. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {divergence >= 0
+            ? `as duas versões se separam na decisão ${divergence + 1}`
+            : "nenhum empate nesta entrada: as duas versões coincidem"}
+        </span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
@@ -180,31 +191,31 @@ export function MergeEmpate() {
               onClick={() => setPresetKey(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="hs-filas">
-          <Fila regs={entrada} marcados={new Set()} titulo="Entrada, na ordem em que chegou" />
-          <Fila regs={esq} marcados={new Set()} titulo="Metade esquerda, já ordenada pela recursão" />
-          <Fila regs={dir} marcados={new Set()} titulo="Metade direita, já ordenada pela recursão" />
+          <Fila recs={input} marked={new Set()} title="Entrada, na ordem em que chegou" />
+          <Fila recs={left} marked={new Set()} title="Metade esquerda, já ordenada pela recursão" />
+          <Fila recs={right} marked={new Set()} title="Metade direita, já ordenada pela recursão" />
         </div>
 
         <div className="ms-operadores">
           <div className="ms-op ok">
             <div className="bb-formula-cab">
               <span className="bb-formula-tit">esq[i] &lt;= dir[j]</span>
-              <span className="bb-formula-selo">{mIgual.size > 0 ? "empates trocados" : "estável"}</span>
+              <span className="bb-formula-selo">{tiesLte.size > 0 ? "empates trocados" : "estável"}</span>
             </div>
             <div className="hp-arr">
-              {comIgual.saida.map((r) => (
-                <span key={r.orig} className={`hp-cel reg${mIgual.has(r.orig) ? " inverteu" : ""}`}>
+              {withLte.output.map((r) => (
+                <span key={r.orig} className={`hp-cel reg${tiesLte.has(r.orig) ? " inverteu" : ""}`}>
                   <i>entrou em {r.orig}</i>
-                  <b>{r.chave}</b>
-                  <em>{r.etiq}</em>
+                  <b>{r.key}</b>
+                  <em>{r.tag}</em>
                 </span>
               ))}
             </div>
@@ -213,17 +224,17 @@ export function MergeEmpate() {
               antes, a ordem de chegada é preservada.
             </p>
           </div>
-          <div className={`ms-op${mEstrito.size > 0 ? " quebrou" : ""}`}>
+          <div className={`ms-op${tiesLt.size > 0 ? " quebrou" : ""}`}>
             <div className="bb-formula-cab">
               <span className="bb-formula-tit">esq[i] &lt; dir[j]</span>
-              <span className="bb-formula-selo">{mEstrito.size > 0 ? "empates trocados" : "coincidiu desta vez"}</span>
+              <span className="bb-formula-selo">{tiesLt.size > 0 ? "empates trocados" : "coincidiu desta vez"}</span>
             </div>
             <div className="hp-arr">
-              {comEstrito.saida.map((r) => (
-                <span key={r.orig} className={`hp-cel reg${mEstrito.has(r.orig) ? " inverteu" : ""}`}>
+              {withLt.output.map((r) => (
+                <span key={r.orig} className={`hp-cel reg${tiesLt.has(r.orig) ? " inverteu" : ""}`}>
                   <i>entrou em {r.orig}</i>
-                  <b>{r.chave}</b>
-                  <em>{r.etiq}</em>
+                  <b>{r.key}</b>
+                  <em>{r.tag}</em>
                 </span>
               ))}
             </div>
@@ -239,17 +250,17 @@ export function MergeEmpate() {
             As decisões da intercalação <em>a linha destacada é onde as duas versões se separam</em>
           </div>
           <ol className="bb-passos">
-            {comIgual.decisoes.map((d, k) => (
-              <li key={k} className={k === divergencia ? "ruim" : ""}>
+            {withLte.decisions.map((d, k) => (
+              <li key={k} className={k === divergence ? "ruim" : ""}>
                 <span>
-                  {d.esq ? `esquerda ${d.esq.chave} (${d.esq.etiq})` : "esquerda vazia"} contra{" "}
-                  {d.dir ? `direita ${d.dir.chave} (${d.dir.etiq})` : "direita vazia"}
-                  {d.empate ? ", empate" : ""}
+                  {d.left ? `esquerda ${d.left.key} (${d.left.tag})` : "esquerda vazia"} contra{" "}
+                  {d.right ? `direita ${d.right.key} (${d.right.tag})` : "direita vazia"}
+                  {d.tie ? ", empate" : ""}
                 </span>
                 <b>
-                  {d.escolhido.etiq}
-                  {comEstrito.decisoes[k].escolhido.orig !== d.escolhido.orig
-                    ? ` / com < sairia ${comEstrito.decisoes[k].escolhido.etiq}`
+                  {d.chosen.tag}
+                  {withLt.decisions[k].chosen.orig !== d.chosen.orig
+                    ? ` / com < sairia ${withLt.decisions[k].chosen.tag}`
                     : ""}
                 </b>
               </li>
@@ -257,12 +268,12 @@ export function MergeEmpate() {
           </ol>
         </div>
 
-        <p className={`viz-note${mEstrito.size > 0 ? " invalid" : " ok"}`}>
-          {divergencia >= 0 ? (
+        <p className={`viz-note${tiesLt.size > 0 ? " invalid" : " ok"}`}>
+          {divergence >= 0 ? (
             <>
               As duas saídas estão <strong>corretas pela chave</strong>
-              {chavesIguais ? ": a sequência de chaves é idêntica nas duas" : ""}. As decisões são as mesmas até
-              a de número {divergencia + 1}, que é o primeiro empate. Ali o operador escolhe: com{" "}
+              {sameKeys ? ": a sequência de chaves é idêntica nas duas" : ""}. As decisões são as mesmas até
+              a de número {divergence + 1}, que é o primeiro empate. Ali o operador escolhe: com{" "}
               <strong>&lt;=</strong> a condição é verdadeira e sai o da esquerda; com <strong>&lt;</strong> ela
               é falsa e sai o da direita. Um caractere separa um algoritmo estável de um instável, e nenhum
               teste que confira apenas a ordem das chaves consegue notar a diferença.
@@ -284,6 +295,9 @@ export function MergeEmpate() {
           lado é um trecho contíguo do array original.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o rodapé não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/MergeSortNiveis.tsx
+++ b/content/visualizers/MergeSortNiveis.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 import { segments } from "./MergeSortVisualizer";
 
 // ---------------------------------------------------------------------------
@@ -18,9 +19,16 @@ import { segments } from "./MergeSortVisualizer";
 // move menos que n e o card viraria uma meia verdade.
 //
 // Interativo sem linha do tempo: a variável é o TAMANHO da entrada, não o tempo.
+//
+// Sobre a casca: `total: 1` (não há passo a passo, e o número que resume o
+// estado entra no lugar do contador) e `collapsible: false` (não há bloco
+// dispensável — as faixas, os cartões e a tabela SÃO o conteúdo). O que a peça
+// ganha é o painel expandido com o cabeçalho parado enquanto o miolo rola, que
+// é justamente o que falta a ela: com n = 64 ela pede 1.001px de um orçamento
+// de 816 a 1512x900, e 1.015 de 616 a 1440x700.
 // ---------------------------------------------------------------------------
 
-const TAMANHOS = [8, 16, 32, 64];
+const SIZES = [8, 16, 32, 64];
 
 // Formatador determinístico: Intl.NumberFormat diverge entre build e cliente e
 // quebra a hidratação.
@@ -28,7 +36,7 @@ function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function compacto(v: number): string {
+function compact(v: number): string {
   if (v >= 1e15) return `${num(v / 1e15)} quatri`;
   if (v >= 1e12) return `${num(v / 1e12)} tri`;
   if (v >= 1e9) return `${num(v / 1e9)} bi`;
@@ -36,32 +44,40 @@ function compacto(v: number): string {
   return num(v);
 }
 
-const ESCALAS = [1_000, 1_000_000, 1_000_000_000];
+const SCALES = [1_000, 1_000_000, 1_000_000_000];
 
 export function MergeSortNiveis() {
   const [n, setN] = useState(16);
-  const niveis = useMemo(() => segments(n), [n]);
-  const rodadas = Math.log2(n); // n é sempre potência de 2 aqui
-  const movimentos = n * rodadas;
-  const quadratico = (n * (n - 1)) / 2;
+  const levels = useMemo(() => segments(n), [n]);
+  const rounds = Math.log2(n); // n é sempre potência de 2 aqui
+  const moves = n * rounds;
+  const quadratic = (n * (n - 1)) / 2;
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o n log n desenhado: altura vezes largura</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {rodadas} rodadas de intercalação x {n} elementos = {movimentos} movimentos
-          </span>
-        </div>
-      </div>
+  const viz = useVisualizer({
+    title: "Visualizador · o n log n desenhado: altura vezes largura",
+    // Sem linha do tempo: a variável é o tamanho da entrada, não o tempo.
+    total: 1,
+    // Sem bloco dispensável: as faixas, os cartões e a tabela são o conteúdo.
+    collapsible: false,
+    // `measureOn` fica de fora: com `collapsible: false` não há decisão a tomar
+    // e o hook nem espera as fontes. Passar a lista anunciaria uma medição que
+    // não acontece — e o eixo de altura desta peça (o `n`) é real, então a
+    // tentação de listá-lo é grande.
+  });
 
-      <div className="viz-body">
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem "passo N de M": o número que resume o estado entra no lugar dele,
+          com o rótulo junto, como manda a §6 do contrato. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {rounds} rodadas de intercalação x {n} elementos = {moves} movimentos
+        </span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {TAMANHOS.map((t) => (
+          {SIZES.map((t) => (
             <button key={t} className={`bigo-chip${n === t ? " on" : ""}`} onClick={() => setN(t)} aria-pressed={n === t}>
               n = {t}
             </button>
@@ -76,19 +92,19 @@ export function MergeSortNiveis() {
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
-            A recursão inteira <em>cada faixa soma {n} elementos, e são {rodadas} rodadas de intercalação</em>
+            A recursão inteira <em>cada faixa soma {n} elementos, e são {rounds} rodadas de intercalação</em>
           </div>
           <div className="ms-niveis">
-            {niveis.map((segs, prof) => (
-              <div className="ms-nivel" key={prof}>
+            {levels.map((segs, depth) => (
+              <div className="ms-nivel" key={depth}>
                 <span className="ms-nivel-rot">
-                  nível {prof} · {segs.length} trecho{segs.length === 1 ? "" : "s"} de {n / segs.length}
+                  nível {depth} · {segs.length} trecho{segs.length === 1 ? "" : "s"} de {n / segs.length}
                 </span>
                 <div className="ms-nivel-faixa" style={{ gridTemplateColumns: `repeat(${n}, minmax(0, 1fr))` }}>
                   {segs.map((s) => (
                     <span
                       key={`${s.lo}-${s.hi}`}
-                      className={`ms-seg${prof === niveis.length - 1 ? " folha" : ""}`}
+                      className={`ms-seg${depth === levels.length - 1 ? " folha" : ""}`}
                       style={{ gridColumn: `${s.lo + 1} / ${s.hi + 2}` }}
                     >
                       {n <= 16 ? (s.lo === s.hi ? s.lo : `${s.lo}..${s.hi}`) : ""}
@@ -107,23 +123,23 @@ export function MergeSortNiveis() {
           </div>
           <div className="bigo-stat">
             <span>rodadas de intercalação</span>
-            <strong>{rodadas}</strong>
+            <strong>{rounds}</strong>
           </div>
           <div className="bigo-stat">
             <span>movimentos totais</span>
-            <strong>{num(movimentos)}</strong>
+            <strong>{num(moves)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso de um O(n²)</span>
-            <strong>{num(quadratico)}</strong>
+            <strong>{num(quadratic)}</strong>
           </div>
         </div>
 
         <p className="viz-note ok">
-          Com {n} elementos dá para partir ao meio <strong>{rodadas} vezes</strong> antes de sobrar um elemento
-          por trecho, porque {n} = 2<sup>{rodadas}</sup>. Cada rodada de intercalação toca cada elemento uma vez
-          e só uma, então o trabalho de uma rodada é sempre {n}. O total é o produto: {n} x {rodadas} ={" "}
-          {num(movimentos)} movimentos. É literalmente isso que a notação n log n descreve, e é por isso que ela
+          Com {n} elementos dá para partir ao meio <strong>{rounds} vezes</strong> antes de sobrar um elemento
+          por trecho, porque {n} = 2<sup>{rounds}</sup>. Cada rodada de intercalação toca cada elemento uma vez
+          e só uma, então o trabalho de uma rodada é sempre {n}. O total é o produto: {n} x {rounds} ={" "}
+          {num(moves)} movimentos. É literalmente isso que a notação n log n descreve, e é por isso que ela
           vale no melhor, no médio e no pior caso: a estrutura da recursão não olha para os dados.
         </p>
 
@@ -143,21 +159,21 @@ export function MergeSortNiveis() {
                 </tr>
               </thead>
               <tbody>
-                {ESCALAS.map((e) => {
+                {SCALES.map((e) => {
                   const r = Math.ceil(Math.log2(e));
                   const ms = e * r;
                   const q = (e * (e - 1)) / 2;
                   return (
                     <tr key={e}>
-                      <td>{compacto(e)}</td>
+                      <td>{compact(e)}</td>
                       <td className="nums">{r}</td>
                       <td className="nums">
-                        <span className="hp-custo c-otimo">{compacto(ms)}</span>
+                        <span className="hp-custo c-otimo">{compact(ms)}</span>
                       </td>
                       <td className="nums">
-                        <span className="hp-custo c-ruim">{compacto(q)}</span>
+                        <span className="hp-custo c-ruim">{compact(q)}</span>
                       </td>
-                      <td className="nums">{compacto(q / ms)} vezes</td>
+                      <td className="nums">{compact(q / ms)} vezes</td>
                     </tr>
                   );
                 })}
@@ -173,6 +189,11 @@ export function MergeSortNiveis() {
           é a diferença entre 0,2 segundo e mais de uma hora.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o rodapé não desenha nada — é o
+          comportamento documentado do hook. Fica aqui para que acrescentar um
+          controle depois não passe por reescrever a casca à mão. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/OrdenacaoBasicaCorrida.tsx
+++ b/content/visualizers/OrdenacaoBasicaCorrida.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 import { ALGOS, NAMES, PRESETS, cost, inversions, type Algorithm } from "./OrdenacaoBasicaVisualizer";
 
 // ---------------------------------------------------------------------------
@@ -22,6 +23,11 @@ import { ALGOS, NAMES, PRESETS, cost, inversions, type Algorithm } from "./Orden
 // bubble paga 2 escritas por inversão, insertion paga 1 por inversão mais as
 // n - 1 colocações, e o selection não paga por inversão nenhuma. Sem ela as
 // barras seriam só três números bonitos sem explicação.
+//
+// Sobre a casca: `total: 1` e `collapsible: false`. Não há passo a passo nem
+// bloco dispensável — as seis barras e a lei das inversões SÃO o conteúdo. É a
+// peça da rodada em que a régua de 1512x900 mais engana: ali ela cabe (727px de
+// 816) e a 1440x700 passa do orçamento (748 de 616), que é o corolário da §3.
 // ---------------------------------------------------------------------------
 
 type Row = { algo: Algorithm; comps: number; writes: number };
@@ -53,21 +59,25 @@ export function OrdenacaoBasicaCorrida() {
   const floor = n - 1;
   const ceiling = (n * (n - 1)) / 2;
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o mesmo array custa três preços diferentes</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {inv} inversões na entrada · piso {floor}, teto {ceiling} comparações
-          </span>
-        </div>
-      </div>
+  const viz = useVisualizer({
+    title: "Visualizador · o mesmo array custa três preços diferentes",
+    // Sem linha do tempo: a variável é a entrada, e as seis barras respondem juntas.
+    total: 1,
+    // Sem bloco dispensável: as barras e a lei das inversões são o conteúdo.
+    collapsible: false,
+  });
 
-      <div className="viz-body">
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem "passo N de M": entra o número que resume o estado, com o rótulo
+          junto, como manda a §6 do contrato. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {inv} inversões na entrada · piso {floor}, teto {ceiling} comparações
+        </span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
@@ -124,6 +134,9 @@ export function OrdenacaoBasicaCorrida() {
           não são intercambiáveis: O(n²) é o teto, não a conta.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o rodapé não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/OrdenacaoBasicaEstabilidade.tsx
+++ b/content/visualizers/OrdenacaoBasicaEstabilidade.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // OrdenacaoBasicaEstabilidade, a distância do movimento como causa.
@@ -21,19 +22,25 @@ import { useMemo, useState } from "react";
 // adjacentes), e as inversões de empate são detectadas comparando a posição de
 // ENTRADA de cada registro. Nada de resultado fixo: trocar o preset não exige
 // reescrever nenhuma expectativa.
+//
+// Sobre a casca: `total: 1` e `collapsible: false`. Não há passo a passo nem
+// bloco dispensável — as quatro filas e a explicação SÃO o conteúdo. O que a
+// peça ganha é o painel expandido com o cabeçalho parado enquanto o miolo rola,
+// e ela precisa: pede 945px de um orçamento de 816 a 1512x900, 966 de 616 a
+// 1440x700 e 1.640 de 760 a 390x844.
 // ---------------------------------------------------------------------------
 
-type Reg = { chave: number; etiq: string; orig: number };
+type Rec = { key: number; tag: string; orig: number };
 
-type Saida = { regs: Reg[]; trocas: number; maiorSalto: number };
+type Result = { recs: Rec[]; swaps: number; longestSwap: number };
 
-type Preset = { key: string; rotulo: string; dados: [number, string][]; dica: string };
+type Preset = { key: string; label: string; data: [number, string][]; hint: string };
 
 const PRESETS: Preset[] = [
   {
     key: "chamados",
-    rotulo: "Chamados na ordem de chegada, ordenando por prioridade",
-    dados: [
+    label: "Chamados na ordem de chegada, ordenando por prioridade",
+    data: [
       [2, "#41"],
       [2, "#42"],
       [1, "#43"],
@@ -41,23 +48,23 @@ const PRESETS: Preset[] = [
       [3, "#45"],
       [5, "#46"],
     ],
-    dica: "A fila chegou em ordem e o critério de ordenação é a prioridade. O esperado é que, dentro da mesma prioridade, quem chegou antes continue sendo atendido antes.",
+    hint: "A fila chegou em ordem e o critério de ordenação é a prioridade. O esperado é que, dentro da mesma prioridade, quem chegou antes continue sendo atendido antes.",
   },
   {
     key: "sorte",
-    rotulo: "Um empate que sobrevive por sorte",
-    dados: [
+    label: "Um empate que sobrevive por sorte",
+    data: [
       [3, "#51"],
       [3, "#52"],
       [1, "#53"],
       [2, "#54"],
     ],
-    dica: "Aqui os três devolvem a mesma coisa, inclusive o selection sort. É justamente esse o perigo: instável quer dizer sem garantia, não sempre errado. Um código apoiado neste resultado passa nos testes hoje e quebra quando entrar mais um chamado.",
+    hint: "Aqui os três devolvem a mesma coisa, inclusive o selection sort. É justamente esse o perigo: instável quer dizer sem garantia, não sempre errado. Um código apoiado neste resultado passa nos testes hoje e quebra quando entrar mais um chamado.",
   },
   {
     key: "muitos",
-    rotulo: "Fila embaralhada, com empate em toda prioridade",
-    dados: [
+    label: "Fila embaralhada, com empate em toda prioridade",
+    data: [
       [3, "#61"],
       [2, "#62"],
       [3, "#63"],
@@ -65,93 +72,93 @@ const PRESETS: Preset[] = [
       [2, "#65"],
       [1, "#66"],
     ],
-    dica: "Com empate em todas as prioridades, o salto longo do selection sort tem muito mais chance de acontecer. Repare que ele erra em dois pares de uma vez, e que os outros dois continuam intactos.",
+    hint: "Com empate em todas as prioridades, o salto longo do selection sort tem muito mais chance de acontecer. Repare que ele erra em dois pares de uma vez, e que os outros dois continuam intactos.",
   },
 ];
 
 // Os três na forma baseada em TROCAS, para a distância de cada movimento ser
 // comparável entre eles. Cada troca é registrada, e é daí que sai o maior salto.
-function rodar(algo: "bubble" | "selection" | "insertion", entrada: Reg[]): Saida {
-  const a = entrada.map((r) => ({ ...r }));
+function run(algo: "bubble" | "selection" | "insertion", input: Rec[]): Result {
+  const a = input.map((r) => ({ ...r }));
   const n = a.length;
-  let trocas = 0;
-  let maiorSalto = 0;
-  const troca = (x: number, y: number) => {
+  let swaps = 0;
+  let longestSwap = 0;
+  const swap = (x: number, y: number) => {
     [a[x], a[y]] = [a[y], a[x]];
-    trocas++;
-    maiorSalto = Math.max(maiorSalto, Math.abs(x - y));
+    swaps++;
+    longestSwap = Math.max(longestSwap, Math.abs(x - y));
   };
 
   if (algo === "bubble") {
-    for (let fim = n - 1; fim > 0; fim--) {
-      let mexeu = false;
-      for (let j = 0; j < fim; j++)
-        if (a[j].chave > a[j + 1].chave) {
-          troca(j, j + 1);
-          mexeu = true;
+    for (let end = n - 1; end > 0; end--) {
+      let moved = false;
+      for (let j = 0; j < end; j++)
+        if (a[j].key > a[j + 1].key) {
+          swap(j, j + 1);
+          moved = true;
         }
-      if (!mexeu) break;
+      if (!moved) break;
     }
   } else if (algo === "selection") {
     for (let i = 0; i < n - 1; i++) {
-      let menor = i;
-      for (let j = i + 1; j < n; j++) if (a[j].chave < a[menor].chave) menor = j;
-      if (menor !== i) troca(i, menor);
+      let smallest = i;
+      for (let j = i + 1; j < n; j++) if (a[j].key < a[smallest].key) smallest = j;
+      if (smallest !== i) swap(i, smallest);
     }
   } else {
     for (let i = 1; i < n; i++) {
       let j = i;
-      while (j > 0 && a[j - 1].chave > a[j].chave) {
-        troca(j - 1, j);
+      while (j > 0 && a[j - 1].key > a[j].key) {
+        swap(j - 1, j);
         j--;
       }
     }
   }
-  return { regs: a, trocas, maiorSalto };
+  return { recs: a, swaps, longestSwap };
 }
 
 // Um empate inverteu se, entre dois registros de mesma chave, o que entrou
 // depois aparece antes na saída.
-function invertidos(saida: Reg[]): Set<number> {
-  const marcados = new Set<number>();
-  for (let i = 0; i < saida.length; i++)
-    for (let j = i + 1; j < saida.length; j++)
-      if (saida[i].chave === saida[j].chave && saida[i].orig > saida[j].orig) {
-        marcados.add(saida[i].orig);
-        marcados.add(saida[j].orig);
+function inverted(output: Rec[]): Set<number> {
+  const marked = new Set<number>();
+  for (let i = 0; i < output.length; i++)
+    for (let j = i + 1; j < output.length; j++)
+      if (output[i].key === output[j].key && output[i].orig > output[j].orig) {
+        marked.add(output[i].orig);
+        marked.add(output[j].orig);
       }
-  return marcados;
+  return marked;
 }
 
 function Fila({
-  regs,
-  marcados,
-  titulo,
-  selo,
-  detalhe,
+  recs,
+  marked,
+  title,
+  badge,
+  detail,
 }: {
-  regs: Reg[];
-  marcados: Set<number>;
-  titulo: string;
-  selo: string;
-  detalhe?: string;
+  recs: Rec[];
+  marked: Set<number>;
+  title: string;
+  badge: string;
+  detail?: string;
 }) {
   return (
     <div className="hs-fila">
       <div className="hs-fila-cab">
-        <span className="hs-fila-tit">{titulo}</span>
-        <span className={`hs-fila-selo${marcados.size > 0 ? " quebrou" : ""}`}>{selo}</span>
+        <span className="hs-fila-tit">{title}</span>
+        <span className={`hs-fila-selo${marked.size > 0 ? " quebrou" : ""}`}>{badge}</span>
       </div>
       <div className="hp-arr">
-        {regs.map((r) => (
-          <span key={r.orig} className={`hp-cel reg${marcados.has(r.orig) ? " inverteu" : ""}`}>
+        {recs.map((r) => (
+          <span key={r.orig} className={`hp-cel reg${marked.has(r.orig) ? " inverteu" : ""}`}>
             <i>chegou em {r.orig}</i>
-            <b>p{r.chave}</b>
-            <em>{r.etiq}</em>
+            <b>p{r.key}</b>
+            <em>{r.tag}</em>
           </span>
         ))}
       </div>
-      {detalhe ? <p className="bb-array-nota" style={{ marginTop: 8 }}>{detalhe}</p> : null}
+      {detail ? <p className="bb-array-nota" style={{ marginTop: 8 }}>{detail}</p> : null}
     </div>
   );
 }
@@ -160,49 +167,53 @@ export function OrdenacaoBasicaEstabilidade() {
   const [presetKey, setPresetKey] = useState("chamados");
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
 
-  const entrada: Reg[] = useMemo(
-    () => preset.dados.map(([chave, etiq], orig) => ({ chave, etiq, orig })),
+  const input: Rec[] = useMemo(
+    () => preset.data.map(([key, tag], orig) => ({ key, tag, orig })),
     [preset]
   );
 
-  const bubble = useMemo(() => rodar("bubble", entrada), [entrada]);
-  const selection = useMemo(() => rodar("selection", entrada), [entrada]);
-  const insertion = useMemo(() => rodar("insertion", entrada), [entrada]);
+  const bubble = useMemo(() => run("bubble", input), [input]);
+  const selection = useMemo(() => run("selection", input), [input]);
+  const insertion = useMemo(() => run("insertion", input), [input]);
 
-  const mB = useMemo(() => invertidos(bubble.regs), [bubble]);
-  const mS = useMemo(() => invertidos(selection.regs), [selection]);
-  const mI = useMemo(() => invertidos(insertion.regs), [insertion]);
+  const tiesB = useMemo(() => inverted(bubble.recs), [bubble]);
+  const tiesS = useMemo(() => inverted(selection.recs), [selection]);
+  const tiesI = useMemo(() => inverted(insertion.recs), [insertion]);
 
-  const chavesIguais =
-    selection.regs.map((r) => r.chave).join(",") === bubble.regs.map((r) => r.chave).join(",");
+  const sameKeys =
+    selection.recs.map((r) => r.key).join(",") === bubble.recs.map((r) => r.key).join(",");
 
   // O par concreto que trocou de lugar, para a explicação citar etiquetas reais.
-  const parTrocado = useMemo(() => {
-    const s = selection.regs;
+  const swappedPair = useMemo(() => {
+    const s = selection.recs;
     for (let i = 0; i < s.length; i++)
       for (let j = i + 1; j < s.length; j++)
-        if (s[i].chave === s[j].chave && s[i].orig > s[j].orig) return { antes: s[j], depois: s[i] };
+        if (s[i].key === s[j].key && s[i].orig > s[j].orig) return { before: s[j], after: s[i] };
     return null;
   }, [selection]);
 
-  const detalhe = (r: Saida) =>
-    `${r.trocas} troca${r.trocas === 1 ? "" : "s"}, a mais longa com distância ${r.maiorSalto || 0}`;
+  const detail = (r: Result) =>
+    `${r.swaps} troca${r.swaps === 1 ? "" : "s"}, a mais longa com distância ${r.longestSwap || 0}`;
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a distância da troca decide a estabilidade</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {mS.size > 0 ? `${mS.size} chamados fora da ordem de chegada` : "nenhum empate trocou desta vez"}
-          </span>
-        </div>
-      </div>
+  const viz = useVisualizer({
+    title: "Visualizador · a distância da troca decide a estabilidade",
+    // Sem linha do tempo: a variável é o preset, não o tempo.
+    total: 1,
+    // Sem bloco dispensável: as quatro filas e a explicação são o conteúdo.
+    collapsible: false,
+  });
 
-      <div className="viz-body">
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem "passo N de M": entra o número que resume o estado, com o rótulo
+          junto, como manda a §6 do contrato. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {tiesS.size > 0 ? `${tiesS.size} chamados fora da ordem de chegada` : "nenhum empate trocou desta vez"}
+        </span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
@@ -211,49 +222,49 @@ export function OrdenacaoBasicaEstabilidade() {
               onClick={() => setPresetKey(pr.key)}
               aria-pressed={presetKey === pr.key}
             >
-              {pr.rotulo}
+              {pr.label}
             </button>
           ))}
         </div>
 
-        <p className="tt-legenda-arvore">{preset.dica}</p>
+        <p className="tt-legenda-arvore">{preset.hint}</p>
 
         <div className="hs-filas">
-          <Fila regs={entrada} marcados={new Set()} titulo="Entrada" selo="como chegou" />
+          <Fila recs={input} marked={new Set()} title="Entrada" badge="como chegou" />
           <Fila
-            regs={bubble.regs}
-            marcados={mB}
-            titulo="Bubble sort"
-            selo={mB.size > 0 ? "empates trocados" : "empates preservados"}
-            detalhe={detalhe(bubble)}
+            recs={bubble.recs}
+            marked={tiesB}
+            title="Bubble sort"
+            badge={tiesB.size > 0 ? "empates trocados" : "empates preservados"}
+            detail={detail(bubble)}
           />
           <Fila
-            regs={insertion.regs}
-            marcados={mI}
-            titulo="Insertion sort"
-            selo={mI.size > 0 ? "empates trocados" : "empates preservados"}
-            detalhe={detalhe(insertion)}
+            recs={insertion.recs}
+            marked={tiesI}
+            title="Insertion sort"
+            badge={tiesI.size > 0 ? "empates trocados" : "empates preservados"}
+            detail={detail(insertion)}
           />
           <Fila
-            regs={selection.regs}
-            marcados={mS}
-            titulo="Selection sort"
-            selo={mS.size > 0 ? "empates trocados" : "empates preservados"}
-            detalhe={detalhe(selection)}
+            recs={selection.recs}
+            marked={tiesS}
+            title="Selection sort"
+            badge={tiesS.size > 0 ? "empates trocados" : "empates preservados"}
+            detail={detail(selection)}
           />
         </div>
 
-        <p className={`viz-note${mS.size > 0 ? " invalid" : " ok"}`}>
-          {parTrocado ? (
+        <p className={`viz-note${tiesS.size > 0 ? " invalid" : " ok"}`}>
+          {swappedPair ? (
             <>
               As três saídas estão <strong>corretas pela prioridade</strong>
-              {chavesIguais ? ": a sequência de prioridades é idêntica nas três" : ""}. O que mudou foi o
-              desempate. <strong>{parTrocado.depois.etiq}</strong> chegou na posição {parTrocado.depois.orig} e{" "}
-              <strong>{parTrocado.antes.etiq}</strong> na {parTrocado.antes.orig}, os dois com prioridade{" "}
-              {parTrocado.antes.chave}, e o selection sort devolveu {parTrocado.depois.etiq} na frente. Repare
+              {sameKeys ? ": a sequência de prioridades é idêntica nas três" : ""}. O que mudou foi o
+              desempate. <strong>{swappedPair.after.tag}</strong> chegou na posição {swappedPair.after.orig} e{" "}
+              <strong>{swappedPair.before.tag}</strong> na {swappedPair.before.orig}, os dois com prioridade{" "}
+              {swappedPair.before.key}, e o selection sort devolveu {swappedPair.after.tag} na frente. Repare
               na causa, logo acima: a maior troca do bubble e do insertion tem distância{" "}
-              {Math.max(bubble.maiorSalto, insertion.maiorSalto)}, e a do selection tem distância{" "}
-              {selection.maiorSalto}. Uma troca de distância 1 não consegue pular por cima de ninguém, então
+              {Math.max(bubble.longestSwap, insertion.longestSwap)}, e a do selection tem distância{" "}
+              {selection.longestSwap}. Uma troca de distância 1 não consegue pular por cima de ninguém, então
               empate nunca muda de ordem. Uma troca longa passa por cima de quem estiver no caminho, e nada no
               algoritmo confere se aquele alguém tem a mesma chave.
             </>
@@ -261,7 +272,7 @@ export function OrdenacaoBasicaEstabilidade() {
             <>
               Neste preset nenhum empate mudou de lugar, nem no selection sort. Isso não o torna estável:
               instável quer dizer que ele <strong>não garante nada</strong> sobre empates. Repare que a maior
-              troca dele já tem distância {selection.maiorSalto}, ou seja, a capacidade de atropelar um igual
+              troca dele já tem distância {selection.longestSwap}, ou seja, a capacidade de atropelar um igual
               está lá; foi só o acaso do arranjo que não cobrou. Troque de preset para ver a garantia falhar.
             </>
           )}
@@ -275,6 +286,9 @@ export function OrdenacaoBasicaEstabilidade() {
           menos escreve no array. As duas coisas têm a mesma causa.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o rodapé não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/tests/viz-heap-sort.spec.ts
+++ b/tests/viz-heap-sort.spec.ts
@@ -272,6 +272,7 @@ test.describe("heap-sort", () => {
             passos: number;
             erros: string[];
             comparacoes: number[];
+            passosVazios: number[];
             primeiroArr: number[];
             ultimoArr: number[];
             ultimoOrdenado: string;
@@ -282,6 +283,7 @@ test.describe("heap-sort", () => {
             ) as HTMLButtonElement;
             const erros: string[] = [];
             const comparacoes: number[] = [];
+            const passosVazios: number[] = [];
             let primeiroArr: number[] = [];
             let ultimoArr: number[] = [];
             let ultimoOrdenado = "";
@@ -328,20 +330,34 @@ test.describe("heap-sort", () => {
             const ler = () => {
               const { i } = contador();
               const txt = f.querySelector(".hs-fase-txt")!.textContent!.replace(/\s+/g, " ").trim();
-              const m = txt.match(/heap ativo: posições 0 a (\d+) · já ordenado: (\d+) de (\d+)/);
+              const n = parseInt(varDe("n (heap ativo)"), 10);
+
+              // O rótulo tem DOIS lados e os dois são afirmados. Com heap ativo
+              // ele nomeia a faixa de posições; com o heap vazio não há faixa a
+              // nomear, e prometer "posições 0 a 0" é dizer que a posição 0
+              // ainda está no heap. Cobrir só o lado de cima deixaria passar
+              // exatamente o defeito que este commit conserta.
+              const ativo = txt.match(/^heap ativo: posições 0 a (\d+) · já ordenado: (\d+) de (\d+)$/);
+              const vazio = txt.match(/^heap vazio · já ordenado: (\d+) de (\d+)$/);
+              const m = ativo ?? vazio;
               if (!m) {
                 erros.push(`passo ${i}: o cartao da fase nao casou: "${txt}"`);
                 return;
               }
-              const ultimo = parseInt(m[1], 10);
-              const ordenados = parseInt(m[2], 10);
-              const tamanho = parseInt(m[3], 10);
+              if (n === 0 && !vazio)
+                erros.push(`passo ${i}: n=0 e o cartao ainda anuncia uma faixa: "${txt}"`);
+              if (n > 0 && !ativo)
+                erros.push(`passo ${i}: n=${n} e o cartao diz que o heap esta vazio: "${txt}"`);
+              if (vazio) passosVazios.push(i);
 
-              const n = parseInt(varDe("n (heap ativo)"), 10);
+              const ultimo = ativo ? parseInt(ativo[1], 10) : -1;
+              const ordenados = parseInt(ativo ? ativo[2] : vazio![1], 10);
+              const tamanho = parseInt(ativo ? ativo[3] : vazio![2], 10);
+
               const celulas = [...f.querySelectorAll(".hp-cel")];
               const verdes = celulas.filter((c) => c.classList.contains("fixo")).length;
 
-              if (ultimo !== Math.max(n - 1, 0))
+              if (ativo && ultimo !== n - 1)
                 erros.push(`passo ${i}: cartao diz ate ${ultimo}, painel diz n=${n}`);
               if (ordenados !== tamanho - n)
                 erros.push(`passo ${i}: cartao diz ${ordenados} ordenados, n=${n} de ${tamanho}`);
@@ -369,7 +385,7 @@ test.describe("heap-sort", () => {
               ler();
               k++;
               if (k >= total) {
-                resolve({ passos: total, erros, comparacoes, primeiroArr, ultimoArr, ultimoOrdenado });
+                resolve({ passos: total, erros, comparacoes, passosVazios, primeiroArr, ultimoArr, ultimoOrdenado });
                 return;
               }
               prox.click();
@@ -396,6 +412,13 @@ test.describe("heap-sort", () => {
       // array final tem que ser o PRIMEIRO ordenado, o que exige as duas
       // coisas de uma vez: mesma multiplicidade de valores e ordem crescente.
       expect(leitura.ultimoArr.filter((v) => Number.isNaN(v)), "li NaN no lugar do valor").toEqual([]);
+
+      // O outro lado da condicional do rótulo: "heap vazio" acontece EXATAMENTE
+      // uma vez, e é o último passo. Sem esta asserção, um rótulo que dissesse
+      // "heap vazio" a animação inteira passaria pelas checagens acima.
+      expect(leitura.passosVazios, "o 'heap vazio' tem que ser so o ultimo passo").toEqual([
+        leitura.passos,
+      ]);
       expect(leitura.primeiroArr.length, "o array de entrada nao foi lido").toBeGreaterThan(1);
       expect(leitura.ultimoOrdenado).toBe(`${leitura.ultimoArr.length} de ${leitura.ultimoArr.length}`);
       expect(leitura.ultimoArr, "o heap sort terminou com o array fora de ordem").toEqual(

--- a/tests/viz-heap-sort.spec.ts
+++ b/tests/viz-heap-sort.spec.ts
@@ -10,7 +10,11 @@ import { test, expect, type Page } from "@playwright/test";
 // HeapSortEstabilidade (28 `.hp-cel` na página, 10 são desta peça). Tudo aqui
 // desce a partir da figura, nunca da página.
 
-const ARTIGO = "article figure.viz-fit";
+// As DUAS figuras da página estão na casca agora, então `figure.viz-fit` casava
+// 1 e passou a casar 2 — em `page.locator()` isso é violação de strict mode, e
+// em `document.querySelector()` seria a peça errada EM SILÊNCIO. O discriminante
+// é o bloco recolhível: só o passo a passo tem `.viz-code-slot`.
+const ARTIGO = "article figure.viz-fit:has(.viz-code-slot)";
 const PAINEL = ".viz-overlay-fit figure.viz-fit";
 
 /** Folga de subpixel, o mesmo valor que o hook usa para decidir. */
@@ -365,6 +369,149 @@ test.describe("heap-sort", () => {
       expect(leitura.ultimoArr, "o heap sort terminou com o array fora de ordem").toEqual(
         [...leitura.ultimoArr].sort((a, b) => a - b)
       );
+    });
+  });
+
+  // ------------------------------------------------------- a peça sem passos
+  // O `HeapSortEstabilidade` vestia `figure.viz` — a MESMA moldura do passo a
+  // passo — sem botão Expandir, sem diálogo, sem trava de rolagem, sem Esc e
+  // sem foco. Uma peça muda para uma que expandia, com aparência idêntica.
+  //
+  // Entra com `total: 1` e `collapsible: false`: não há passo a passo nem bloco
+  // dispensável. Sem rodapé, o controle cuja posição carrega o sentido da
+  // camada 1 é o `✕ Fechar`, que é a saída do diálogo.
+  //
+  // Réguas medidas antes de escrever (artigo, altura da peça): 696..720 a
+  // 1512x900 (orçamento 816: CABE), 696..720 a 1440x700 (orçamento 616: NÃO
+  // cabe) e 1.173..1.285 a 390x844 (orçamento 760). Sobra do miolo no painel:
+  // 0 a 1512x900, 34 a 1440x600 e 461 a 390x844 — por isso o teste de rolagem
+  // mora na régua de celular, que é onde existe o que rolar.
+  test.describe("estabilidade", () => {
+    const MUDA = 'o que "instável" significa na prática';
+    const muda = (page: Page) =>
+      page.locator("article figure.viz-fit").filter({ hasText: "significa na prática" });
+
+    test.describe("afordancia", () => {
+      test.use({ viewport: { width: 1512, height: 900 } });
+
+      test("as duas peças anunciam o mesmo botão, e o rótulo diz o que a peça mostra", async ({ page }) => {
+        await abrirTopico(page);
+        // era 1 Expandir para 2 figuras de aparência idêntica
+        await expect(page.locator("article figure.viz")).toHaveCount(2);
+        await expect(page.locator("article figure.viz-fit")).toHaveCount(2);
+        await expect(page.getByRole("button", { name: "⤢ Expandir" })).toHaveCount(2);
+        // o discriminante do passo a passo continua único
+        await expect(page.locator(ARTIGO)).toHaveCount(1);
+        await expect(page.locator("article .viz-code-slot")).toHaveCount(1);
+
+        const fig = muda(page);
+        await expect(fig).toHaveCount(1);
+        await expect(fig.locator(".viz-step")).toHaveCount(1);
+        // rótulo e valor no mesmo locator, e o número tem que bater com as
+        // células marcadas na fila do heap sort
+        await expect(fig.locator(".viz-step")).toHaveText("6 registros fora da ordem original");
+        await expect(fig.locator(".hs-fila").nth(2).locator(".hp-cel.reg.inverteu")).toHaveCount(6);
+      });
+
+      test("ela não promete esconder um bloco que não tem", async ({ page }) => {
+        await abrirTopico(page);
+        const fig = muda(page);
+        await expect(fig.locator(".viz-code-slot")).toHaveCount(0);
+        await expect(fig.locator(".viz-toggle-codigo")).toHaveCount(0);
+        await expect(fig.getByRole("button", { name: /código/ })).toHaveCount(0);
+        await expect(fig.locator(".viz-foot")).toHaveCount(0);
+        await expect(fig.locator(".viz-atalhos")).toHaveCount(0);
+        await expect(fig.getByRole("button", { name: /Rodar|Próximo|Anterior/ })).toHaveCount(0);
+        await expect(fig.locator(".viz-step")).not.toHaveText(/passo \d+ de \d+/);
+      });
+    });
+
+    test.describe("camada 1", () => {
+      test.use({ viewport: { width: 390, height: 844 } });
+
+      test("o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
+        expect(page.viewportSize()).toEqual({ width: 390, height: 844 });
+        await abrirTopico(page);
+        const fig = muda(page);
+        await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+        const painel = page.locator(PAINEL);
+        await expect(painel).toBeVisible();
+        // `toBeVisible()` não é "pronto para o teclado": o foco entrando é o
+        // sinal de que o commit do listener já rodou.
+        await expect(painel).toBeFocused();
+
+        // --- pré-condições ---
+        await expect(painel.locator(".viz-foot"), "esta peça não tem rodapé").toHaveCount(0);
+        const fechar = painel.getByRole("button", { name: "✕ Fechar" });
+        await expect(fechar).toHaveCount(1);
+
+        const antes = await painel.evaluate((f) => {
+          const b = f.querySelector(".viz-body") as HTMLElement;
+          // o click() do Playwright ROLA o contêiner para alcançar o alvo
+          f.scrollTop = 0;
+          b.scrollTop = 0;
+          const x = [...f.querySelectorAll("button")].find((n) => /Fechar/.test(n.textContent ?? ""))!;
+          return {
+            sobraMiolo: b.scrollHeight - b.clientHeight,
+            sobraFigura: f.scrollHeight - f.clientHeight,
+            head: f.querySelector(".viz-head")!.getBoundingClientRect().y,
+            fechar: x.getBoundingClientRect().y,
+          };
+        });
+        expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(SLACK);
+        expect(antes.sobraFigura, "a figura não pode ter sobra própria").toBeLessThanOrEqual(SLACK);
+
+        // --- a ação ---
+        const depois = await painel.evaluate((f) => {
+          const b = f.querySelector(".viz-body") as HTMLElement;
+          b.scrollTop = b.scrollHeight;
+          const x = [...f.querySelectorAll("button")].find((n) => /Fechar/.test(n.textContent ?? ""))!;
+          return {
+            rolouMiolo: b.scrollTop,
+            rolouFigura: f.scrollTop,
+            head: f.querySelector(".viz-head")!.getBoundingClientRect().y,
+            fechar: x.getBoundingClientRect().y,
+          };
+        });
+        expect(depois.rolouMiolo, "quem rolou tem que ser o miolo").toBeGreaterThan(0);
+        expect(depois.rolouFigura, "a figura não pode rolar").toBe(0);
+
+        // --- as asserções que carregam o sentido ---
+        expect(Math.abs(depois.head - antes.head), "o cabeçalho andou junto com o miolo").toBeLessThanOrEqual(2);
+        expect(
+          Math.abs(depois.fechar - antes.fechar),
+          "o ✕ Fechar andou junto com o miolo"
+        ).toBeLessThanOrEqual(2);
+        await expect(fechar).toBeInViewport({ ratio: 1 });
+      });
+
+      test("o painel é um diálogo de verdade: foco, Tab preso, Esc e rolagem travada", async ({ page }) => {
+        await abrirTopico(page);
+        await muda(page).getByRole("button", { name: "⤢ Expandir" }).click();
+        const overlay = page.locator(".viz-overlay-fit");
+        await expect(overlay).toBeVisible();
+        await expect(overlay).toHaveAttribute("role", "dialog");
+        await expect(overlay).toHaveAttribute("aria-modal", "true");
+        // o rótulo do diálogo é o título DESTA peça, não um genérico
+        await expect(overlay).toHaveAttribute("aria-label", `Visualizador · ${MUDA}`);
+        expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+
+        const fugas: string[] = [];
+        for (let i = 0; i < 14; i++) {
+          await page.keyboard.press("Tab");
+          const onde = await page.evaluate(() => {
+            const a = document.activeElement;
+            const f = document.querySelector(".viz-overlay-fit figure.viz-fit");
+            return { dentro: !!(f && a && f.contains(a)), quem: a?.className || a?.tagName || "?" };
+          });
+          if (!onde.dentro) fugas.push(`volta ${i + 1}: ${onde.quem}`);
+        }
+        expect(fugas, "o foco vazou do painel").toEqual([]);
+
+        await page.keyboard.press("Escape");
+        await expect(page.locator(".viz-overlay-fit")).toHaveCount(0);
+        expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+      });
     });
   });
 });

--- a/tests/viz-heap-sort.spec.ts
+++ b/tests/viz-heap-sort.spec.ts
@@ -272,6 +272,7 @@ test.describe("heap-sort", () => {
             passos: number;
             erros: string[];
             comparacoes: number[];
+            primeiroArr: number[];
             ultimoArr: number[];
             ultimoOrdenado: string;
           }>((resolve) => {
@@ -281,6 +282,7 @@ test.describe("heap-sort", () => {
             ) as HTMLButtonElement;
             const erros: string[] = [];
             const comparacoes: number[] = [];
+            let primeiroArr: number[] = [];
             let ultimoArr: number[] = [];
             let ultimoOrdenado = "";
 
@@ -306,6 +308,22 @@ test.describe("heap-sort", () => {
               if (!c) throw new Error(`nao achei o cartao "${nome}"`);
               return c.querySelector("strong")!.textContent!.trim();
             };
+            // A célula é `<span class="hp-cel"><i>4</i>6</span>`: o índice mora
+            // no <i> e o VALOR é um nó de texto irmão, sem elemento próprio.
+            // `textContent` concatena os dois ("46"), e fatiar isso com
+            // `replace(/^\d+/, "")` come a string inteira: o regex é guloso e
+            // não sabe onde o índice termina. Sobrava "" e `parseInt` devolvia
+            // NaN em TODAS as células. Descer até o nó do valor é o que faz a
+            // leitura existir.
+            const valorDe = (c: Element) =>
+              parseInt(
+                [...c.childNodes]
+                  .filter((x) => x.nodeType === 3)
+                  .map((x) => x.textContent ?? "")
+                  .join("")
+                  .trim(),
+                10
+              );
 
             const ler = () => {
               const { i } = contador();
@@ -335,7 +353,13 @@ test.describe("heap-sort", () => {
                 erros.push(`passo ${i}: o cartao de tamanho diz ${statDe("tamanho do array")}`);
 
               comparacoes.push(parseInt(statDe("comparações"), 10));
-              ultimoArr = celulas.map((c) => parseInt(c.textContent!.replace(/^\d+/, ""), 10));
+              const valores = celulas.map(valorDe);
+              if (valores.some((v) => Number.isNaN(v)))
+                erros.push(
+                  `passo ${i}: li NaN no array: "${celulas.map((c) => c.textContent).join("|")}"`
+                );
+              if (!primeiroArr.length) primeiroArr = valores;
+              ultimoArr = valores;
               ultimoOrdenado = `${ordenados} de ${tamanho}`;
             };
 
@@ -345,7 +369,7 @@ test.describe("heap-sort", () => {
               ler();
               k++;
               if (k >= total) {
-                resolve({ passos: total, erros, comparacoes, ultimoArr, ultimoOrdenado });
+                resolve({ passos: total, erros, comparacoes, primeiroArr, ultimoArr, ultimoOrdenado });
                 return;
               }
               prox.click();
@@ -365,9 +389,17 @@ test.describe("heap-sort", () => {
       expect(recuos, "o contador de comparacoes andou para tras").toEqual([]);
 
       // E no fim o array está ordenado, com a fronteira cobrindo tudo.
+      //
+      // Esta é a TESE da peça, e até aqui ela não era verificada: a leitura do
+      // valor da célula devolvia NaN, e `[NaN, NaN]` é igual a `[NaN, NaN]`
+      // ordenado, então a asserção passava com qualquer coisa na tela. Agora o
+      // array final tem que ser o PRIMEIRO ordenado, o que exige as duas
+      // coisas de uma vez: mesma multiplicidade de valores e ordem crescente.
+      expect(leitura.ultimoArr.filter((v) => Number.isNaN(v)), "li NaN no lugar do valor").toEqual([]);
+      expect(leitura.primeiroArr.length, "o array de entrada nao foi lido").toBeGreaterThan(1);
       expect(leitura.ultimoOrdenado).toBe(`${leitura.ultimoArr.length} de ${leitura.ultimoArr.length}`);
       expect(leitura.ultimoArr, "o heap sort terminou com o array fora de ordem").toEqual(
-        [...leitura.ultimoArr].sort((a, b) => a - b)
+        [...leitura.primeiroArr].sort((a, b) => a - b)
       );
     });
   });

--- a/tests/viz-merge-sort.spec.ts
+++ b/tests/viz-merge-sort.spec.ts
@@ -11,9 +11,21 @@ import { test, expect, type Page, type Locator } from "@playwright/test";
 
 const SLACK = 8;
 
-/** A figura adaptada é a primeira do artigo. */
+// As TRÊS figuras da página estão na casca agora. `figure.viz-fit` casava 1 e
+// passou a casar 3, então o seletor precisa de um discriminante: só o
+// visualizador principal tem bloco recolhível, e é o `.viz-code-slot` que diz
+// isso — ele existe porque a peça É recolhível, enquanto o conteúdo dentro dele
+// é o que um dia pode virar condicional.
+const PRINCIPAL = "article figure.viz-fit:has(.viz-code-slot)";
+
+/** O visualizador principal, o único dos três com bloco de código. */
 function figura(page: Page): Locator {
-  return page.locator("article figure.viz-fit");
+  return page.locator(PRINCIPAL);
+}
+
+/** As duas peças sem linha do tempo, pelo rótulo do cabeçalho. */
+function muda(page: Page, titulo: string): Locator {
+  return page.locator("article figure.viz-fit").filter({ hasText: titulo });
 }
 
 async function abrir(page: Page, w: number, h: number) {
@@ -35,10 +47,10 @@ async function alturaEstavel(page: Page): Promise<number> {
   let iguais = 0;
   let ultimo = -1;
   for (let i = 0; i < 60; i++) {
-    const v = await page.evaluate(() => {
-      const f = document.querySelector("article figure.viz-fit") as HTMLElement;
+    const v = await page.evaluate((sel) => {
+      const f = document.querySelector(sel) as HTMLElement;
       return Math.round(f.getBoundingClientRect().height);
-    });
+    }, PRINCIPAL);
     if (v === ultimo) iguais++;
     else {
       iguais = 1;
@@ -67,11 +79,16 @@ async function preset(fig: Locator, nome: string) {
 }
 
 test.describe("merge sort · casca adaptativa", () => {
-  test("a página tem três figuras e só a primeira é a adaptada", async ({ page }) => {
+  test("as três figuras da página estão na casca, e o seletor pega só a minha", async ({ page }) => {
     await abrir(page, 1512, 900);
-    // se este número mudar, todo seletor escopado deste arquivo precisa de revisão
+    // se algum destes números mudar, todo seletor escopado deste arquivo
+    // precisa de revisão: `figure.viz-fit` já casou 1 e hoje casa 3
     await expect(page.locator("article figure.viz")).toHaveCount(3);
+    await expect(page.locator("article figure.viz-fit")).toHaveCount(3);
     await expect(page.locator("article .viz-step")).toHaveCount(3);
+    // o discriminante do principal é o bloco recolhível, e ele é único
+    await expect(page.locator(PRINCIPAL)).toHaveCount(1);
+    await expect(page.locator("article .viz-code-slot")).toHaveCount(1);
     const fig = figura(page);
     await expect(fig.locator(".viz-step")).toHaveCount(1);
     await expect(fig.locator(".viz-step")).toHaveText(/^passo \d+ de \d+$/);
@@ -291,5 +308,192 @@ test.describe("merge sort · casca adaptativa", () => {
     await andar(fig, 92);
     expect(await ficha(fig, "comparações")).toBe("17");
     expect(await ficha(fig, "cópias para o buffer")).toBe("24");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// As duas peças que vestiam `figure.viz` sem nada da casca: mesma moldura do
+// visualizador principal, sem botão Expandir, sem diálogo, sem trava de
+// rolagem, sem Esc e sem foco. O aluno via duas peças mudas para uma que
+// expandia, aprendia que o botão não existe e parava de procurar.
+//
+// Elas entram com `total: 1` e `collapsible: false`: não têm passo a passo nem
+// bloco dispensável, então da casca elas usam o que lhes cabe — o painel com o
+// cabeçalho parado enquanto o miolo rola. Sem rodapé, o controle cuja posição
+// carrega o sentido da camada 1 é o `✕ Fechar`, que é a saída do diálogo.
+//
+// Réguas medidas antes de escrever (artigo, altura da peça):
+//   · MergeSortNiveis  911..1037 (1512x900), 925..1051 (1440x700), 1351..1477 (390x844)
+//   · MergeEmpate      1077..1213, 1077..1213, 1964..2214
+// e a sobra do miolo no painel a 1440x600: 274 e 500px. A 1512x900 o
+// MergeSortNiveis sobra 0 — teste de rolagem ali seria decoração verde.
+// ---------------------------------------------------------------------------
+
+const TITULO_NIVEIS = "o n log n desenhado: altura vezes largura";
+const TITULO_EMPATE = "o sinal que decide a estabilidade";
+
+async function abrirPainel(page: Page, fig: Locator): Promise<Locator> {
+  await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+  await expect(painel).toBeVisible();
+  // `toBeVisible()` não é "pronto para o teclado": o listener de keydown nasce
+  // num efeito passivo, no mesmo commit que traz o foco para a figura. Esperar
+  // o foco chegar é a pré-condição que prova que aquele commit já rodou.
+  await expect(painel).toBeFocused();
+  return painel;
+}
+
+/** Camada 1 numa peça SEM rodapé: quem não pode andar é o cabeçalho e o ✕ Fechar. */
+async function provarCamada1(page: Page, painel: Locator) {
+  // --- pré-condições: a situação que o teste afirma existe mesmo ---
+  await expect(painel.locator(".viz-foot"), "esta peça não tem rodapé").toHaveCount(0);
+  const fechar = painel.getByRole("button", { name: "✕ Fechar" });
+  await expect(fechar).toHaveCount(1);
+
+  const antes = await painel.evaluate((f) => {
+    const b = f.querySelector(".viz-body") as HTMLElement;
+    // o click() do Playwright ROLA o contêiner para alcançar o alvo: zerar aqui
+    // é o que impede de medir a rolagem que o próprio teste causou
+    f.scrollTop = 0;
+    b.scrollTop = 0;
+    const x = [...f.querySelectorAll("button")].find((n) => /Fechar/.test(n.textContent ?? ""))!;
+    return {
+      sobraMiolo: b.scrollHeight - b.clientHeight,
+      sobraFigura: f.scrollHeight - f.clientHeight,
+      head: f.querySelector(".viz-head")!.getBoundingClientRect().y,
+      fechar: x.getBoundingClientRect().y,
+    };
+  });
+  expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(SLACK);
+  expect(antes.sobraFigura, "a figura não pode ter sobra própria").toBeLessThanOrEqual(SLACK);
+
+  // --- a ação: rolar o MIOLO até o fim ---
+  const depois = await painel.evaluate((f) => {
+    const b = f.querySelector(".viz-body") as HTMLElement;
+    b.scrollTop = b.scrollHeight;
+    const x = [...f.querySelectorAll("button")].find((n) => /Fechar/.test(n.textContent ?? ""))!;
+    return {
+      rolouMiolo: b.scrollTop,
+      rolouFigura: f.scrollTop,
+      head: f.querySelector(".viz-head")!.getBoundingClientRect().y,
+      fechar: x.getBoundingClientRect().y,
+    };
+  });
+  expect(depois.rolouMiolo, "quem rolou tem que ser o miolo").toBeGreaterThan(0);
+  expect(depois.rolouFigura, "a figura não pode rolar").toBe(0);
+
+  // --- as asserções que carregam o sentido: posição comparada com ela mesma ---
+  // `toBeInViewport()` sozinho passa nas DUAS pontas da rolagem e aprovaria a
+  // quebra canônica; ele entra só como complemento.
+  expect(Math.abs(depois.head - antes.head), "o cabeçalho andou junto com o miolo").toBeLessThanOrEqual(2);
+  expect(Math.abs(depois.fechar - antes.fechar), "o ✕ Fechar andou junto com o miolo").toBeLessThanOrEqual(2);
+  await expect(fechar).toBeInViewport({ ratio: 1 });
+}
+
+test.describe("merge sort · as duas peças sem linha do tempo", () => {
+  test("as três peças anunciam o mesmo botão, e cada rótulo diz o que a peça mostra", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    // a afordância é a mesma nas três: era 1 Expandir para 3 figuras iguais
+    await expect(page.getByRole("button", { name: "⤢ Expandir" })).toHaveCount(3);
+
+    // rótulo e valor no mesmo locator, um por figura — comportamento certo com
+    // rótulo errado ensina errado do mesmo jeito
+    const niveis = muda(page, TITULO_NIVEIS);
+    const empate = muda(page, TITULO_EMPATE);
+    await expect(niveis).toHaveCount(1);
+    await expect(empate).toHaveCount(1);
+    await expect(niveis.locator(".viz-step")).toHaveCount(1);
+    await expect(empate.locator(".viz-step")).toHaveCount(1);
+    await expect(niveis.locator(".viz-step")).toHaveText(
+      "4 rodadas de intercalação x 16 elementos = 64 movimentos"
+    );
+    await expect(empate.locator(".viz-step")).toHaveText("as duas versões se separam na decisão 2");
+  });
+
+  test("nenhuma das duas promete esconder um bloco que ela não tem", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    for (const titulo of [TITULO_NIVEIS, TITULO_EMPATE]) {
+      const fig = muda(page, titulo);
+      await expect(fig.locator(".viz-code-slot"), `${titulo}: não há bloco recolhível`).toHaveCount(0);
+      await expect(fig.locator(".viz-toggle-codigo")).toHaveCount(0);
+      await expect(fig.getByRole("button", { name: /código/ })).toHaveCount(0);
+      // e sem linha do tempo não há reprodução nenhuma para prometer
+      await expect(fig.locator(".viz-foot")).toHaveCount(0);
+      await expect(fig.locator(".viz-atalhos")).toHaveCount(0);
+      await expect(fig.getByRole("button", { name: /Rodar|Próximo|Anterior/ })).toHaveCount(0);
+      await expect(fig.locator(".viz-step")).not.toHaveText(/passo \d+ de \d+/);
+    }
+  });
+
+  test("o mapa de níveis: o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
+    await abrir(page, 1440, 600);
+    const painel = await abrirPainel(page, muda(page, TITULO_NIVEIS));
+    await provarCamada1(page, painel);
+  });
+
+  test("o comparador de empate: o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
+    await abrir(page, 1440, 600);
+    const painel = await abrirPainel(page, muda(page, TITULO_EMPATE));
+    await provarCamada1(page, painel);
+  });
+
+  test("o painel é um diálogo de verdade: foco, Tab preso, Esc e rolagem travada", async ({ page }) => {
+    await abrir(page, 1440, 600);
+    const painel = await abrirPainel(page, muda(page, TITULO_EMPATE));
+
+    const overlay = page.locator(".viz-overlay-fit");
+    await expect(overlay).toHaveAttribute("role", "dialog");
+    await expect(overlay).toHaveAttribute("aria-modal", "true");
+    // o rótulo do diálogo é o título DESTA peça, não um genérico
+    await expect(overlay).toHaveAttribute("aria-label", "Visualizador · o sinal que decide a estabilidade");
+    // a página atrás fica travada: quem rola é o painel
+    expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+
+    // Tab circula DENTRO: sem trava, o foco cairia no <body> e seguiria para os
+    // links do cabeçalho do site. Voltas suficientes para duas passadas.
+    const fugas: string[] = [];
+    for (let i = 0; i < 14; i++) {
+      await page.keyboard.press("Tab");
+      const onde = await page.evaluate(() => {
+        const a = document.activeElement;
+        const f = document.querySelector(".viz-overlay-fit figure.viz-fit");
+        return { dentro: !!(f && a && f.contains(a)), quem: a?.className || a?.tagName || "?" };
+      });
+      if (!onde.dentro) fugas.push(`volta ${i + 1}: ${onde.quem}`);
+    }
+    expect(fugas, "o foco vazou do painel").toEqual([]);
+
+    await page.keyboard.press("Escape");
+    await expect(page.locator(".viz-overlay-fit")).toHaveCount(0);
+    expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+  });
+
+  test("no mapa de níveis o n É eixo de altura: cada dobra acrescenta uma faixa", async ({ page }) => {
+    await abrir(page, 1512, 900);
+    const fig = muda(page, TITULO_NIVEIS);
+    const cartao = (rot: string) => fig.locator(".bigo-stat").filter({ hasText: rot }).locator("strong");
+    const altura = () => fig.evaluate((f) => Math.round(f.getBoundingClientRect().height));
+
+    // O `.ms-niveis` do visualizador principal mede 163px constantes nos quatro
+    // presets, porque 7 e 8 elementos caem no mesmo degrau de log2. Aqui o mesmo
+    // desenho tem um controle que ATRAVESSA três degraus, e aí ele é eixo.
+    const medidas: number[] = [];
+    for (const [n, faixas] of [
+      ["8", 4],
+      ["16", 5],
+      ["32", 6],
+      ["64", 7],
+    ] as const) {
+      await fig.getByRole("button", { name: `n = ${n}`, exact: true }).click();
+      await expect(fig.locator(".ms-nivel")).toHaveCount(faixas);
+      // rótulo e valor do MESMO cartão
+      await expect(cartao("tamanho do array")).toHaveText(n);
+      await expect(cartao("rodadas de intercalação")).toHaveText(String(faixas - 1));
+      medidas.push(await altura());
+    }
+    // uma faixa a mais por dobra, e a peça cresce o mesmo tanto a cada degrau
+    const passos = medidas.slice(1).map((v, i) => v - medidas[i]);
+    expect(passos, `alturas medidas: ${medidas.join(", ")}`).toEqual([passos[0], passos[0], passos[0]]);
+    expect(passos[0]).toBeGreaterThan(20);
   });
 });

--- a/tests/viz-merge-sort.spec.ts
+++ b/tests/viz-merge-sort.spec.ts
@@ -344,7 +344,7 @@ async function abrirPainel(page: Page, fig: Locator): Promise<Locator> {
 }
 
 /** Camada 1 numa peça SEM rodapé: quem não pode andar é o cabeçalho e o ✕ Fechar. */
-async function provarCamada1(page: Page, painel: Locator) {
+async function provarCamada1(painel: Locator) {
   // --- pré-condições: a situação que o teste afirma existe mesmo ---
   await expect(painel.locator(".viz-foot"), "esta peça não tem rodapé").toHaveCount(0);
   const fechar = painel.getByRole("button", { name: "✕ Fechar" });
@@ -428,13 +428,13 @@ test.describe("merge sort · as duas peças sem linha do tempo", () => {
   test("o mapa de níveis: o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
     await abrir(page, 1440, 600);
     const painel = await abrirPainel(page, muda(page, TITULO_NIVEIS));
-    await provarCamada1(page, painel);
+    await provarCamada1(painel);
   });
 
   test("o comparador de empate: o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
     await abrir(page, 1440, 600);
     const painel = await abrirPainel(page, muda(page, TITULO_EMPATE));
-    await provarCamada1(page, painel);
+    await provarCamada1(painel);
   });
 
   test("o painel é um diálogo de verdade: foco, Tab preso, Esc e rolagem travada", async ({ page }) => {

--- a/tests/viz-ordenacao-basica.spec.ts
+++ b/tests/viz-ordenacao-basica.spec.ts
@@ -25,9 +25,15 @@ const SLACK = 8;
 // o `.viz-code-slot` que diz isso — ele existe porque a peça É recolhível.
 const PRINCIPAL = "article figure.viz-fit:has(.viz-code-slot)";
 
-/** A minha peça é a PRIMEIRA das três figuras do artigo. */
+/**
+ * A minha peça, escolhida por QUAL figura é e não por posição. O `.first()` que
+ * estava aqui reprovava calado no dia em que a ordem das figuras do artigo
+ * mudasse: o resto da suíte passaria a medir a peça errada sem uma linha
+ * vermelha. Com o `PRINCIPAL`, um segundo bloco recolhível na página faz o
+ * locator casar duas figuras e o Playwright reclamar em voz alta.
+ */
 function noArtigo(page: Page): Locator {
-  return page.locator("article figure.viz").first();
+  return page.locator(PRINCIPAL);
 }
 
 /** Expandida, a figura vai para um portal no `body`, fora do `<article>`. */

--- a/tests/viz-ordenacao-basica.spec.ts
+++ b/tests/viz-ordenacao-basica.spec.ts
@@ -21,6 +21,10 @@ import { test, expect, type Page, type Locator } from "@playwright/test";
 const URL = "/topico/ordenacao-basica/";
 const SLACK = 8;
 
+// As três figuras estão na casca. Só o passo a passo tem bloco recolhível, e é
+// o `.viz-code-slot` que diz isso — ele existe porque a peça É recolhível.
+const PRINCIPAL = "article figure.viz-fit:has(.viz-code-slot)";
+
 /** A minha peça é a PRIMEIRA das três figuras do artigo. */
 function noArtigo(page: Page): Locator {
   return page.locator("article figure.viz").first();
@@ -49,8 +53,11 @@ test("a página tem três figuras, e os seletores desta suíte pegam só a minha
   await expect(page.locator("article .viz-step")).toHaveCount(3);
   await expect(fig.locator(".viz-step")).toHaveCount(1);
   await expect(fig.locator(".viz-step")).toHaveText(/^passo \d+ de \d+$/);
-  // Só a minha peça tem a casca; as outras duas não têm overlay.
-  await expect(page.locator("article figure.viz-fit")).toHaveCount(1);
+  // As TRÊS estão na casca agora: `figure.viz-fit` casava 1 e passou a casar 3.
+  // O discriminante da minha é o bloco recolhível, que só ela tem.
+  await expect(page.locator("article figure.viz-fit")).toHaveCount(3);
+  await expect(page.locator("article .viz-code-slot")).toHaveCount(1);
+  await expect(page.locator(PRINCIPAL)).toHaveCount(1);
   await expect(fig.locator(".viz-foot")).toHaveCount(1);
 });
 
@@ -231,4 +238,185 @@ test("recolhida, a peça cabe no orçamento do artigo a 1512x900", async ({ page
   await expect(card.locator("strong")).toHaveText("12");
   const tam = fig.locator(".bigo-stat").filter({ hasText: /^tamanho do array/ });
   await expect(tam.locator("strong")).toHaveText("8");
+});
+
+// ---------------------------------------------------------------------------
+// A corrida e o comparador de estabilidade vestiam `figure.viz` — a MESMA
+// moldura do passo a passo — sem botão Expandir, sem diálogo, sem trava de
+// rolagem, sem Esc e sem foco. Duas peças mudas para uma que expandia.
+//
+// As duas entram com `total: 1` e `collapsible: false`: não há passo a passo
+// nem bloco dispensável. Sem rodapé, o controle cuja posição carrega o sentido
+// da camada 1 é o `✕ Fechar`, que é a saída do diálogo.
+//
+// Réguas medidas antes de escrever (artigo, altura da peça):
+//   · corrida        763 (1512x900), 784 (1440x700), 1327..1345 (390x844)
+//   · estabilidade   929..953,       929..974,       1552..1685
+// A corrida é a peça em que a régua de 1512x900 mais engana: ali ela cabe
+// (763 de 816) e a 1440x700 passa (784 de 616). Sobra do miolo no painel a
+// 1440x600: 49 e 268px — a 1512x900 as duas sobram 0, e o teste seria decoração.
+// ---------------------------------------------------------------------------
+
+const TITULO_CORRIDA = "o mesmo array custa três preços diferentes";
+const TITULO_ESTABILIDADE = "a distância da troca decide a estabilidade";
+
+function muda(page: Page, titulo: string): Locator {
+  return page.locator("article figure.viz-fit").filter({ hasText: titulo });
+}
+
+async function abrirPainel(page: Page, fig: Locator): Promise<Locator> {
+  await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+  const painel = page.locator(".viz-overlay-fit figure.viz-fit");
+  await expect(painel).toBeVisible();
+  // `toBeVisible()` não é "pronto para o teclado": o listener de keydown nasce
+  // num efeito passivo, no mesmo commit que traz o foco para a figura.
+  await expect(painel).toBeFocused();
+  return painel;
+}
+
+/** Camada 1 numa peça SEM rodapé: quem não pode andar é o cabeçalho e o ✕ Fechar. */
+async function provarCamada1(painel: Locator) {
+  await expect(painel.locator(".viz-foot"), "esta peça não tem rodapé").toHaveCount(0);
+  const fechar = painel.getByRole("button", { name: "✕ Fechar" });
+  await expect(fechar).toHaveCount(1);
+
+  const antes = await painel.evaluate((f) => {
+    const b = f.querySelector(".viz-body") as HTMLElement;
+    // o click() do Playwright ROLA o contêiner para alcançar o alvo
+    f.scrollTop = 0;
+    b.scrollTop = 0;
+    const x = [...f.querySelectorAll("button")].find((n) => /Fechar/.test(n.textContent ?? ""))!;
+    return {
+      sobraMiolo: b.scrollHeight - b.clientHeight,
+      sobraFigura: f.scrollHeight - f.clientHeight,
+      head: f.querySelector(".viz-head")!.getBoundingClientRect().y,
+      fechar: x.getBoundingClientRect().y,
+    };
+  });
+  expect(antes.sobraMiolo, "o miolo precisa estourar para haver o que rolar").toBeGreaterThan(SLACK);
+  expect(antes.sobraFigura, "a figura não pode ter sobra própria").toBeLessThanOrEqual(SLACK);
+
+  const depois = await painel.evaluate((f) => {
+    const b = f.querySelector(".viz-body") as HTMLElement;
+    b.scrollTop = b.scrollHeight;
+    const x = [...f.querySelectorAll("button")].find((n) => /Fechar/.test(n.textContent ?? ""))!;
+    return {
+      rolouMiolo: b.scrollTop,
+      rolouFigura: f.scrollTop,
+      head: f.querySelector(".viz-head")!.getBoundingClientRect().y,
+      fechar: x.getBoundingClientRect().y,
+    };
+  });
+  expect(depois.rolouMiolo, "quem rolou tem que ser o miolo").toBeGreaterThan(0);
+  expect(depois.rolouFigura, "a figura não pode rolar").toBe(0);
+
+  // A asserção que carrega o sentido é a posição comparada com ela mesma:
+  // `toBeInViewport()` sozinho passa nas duas pontas da rolagem.
+  expect(Math.abs(depois.head - antes.head), "o cabeçalho andou junto com o miolo").toBeLessThanOrEqual(2);
+  expect(Math.abs(depois.fechar - antes.fechar), "o ✕ Fechar andou junto com o miolo").toBeLessThanOrEqual(2);
+  await expect(fechar).toBeInViewport({ ratio: 1 });
+}
+
+test("as três peças anunciam o mesmo botão, e cada rótulo diz o que a peça mostra", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  // a afordância é a mesma nas três: era 1 Expandir para 3 figuras iguais
+  await expect(page.getByRole("button", { name: "⤢ Expandir" })).toHaveCount(3);
+
+  const corrida = muda(page, TITULO_CORRIDA);
+  const estab = muda(page, TITULO_ESTABILIDADE);
+  await expect(corrida).toHaveCount(1);
+  await expect(estab).toHaveCount(1);
+  // rótulo e valor no mesmo locator. E os números do cabeçalho da corrida têm
+  // que bater com as barras: o teto é o que o selection sort gasta sempre.
+  await expect(corrida.locator(".viz-step")).toHaveText(
+    "12 inversões na entrada · piso 7, teto 28 comparações"
+  );
+  await expect(corrida.locator(".ord-linha").nth(1).locator(".bb-barra-txt").first()).toHaveText("28");
+  await expect(estab.locator(".viz-step")).toHaveText("2 chamados fora da ordem de chegada");
+  await expect(estab.locator(".hs-fila").nth(3).locator(".hp-cel.reg.inverteu")).toHaveCount(2);
+});
+
+test("nenhuma das duas promete esconder um bloco que ela não tem", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  for (const titulo of [TITULO_CORRIDA, TITULO_ESTABILIDADE]) {
+    const fig = muda(page, titulo);
+    await expect(fig.locator(".viz-code-slot"), `${titulo}: não há bloco recolhível`).toHaveCount(0);
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveCount(0);
+    await expect(fig.getByRole("button", { name: /código/ })).toHaveCount(0);
+    await expect(fig.locator(".viz-foot")).toHaveCount(0);
+    await expect(fig.locator(".viz-atalhos")).toHaveCount(0);
+    await expect(fig.getByRole("button", { name: /Rodar|Próximo|Anterior/ })).toHaveCount(0);
+    await expect(fig.locator(".viz-step")).not.toHaveText(/passo \d+ de \d+/);
+  }
+});
+
+test("a corrida: o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
+  await abrir(page, 1440, 600);
+  await provarCamada1(await abrirPainel(page, muda(page, TITULO_CORRIDA)));
+});
+
+test("a estabilidade: o cabeçalho e o ✕ Fechar ficam parados enquanto o miolo rola", async ({ page }) => {
+  await abrir(page, 1440, 600);
+  await provarCamada1(await abrirPainel(page, muda(page, TITULO_ESTABILIDADE)));
+});
+
+test("o painel das peças novas é um diálogo de verdade: foco, Tab preso, Esc e rolagem travada", async ({
+  page,
+}) => {
+  await abrir(page, 1440, 600);
+  await abrirPainel(page, muda(page, TITULO_ESTABILIDADE));
+
+  const overlay = page.locator(".viz-overlay-fit");
+  await expect(overlay).toHaveAttribute("role", "dialog");
+  await expect(overlay).toHaveAttribute("aria-modal", "true");
+  // o rótulo do diálogo é o título DESTA peça, não um genérico
+  await expect(overlay).toHaveAttribute(
+    "aria-label",
+    "Visualizador · a distância da troca decide a estabilidade"
+  );
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+
+  const fugas: string[] = [];
+  for (let i = 0; i < 14; i++) {
+    await page.keyboard.press("Tab");
+    const onde = await page.evaluate(() => {
+      const a = document.activeElement;
+      const f = document.querySelector(".viz-overlay-fit figure.viz-fit");
+      return { dentro: !!(f && a && f.contains(a)), quem: a?.className || a?.tagName || "?" };
+    });
+    if (!onde.dentro) fugas.push(`volta ${i + 1}: ${onde.quem}`);
+  }
+  expect(fugas, "o foco vazou do painel").toEqual([]);
+
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay-fit")).toHaveCount(0);
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+});
+
+test("a corrida cabe a 1512x900 e NÃO cabe a 1440x700: é o corolário da §3", async ({ page }) => {
+  const medir = (page: Page) =>
+    muda(page, TITULO_CORRIDA).evaluate((f) => {
+      const hh = parseFloat(
+        getComputedStyle(document.documentElement).getPropertyValue("--ccc-header-h")
+      );
+      return {
+        altura: Math.round(f.getBoundingClientRect().height),
+        orcamento: Math.round(window.innerHeight - (Number.isFinite(hh) && hh > 0 ? hh : 60) - 24),
+      };
+    });
+
+  await abrir(page, 1512, 900);
+  const alta = await medir(page);
+  expect(alta.altura, `peça ${alta.altura}px, orçamento ${alta.orcamento}px`).toBeLessThanOrEqual(
+    alta.orcamento
+  );
+
+  await abrir(page, 1440, 700);
+  const baixa = await medir(page);
+  // A régua do contrato responde "a camada 3 é necessária?", não "a camada 1 é
+  // necessária?". Aqui a mesma peça passa do orçamento cem pixels mais abaixo,
+  // e é por isso que ela precisava do painel.
+  expect(baixa.altura, `peça ${baixa.altura}px, orçamento ${baixa.orcamento}px`).toBeGreaterThan(
+    baixa.orcamento
+  );
 });


### PR DESCRIPTION
Cinco `figure.viz` de três páginas entram na casca adaptativa. Elas vestiam **a
mesma moldura** das peças já adaptadas ao lado, e não tinham **nada** do
contrato: sem botão `⤢ Expandir`, sem diálogo, sem trava de rolagem, sem `Esc`,
sem foco e sem medição.

O que o aluno via, e é isto que faz disto um defeito e não uma métrica: em
`merge-sort` e `ordenacao-basica`, **2 peças mudas para 1 que expandia**; em
`heap-sort`, 1 para 1. Aparência idêntica, afordância diferente. Ele aprende que
o botão não existe e para de procurar, inclusive nas que o têm.

| tópico | peças |
|---|---|
| `merge-sort` | `MergeSortNiveis`, `MergeEmpate` |
| `ordenacao-basica` | `OrdenacaoBasicaCorrida`, `OrdenacaoBasicaEstabilidade` |
| `heap-sort` | `HeapSortEstabilidade` |

As cinco entram com **`total: 1`** (não há passo a passo: a variável é o preset,
o operador ou o tamanho da entrada) e **`collapsible: false`** (não há bloco
dispensável: as filas, as barras e a tabela são o conteúdo). Sem `children` no
`VizFooter` o rodapé some inteiro, então o que elas ganham é o painel expandido
com o cabeçalho parado enquanto o miolo rola. **Zero linha de CSS novo.**

Com este PR, `merge-sort`, `ordenacao-basica` e `heap-sort` ficam **inteiramente
na casca**: 3 das 10 páginas com peça muda fecham.

---

## Placar da casca

Medido na branch (`grep -L useVisualizer | xargs grep -l 'className="viz"'`):

```
87  arquivos .tsx em content/visualizers/
66  com o hook useVisualizer   (61 na base + as 5 deste PR)
12  fora do hook, mas vestindo figure.viz
```

A base desta branch é a `main` em `e35c1b2`, **sem** o PR #47 (o gráfico do Big
O). Quando ele entrar, a conta passa a **67 de 87**, com **11 peças mudas** em
**7 páginas**: `backtracking`, `binary-heap`, `binary-numbers`, `busca-binaria`,
`negative-binary`, `quick-sort` e `shell-sort`.

---

## Medição

Três réguas, com as fontes esperadas (`document.fonts.ready`), a janela afirmada
contra o que foi pedido (`page.viewportSize()`) e o `scrollTop` zerado antes de
cada leitura de posição. **17 estados** (todos os presets das cinco peças) antes
e depois.

### Altura no artigo, antes → depois

| peça | 1512x900 (orç. 816) | 1440x700 (orç. 616) | 390x844 (orç. 760) |
|---|---|---|---|
| `MergeSortNiveis` | 875..1001 → **911..1037** (+36) | 889..1015 → **925..1051** (+36) | 1303..1429 → **1351..1477** (+48) |
| `MergeEmpate` | 1069..1205 → **1077..1213** (+8) | 1069..1205 → **1077..1213** (+8) | 1935..2185 → **1964..2214** (+29) |
| `OrdenacaoBasicaCorrida` | 727 → **763** (+36) | 748 → **784** (+36) | 1267..1285 → **1327..1345** (+60) |
| `OrdenacaoBasicaEstabilidade` | 921..945 → **929..953** (+8) | 921..966 → **929..974** (+8) | 1529..1640 → **1552..1685** (+23..45) |
| `HeapSortEstabilidade` | 688..712 → **696..720** (+8) | 688..712 → **696..720** (+8) | 1153..1240 → **1173..1285** (+20..45) |

### E o +N não é o que o contrato prevê. Vale a pena olhar.

A §9 mede o custo de adotar a casca em três peças `collapsible: false` e conclui
**+28, +10, −4**, com o mecanismo declarado: `+10` é o custo fixo do `.viz-foot`,
`−4` é o `padding-bottom` que passa de 18 para 14 quando não há rodapé nenhum.
As cinco daqui são o caso `−4` (`total: 1` **e** sem `children`), e eu ia
escrever isso. **Medido: +8 em três e +36 em duas.**

A decomposição, feita escondendo o botão com `display: none` no build novo, numa
leitura só e sem rebuild:

| peça | `.viz-head` sem o botão | com o botão | conta |
|---|---:|---:|---|
| `MergeEmpate` | 41px | **53** | −4 + 12 = **+8** |
| `OrdenacaoBasicaEstabilidade` | 41px | **53** | −4 + 12 = **+8** |
| `HeapSortEstabilidade` | 41px | **53** | −4 + 12 = **+8** |
| `MergeSortNiveis` | 41px | **81** | −4 + 40 = **+36** |
| `OrdenacaoBasicaCorrida` | 41px | **81** | −4 + 40 = **+36** |

O `−4` da §9 está **confirmado nas cinco**. O que a §9 não prevê é o segundo
termo: `.viz-fit .viz-head-right` é `flex-wrap: wrap`, e o que decide se o botão
quebra a linha é o **comprimento do `children` do `VizHeader`** — que a §6 manda
alongar justamente numa peça `total: 1`, porque ali ele **substitui** um
"passo 12 de 93" de 12 caracteres por uma frase com rótulo. O corte medido fica
perto de 40 caracteres:

| peça | rótulo do `.viz-step` | car. | quebrou |
|---|---|---:|---|
| `HeapSortEstabilidade` | `6 registros fora da ordem original` | 34 | não |
| `OrdenacaoBasicaEstabilidade` | `2 chamados fora da ordem de chegada` | 35 | não |
| `MergeEmpate` | `as duas versões se separam na decisão 2` | 38 | não |
| `OrdenacaoBasicaCorrida` | `12 inversões na entrada · piso 7, teto 28 comparações` | 53 | **sim** |
| `MergeSortNiveis` | `4 rodadas de intercalação x 16 elementos = 64 movimentos` | 55 | **sim** |

A §9 já tem a subseção do eixo do cabeçalho, medida no `AStarVisualizer`: 53 →
81px em **19 dos 514 estados**, e só a 1440px. Ali é caso de borda; numa peça
`total: 1` é o **estado permanente**, em todas as réguas.

A 390x844 muda de novo: o cabeçalho já tem duas linhas sem o botão (99px), a
casca passa a **custar** 10 em vez de devolver 4, e o botão cobra 38.

### Painel expandido: o que antes não existia

Antes: **não havia painel**. Depois, medido nas cinco peças e nas quatro réguas:

| régua | sobra do miolo (o que passa a rolar) | sobra da figura | cabeçalho | `✕ Fechar` |
|---|---|---:|---:|---:|
| 1512x900 | 0, 214, 0, 0, 0 | **0** | **0px** | **0px** |
| 1440x700 | 179, 405, 0, 173, 0 | **0** | **0px** | **0px** |
| 1440x600 | 274, 500, 49, 268, 34 | **0** | **0px** | **0px** |
| 390x844 | 565, 1403, 503, 843, 461 | **0** | **0px** | **0px** |

(na ordem: níveis, empate, corrida, estabilidade da ordenação, estabilidade do
heap.) Quem rola é o miolo; a figura sobra 0 nas 20 combinações. Nas quatro
réguas o `role="dialog"`, o `aria-modal="true"`, o `aria-label` com o título
**daquela** peça, o foco entrando na figura, o `body { overflow: hidden }`
enquanto o painel está aberto e o `Esc` devolvendo a rolagem foram todos lidos.

**Onde o teste de rolagem mora, e por quê:** a 1512x900 três das cinco sobram
**0** no painel. Teste de rolagem sem o que rolar é decoração verde, então a
camada 1 é provada a 1440x600 (merge sort e ordenação básica) e a 390x844
(heap sort, onde a peça tem 461px de sobra contra 34 a 1440x600).

### O corolário da §3, com os dois lados no mesmo teste

`OrdenacaoBasicaCorrida` **cabe** a 1512x900 (763 de 816) e **passa do
orçamento** a 1440x700 (784 de 616). `HeapSortEstabilidade` idem (720 de 816 e
720 de 616). A régua do contrato responde *"a camada 3 é necessária?"*, não
*"a camada 1 é necessária?"* — e as duas peças que pareciam sadias na régua
oficial são justamente as que não cabem cem pixels mais abaixo.

### Um eixo de altura que a rodada anterior mediu como constante

O `.ms-niveis` do `MergeSortVisualizer` mede **163px constantes nos 358
estados**: os presets têm 7 e 8 elementos e `segments()` devolve 4 níveis para
os dois. O `MergeSortNiveis` desenha `.ms-niveis` **com a mesma função
exportada e a mesma classe**, e os chips dele vão de 8 a 64, atravessando três
degraus de log₂: **911, 953, 995 e 1037px** a 1512x900, 42px por faixa, exatos.
Mesmo desenho, mesma função, eixo oposto. Virou teste.

---

## Provas de quebra

Todas com o **build visível**, `failed` **e** `passed` impressos, filtro
restrito ao arquivo certo, e restauração por `cp` (nunca `git checkout --`),
com `git status --porcelain` vazio depois de cada uma.

| # | quebra | teste | resultado |
|---|---|---|---|
| A1 | `VizHeader` para dentro do `.viz-body` no `MergeSortNiveis` | o mapa de níveis: cabeçalho e ✕ Fechar parados | **1 failed / 0 passed** |
| A2 | idem, `MergeEmpate` | o comparador de empate | **1 failed / 0 passed** |
| A3 | idem, `OrdenacaoBasicaCorrida` | a corrida | **1 failed / 0 passed** |
| A4 | idem, `OrdenacaoBasicaEstabilidade` | a estabilidade | **1 failed / 0 passed** |
| A5 | idem, `HeapSortEstabilidade` | camada 1 do heap sort | **1 failed / 0 passed** |
| A1' | A1 **com a asserção do cabeçalho apagada** | idem | **1 failed / 0 passed**, em `o ✕ Fechar andou junto com o miolo`, **Received: 274** |
| B1 | `collapsible: true` no `MergeEmpate` | nenhuma das duas promete esconder um bloco | **1 failed / 0 passed** |
| B2 | idem, `HeapSortEstabilidade` | ela não promete esconder um bloco | **1 failed / 0 passed** |
| C1 | `total: 2` no `MergeSortNiveis` | nenhuma das duas promete esconder um bloco | **1 failed / 0 passed** |
| C2 | idem, `OrdenacaoBasicaCorrida` | idem, na ordenação básica | **1 failed / 0 passed** |
| D | `aria-label={title}` → `aria-label="Visualizador"` **no hook** | os três testes de diálogo | **3 failed / 0 passed** |
| E1 | `ARTIGO` volta a `article figure.viz-fit` | `tests/viz-heap-sort.spec.ts` inteiro | **11 failed / 0 passed**, com `strict mode violation: resolved to 2 elements` |
| E2 | `PRINCIPAL` volta a `article figure.viz-fit` | `tests/viz-merge-sort.spec.ts` inteiro | **16 failed / 0 passed** |
| F | `segments(n)` → `segments(16)` | no mapa de níveis o n É eixo de altura | **1 failed / 0 passed** |
| G | o `.viz-step` do heap passa a somar o sort **estável** | as duas peças anunciam o mesmo botão | **1 failed / 0 passed**, no `toHaveText` |

Três notas de execução, e as três valem mais que o `1 failed`:

- **A1' responde "qual asserção está trabalhando".** Com o `1 failed` da A1 eu
  sabia que o teste pega a quebra, e não sabia **qual** das duas asserções. Apaguei
  a do cabeçalho, reapliquei a quebra e o `✕ Fechar` reprovou sozinho, com 274px
  (exatamente a sobra do miolo). Aqui as duas medem a mesma coisa por dois
  caminhos, ao contrário do caso com rodapé, onde a do cabeçalho passa.
- **A quebra óbvia do D reprova pelo motivo errado.** Trocar o `title` da peça
  por um genérico faz o locator `filter({ hasText: <título> })` deixar de casar,
  e o teste morre num `locator.click: Test timeout of 30000ms` três linhas antes
  da asserção. O `title` alimenta o cabeçalho **e** o `aria-label`. A quebra que
  vale está no hook.
- **O `src/lib/visualizer.tsx` foi quebrado uma vez, como experimento** (o D
  acima), e restaurado por `cp`. `git diff src/lib/visualizer.tsx` sai vazio, e a
  branch **não entrega** nenhuma mudança nele.

---

## Dois achados de outra lane, consertados aqui

Os dois caíram em arquivos que este PR é dono, e por isso vieram para cá em vez
de virar PR próprio. Cada um é um commit.

### 1. A asserção que carrega a tese do heap sort nunca a verificou

`tests/viz-heap-sort.spec.ts` afirmava, no fim da varredura da animação, que o
array final está ordenado. Ele nunca esteve sendo lido. A célula é
`<span class="hp-cel"><i>4</i>6</span>`: o índice mora no `<i>` e o **valor é um
nó de texto irmão, sem elemento próprio**. O `textContent` concatena os dois
(`"46"`) e o `replace(/^\d+/, "")` que fatiava isso é guloso, come a string
inteira, sobra `""` e `parseInt("")` devolve **NaN em todas as células**. Como
`[NaN, NaN]` é igual a `[NaN, NaN]` ordenado, o `toEqual` passava com qualquer
coisa na tela.

A leitura agora desce até o nó do valor, e a asserção passa a exigir que o array
final seja o **primeiro ordenado**, o que cobra duas coisas de uma vez: mesma
multiplicidade de valores e ordem crescente. Mais duas guardas: nenhum NaN entre
os valores lidos, e o array de entrada foi mesmo lido.

**A prova é a mesma quebra nos dois lados.** Invertendo `a[left] > a[largest]`
no sift down, o max-heap deixa de ser max-heap e o array final sai desordenado
(e compila):

| asserção | contra a MESMA quebra |
|---|---|
| a nova | **1 failed / 0 passed**, na linha do `toEqual`, com o array desordenado no `Received` |
| a antiga | **0 failed / 1 passed** |

É a diferença entre um teste e um enfeite verde, medida no mesmo build.

### 2. A faixa de fase anunciava `posições 0 a 0` com o heap vazio

`content/visualizers/HeapSortVisualizer.tsx`, no passo final: o heap ativo tem
zero elementos e a faixa dizia **`heap ativo: posições 0 a 0`**, porque o
`Math.max(s.n - 1, 0)` transformava o `-1` num `0`. Ela afirma que a posição 0
ainda está no heap, ao lado de um desenho que diz `heap vazio: tudo virou
resultado`.

**E o defeito é maior do que parece de fora:** essa frase é *exatamente a mesma*
que o passo com `n = 1` mostra, onde ela é **verdadeira**. Eram dois estados
diferentes com um texto só, e um deles mentindo. Medido nos 4 presets, passo a
passo (289 estados): `posições 0 a 0` aparecia em **12** deles, **8 com n = 1**
(certo) e **4 com n = 0** (errado).

O conserto segue o caminho do selo `gap 0` do ShellSort (PR #46): em vez de
sumir com a faixa (ela é a única marca de fase, e sumir deixa buraco), o
primeiro lado dela passa a dizer `heap vazio`, que é o vocabulário que o desenho
ao lado já usa. O segundo lado, `já ordenado: N de M`, é verdadeiro sempre e
fica.

**Diff do texto renderizado, 289 estados dos 4 presets, antes contra depois: 4
linhas mudam**, e são os 4 passos finais. Os 8 estados com `n = 1` continuam
idênticos:

```
78c78
< preset0 passo 78/78 n=0 txt="heap ativo: posições 0 a 0 · já ordenado: 10 de 10"
> preset0 passo 78/78 n=0 txt="heap vazio · já ordenado: 10 de 10"
   (mais 3, um por preset; nenhuma outra linha difere)
```

O teste da fronteira acompanha e passa a cobrir os **dois lados** da condicional:
reconhece as duas formas do rótulo, exige `heap vazio` quando `n = 0`, exige a
faixa quando `n > 0`, e afirma que o `heap vazio` acontece **exatamente uma vez
e no último passo**. A comparação `ultimo !== Math.max(n - 1, 0)` virou
`ultimo !== n - 1`, porque o clamp do teste espelhava a mesma mentira do
componente.

**Prova de quebra:** com o rótulo antigo de volta, **1 failed / 0 passed**, na
linha do `expect(leitura.erros)`, com o valor antigo no `Received`:

```
"passo 78: n=0 e o cartao ainda anuncia uma faixa:
 \"heap ativo: posições 0 a 0 · já ordenado: 10 de 10\""
"passo 78: cartao diz ate 0, painel diz n=0"
```

**Conferência de 390x844 reaberta**, porque isto muda string renderizada: a
faixa mede 59px, fonte de 11,5px, nada vaza da própria caixa e a página não rola
na horizontal.

⚠️ **Este é o único arquivo do PR que outra lane também toca:** o
`HeapSortVisualizer.tsx` está aberto no **PR #62**. Ele é idêntico entre a base
desta branch e a `origin/main` de agora, então não há conflito com o que já
mergeou; quem mergear depois resolve. A mudança daqui são **duas linhas** (uma
constante nova e a interpolação que a usa), de propósito.

---

## O que NÃO mudou

- **Nenhuma palavra de tela nas cinco peças da adaptação.** A prova é o texto
  renderizado do build, estado a estado: os **17 estados**, elemento a elemento,
  com a classe, o `aria-pressed` e o `gridColumn` de cada um, `origin/main`
  contra esta branch. São **1.946 linhas**, e a única diferença são as **17
  ocorrências** do botão `⤢ Expandir` novo, uma por estado. O miolo
  (`.viz-body`) sai com **zero** diferenças.
- **Uma exceção declarada, e é o achado 2 acima:** o `HeapSortVisualizer` muda
  texto de tela **de propósito**, em **4 dos 289 estados** varridos (o passo
  final de cada preset). Nenhum outro estado dele difere, e nenhuma das cinco
  peças da adaptação foi tocada por essa mudança.
- **Nenhuma linha de CSS.** `src/app/globals.css` intocado.
- **Nenhum arquivo compartilhado na entrega:** o hook, o contrato, o
  `globals.css`, o `playwright.config.ts`, o `mdx-components.tsx`, o
  `content/roadmap.ts`, o `content/topics/**` e o `tests/navegacao.spec.ts`
  ficaram como estavam. O diff toca **9 arquivos**: seis componentes e três
  specs. O `HeapSortVisualizer.tsx` entrou pelo achado 2, com duas linhas.
- **Nenhum literal que vira classe foi traduzido.** `quebrou`, `inverteu`, `on`,
  `invalid`, `ok`, `folha` e `melhor` continuam como o `globals.css` os escreve,
  conferidos por `grep` de todo `` className={`…${ `` dos cinco arquivos antes do
  rename.
- **Nenhuma âncora na gravação.** `grep` por `encontro`, `gravaç`, `no vídeo`,
  `quadro`, `ao vivo`, `na aula`, `reunião`, `comunidade` e `do canal` nos cinco
  componentes e nos três `.mdx` sai vazio. Os rótulos de preset descrevem a
  entrada (`Linhas de log com o mesmo segundo`, `Chaves todas iguais`).

## Idioma

Identificadores para o inglês nas cinco peças (o `OrdenacaoBasicaCorrida` já
estava, porque importa os símbolos do vizinho). O `guarda-idioma.py` sai com a
lista "suja" normal de uma adaptação: as seis strings que somem em todas
(`viz`, `viz-body`, `viz-head`, `viz-head-right`, `viz-head-title`, `dot`) são as
que o hook passou a ser dono. As duas linhas que não são isso foram conferidas
uma a uma:

- `MergeEmpate`: `esq`/`dir` → `left`/`right` era o valor da união `side`, **que
  não era renderizado em lugar nenhum**; o campo saiu inteiro na revisão, por
  ser estado morto. O texto de tela `esq[i] <= dir[j]` continua igual, porque é
  a fórmula que a peça ensina;
- `HeapSortEstabilidade`: o título saiu de nó JSX com `&quot;` para literal de
  string; o texto renderizado é idêntico.

Como o guarda tem dois buracos abertos (crase aninhada e texto colado a
interpolação) e está sendo reescrito noutro PR, **a prova que vale aqui é o
texto renderizado do build**, acima.

---

## Verificação

- `npm run build` ✓, `npx tsc --noEmit` ✓
- `npm run test:build` na porta 4412, com a máquina livre: **475 passed, 0
  failed**, rodada de novo depois dos dois achados acima e com o mesmo
  resultado (antes do PR: 459; os 16 testes novos são meus, 6 + 6 + 4, e os dois
  consertos são asserções dentro de testes que já existiam). Inclui
  `tests/viz-strings.spec.ts`, que passou inteiro nas duas rodadas: **nenhum
  flake nesta máquina**.
- 390x844 nas três páginas: 0 overflow de página, 0 elemento do cabeçalho
  vazando da própria caixa, 0 rótulo com fonte abaixo de 8px. Reaberta depois do
  achado 2, que muda string renderizada.

## O que achei e NÃO consertei

- **`content/visualizers/MergeEmpate.tsx:253`** — a linha da divergência recebe
  `className="ruim"` (vermelho), e o título do painel logo acima diz apenas
  *"a linha destacada é onde as duas versões se separam"*. Vermelho é uma
  afirmação de falha, e separar-se não é falhar: com `<=` aquela decisão está
  **certa**. É a mesma classe do achado de Backtracking sobre cor como rótulo, e
  o conserto (um estado neutro, como o `.bb-passos li.foco`) é **CSS
  compartilhado**, que esta branch não toca. Pré-existente à adaptação.
- **`tests/navegacao.spec.ts:221`** — `const CONTADOR = "figure.viz-fit"` segue
  sem escopo. Conferi que os três testes que o usam só visitam `/topico/big-o/`,
  então este PR não o alcança; o PR #47 já o está consertando na lane dele.
- **Nenhuma peça pediu CSS novo.** As cinco couberam no contrato como ele está,
  com `total: 1` e `collapsible: false`, exatamente como a `§6` prevê.

## Proposta para o contrato

Quatro parágrafos prontos para colar (§9 duas vezes, §8 uma, e o
`armadilhas.md`) ficaram no aprendizado desta rodada, em
`helpeer/.claude/skills/adaptar-visualizadores-dsa/references/aprendizados/grupo-ordenacao-mudas.md`.
O principal: **numa peça `total: 1` o custo de adotar a casca é a linha do
cabeçalho, não o rodapé**, e quem citar o `−4` da §9 sem medir vai errar por
40px.

