### PR TITLE
feat(viz): casca nas quatro peças mudas de binary-numbers e negative-binary

### DIFF
--- a/content/visualizers/BinarioBases.tsx
+++ b/content/visualizers/BinarioBases.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinarioBases, o mesmo número em quatro sistemas, e o que cabe em cada tipo.
@@ -23,13 +24,13 @@ import { useMemo, useState } from "react";
 // do tempo: a variável é o número.
 // ---------------------------------------------------------------------------
 
-const VALORES = [53, 201, 255, 4095, 48879];
+const VALUES = [53, 201, 255, 4095, 48879];
 
-const BASES: { base: number; nome: string; nota: string }[] = [
-  { base: 2, nome: "binário", nota: "2 símbolos: 0 e 1. É o que existe no hardware." },
-  { base: 8, nome: "octal", nota: "8 símbolos. Cada dígito vale exatamente 3 bits. Sobrevive nas permissões de arquivo do Unix." },
-  { base: 10, nome: "decimal", nota: "10 símbolos. É o único da lista que não tem relação com potências de dois." },
-  { base: 16, nome: "hexadecimal", nota: "16 símbolos, de 0 a F. Cada dígito vale exatamente 4 bits, e é por isso que ele é a forma curta de escrever binário." },
+const BASES: { base: number; name: string; note: string }[] = [
+  { base: 2, name: "binário", note: "2 símbolos: 0 e 1. É o que existe no hardware." },
+  { base: 8, name: "octal", note: "8 símbolos. Cada dígito vale exatamente 3 bits. Sobrevive nas permissões de arquivo do Unix." },
+  { base: 10, name: "decimal", note: "10 símbolos. É o único da lista que não tem relação com potências de dois." },
+  { base: 16, name: "hexadecimal", note: "16 símbolos, de 0 a F. Cada dígito vale exatamente 4 bits, e é por isso que ele é a forma curta de escrever binário." },
 ];
 
 // Formatador determinístico: Intl.NumberFormat diverge entre build e cliente.
@@ -37,7 +38,7 @@ function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function compacto(v: number): string {
+function compact(v: number): string {
   if (v >= 1e18) return `${num(v / 1e18)} qui`;
   if (v >= 1e15) return `${num(v / 1e15)} quatri`;
   if (v >= 1e12) return `${num(v / 1e12)} tri`;
@@ -46,45 +47,53 @@ function compacto(v: number): string {
   return num(v);
 }
 
-const TIPOS = [
-  { bits: 8, nome: "byte", exemplo: "byte, char, uint8" },
-  { bits: 16, nome: "16 bits", exemplo: "short, uint16" },
-  { bits: 32, nome: "32 bits", exemplo: "int, float, cor RGBA" },
-  { bits: 64, nome: "64 bits", exemplo: "long, double, ponteiro" },
+const TYPES = [
+  { bits: 8, name: "byte", example: "byte, char, uint8" },
+  { bits: 16, name: "16 bits", example: "short, uint16" },
+  { bits: 32, name: "32 bits", example: "int, float, cor RGBA" },
+  { bits: 64, name: "64 bits", example: "long, double, ponteiro" },
 ];
 
 export function BinarioBases() {
-  const [valor, setValor] = useState(255);
-  const bin = useMemo(() => valor.toString(2), [valor]);
-  const hex = useMemo(() => valor.toString(16).toUpperCase(), [valor]);
+  const [value, setValue] = useState(255);
+  const bin = useMemo(() => value.toString(2), [value]);
+  const hex = useMemo(() => value.toString(16).toUpperCase(), [value]);
+
+  const viz = useVisualizer({
+    title: "Visualizador · a base é um parâmetro, e os bits são um orçamento",
+    // Não é uma animação: a tabela responde ao valor escolhido e pronto. Com
+    // `total: 1` somem o contador de passo, o rodapé e os atalhos.
+    total: 1,
+    // As duas tabelas e a fita de grupos SÃO o conteúdo: não há bloco
+    // dispensável para recolher, e prometer esconder um seria rótulo mentindo.
+    collapsible: false,
+    // `measureOn` fica de fora de propósito: com `collapsible: false` não há
+    // decisão a tomar, e o hook nem espera as fontes.
+  });
 
   // Os grupos de 4 bits que formam cada dígito hexadecimal, alinhados pela
   // direita: é a demonstração de que hexa é binário com outra roupa.
-  const grupos = useMemo(() => {
-    const preenchido = bin.padStart(Math.ceil(bin.length / 4) * 4, "0");
+  const groups = useMemo(() => {
+    const padded = bin.padStart(Math.ceil(bin.length / 4) * 4, "0");
     const out: string[] = [];
-    for (let i = 0; i < preenchido.length; i += 4) out.push(preenchido.slice(i, i + 4));
+    for (let i = 0; i < padded.length; i += 4) out.push(padded.slice(i, i + 4));
     return out;
   }, [bin]);
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a base é um parâmetro, e os bits são um orçamento</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {num(valor)} = 0x{hex} = 0b{bin}
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo não há "passo N de M": o número que resume o estado
+          entra no lugar dele, com os três formatos juntos. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {num(value)} = 0x{hex} = 0b{bin}
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {VALORES.map((v) => (
-            <button key={v} className={`bigo-chip${valor === v ? " on" : ""}`} onClick={() => setValor(v)} aria-pressed={valor === v}>
+          {VALUES.map((v) => (
+            <button key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
               {num(v)}
             </button>
           ))}
@@ -98,7 +107,7 @@ export function BinarioBases() {
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
-            O mesmo {num(valor)} em quatro bases <em>quanto menor a base, mais dígitos</em>
+            O mesmo {num(value)} em quatro bases <em>quanto menor a base, mais dígitos</em>
           </div>
           <div className="bigo-fam-scroll">
             <table className="bigo-fam-table">
@@ -112,20 +121,20 @@ export function BinarioBases() {
               </thead>
               <tbody>
                 {BASES.map((b) => {
-                  const escrita = valor.toString(b.base).toUpperCase();
+                  const written = value.toString(b.base).toUpperCase();
                   return (
                     <tr key={b.base} className={b.base === 16 ? "hp-destaque" : ""}>
                       <td>
                         <div className="bigo-fam-not hp-nome">
-                          {b.nome} ({b.base})
+                          {b.name} ({b.base})
                         </div>
                       </td>
                       <td>
-                        <span className="bn-escrita">{escrita}</span>
+                        <span className="bn-escrita">{written}</span>
                       </td>
-                      <td className="nums">{escrita.length}</td>
+                      <td className="nums">{written.length}</td>
                       <td>
-                        <div className="hp-veredito">{b.nota}</div>
+                        <div className="hp-veredito">{b.note}</div>
                       </td>
                     </tr>
                   );
@@ -140,7 +149,7 @@ export function BinarioBases() {
             Por que hexadecimal e não decimal <em>cada dígito hexa é um grupo de 4 bits, sem sobra</em>
           </div>
           <div className="bn-grupos">
-            {grupos.map((g, k) => (
+            {groups.map((g, k) => (
               <span className="bn-grupo" key={k}>
                 <span className="bn-grupo-bits">{g}</span>
                 <span className="bn-grupo-hex">{parseInt(g, 2).toString(16).toUpperCase()}</span>
@@ -169,25 +178,25 @@ export function BinarioBases() {
                 </tr>
               </thead>
               <tbody>
-                {TIPOS.map((t) => {
+                {TYPES.map((t) => {
                   const combos = Math.pow(2, t.bits);
-                  const cabe = valor < combos;
+                  const fits = value < combos;
                   return (
                     <tr key={t.bits}>
                       <td>
-                        <div className="bigo-fam-not hp-nome">{t.nome}</div>
+                        <div className="bigo-fam-not hp-nome">{t.name}</div>
                         <div className="bigo-fam-nome">{t.bits} bits</div>
                       </td>
                       <td className="nums">
                         <span className="hp-custo c-bom">2^{t.bits}</span>
                       </td>
                       <td className="nums">
-                        <span className={`hp-custo ${cabe ? "c-otimo" : "c-ruim"}`}>{compacto(combos - 1)}</span>
+                        <span className={`hp-custo ${fits ? "c-otimo" : "c-ruim"}`}>{compact(combos - 1)}</span>
                       </td>
                       <td>
                         <div className="hp-veredito">
-                          {t.exemplo}
-                          {cabe ? "" : ` · o ${num(valor)} escolhido acima NÃO cabe aqui`}
+                          {t.example}
+                          {fits ? "" : ` · o ${num(value)} escolhido acima NÃO cabe aqui`}
                         </div>
                       </td>
                     </tr>
@@ -199,7 +208,7 @@ export function BinarioBases() {
         </div>
 
         <p className="viz-note ok">
-          Os {num(valor)} escolhidos precisam de <strong>{bin.length} bits</strong> para serem escritos, ou{" "}
+          Os {num(value)} escolhidos precisam de <strong>{bin.length} bits</strong> para serem escritos, ou{" "}
           {hex.length} dígitos hexadecimais. Repare que dobrar a quantidade de bits não dobra o alcance, ele
           eleva ao quadrado: 8 bits vão até 255, 16 até 65.535, e 32 até mais de 4 bilhões. É a mesma curva
           exponencial de sempre, vista do lado de dentro.
@@ -212,6 +221,10 @@ export function BinarioBases() {
           32 bits é uma decisão, não um detalhe.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem controles próprios, o rodapé some inteiro —
+          é o que devolve os 4px medidos no contrato, §9. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/BinarioConversor.tsx
+++ b/content/visualizers/BinarioConversor.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinarioConversor, o número binário como uma soma que dá para ver.
@@ -22,81 +23,87 @@ import { useMemo, useState } from "react";
 
 const N = 8;
 
-type Preset = { key: string; rotulo: string; valor: number; dica: string };
+type Preset = { key: string; label: string; value: number; hint: string };
 
 const PRESETS: Preset[] = [
   {
-    key: "cinquenta",
-    rotulo: "53",
-    valor: 53,
-    dica: "Um número qualquer. Repare que os únicos termos que entram na soma são os dos bits ligados: os zeros multiplicam a potência por zero e somem da conta, e é literalmente por isso que eles não valem nada.",
+    key: "fifty",
+    label: "53",
+    value: 53,
+    hint: "Um número qualquer. Repare que os únicos termos que entram na soma são os dos bits ligados: os zeros multiplicam a potência por zero e somem da conta, e é literalmente por isso que eles não valem nada.",
   },
   {
-    key: "duzentos",
-    rotulo: "201",
-    valor: 201,
-    dica: "Mais um caso comum. Este é o número que aparece no visualizador seguinte, o das divisões por 2: vale conferir se os dois caminhos chegam ao mesmo lugar.",
+    key: "twoHundred",
+    label: "201",
+    value: 201,
+    hint: "Mais um caso comum. Este é o número que aparece no visualizador seguinte, o das divisões por 2: vale conferir se os dois caminhos chegam ao mesmo lugar.",
   },
   {
-    key: "todos",
-    rotulo: "255, todos os bits ligados",
-    valor: 255,
-    dica: "O teto de um byte. Repare que 255 é 256 menos 1, e não 256: com 8 bits existem 256 combinações, mas uma delas é o zero. A soma 128 + 64 + 32 + 16 + 8 + 4 + 2 + 1 sempre dá um a menos que a próxima potência.",
+    key: "all",
+    label: "255, todos os bits ligados",
+    value: 255,
+    hint: "O teto de um byte. Repare que 255 é 256 menos 1, e não 256: com 8 bits existem 256 combinações, mas uma delas é o zero. A soma 128 + 64 + 32 + 16 + 8 + 4 + 2 + 1 sempre dá um a menos que a próxima potência.",
   },
   {
-    key: "potencia",
-    rotulo: "128, um bit só",
-    valor: 128,
-    dica: "Com um único bit ligado, o valor é a própria potência de dois. Ligue o bit da direita em vez do da esquerda e o número cai de 128 para 1: mesma quantidade de bits ligados, valores separados por um fator de 128.",
+    key: "power",
+    label: "128, um bit só",
+    value: 128,
+    hint: "Com um único bit ligado, o valor é a própria potência de dois. Ligue o bit da direita em vez do da esquerda e o número cai de 128 para 1: mesma quantidade de bits ligados, valores separados por um fator de 128.",
   },
   {
-    key: "zero",
-    rotulo: "0, nenhum bit",
-    valor: 0,
-    dica: "Todos os bits desligados. Vale reparar que o zero tem uma representação e só uma, o que parece óbvio agora e vai deixar de ser quando os números negativos entrarem.",
+    key: "none",
+    label: "0, nenhum bit",
+    value: 0,
+    hint: "Todos os bits desligados. Vale reparar que o zero tem uma representação e só uma, o que parece óbvio agora e vai deixar de ser quando os números negativos entrarem.",
   },
 ];
 
 export function BinarioConversor() {
-  const [valor, setValor] = useState(53);
-  const bits = useMemo(() => Array.from({ length: N }, (_, k) => (valor >> (N - 1 - k)) & 1), [valor]);
+  const [value, setValue] = useState(53);
+  const bits = useMemo(() => Array.from({ length: N }, (_, k) => (value >> (N - 1 - k)) & 1), [value]);
 
-  const alternar = (k: number) => setValor((v) => v ^ (1 << (N - 1 - k)));
-  const ligados = bits.filter((b) => b === 1).length;
-  const termos = bits.map((b, k) => ({ bit: b, exp: N - 1 - k, peso: 1 << (N - 1 - k) })).filter((t) => t.bit === 1);
-  const presetAtivo = PRESETS.find((p) => p.valor === valor);
+  const viz = useVisualizer({
+    title: "Visualizador · o binário é uma soma de potências de dois",
+    // A variável é o NÚMERO, não um passo: `total: 1` tira o contador, o rodapé
+    // e os atalhos, que aqui não teriam o que dirigir.
+    total: 1,
+    // Os bits, a conta escrita e os cartões SÃO o conteúdo. Não há bloco
+    // dispensável, e inventar um só para ganhar o botão seria rótulo mentindo.
+    collapsible: false,
+  });
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o binário é uma soma de potências de dois</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {bits.join("")} = {valor}
-          </span>
-        </div>
-      </div>
+  const toggleBit = (k: number) => setValue((v) => v ^ (1 << (N - 1 - k)));
+  const onBits = bits.filter((b) => b === 1).length;
+  const terms = bits.map((b, k) => ({ bit: b, exp: N - 1 - k, weight: 1 << (N - 1 - k) })).filter((t) => t.bit === 1);
+  const activePreset = PRESETS.find((p) => p.value === value);
 
-      <div className="viz-body">
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo, o número que resume o estado ocupa o lugar do
+          "passo N de M" — com o padrão de bits junto, que é o contexto dele. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {bits.join("")} = {value}
+        </span>
+      </VizHeader>
+
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((p) => (
             <button
               key={p.key}
-              className={`bigo-chip${valor === p.valor ? " on" : ""}`}
-              onClick={() => setValor(p.valor)}
-              aria-pressed={valor === p.valor}
+              className={`bigo-chip${value === p.value ? " on" : ""}`}
+              onClick={() => setValue(p.value)}
+              aria-pressed={value === p.value}
             >
-              {p.rotulo}
+              {p.label}
             </button>
           ))}
         </div>
 
         <p className="tt-legenda-arvore">
-          {presetAtivo
-            ? presetAtivo.dica
+          {activePreset
+            ? activePreset.hint
             : "Clique nos bits para ligar e desligar. Cada posição vale o dobro da posição à direita dela, e o número é só a soma das posições ligadas."}
         </p>
 
@@ -111,7 +118,7 @@ export function BinarioConversor() {
                 <button
                   key={k}
                   className={`bn-bit${b ? " on" : ""}`}
-                  onClick={() => alternar(k)}
+                  onClick={() => toggleBit(k)}
                   aria-pressed={b === 1}
                   aria-label={`Bit de expoente ${exp}, valor ${1 << exp}, ${b ? "ligado" : "desligado"}`}
                 >
@@ -135,10 +142,10 @@ export function BinarioConversor() {
             A conta, escrita por extenso <em>os bits desligados multiplicam por zero e somem</em>
           </div>
           <p className="bn-conta">
-            {termos.length === 0 ? (
+            {terms.length === 0 ? (
               <span className="bn-termo">0</span>
             ) : (
-              termos.map((t, k) => (
+              terms.map((t, k) => (
                 <span key={t.exp}>
                   {k > 0 ? <span className="bn-mais"> + </span> : null}
                   <span className="bn-termo">
@@ -149,28 +156,28 @@ export function BinarioConversor() {
             )}
           </p>
           <p className="bn-conta">
-            {termos.length === 0 ? (
+            {terms.length === 0 ? (
               <span className="bn-termo">0</span>
             ) : (
-              termos.map((t, k) => (
+              terms.map((t, k) => (
                 <span key={t.exp}>
                   {k > 0 ? <span className="bn-mais"> + </span> : null}
-                  <span className="bn-termo forte">{t.peso}</span>
+                  <span className="bn-termo forte">{t.weight}</span>
                 </span>
               ))
             )}
-            <span className="bn-igual"> = {valor}</span>
+            <span className="bn-igual"> = {value}</span>
           </p>
         </div>
 
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>valor decimal</span>
-            <strong>{valor}</strong>
+            <strong>{value}</strong>
           </div>
           <div className="bigo-stat">
             <span>bits ligados</span>
-            <strong>{ligados}</strong>
+            <strong>{onBits}</strong>
           </div>
           <div className="bigo-stat">
             <span>combinações com 8 bits</span>
@@ -190,6 +197,10 @@ export function BinarioConversor() {
           mesma diferença entre a centena e a unidade.
         </p>
       </div>
+
+      {/* `total: 1` e sem controles próprios: o `VizFooter` some inteiro, e é
+          isso que devolve os 4px medidos no §9 do contrato. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/BinarioFaixa.tsx
+++ b/content/visualizers/BinarioFaixa.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinarioFaixa, o mesmo padrão de bits lido de dois jeitos.
@@ -24,96 +25,103 @@ import { useMemo, useState } from "react";
 
 const N = 8;
 
-const paraBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
-const comSinal = (v: number) => (v >= 128 ? v - 256 : v);
+const toBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
+const asSigned = (v: number) => (v >= 128 ? v - 256 : v);
 
-type Marco = { valor: number; rotulo: string; nota: string };
+type Milestone = { value: number; label: string; note: string };
 
-const MARCOS: Marco[] = [
+const MILESTONES: Milestone[] = [
   {
-    valor: 0,
-    rotulo: "00000000",
-    nota: "O zero, e ele é o mesmo nos dois mundos. É o único padrão em que as duas leituras coincidem por definição, e não por acaso.",
+    value: 0,
+    label: "00000000",
+    note: "O zero, e ele é o mesmo nos dois mundos. É o único padrão em que as duas leituras coincidem por definição, e não por acaso.",
   },
   {
-    valor: 1,
-    rotulo: "00000001",
-    nota: "Um bit ligado, o da direita. Com o bit de sinal desligado, as duas leituras continuam iguais, e vão continuar assim em toda a metade de baixo da tabela.",
+    value: 1,
+    label: "00000001",
+    note: "Um bit ligado, o da direita. Com o bit de sinal desligado, as duas leituras continuam iguais, e vão continuar assim em toda a metade de baixo da tabela.",
   },
   {
-    valor: 127,
-    rotulo: "01111111",
-    nota: "O último padrão em que as duas leituras coincidem: 127 nos dois. Some 1 e veja o que acontece, porque é aqui que mora o estouro de inteiro com sinal.",
+    value: 127,
+    label: "01111111",
+    note: "O último padrão em que as duas leituras coincidem: 127 nos dois. Some 1 e veja o que acontece, porque é aqui que mora o estouro de inteiro com sinal.",
   },
   {
-    valor: 128,
-    rotulo: "10000000",
-    nota: "O salto. Somar 1 a 127 acende o bit de sinal, e a leitura com sinal desaba de 127 para -128. Nenhum erro é reportado: para a máquina isso é só o padrão seguinte. Este é o estouro de inteiro que derruba sistema de verdade.",
+    value: 128,
+    label: "10000000",
+    note: "O salto. Somar 1 a 127 acende o bit de sinal, e a leitura com sinal desaba de 127 para -128. Nenhum erro é reportado: para a máquina isso é só o padrão seguinte. Este é o estouro de inteiro que derruba sistema de verdade.",
   },
   {
-    valor: 129,
-    rotulo: "10000001",
-    nota: "Continuando a partir do fundo: com o bit de sinal ligado, acender bits à direita SOMA. -128 + 1 = -127, e daqui até 11111111 os números negativos vão subindo até chegar a -1.",
+    value: 129,
+    label: "10000001",
+    note: "Continuando a partir do fundo: com o bit de sinal ligado, acender bits à direita SOMA. -128 + 1 = -127, e daqui até 11111111 os números negativos vão subindo até chegar a -1.",
   },
   {
-    valor: 255,
-    rotulo: "11111111",
-    nota: "Todos os bits ligados. É 255 sem sinal e -1 com sinal, e as duas coisas são verdade ao mesmo tempo: o padrão é o mesmo, o que muda é o tipo com que ele é lido.",
+    value: 255,
+    label: "11111111",
+    note: "Todos os bits ligados. É 255 sem sinal e -1 com sinal, e as duas coisas são verdade ao mesmo tempo: o padrão é o mesmo, o que muda é o tipo com que ele é lido.",
   },
 ];
 
-const TIPOS = [
-  { bits: 8, semSinal: "0 a 255", comSinal: "-128 a 127" },
-  { bits: 16, semSinal: "0 a 65.535", comSinal: "-32.768 a 32.767" },
-  { bits: 32, semSinal: "0 a 4.294.967.295", comSinal: "-2.147.483.648 a 2.147.483.647" },
-  { bits: 64, semSinal: "0 a mais de 18 quintilhões", comSinal: "cerca de -9,2 a 9,2 quintilhões" },
+const TYPES = [
+  { bits: 8, unsigned: "0 a 255", signed: "-128 a 127" },
+  { bits: 16, unsigned: "0 a 65.535", signed: "-32.768 a 32.767" },
+  { bits: 32, unsigned: "0 a 4.294.967.295", signed: "-2.147.483.648 a 2.147.483.647" },
+  { bits: 64, unsigned: "0 a mais de 18 quintilhões", signed: "cerca de -9,2 a 9,2 quintilhões" },
 ];
 
 export function BinarioFaixa() {
-  const [valor, setValor] = useState(128);
-  const bits = useMemo(() => paraBits(valor), [valor]);
-  const marco = MARCOS.find((m) => m.valor === valor);
-  const assinado = comSinal(valor);
+  const [value, setValue] = useState(128);
+  const bits = useMemo(() => toBits(value), [value]);
+  const milestone = MILESTONES.find((m) => m.value === value);
+  const signed = asSigned(value);
+
+  const viz = useVisualizer({
+    title: "Visualizador · o mesmo padrão, duas leituras",
+    // Andar pelos padrões vizinhos é um ciclo de 256 estados sem começo nem
+    // fim, não uma linha do tempo: `total: 1` tira contador, atalhos e barra,
+    // e os dois botões que andam ficam no rodapé, parados no painel.
+    total: 1,
+    // A fita, as duas leituras e a tabela SÃO o conteúdo: não há bloco
+    // dispensável para recolher.
+    collapsible: false,
+  });
 
   // A decomposição com o peso do bit de sinal negativo: é a regra de leitura
   // inteira do complemento de dois, escrita como soma.
-  const termos = bits
-    .map((b, k) => ({ b, peso: k === 0 ? -128 : 1 << (N - 1 - k) }))
+  const terms = bits
+    .map((b, k) => ({ b, weight: k === 0 ? -128 : 1 << (N - 1 - k) }))
     .filter((t) => t.b === 1);
 
-  const andar = (d: number) => setValor((v) => (v + d + 256) % 256);
+  const walk = (d: number) => setValue((v) => (v + d + 256) % 256);
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · o mesmo padrão, duas leituras</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {bits.join("")} · sem sinal {valor} · com sinal {assinado}
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo, o padrão e as duas leituras dele ocupam o lugar do
+          "passo N de M", com os rótulos junto dos números. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {bits.join("")} · sem sinal {value} · com sinal {signed}
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {MARCOS.map((m) => (
+          {MILESTONES.map((m) => (
             <button
-              key={m.valor}
-              className={`bigo-chip${valor === m.valor ? " on" : ""}`}
-              onClick={() => setValor(m.valor)}
-              aria-pressed={valor === m.valor}
+              key={m.value}
+              className={`bigo-chip${value === m.value ? " on" : ""}`}
+              onClick={() => setValue(m.value)}
+              aria-pressed={value === m.value}
             >
-              {m.rotulo}
+              {m.label}
             </button>
           ))}
         </div>
 
         <p className="tt-legenda-arvore">
-          {marco
-            ? marco.nota
+          {milestone
+            ? milestone.note
             : "Use os botões de menos 1 e mais 1 para andar pelos padrões vizinhos e acompanhar as duas leituras."}
         </p>
 
@@ -138,15 +146,6 @@ export function BinarioFaixa() {
               </span>
             ))}
           </div>
-          <div className="bn-passeio">
-            <button className="viz-btn" onClick={() => andar(-1)} aria-label="Padrão anterior">
-              ‹ menos 1
-            </button>
-            <span className="bn-passeio-txt">andar pelos padrões vizinhos</span>
-            <button className="viz-btn" onClick={() => andar(1)} aria-label="Próximo padrão">
-              mais 1 ›
-            </button>
-          </div>
         </div>
 
         {/* Os dois cards ficam neutros de propósito. Nenhuma das duas leituras é
@@ -164,16 +163,16 @@ export function BinarioFaixa() {
                 <span className="bn-termo forte">0</span>
               ) : (
                 bits
-                  .map((b, k) => ({ b, peso: 1 << (N - 1 - k) }))
+                  .map((b, k) => ({ b, weight: 1 << (N - 1 - k) }))
                   .filter((t) => t.b === 1)
                   .map((t, k) => (
-                    <span key={t.peso}>
+                    <span key={t.weight}>
                       {k > 0 ? <span className="bn-mais"> + </span> : null}
-                      <span className="bn-termo forte">{t.peso}</span>
+                      <span className="bn-termo forte">{t.weight}</span>
                     </span>
                   ))
               )}
-              <span className="bn-igual"> = {valor}</span>
+              <span className="bn-igual"> = {value}</span>
             </p>
             <p className="bb-formula-fim">Todos os oito bits valem magnitude. A faixa vai de 0 a 255.</p>
           </div>
@@ -183,17 +182,17 @@ export function BinarioFaixa() {
               <span className="bb-formula-selo">sbyte, int8</span>
             </div>
             <p className="bn-conta">
-              {termos.length === 0 ? (
+              {terms.length === 0 ? (
                 <span className="bn-termo forte">0</span>
               ) : (
-                termos.map((t, k) => (
-                  <span key={t.peso}>
+                terms.map((t, k) => (
+                  <span key={t.weight}>
                     {k > 0 ? <span className="bn-mais"> + </span> : null}
-                    <span className={`bn-termo forte${t.peso < 0 ? " negativo" : ""}`}>{t.peso}</span>
+                    <span className={`bn-termo forte${t.weight < 0 ? " negativo" : ""}`}>{t.weight}</span>
                   </span>
                 ))
               )}
-              <span className="bn-igual"> = {assinado}</span>
+              <span className="bn-igual"> = {signed}</span>
             </p>
             <p className="bb-formula-fim">
               O bit da esquerda vale <strong>-128</strong> em vez de +128. Todo o resto da conta é idêntico, e é
@@ -202,8 +201,8 @@ export function BinarioFaixa() {
           </div>
         </div>
 
-        <p className={`viz-note${valor === 128 ? " invalid" : " ok"}`}>
-          {valor === 128 ? (
+        <p className={`viz-note${value === 128 ? " invalid" : " ok"}`}>
+          {value === 128 ? (
             <>
               Este é o padrão da virada. Vindo de <strong>01111111</strong> (127) e somando 1, o vai-um sobe até
               o bit de sinal e o número desaba para <strong>-128</strong>. Nenhuma exceção é lançada e nenhum
@@ -212,8 +211,8 @@ export function BinarioFaixa() {
             </>
           ) : (
             <>
-              O padrão <strong>{bits.join("")}</strong> vale <strong>{valor}</strong> lido como byte sem sinal e{" "}
-              <strong>{assinado}</strong> lido como byte com sinal. Os dois números estão certos: nada na
+              O padrão <strong>{bits.join("")}</strong> vale <strong>{value}</strong> lido como byte sem sinal e{" "}
+              <strong>{signed}</strong> lido como byte com sinal. Os dois números estão certos: nada na
               memória diz qual é o correto, quem decide é o tipo declarado na variável. Um valor lido com o tipo
               errado não dá erro, dá outro número.
             </>
@@ -234,16 +233,16 @@ export function BinarioFaixa() {
                 </tr>
               </thead>
               <tbody>
-                {TIPOS.map((t) => (
+                {TYPES.map((t) => (
                   <tr key={t.bits} className={t.bits === 8 ? "hp-destaque" : ""}>
                     <td>
                       <div className="bigo-fam-not hp-nome">{t.bits}</div>
                     </td>
                     <td>
-                      <span className="bn-escrita">{t.semSinal}</span>
+                      <span className="bn-escrita">{t.unsigned}</span>
                     </td>
                     <td>
-                      <span className="bn-escrita">{t.comSinal}</span>
+                      <span className="bn-escrita">{t.signed}</span>
                     </td>
                   </tr>
                 ))}
@@ -260,6 +259,25 @@ export function BinarioFaixa() {
           `abs(-2147483648)` devolver um número negativo em C: não existe o positivo correspondente.
         </p>
       </div>
+
+      {/* Os dois botões que andam pelos padrões são o que faz esta peça se
+          mexer, e por isso vão para o `.viz-foot`: fora do `.viz-body`, ficam
+          parados no pé do painel enquanto o miolo rola. Dentro do miolo eles
+          saíam de vista quando o aluno chegava à tabela do fim — medido, com o
+          miolo rolado até o fim: 358px ACIMA do topo visível a 390x844, e
+          apenas 15px de folga a 1440x700. A legenda vem junto, então a linha
+          continua se explicando sozinha onde quer que esteja. */}
+      <VizFooter viz={viz}>
+        <div className="bn-passeio">
+          <button className="viz-btn" onClick={() => walk(-1)} aria-label="Padrão anterior">
+            ‹ menos 1
+          </button>
+          <span className="bn-passeio-txt">andar pelos padrões vizinhos</span>
+          <button className="viz-btn" onClick={() => walk(1)} aria-label="Próximo padrão">
+            mais 1 ›
+          </button>
+        </div>
+      </VizFooter>
     </figure>
   );
 }

--- a/content/visualizers/BinarioTresFormas.tsx
+++ b/content/visualizers/BinarioTresFormas.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
 // BinarioTresFormas, por que o complemento de dois venceu.
@@ -22,82 +23,92 @@ import { useMemo, useState } from "react";
 
 const N = 8;
 
-type Forma = "sinal" | "um" | "dois";
+// Os três valores da união nunca chegam à tela: eles indexam `NAMES` e `HOW`, e
+// viram `key` de lista. Ficam em português de propósito — `"sinal"` também é
+// classe do `.bn-bit` neste mesmo arquivo, e trocar um dos dois papéis pede a
+// reação que re-quebra o outro (contrato §0, "literal com dois papéis").
+type Form = "sinal" | "um" | "dois";
 
-const NOMES: Record<Forma, string> = {
+const NAMES: Record<Form, string> = {
   sinal: "Sinal e magnitude",
   um: "Complemento de um",
   dois: "Complemento de dois",
 };
 
-const COMO: Record<Forma, string> = {
+const HOW: Record<Form, string> = {
   sinal: "liga o bit da esquerda e deixa o resto como está",
   um: "inverte todos os bits",
   dois: "inverte todos os bits e soma 1",
 };
 
-const paraBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
-const paraNum = (b: number[]) => b.reduce((acc, x, k) => acc + (x << (N - 1 - k)), 0);
+const toBits = (v: number) => Array.from({ length: N }, (_, k) => (v >> (N - 1 - k)) & 1);
+const toNumber = (b: number[]) => b.reduce((acc, x, k) => acc + (x << (N - 1 - k)), 0);
 
-function negar(v: number, forma: Forma): number[] {
-  const b = paraBits(v);
-  if (forma === "sinal") return [1, ...b.slice(1)];
+function negate(v: number, form: Form): number[] {
+  const b = toBits(v);
+  if (form === "sinal") return [1, ...b.slice(1)];
   const inv = b.map((x) => 1 - x);
-  if (forma === "um") return inv;
-  return paraBits((paraNum(inv) + 1) & 0xff);
+  if (form === "um") return inv;
+  return toBits((toNumber(inv) + 1) & 0xff);
 }
 
 // Como cada convenção LÊ um padrão de bits de volta para um número. É a leitura
 // que fecha o par com a escrita, e é ela que diz se a convenção é coerente.
-function ler(b: number[], forma: Forma): number {
-  const semSinal = paraNum(b);
-  if (forma === "sinal") return b[0] === 1 ? -(semSinal - 128) : semSinal;
-  if (forma === "um") return b[0] === 1 ? -(255 - semSinal) : semSinal;
-  return b[0] === 1 ? semSinal - 256 : semSinal;
+function read(b: number[], form: Form): number {
+  const unsigned = toNumber(b);
+  if (form === "sinal") return b[0] === 1 ? -(unsigned - 128) : unsigned;
+  if (form === "um") return b[0] === 1 ? -(255 - unsigned) : unsigned;
+  return b[0] === 1 ? unsigned - 256 : unsigned;
 }
 
-const VALORES = [26, 1, 127, 0];
+const VALUES = [26, 1, 127, 0];
 
 export function BinarioTresFormas() {
-  const [valor, setValor] = useState(26);
-  const FORMAS: Forma[] = ["sinal", "um", "dois"];
+  const [value, setValue] = useState(26);
+  const FORMS: Form[] = ["sinal", "um", "dois"];
 
-  const linhas = useMemo(
+  const viz = useVisualizer({
+    title: "Visualizador · três formas de escrever um negativo, e três testes",
+    // As três convenções respondem juntas ao número escolhido: não há linha do
+    // tempo para o rodapé dirigir, e `total: 1` tira contador, atalhos e barra.
+    total: 1,
+    // Os três cartões SÃO o conteúdo; não há bloco dispensável para recolher.
+    collapsible: false,
+  });
+
+  const rows = useMemo(
     () =>
-      FORMAS.map((f) => {
-        const neg = negar(valor, f);
-        const pos = paraBits(valor);
+      FORMS.map((f) => {
+        const neg = negate(value, f);
+        const pos = toBits(value);
         // teste 1: quantos padrões de bits são lidos como zero
-        const zeros = Array.from({ length: 256 }, (_, k) => paraBits(k)).filter((b) => ler(b, f) === 0).length;
+        const zeros = Array.from({ length: 256 }, (_, k) => toBits(k)).filter((b) => read(b, f) === 0).length;
         // teste 2: somar os dois padrões (em 8 bits, descartando o vai-um) dá zero?
-        const soma = (paraNum(pos) + paraNum(neg)) & 0xff;
+        const sum = (toNumber(pos) + toNumber(neg)) & 0xff;
         // teste 3: quantos números DISTINTOS os 256 padrões conseguem escrever.
         // Zero duplicado é padrão desperdiçado, e o desperdício aparece aqui.
-        const distintos = new Set(Array.from({ length: 256 }, (_, k) => ler(paraBits(k), f))).size;
-        const faixa = Array.from({ length: 256 }, (_, k) => ler(paraBits(k), f));
-        return { forma: f, pos, neg, zeros, soma, distintos, min: Math.min(...faixa), max: Math.max(...faixa), lido: ler(neg, f) };
+        const distinct = new Set(Array.from({ length: 256 }, (_, k) => read(toBits(k), f))).size;
+        const range = Array.from({ length: 256 }, (_, k) => read(toBits(k), f));
+        return { form: f, pos, neg, zeros, sum, distinct, min: Math.min(...range), max: Math.max(...range), readBack: read(neg, f) };
       }),
-    [valor]
+    [value]
   );
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · três formas de escrever um negativo, e três testes</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {linhas.filter((l) => l.zeros === 1 && l.soma === 0 && l.distintos === 256).length} de 3 passam nos três testes
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      {/* Sem linha do tempo, o placar dos três testes ocupa o lugar do
+          "passo N de M" — com o rótulo junto, porque o número sozinho não diz
+          de que ele fala. */}
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {rows.filter((l) => l.zeros === 1 && l.sum === 0 && l.distinct === 256).length} de 3 passam nos três testes
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          {VALORES.map((v) => (
-            <button key={v} className={`bigo-chip${valor === v ? " on" : ""}`} onClick={() => setValor(v)} aria-pressed={valor === v}>
+          {VALUES.map((v) => (
+            <button key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
               negar {v}
             </button>
           ))}
@@ -112,16 +123,16 @@ export function BinarioTresFormas() {
         </p>
 
         <div className="ms-operadores">
-          {linhas.map((l) => {
-            const passa = l.zeros === 1 && l.soma === 0 && l.distintos === 256;
+          {rows.map((l) => {
+            const passes = l.zeros === 1 && l.sum === 0 && l.distinct === 256;
             return (
-              <div className={`ms-op${passa ? " ok" : " quebrou"}`} key={l.forma}>
+              <div className={`ms-op${passes ? " ok" : " quebrou"}`} key={l.form}>
                 <div className="bb-formula-cab">
-                  <span className="bb-formula-tit">{NOMES[l.forma]}</span>
-                  <span className="bb-formula-selo">{passa ? "passa nos três" : "reprova"}</span>
+                  <span className="bb-formula-tit">{NAMES[l.form]}</span>
+                  <span className="bb-formula-selo">{passes ? "passa nos três" : "reprova"}</span>
                 </div>
                 <p className="bb-array-nota" style={{ marginBottom: 8 }}>
-                  Para negar, {COMO[l.forma]}.
+                  Para negar, {HOW[l.form]}.
                 </p>
                 <div className="bn-fita compacta">
                   {l.neg.map((b, k) => (
@@ -131,21 +142,21 @@ export function BinarioTresFormas() {
                   ))}
                 </div>
                 <p className="bb-formula-fim">
-                  Lido de volta: <strong>{l.lido}</strong>
-                  {l.lido === -valor ? "" : " (não bate com o esperado)"}
+                  Lido de volta: <strong>{l.readBack}</strong>
+                  {l.readBack === -value ? "" : " (não bate com o esperado)"}
                 </p>
                 <ol className="bb-passos">
                   <li className={l.zeros === 1 ? "" : "ruim"}>
                     <span>padrões de bits que valem zero</span>
                     <b>{l.zeros}</b>
                   </li>
-                  <li className={l.soma === 0 ? "" : "ruim"}>
+                  <li className={l.sum === 0 ? "" : "ruim"}>
                     <span>x + (-x) em 8 bits</span>
-                    <b>{l.soma}</b>
+                    <b>{l.sum}</b>
                   </li>
-                  <li className={l.distintos === 256 ? "" : "ruim"}>
+                  <li className={l.distinct === 256 ? "" : "ruim"}>
                     <span>números distintos nos 256 padrões</span>
-                    <b>{l.distintos}</b>
+                    <b>{l.distinct}</b>
                   </li>
                   <li>
                     <span>faixa que ela alcança</span>
@@ -180,6 +191,9 @@ export function BinarioTresFormas() {
           de propósito.
         </p>
       </div>
+
+      {/* `total: 1` e sem controles próprios: o `VizFooter` some inteiro. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/BinarioTresFormas.tsx
+++ b/content/visualizers/BinarioTresFormas.tsx
@@ -63,9 +63,15 @@ function read(b: number[], form: Form): number {
 
 const VALUES = [26, 1, 127, 0];
 
+// Fica no módulo, e não dentro do componente, porque é constante: lá dentro ele
+// seria recriado a cada render e alimentaria um `useMemo` que não o declara nas
+// dependências. Hoje funciona por acidente (o conteúdo nunca muda); no dia em
+// que a lista virar condicional, o memo devolve o valor velho sem avisar.
+// A ordem é conteúdo: ela é a ordem dos três cartões na tela.
+const FORMS: Form[] = ["sinal", "um", "dois"];
+
 export function BinarioTresFormas() {
   const [value, setValue] = useState(26);
-  const FORMS: Form[] = ["sinal", "um", "dois"];
 
   const viz = useVisualizer({
     title: "Visualizador · três formas de escrever um negativo, e três testes",

--- a/tests/viz-binary-numbers.spec.ts
+++ b/tests/viz-binary-numbers.spec.ts
@@ -1,12 +1,18 @@
 import { test, expect, type Locator, type Page } from "@playwright/test";
 
-// Casca adaptativa do BinarioDivisoes.
+// Casca adaptativa dos três visualizadores do tópico binary-numbers.
 //
-// A página tem TRÊS `figure.viz` (o conversor de binário para decimal, as
-// divisões sucessivas e a tabela de bases) e só a do meio é `.viz-fit` — as
-// outras duas não têm overlay, então não há painel para arrumar nelas. Todo
-// seletor daqui é escopado na figura certa, e o primeiro teste confere as
-// contagens na página e na figura.
+// A página tem TRÊS `figure.viz` — o conversor de binário para decimal, as
+// divisões sucessivas e a tabela de bases — e **as três** estão na casca. As
+// duas das pontas não têm linha do tempo (`total: 1`) nem bloco recolhível
+// (`collapsible: false`): elas ganham o painel, o `Esc`, o foco e a trava de
+// rolagem, e nada de reprodução.
+//
+// Por isso NENHUM seletor daqui pode viver solto na página: `figure.viz-fit`
+// casava 1 e passou a casar 3, e `.viz-step` casa três coisas com sentidos
+// diferentes ("00110101 = 53" no conversor, "passo N de M" nas divisões e
+// "255 = 0xFF = 0b11111111" na tabela). Toda figura é escolhida pelo TÍTULO,
+// nunca por posição, e as contagens são afirmadas nos dois níveis.
 //
 // Esta peça é uma das poucas da série em que o eixo de altura é o DESENHO e não
 // a prosa: a lista de divisões acumula uma linha por passo, 36px cada. Números
@@ -34,9 +40,22 @@ const ORCAMENTO = (h: number) => h - 60 - 24;
 /** O passo mais alto do preset padrão: oito divisões na lista e a nota longa. */
 const PICO = 9;
 
-/** A figura adaptada, no fluxo do artigo. */
-const noArtigo = (page: Page) => page.locator("article figure.viz-fit");
-/** A figura adaptada, dentro do painel expandido. */
+/** Título de cada uma das três, para escolher pelo CONTEÚDO e não por posição. */
+const TITULOS = {
+  conversor: "o binário é uma soma de potências de dois",
+  divisoes: "de decimal para binário, dividindo por 2",
+  bases: "a base é um parâmetro, e os bits são um orçamento",
+};
+
+/** Uma figura do artigo, escolhida pelo título do cabeçalho. */
+const noArtigoPor = (page: Page, titulo: string) =>
+  page
+    .locator("article figure.viz-fit")
+    .filter({ has: page.locator(".viz-head-title", { hasText: titulo }) });
+
+/** A figura das divisões, que é a única com linha do tempo e bloco de código. */
+const noArtigo = (page: Page) => noArtigoPor(page, TITULOS.divisoes);
+/** A figura dentro do painel expandido — só uma existe por vez. */
 const noPainel = (page: Page) => page.locator(".viz-overlay figure.viz-fit");
 
 /** Espera a casca terminar a medição: `data-anim` só vira "on" depois dela. */
@@ -97,28 +116,157 @@ const alturaDa = (loc: Locator) =>
 test.describe("binary numbers · a figura certa", () => {
   test.use({ viewport: { width: 1512, height: 900 } });
 
-  test("a casca alcança um dos três visualizadores, e é o das divisões", async ({ page }) => {
+  test("as três estão na casca, e cada seletor casa uma só dentro da sua", async ({ page }) => {
     const fig = await abrir(page);
     expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
 
-    // A ambiguidade é da PÁGINA, não da casca: três figuras no mesmo documento.
+    // A ambiguidade é da PÁGINA, não da casca: três figuras no mesmo documento,
+    // e agora as três com as mesmas classes. Contagem nos DOIS níveis.
     expect(await page.locator("article figure.viz").count()).toBe(3);
+    expect(await page.locator("article figure.viz-fit").count()).toBe(3);
     expect(await fig.count()).toBe(1);
-    // Os três `.viz-step` da página dizem coisas DIFERENTES — "00110101 = 53" no
-    // conversor e "255 = 0xFF = 0b11111111" na tabela de bases —, e só o do meio
-    // é um contador de passo. Um seletor não escopado pega o primeiro em
-    // silêncio, e `split(" de ")[1]` viraria `NaN` sem ninguém reclamar.
+    expect(await noArtigoPor(page, TITULOS.conversor).count()).toBe(1);
+    expect(await noArtigoPor(page, TITULOS.bases).count()).toBe(1);
+
+    // Os três `.viz-step` da página dizem coisas DIFERENTES, e só o do meio é um
+    // contador de passo. Um seletor não escopado pega o primeiro em silêncio, e
+    // `split(" de ")[1]` viraria `NaN` sem ninguém reclamar.
     expect(await page.locator("article .viz-step").count()).toBe(3);
     expect(await fig.locator(".viz-step").count()).toBe(1);
-    await expect(page.locator("article .viz-step").first()).toHaveText("00110101 = 53");
+    await expect(noArtigoPor(page, TITULOS.conversor).locator(".viz-step")).toHaveText(
+      "00110101 = 53"
+    );
+    await expect(noArtigoPor(page, TITULOS.bases).locator(".viz-step")).toHaveText(
+      "255 = 0xFF = 0b11111111"
+    );
     expect(await fig.locator("input[type=range]").count()).toBe(1);
     expect(await fig.locator(".viz-foot").count()).toBe(1);
     expect(await fig.locator(".viz-code-slot").count()).toBe(1);
 
-    await expect(fig.locator(".viz-head-title")).toContainText(
-      "de decimal para binário, dividindo por 2"
-    );
+    await expect(fig.locator(".viz-head-title")).toContainText(TITULOS.divisoes);
     await expect(fig.locator(".viz-step")).toHaveText("passo 1 de 10");
+
+    // A afordância que faltava: agora as três oferecem o mesmo botão. Era 1 para
+    // 3 figuras iguais, e o aluno aprendia que o botão não existe.
+    expect(await page.locator("article button", { hasText: "Expandir" }).count()).toBe(3);
+  });
+});
+
+test.describe("binary numbers · as duas peças sem linha do tempo", () => {
+  test.use({ viewport: { width: 1512, height: 900 } });
+
+  test("nenhum botão promete esconder um bloco que a peça não tem", async ({ page }) => {
+    await abrir(page);
+    // Os itens 2, 3 e 4 da §8 do contrato não existem com `collapsible: false`.
+    // No lugar deles, a prova de que a AUSÊNCIA tem o rótulo certo: nenhuma das
+    // duas oferece "Mostrar código", e nenhuma tem bloco para esconder.
+    for (const titulo of [TITULOS.conversor, TITULOS.bases]) {
+      const f = noArtigoPor(page, titulo);
+      expect(await f.locator(".viz-toggle-codigo").count()).toBe(0);
+      expect(await f.locator(".viz-code").count()).toBe(0);
+      expect(await f.locator(".viz-code-slot").count()).toBe(0);
+      // E `total: 1` tira a reprodução inteira: sem rodapé, sem atalhos, sem
+      // barra de progresso e sem contador de passo — o `.viz-step` que sobra é o
+      // resumo do estado, com o rótulo junto do número.
+      expect(await f.locator(".viz-foot").count()).toBe(0);
+      expect(await f.locator(".viz-atalhos").count()).toBe(0);
+      expect(await f.locator(".viz-progress").count()).toBe(0);
+      expect(await f.locator("button", { hasText: "Rodar" }).count()).toBe(0);
+      await expect(f.locator(".viz-step")).not.toContainText("passo ");
+      // Um botão só no cabeçalho, e ele é o Expandir.
+      expect(await f.locator(".viz-head button").count()).toBe(1);
+      await expect(f.locator(".viz-head button")).toHaveText("⤢ Expandir");
+    }
+  });
+
+  test("o resumo do cabeçalho acompanha o estado, com o rótulo junto", async ({ page }) => {
+    await abrir(page);
+    const conv = noArtigoPor(page, TITULOS.conversor);
+    const bases = noArtigoPor(page, TITULOS.bases);
+
+    // Rótulo e valor lidos no MESMO elemento: "53" sozinho não diria de quê.
+    await expect(conv.locator(".viz-step")).toHaveText("00110101 = 53");
+    // Uma ação só: clicar no bit mais significativo soma 128 e o resumo segue.
+    await conv.locator(".bn-fita .bn-bit").first().click();
+    await expect(conv.locator(".viz-step")).toHaveText("10110101 = 181");
+    await expect(conv.locator(".bigo-stat").filter({ hasText: "valor decimal" }).locator("strong")).toHaveText("181");
+
+    await expect(bases.locator(".viz-step")).toHaveText("255 = 0xFF = 0b11111111");
+    await bases.locator(".bigo-chip", { hasText: "48.879" }).click();
+    await expect(bases.locator(".viz-step")).toHaveText("48.879 = 0xBEEF = 0b1011111011101111");
+  });
+
+  test("no painel o cabeçalho não anda quando o miolo rola, e o Esc devolve o foco", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 700 });
+    await page.goto("/topico/binary-numbers/");
+    await page.evaluate(() => document.fonts.ready);
+    const f = noArtigoPor(page, TITULOS.bases);
+    // `pronta()` não serve aqui: com `collapsible: false` o hook nem espera as
+    // fontes e nunca acende o `data-anim` — não há decisão a tomar, e portanto
+    // não há transição a religar depois de medir.
+    await expect(f).toBeVisible();
+    await expect(f).toHaveAttribute("data-anim", "off");
+    expect(page.viewportSize()).toEqual({ width: 1440, height: 700 });
+
+    const botao = f.locator("button", { hasText: "Expandir" });
+    await botao.click();
+    const p = noPainel(page);
+    await expect(p).toBeVisible();
+    // Diálogo de verdade, e o rótulo dele é o título DESTA peça.
+    const overlay = page.locator(".viz-overlay-fit");
+    await expect(overlay).toHaveAttribute("role", "dialog");
+    await expect(overlay).toHaveAttribute("aria-modal", "true");
+    await expect(overlay).toHaveAttribute(
+      "aria-label",
+      "Visualizador · a base é um parâmetro, e os bits são um orçamento"
+    );
+    // A página atrás fica travada enquanto o painel está aberto.
+    expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+
+    const cabeca = p.locator(".viz-head");
+    const corpo = p.locator(".viz-body");
+    // O `click()` do Playwright rola o contêiner para alcançar o alvo: a posição
+    // de referência só vale com o `scrollTop` zerado.
+    await corpo.evaluate((e) => { e.scrollTop = 0; });
+    const antes = (await cabeca.boundingBox())!.y;
+    const chipAntes = (await p.locator(".bigo-chip").first().boundingBox())!.y;
+    // Sem número mágico: o conteúdo tem que andar exatamente o que o miolo
+    // rolou. Um `< -100` escrito de cabeça reprova por 55px de folga e não diz
+    // nada sobre QUEM rolou.
+    const rolou = await corpo.evaluate((e) => {
+      e.scrollTop = e.scrollHeight;
+      return Math.round(e.scrollTop);
+    });
+    const depois = (await cabeca.boundingBox())!.y;
+    const chipDepois = (await p.locator(".bigo-chip").first().boundingBox())!.y;
+
+    // A asserção que carrega o sentido, para uma peça SEM rodapé: o cabeçalho
+    // comparado com ele mesmo, e o miolo comparado com ele mesmo. Se a figura
+    // inteira voltar a rolar, o cabeçalho sobe junto com o conteúdo.
+    expect(Math.round(depois - antes)).toBe(0);
+    expect(Math.round(chipDepois - chipAntes)).toBe(-rolou);
+    await expect(cabeca).toBeInViewport({ ratio: 1 });
+
+    // Premissas DEPOIS das asserções: a quebra que devolve a rolagem à figura
+    // desfaz a primeira delas, e a mensagem apontaria para o lugar errado.
+    expect(rolou).toBeGreaterThan(8);
+    expect(await corpo.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeGreaterThan(8);
+    expect(await p.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeLessThanOrEqual(8);
+
+    // `Esc` fecha e a trava de rolagem sai.
+    //
+    // O que NÃO é afirmado aqui, de propósito: o contrato (§5) promete que o
+    // foco "volta para onde estava ao fechar", e ele não volta — vai para o
+    // `<body>`. A causa é do hook e alcança todo mundo: `previous` é o próprio
+    // `⤢ Expandir`, que vive DENTRO da figura que o `createPortal` desmonta e
+    // remonta, então o `previous.focus()` da limpeza roda num nó já destacado.
+    // Medido também em `/topico/big-o/`, que é a peça de referência do
+    // contrato. Escrever a asserção do jeito errado aqui cimentaria o defeito.
+    await page.keyboard.press("Escape");
+    await expect(overlay).toHaveCount(0);
+    expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+    // O botão volta para o artigo com o rótulo de abrir, e não o de fechar.
+    await expect(botao).toHaveText("⤢ Expandir");
   });
 });
 

--- a/tests/viz-binary-numbers.spec.ts
+++ b/tests/viz-binary-numbers.spec.ts
@@ -196,7 +196,7 @@ test.describe("binary numbers · as duas peças sem linha do tempo", () => {
     await expect(bases.locator(".viz-step")).toHaveText("48.879 = 0xBEEF = 0b1011111011101111");
   });
 
-  test("no painel o cabeçalho não anda quando o miolo rola, e o Esc devolve o foco", async ({ page }) => {
+  test("no painel o cabeçalho não anda quando o miolo rola, e o Esc fecha e destrava", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 700 });
     await page.goto("/topico/binary-numbers/");
     await page.evaluate(() => document.fonts.ready);
@@ -255,13 +255,17 @@ test.describe("binary numbers · as duas peças sem linha do tempo", () => {
 
     // `Esc` fecha e a trava de rolagem sai.
     //
-    // O que NÃO é afirmado aqui, de propósito: o contrato (§5) promete que o
-    // foco "volta para onde estava ao fechar", e ele não volta — vai para o
-    // `<body>`. A causa é do hook e alcança todo mundo: `previous` é o próprio
+    // O nome deste teste diz "fecha e destrava", e não "devolve o foco", porque
+    // é isso que ele afirma. O contrato (§5) promete também que o foco "volta
+    // para onde estava ao fechar", e ele não volta — vai para o `<body>`. A
+    // causa é do hook e alcança todo mundo: `previous` é o próprio
     // `⤢ Expandir`, que vive DENTRO da figura que o `createPortal` desmonta e
     // remonta, então o `previous.focus()` da limpeza roda num nó já destacado.
     // Medido também em `/topico/big-o/`, que é a peça de referência do
-    // contrato. Escrever a asserção do jeito errado aqui cimentaria o defeito.
+    // contrato. Escrever a asserção do jeito errado aqui cimentaria o defeito;
+    // nomear o teste pelo que ele NÃO faz é pior ainda, porque o relatório da
+    // suíte passa a prometer uma cobertura que não existe. O conserto do hook
+    // está no PR #51, e é lá que a asserção de foco entra.
     await page.keyboard.press("Escape");
     await expect(overlay).toHaveCount(0);
     expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");

--- a/tests/viz-negative-binary.spec.ts
+++ b/tests/viz-negative-binary.spec.ts
@@ -224,7 +224,7 @@ test("no artigo, em 390px, nenhuma das três estoura a largura", async ({ page }
   }
 });
 
-test("o painel das três formas é diálogo, e o Esc devolve o foco de onde saiu", async ({ page }) => {
+test("o painel das três formas é diálogo, e o Esc fecha e destrava a página", async ({ page }) => {
   await abrir(page, 1440, 700);
   const f = por(page, TITULOS.formas);
   const botao = f.locator("button", { hasText: "Expandir" });
@@ -260,11 +260,14 @@ test("o painel das três formas é diálogo, e o Esc devolve o foco de onde saiu
   expect(await corpo.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeGreaterThan(SLACK);
   expect(await p.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeLessThanOrEqual(SLACK);
 
-  // `Esc` fecha e destrava a rolagem da página. O contrato §5 promete também
-  // que o foco volta para onde estava, e isso NÃO acontece: ele vai para o
-  // `<body>`, porque o `⤢ Expandir` mora dentro da figura que o `createPortal`
-  // desmonta. É defeito do hook, alcança todas as peças (medido no `big-o`
-  // também) e não é consertado aqui — por isso não há asserção de foco.
+  // `Esc` fecha e destrava a rolagem da página, e é só isso que o nome deste
+  // teste promete. O contrato §5 promete também que o foco volta para onde
+  // estava, e isso NÃO acontece: ele vai para o `<body>`, porque o
+  // `⤢ Expandir` mora dentro da figura que o `createPortal` desmonta. É defeito
+  // do hook, alcança todas as peças (medido no `big-o` também) e não é
+  // consertado aqui — por isso não há asserção de foco, e por isso o nome do
+  // teste não pode citá-la: nome que promete cobertura inexistente engana quem
+  // lê o relatório da suíte. O conserto do hook está no PR #51.
   await page.keyboard.press("Escape");
   await expect(overlay).toHaveCount(0);
   expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");

--- a/tests/viz-negative-binary.spec.ts
+++ b/tests/viz-negative-binary.spec.ts
@@ -1,18 +1,35 @@
 import { test, expect, type Locator, type Page } from "@playwright/test";
 
-// Casca adaptativa do BinarioComplemento (tópico negative-binary).
+// Casca adaptativa dos três visualizadores do tópico negative-binary.
 //
-// A página tem TRÊS `figure.viz` — o complemento, as três formas e a faixa —, e
-// só a primeira é adaptada. Todo seletor daqui é escopado nela, e as contagens
-// são afirmadas nos dois níveis (página e figura), porque um seletor que casa
-// com o irmão errado devolve um número plausível e nunca reclama.
+// A página tem TRÊS `figure.viz` — o complemento, as três formas e a faixa — e
+// **as três** estão na casca. Só o complemento tem linha do tempo e bloco de
+// código; as outras duas são `total: 1` e `collapsible: false`, e ganham o
+// painel, o `Esc`, o foco e a trava de rolagem, sem nada de reprodução.
+//
+// Todo seletor daqui é escopado na figura certa e escolhido pelo TÍTULO, nunca
+// por posição, e as contagens são afirmadas nos dois níveis (página e figura):
+// `figure.viz-fit` casava 1 e passou a casar 3, e um seletor que casa com o
+// irmão errado devolve um número plausível e nunca reclama.
 
 const URL = "/topico/negative-binary/";
 // Mesma folga de subpixel do hook (`SLACK` em src/lib/visualizer.tsx).
 const SLACK = 8;
 
+const TITULOS = {
+  complemento: "complemento de dois: inverter e somar 1",
+  formas: "três formas de escrever um negativo, e três testes",
+  faixa: "o mesmo padrão, duas leituras",
+};
+
+function por(page: Page, titulo: string): Locator {
+  return page
+    .locator("article figure.viz")
+    .filter({ has: page.locator(".viz-head-title", { hasText: titulo }) });
+}
+
 function figura(page: Page): Locator {
-  return page.locator("article figure.viz").first();
+  return por(page, TITULOS.complemento);
 }
 
 /** Congela transição e animação: ler altura com a transição em voo devolve o meio do caminho. */
@@ -40,21 +57,264 @@ async function irAoFim(f: Locator) {
   return total;
 }
 
-test("a página tem três visualizadores e só o complemento ganhou a casca", async ({ page }) => {
+test("a página tem três visualizadores e os três ganharam a casca", async ({ page }) => {
   await abrir(page, 1512, 900);
   await expect(page.locator("article figure.viz")).toHaveCount(3);
-  await expect(page.locator("article figure.viz-fit")).toHaveCount(1);
+  await expect(page.locator("article figure.viz-fit")).toHaveCount(3);
+  // A afordância que faltava: era 1 botão para 3 figuras de aparência idêntica.
+  await expect(page.locator("article button", { hasText: "Expandir" })).toHaveCount(3);
 
   const f = figura(page);
   await expect(f).toHaveClass(/viz-fit/);
-  await expect(f.locator(".viz-head-title")).toContainText("complemento de dois: inverter e somar 1");
+  await expect(f.locator(".viz-head-title")).toContainText(TITULOS.complemento);
   // Dentro da figura os seletores da casca casam UM elemento cada; na página
   // eles casam mais, porque os irmãos usam as mesmas classes.
+  await expect(f).toHaveCount(1);
+  await expect(por(page, TITULOS.formas)).toHaveCount(1);
+  await expect(por(page, TITULOS.faixa)).toHaveCount(1);
   await expect(f.locator(".viz-step")).toHaveCount(1);
   await expect(f.locator(".viz-code")).toHaveCount(1);
   await expect(f.locator(".viz-code-slot")).toHaveCount(1);
   await expect(f.locator(".bigo-chip")).toHaveCount(5);
   expect(await page.locator("article figure.viz .viz-step").count()).toBeGreaterThan(1);
+});
+
+test("as duas peças de um estado só não prometem esconder bloco nenhum", async ({ page }) => {
+  await abrir(page, 1512, 900);
+  // Com `collapsible: false` os itens 2, 3 e 4 da §8 do contrato não existem.
+  // No lugar deles: a ausência com o rótulo certo. Nenhum botão pode prometer
+  // esconder um bloco que o visualizador não tem.
+  for (const titulo of [TITULOS.formas, TITULOS.faixa]) {
+    const f = por(page, titulo);
+    await expect(f.locator(".viz-toggle-codigo")).toHaveCount(0);
+    await expect(f.locator(".viz-code")).toHaveCount(0);
+    await expect(f.locator(".viz-code-slot")).toHaveCount(0);
+    // `total: 1` tira a reprodução inteira; o `.viz-step` que sobra é o resumo
+    // do estado, com o rótulo junto do número.
+    await expect(f.locator(".viz-atalhos")).toHaveCount(0);
+    await expect(f.locator(".viz-progress")).toHaveCount(0);
+    await expect(f.locator("button", { hasText: "Rodar" })).toHaveCount(0);
+    await expect(f.locator("input[type=range]")).toHaveCount(0);
+    await expect(f.locator(".viz-step")).not.toContainText("passo ");
+    await expect(f.locator(".viz-head button")).toHaveCount(1);
+    await expect(f.locator(".viz-head button")).toHaveText("⤢ Expandir");
+  }
+
+  // O rodapé é a diferença entre as duas: a faixa tem controles próprios (os
+  // que andam pelos padrões), as três formas não têm nenhum — e aí o
+  // `VizFooter` some inteiro em vez de desenhar uma linha vazia.
+  await expect(por(page, TITULOS.formas).locator(".viz-foot")).toHaveCount(0);
+  await expect(por(page, TITULOS.faixa).locator(".viz-foot")).toHaveCount(1);
+  await expect(por(page, TITULOS.faixa).locator(".viz-foot .bn-passeio")).toHaveCount(1);
+});
+
+test("o resumo do cabeçalho das duas acompanha o estado, com o rótulo junto", async ({ page }) => {
+  await abrir(page, 1512, 900);
+
+  // As três formas: o placar dos três testes, e ele muda de acordo com o valor.
+  const formas = por(page, TITULOS.formas);
+  await expect(formas.locator(".viz-step")).toHaveText("1 de 3 passam nos três testes");
+  await formas.locator(".bigo-chip", { hasText: "negar 0" }).click();
+  // Com zero, as três "passam" no teste da soma, mas só o complemento de dois
+  // tem um zero só — o placar continua 1 de 3, e os cartões é que mudam.
+  await expect(formas.locator(".ms-op")).toHaveCount(3);
+  await expect(formas.locator(".ms-op").nth(0).locator(".bb-formula-tit")).toHaveText("Sinal e magnitude");
+  await expect(formas.locator(".ms-op").nth(1).locator(".bb-formula-tit")).toHaveText("Complemento de um");
+  await expect(formas.locator(".ms-op").nth(2).locator(".bb-formula-tit")).toHaveText("Complemento de dois");
+  await expect(formas.locator(".ms-op").nth(2).locator(".bb-formula-selo")).toHaveText("passa nos três");
+  // Rótulo e valor no mesmo cartão: "2" ao lado de "padrões de bits que valem
+  // zero" é o defeito do sinal-magnitude; ao lado de outro rótulo seria ruído.
+  const zerosDe = (n: number) =>
+    formas.locator(".ms-op").nth(n).locator("li").filter({ hasText: "padrões de bits que valem zero" }).locator("b");
+  await expect(zerosDe(0)).toHaveText("2");
+  await expect(zerosDe(1)).toHaveText("2");
+  await expect(zerosDe(2)).toHaveText("1");
+
+  // A faixa: o padrão e as duas leituras dele, lidas juntas no cabeçalho.
+  const faixa = por(page, TITULOS.faixa);
+  await expect(faixa.locator(".viz-step")).toHaveText("10000000 · sem sinal 128 · com sinal -128");
+  await faixa.locator(".viz-foot .bn-passeio button", { hasText: "mais 1" }).click();
+  await expect(faixa.locator(".viz-step")).toHaveText("10000001 · sem sinal 129 · com sinal -127");
+});
+
+test("o mais 1 da faixa fica parado no pé do painel enquanto o miolo rola", async ({ page }) => {
+  // 390x844 de propósito: é a régua em que, com os botões dentro do miolo, o
+  // `mais 1 ›` era arrastado 358px ACIMA do topo visível quando o aluno chegava
+  // à tabela do fim. A 1440x700 sobravam 15px, e a 1512x900 o miolo mal rola.
+  await abrir(page, 390, 844);
+  const f = por(page, TITULOS.faixa);
+  const botao = f.locator("button", { hasText: "Expandir" });
+  await botao.click();
+  const p = page.locator(".viz-overlay figure.viz-fit");
+  await expect(p).toBeVisible();
+
+  const andar = p.locator(".viz-foot .bn-passeio button", { hasText: "mais 1" });
+  const cabeca = p.locator(".viz-head");
+  const corpo = p.locator(".viz-body");
+  await corpo.evaluate((e) => { e.scrollTop = 0; });
+  const antes = {
+    andar: (await andar.boundingBox())!.y,
+    cabeca: (await cabeca.boundingBox())!.y,
+    chip: (await p.locator(".bigo-chip").first().boundingBox())!.y,
+  };
+  await corpo.evaluate((e) => { e.scrollTop = e.scrollHeight; });
+  const depois = {
+    andar: (await andar.boundingBox())!.y,
+    cabeca: (await cabeca.boundingBox())!.y,
+    chip: (await p.locator(".bigo-chip").first().boundingBox())!.y,
+  };
+
+  // A asserção que carrega o sentido: a posição do controle comparada com ela
+  // mesma. `toBeInViewport()` sozinho passa com o botão de volta no miolo,
+  // porque ele aceita qualquer interseção nas duas pontas da rolagem.
+  expect(Math.round(depois.andar - antes.andar), "o mais 1 não anda quando o miolo rola").toBe(0);
+  expect(Math.round(depois.cabeca - antes.cabeca), "o cabeçalho não anda").toBe(0);
+  await expect(andar).toBeInViewport({ ratio: 1 });
+  // E ele continua funcionando de onde está.
+  await andar.click();
+  await expect(p.locator(".viz-step")).toContainText("· sem sinal 129 ·");
+
+  // O rodapé é novo NESTA peça e nasce numa tela de 390px: ele não pode
+  // estourar a largura nem encolher a própria legenda para tamanho ilegível —
+  // uma caixa com texto de 0px não estoura nada e não colapsa nada, então
+  // medir só overflow deixaria isso passar.
+  const legenda = p.locator(".bn-passeio-txt");
+  const m = await legenda.evaluate((e) => ({
+    fonte: parseFloat(getComputedStyle(e).fontSize),
+    estoura: e.scrollWidth - e.clientWidth,
+  }));
+  expect(m.fonte, "a legenda do rodapé continua legível").toBeGreaterThan(9);
+  expect(m.estoura, "a legenda não vaza da própria caixa").toBeLessThanOrEqual(1);
+  expect(
+    await p.evaluate((e) => (e.querySelector(".viz-foot") as HTMLElement).scrollWidth - e.clientWidth),
+    "o rodapé não estoura a largura do painel"
+  ).toBeLessThanOrEqual(1);
+
+  // Premissas depois das asserções: quem rola é o miolo, e ele tem o que rolar.
+  expect(Math.round(depois.chip - antes.chip), "quem anda é o CONTEÚDO").toBeLessThan(-100);
+  expect(await corpo.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeGreaterThan(SLACK);
+  expect(await corpo.evaluate((e) => e.scrollTop)).toBeGreaterThan(0);
+  expect(await p.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeLessThanOrEqual(SLACK);
+});
+
+test("no artigo, em 390px, nenhuma das três estoura a largura", async ({ page }) => {
+  await abrir(page, 390, 844);
+  // A página inteira primeiro...
+  expect(
+    await page.evaluate(() => document.body.scrollWidth - window.innerWidth),
+    "a página não rola na horizontal"
+  ).toBeLessThanOrEqual(0);
+  // ...e depois o que ela não pega: rótulo vazando da própria caixa, que
+  // `minmax(140px, 1fr)` esconde da medição da página.
+  for (const titulo of Object.values(TITULOS)) {
+    const f = por(page, titulo);
+    const cab = f.locator(".viz-head-title span").nth(1);
+    const m = await cab.evaluate((e) => ({
+      fonte: parseFloat(getComputedStyle(e).fontSize),
+      estoura: e.scrollWidth - e.clientWidth,
+    }));
+    expect(m.fonte, `o título de "${titulo}" continua legível`).toBeGreaterThan(9);
+    expect(m.estoura, `o título de "${titulo}" não vaza da caixa`).toBeLessThanOrEqual(1);
+    // O cabeçalho quebra em duas linhas nesta largura (é o eixo de altura que a
+    // casca cria, §9), e o botão precisa continuar inteiro na tela — no artigo
+    // ele está muito abaixo da dobra, então role até ele antes de olhar.
+    const botao = f.locator("button", { hasText: "Expandir" });
+    await botao.scrollIntoViewIfNeeded();
+    await expect(botao).toBeInViewport({ ratio: 1 });
+  }
+});
+
+test("o painel das três formas é diálogo, e o Esc devolve o foco de onde saiu", async ({ page }) => {
+  await abrir(page, 1440, 700);
+  const f = por(page, TITULOS.formas);
+  const botao = f.locator("button", { hasText: "Expandir" });
+  await botao.click();
+
+  const overlay = page.locator(".viz-overlay-fit");
+  await expect(overlay).toHaveAttribute("role", "dialog");
+  await expect(overlay).toHaveAttribute("aria-modal", "true");
+  // O `aria-label` é o título DESTA peça, não o de um irmão.
+  await expect(overlay).toHaveAttribute(
+    "aria-label",
+    "Visualizador · três formas de escrever um negativo, e três testes"
+  );
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).toBe("hidden");
+
+  const p = page.locator(".viz-overlay figure.viz-fit");
+  const corpo = p.locator(".viz-body");
+  const cabeca = p.locator(".viz-head");
+  await corpo.evaluate((e) => { e.scrollTop = 0; });
+  const antes = (await cabeca.boundingBox())!.y;
+  const chipAntes = (await p.locator(".bigo-chip").first().boundingBox())!.y;
+  // Sem número mágico: o conteúdo anda exatamente o que o miolo rolou.
+  const rolou = await corpo.evaluate((e) => {
+    e.scrollTop = e.scrollHeight;
+    return Math.round(e.scrollTop);
+  });
+  expect(Math.round((await cabeca.boundingBox())!.y - antes), "o cabeçalho não anda").toBe(0);
+  expect(
+    Math.round((await p.locator(".bigo-chip").first().boundingBox())!.y - chipAntes),
+    "quem anda é o CONTEÚDO, e exatamente o que o miolo rolou"
+  ).toBe(-rolou);
+  expect(rolou, "o miolo precisa ter o que rolar").toBeGreaterThan(SLACK);
+  expect(await corpo.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeGreaterThan(SLACK);
+  expect(await p.evaluate((e) => e.scrollHeight - e.clientHeight)).toBeLessThanOrEqual(SLACK);
+
+  // `Esc` fecha e destrava a rolagem da página. O contrato §5 promete também
+  // que o foco volta para onde estava, e isso NÃO acontece: ele vai para o
+  // `<body>`, porque o `⤢ Expandir` mora dentro da figura que o `createPortal`
+  // desmonta. É defeito do hook, alcança todas as peças (medido no `big-o`
+  // também) e não é consertado aqui — por isso não há asserção de foco.
+  await page.keyboard.press("Escape");
+  await expect(overlay).toHaveCount(0);
+  expect(await page.evaluate(() => getComputedStyle(document.body).overflow)).not.toBe("hidden");
+  await expect(botao).toHaveText("⤢ Expandir");
+});
+
+test("as três formas recalculam os cartões quando o número muda", async ({ page }) => {
+  // É este teste que guarda o conserto do `FORMAS`: ele saiu de dentro do
+  // componente para o escopo do módulo justamente porque era recriado a cada
+  // render e alimentava um `useMemo` que não o declarava. O que dá para provar
+  // pela tela é o que a regra protege: o memo acompanha a entrada dele.
+  await abrir(page, 1512, 900);
+  const f = por(page, TITULOS.formas);
+  const lidoDe = (n: number) => f.locator(".ms-op").nth(n).locator(".bb-formula-fim");
+  const bitsDe = (n: number) => f.locator(".ms-op").nth(n).locator(".bn-fita .bn-bit .bn-bit-val");
+
+  // A ordem dos três cartões é a do array, e ela é conteúdo: os testes da tela
+  // falam de "sinal e magnitude" primeiro e "complemento de dois" por último.
+  await expect(f.locator(".ms-op .bb-formula-tit")).toHaveText([
+    "Sinal e magnitude",
+    "Complemento de um",
+    "Complemento de dois",
+  ]);
+
+  // 26 = 00011010. Negado: 10011010 (sinal), 11100101 (um), 11100110 (dois).
+  await expect(bitsDe(0)).toHaveText(["1", "0", "0", "1", "1", "0", "1", "0"]);
+  await expect(bitsDe(2)).toHaveText(["1", "1", "1", "0", "0", "1", "1", "0"]);
+  await expect(lidoDe(2)).toContainText("Lido de volta: -26");
+  // As três convenções LEEM de volta o valor certo para todo v ≤ 127, e os
+  // quatro presets (26, 1, 127, 0) são todos ≤ 127: o sufixo
+  // " (não bate com o esperado)" do `:135` não aparece em preset nenhum, em
+  // régua nenhuma. Está reportado como defeito de conteúdo — mesma classe do
+  // "(o desta árvore)" do NAryTreeVisualizer —, e o teste afirma o que a tela
+  // de fato mostra em vez de exigir um texto que ninguém vê.
+  await expect(lidoDe(0)).toHaveText("Lido de volta: -26");
+
+  // Troca o número: os três cartões têm que acompanhar. Com o memo preso à
+  // entrada errada, eles continuariam mostrando a negação de 26.
+  await f.locator(".bigo-chip", { hasText: "negar 127" }).click();
+  await expect(f.locator(".viz-step")).toHaveText("1 de 3 passam nos três testes");
+  // 127 = 01111111. Complemento de dois: 10000001 = -127.
+  await expect(bitsDe(2)).toHaveText(["1", "0", "0", "0", "0", "0", "0", "1"]);
+  await expect(lidoDe(2)).toContainText("Lido de volta: -127");
+  await expect(lidoDe(2)).not.toContainText("(não bate com o esperado)");
+  // E a ordem dos três continua sendo a do array, depois da troca.
+  await expect(f.locator(".ms-op .bb-formula-tit")).toHaveText([
+    "Sinal e magnitude",
+    "Complemento de um",
+    "Complemento de dois",
+  ]);
 });
 
 test("a marcha inicial da peça sobreviveu: o rótulo diz 1.5x ao lado do valor 4", async ({ page }) => {


### PR DESCRIPTION
Quatro peças que vestiam `<figure className="viz">`, a **mesma moldura** das
adaptadas, e não tinham nada do contrato: sem `⤢ Expandir`, sem diálogo, sem
trava de rolagem, sem `Esc`, sem foco e sem medição. Elas dividem a página com
peças adaptadas, então o aluno encontrava **duas peças mudas para uma que
expande**, com aparência idêntica e afordância diferente, e aprendia que o botão
não existe, inclusive nas que o têm.

| página | antes | depois |
|---|---|---|
| `binary-numbers` | 2 mudas + 1 com casca, **1** botão Expandir | 3 com casca, **3** botões |
| `negative-binary` | 2 mudas + 1 com casca, **1** botão Expandir | 3 com casca, **3** botões |

**Placar da casca: 61 de 87 → 65 de 87**, e as peças mudas caem de **17 para
13**, agora em 9 páginas (`backtracking`, `big-o`, `binary-heap`,
`busca-binaria`, `heap-sort`, `merge-sort`, `ordenacao-basica`, `quick-sort`,
`shell-sort`). Com o #47, que tira o `BigOChartVisualizer`, vira 66 de 87 e 12
mudas. As duas páginas deste PR ficam **fechadas**.

As quatro entram como o contrato prevê para o perfil delas (`README.md:568`):
`total: 1`, porque a variável é o número e não um passo, e `collapsible: false`,
porque não há bloco dispensável para recolher. O `.viz-step` que cada uma já
tinha, resumindo o estado, vira `children` do `VizHeader`, no lugar do
"passo N de M". **Nenhuma linha de CSS novo.**

---

## Medição: altura no artigo, por peça e por régua

66 amostras: 22 estados (5, 6, 4 e 7 por peça, incluindo os que não são
alcançáveis por preset) × 3 réguas, dentro do runner, com `document.fonts.ready`
cumprido, transição congelada e `page.viewportSize()` afirmado contra o pedido.

| peça | 1512x900 | 1440x700 | 390x844 |
|---|---|---|---|
| `BinarioConversor` | 608..611 → **616..619** (+8) | 608..611 → **616..619** (+8) | 940..1043 → **976..1079** (+36) |
| `BinarioBases` | 1113..1131 → **1121..1139** (+8) | 1113..1131 → **1121..1167** (+8 e +36) | 1556..1613 → **1576..1658** (+20 e +45) |
| `BinarioTresFormas` | 1040 → **1048** (+8) | 1095 → **1103** (+8) | 1863 → **1883** (+20) |
| `BinarioFaixa` | 890..933 → **947..990** (+57) | 890..948 → **947..1005** (+57) | 1404..1538 → **1498..1616** (+78 e +94) |

### O +8 diverge do −4 do contrato, e a medição bloco a bloco explica

A §9 mede +28, +10, −4 e −184 e manda não citar nenhum sem medir a própria peça.
Aqui deu **+8**, então medi os blocos nos dois builds:

| bloco | antes | depois | por quê |
|---|---|---|---|
| `.viz-body` | `padding-bottom: 18px` | `14px` | **−4px**, em 4 peças sem parentesco e nas 3 réguas |
| `.viz-head` | 41px | 53px | **+12px**: o cabeçalho passa a ter um **botão** onde só havia texto |

**O −4 do contrato é só a metade do `.viz-body`.** As duas peças que o mediram
(`BinaryTreeFormatos` e `GrafoRepresentacao`) **já tinham um `⤢ Expandir`
próprio** no `.viz-head-right` antes da casca, com overlay escrito à mão, então
o cabeçalho delas já media 53px e a adoção só devolvia os 4px do miolo. Estas
quatro não tinham botão nenhum: elas são as peças **realmente mudas**, e pagam a
linha do botão. Confirmado em `git show 09f2f88:content/visualizers/GrafoRepresentacao.tsx`.

Os **+36 / +45 / +20 / +94** são o cabeçalho quebrando em duas linhas, que é o
eixo de altura que a casca cria (§9). O gatilho aqui **não é o contador ganhando
um dígito**, como no `AStarVisualizer`: é o `children` do `VizHeader` ser longo.
A 1440x700 isso só acontece num estado, o de `48.879`, cujo resumo é
`48.879 = 0xBEEF = 0b1011111011101111`. A 390px acontece nas quatro.

### O rodapé do `BinarioFaixa` foi decidido por medição, não por gosto

Os dois botões que andam pelos padrões vizinhos (`‹ menos 1` / `mais 1 ›`) são
o que faz esta peça se mexer. Medi as duas colocações, com o build de cada uma:

| onde | com o miolo do painel rolado até o fim |
|---|---|
| dentro do miolo | 390x844: **358px ACIMA** do topo visível (sumiu). 1440x700: **15px** de folga. 1512x900: o miolo mal rola |
| no `.viz-foot` | o miolo rola **786px** e o botão anda **0px**, nas três réguas |

É o defeito que a camada 1 existe para consertar, e o caso está previsto no §6
("sem linha do tempo E com botões extras"). O preço é o `.viz-foot` (81px no
desktop, 127px a 390px) contra os 50px que o miolo devolve. A legenda "andar
pelos padrões vizinhos" viaja junto, então a linha continua se explicando
sozinha, e **nenhum dos dois artigos cita esses botões** (varrido).

---

## Texto de tela: nada mudou, e está provado estado a estado

Comparei o texto renderizado das quatro figuras nos **66 estados** (22 × 3
réguas), campo a campo:

```
estados comparados: 66  idênticos: 0  com diferença: 66
--- 45 estados:  +⤢ Expandir
--- 21 estados:  +⤢ Expandir
                 -‹ menos 1 / -andar pelos padrões vizinhos / -mais 1 ›
                 +‹ menos 1 / +andar pelos padrões vizinhos / +mais 1 ›
```

O diff do HTML do build contra a `origin/main` diz a mesma coisa: `+⤢ Expandir`
duas vezes por página, e as três linhas do passeio mudando de lugar no
`negative-binary`. **Nenhuma palavra perdida.**

O `guarda-idioma.py` sai com o normal de uma adaptação (`dot`, `viz`,
`viz-body`, `viz-head`, `viz-head-right`, `viz-head-title` sumindo para o hook, e
`@/lib/visualizer` aparecendo). Ele pegou **uma** alteração real de fonte que eu
tinha feito sem querer, um `"` virando `&quot;` no `BinarioFaixa`: revertida,
porque renderiza igual e engorda o diff à toa.

### Identificadores em inglês (contrato §0)

Traduzidos na passagem, com dois casos deixados de propósito:

- as cinco `key` de preset do `BinarioConversor` deram **0 ocorrências** no
  `globals.css` antes de virarem inglês (`cinquenta`→`fifty`, `duzentos`→
  `twoHundred`, `todos`→`all`, `potencia`→`power`, `zero`→`none`);
- os três valores da união `Form` do `BinarioTresFormas` **ficaram em
  português**. `"sinal"` é classe do `.bn-bit` no mesmo arquivo, e traduzir o
  papel de identificador pediria exatamente a reação que re-quebra o outro: é o
  "literal com dois papéis" do §0, e o jeito de não cair nele é não mexer.
  `on`, `estatico`, `negativo`, `forte`, `ruim`, `quebrou`, `compacta`,
  `c-otimo`, `c-ruim` e `hp-destaque` também ficaram, todas conferidas no
  `globals.css`.

---

## `FORMAS`: um defeito latente, e o acoplamento com o #54

`content/visualizers/BinarioTresFormas.tsx:63` declarava `FORMAS` **dentro do
componente** e o usava dentro de um `useMemo` cujo array de dependências não o
incluía. Recriado a cada render, ele é uma referência nova toda vez, e o memo
depende de um valor que não declara. Hoje funciona por acidente (o conteúdo é
constante); no dia em que a lista virar condicional, o memo devolve o valor velho
sem avisar.

A constante sobe para o escopo do módulo, **em commit próprio**. Conteúdo e ordem
intactos: a ordem é a dos três cartões na tela, e o texto renderizado do build
saiu idêntico linha a linha.

> **Para quem integrar:** o **#54** introduziu ESLint com
> `react-hooks/exhaustive-deps` como **erro** e precisou abrir uma exceção só
> para este arquivo. Com este conserto, **a exceção pode cair**. É o único
> acoplamento entre os dois PRs; este aqui não toca no `eslint.config.mjs`.

---

## Prova de quebra: oito, todas compilando, build sempre visível

Cada teste novo foi rodado contra o código quebrado. Nenhuma quebra foi desfeita
com `git checkout --` (cópia e `cp`), o build nunca foi silenciado, e o `out/`
foi reconstruído depois da última.

| # | a quebra | teste | resultado |
|---|---|---|---|
| A | o `<VizHeader>` volta para DENTRO do `.viz-body` (`BinarioBases`) | cabeçalho parado no painel | **1 failed / 0 passed** — `Expected: 0` na posição do cabeçalho |
| B | `collapsible: true` numa peça sem bloco (`BinarioConversor`) | nenhum botão promete esconder | **1 failed / 0 passed** |
| C | `total: 2` numa peça sem linha do tempo (`BinarioBases`) | idem | **1 failed / 0 passed** |
| D | o resumo do cabeçalho mostra `onBits` em vez de `value` | o resumo acompanha o estado | **1 failed / 0 passed** — `Expected: "00110101 = 53"` |
| E | o `.viz-foot` volta para dentro do miolo (`BinarioFaixa`) | o `mais 1 ›` fica parado | **1 failed / 0 passed** — `o mais 1 não anda: Expected 0, Received -786` |
| F | o `useMemo` dos três cartões perde `[value]` | os cartões recalculam | **1 failed / 0 passed** |
| G | o `title` vira o do irmão (vira o `aria-label` do diálogo) | painel das bases | **1 failed / 0 passed** — a figura deixa de ser encontrada pelo título |
| H | **experimento no hook**: `"Escape"` → `"Escapee"` | o painel é diálogo e o `Esc` fecha | **1 failed / 0 passed** — `overlay: Expected 0, Received 1` |

A **H** encostou em `src/lib/visualizer.tsx` como **experimento** e nada mais:
restaurado por `cp`, com `git diff src/lib` vazio antes do commit. Ela existe
porque o `Esc` mora no hook e não há quebra no componente que o alcance.

---

## Testes

`tests/viz-binary-numbers.spec.ts` e `tests/viz-negative-binary.spec.ts`,
**459 → 468** testes na suíte (+9).

Os itens 2, 3 e 4 da §8 (os três que falam do bloco recolhível) não existem com
`collapsible: false`. No lugar deles, a prova de que **a ausência tem o rótulo
certo**: nenhuma das quatro tem `.viz-toggle-codigo`, `.viz-code`,
`.viz-code-slot`, `.viz-atalhos`, `.viz-progress`, `▶ Rodar` nem slider, o
`.viz-step` não contém "passo ", e o único botão do cabeçalho é o `⤢ Expandir`.

**Contagem nos dois níveis**, como manda a §8 e como este tópico já ensinou:
`figure.viz-fit` casava **1** e passou a casar **3** em cada página, e
`.viz-step` casa três coisas com sentidos diferentes na mesma página
(`00110101 = 53`, `passo N de M`, `255 = 0xFF = 0b11111111`). Os seletores dos
testes antigos foram reescritos para escolher a figura **pelo título do
cabeçalho**, nunca por posição. Sem isso, cinco testes de quem veio antes
quebrariam, que é exatamente o que aconteceu quando o gráfico do Big O foi
adaptado.

Nenhuma asserção usa número mágico: onde o conteúdo tem que andar, o teste
compara com o `scrollTop` que o miolo de fato rolou.

**Suíte inteira: 468 passed** (`npm run test:build`, `PORT=4413`, máquina livre).
Numa segunda passada saiu `1 failed / 467 passed`, e a falha foi
`tests/viz-strings.spec.ts:326` — o flake conhecido de tolerância de rolagem,
com conserto no **#53**. `git diff origin/main` vazio nesse arquivo e no
visualizador dele, e `--workers=1` isolado dá **8 passed**.
`npm run build` ✓ e `npx tsc --noEmit` ✓.

---

## O que este PR **não** mudou, e por quê

- **Nenhum arquivo compartilhado.** Zero linhas em `src/lib/visualizer.tsx`
  (fora do experimento H, restaurado), `src/app/globals.css`,
  `eslint.config.mjs`, `content/visualizers/README.md`, `mdx-components.tsx`,
  `content/roadmap.ts`, `content/topics/**`, `playwright.config.ts`,
  `next.config.ts`, `package.json`, `scripts/**` e `.github/**`.
  **Nenhuma linha de CSS novo foi necessária.**
- **Nenhum texto de tela.** É a garantia que sustenta o rename de
  identificadores, e ela não sobrevive a uma correção editorial de carona.

## Três achados reportados e **não** consertados

1. **O foco não volta ao fechar o painel, e isso contradiz o contrato §5**
   (`src/lib/visualizer.tsx:330-335`). O `previous` guardado ao abrir é o próprio
   `⤢ Expandir`, que vive **dentro** da `<figure>` que o `createPortal` desmonta
   e remonta, então o `previous.focus()` da limpeza roda num nó já destacado e o
   foco cai no `<body>`. Medido também em `/topico/big-o/`, que é a **peça de
   referência do contrato**, então alcança todas as 65. É conserto de hook, com
   dois PRs abertos em cima dele. Os testes deste PR **não** afirmam o
   comportamento errado, para não cimentá-lo; há um comentário nos dois arquivos
   explicando a ausência.
2. **Texto morto no `BinarioTresFormas.tsx:135`.** O sufixo
   `" (não bate com o esperado)"` nunca aparece: as três convenções leem de volta
   o valor certo para todo `v ≤ 127`, e os quatro presets (26, 1, 127, 0) são
   todos ≤ 127. **0 ocorrências** nos 12 estados medidos e **0** no HTML do
   build. É a mesma classe do `" (o desta árvore)"` do `NAryTreeVisualizer`
   (backlog §1.1), e é decisão editorial: ou um preset acima de 127 entra, ou a
   promessa sai.
3. **`data-anim` fica `"off"` para sempre** em toda peça com
   `collapsible: false`: o hook só acende o `animate` dentro do efeito de
   medição, que retorna cedo quando não há bloco a recolher. Não é defeito (não
   há transição a religar), mas **quebra o `pronta()`** de qualquer teste que
   espere `data-anim="on"` — anotado nos dois arquivos de teste para o próximo.

Varredura cruzada nas quatro antes de fechar: âncoras na gravação (**vazio**,
nos quatro arquivos e nos dois `.mdx`); `? … : null` que fosse eixo de altura
condicional (**nenhum**: os únicos são os separadores `+` da conta); classe de
erro pintando o que não falhou (**nenhuma**: `ruim`, `quebrou`, `c-ruim` e
`invalid` marcam falhas reais); `stepBy` com aritmética (**nenhum**, não há
linha do tempo); e **ramo condicional que nunca dispara** — a pergunta que
nasceu do achado 2 e que eu fiz às outras três: `NÃO cabe aqui` aparece em 2
estados, o texto livre do conversor em 1, a legenda do passeio da faixa em 1 e
`Este é o padrão da virada` em 1. Só o do `BinarioTresFormas` sai zerado.
