### PR TITLE
feat(viz): as seis últimas peças mudas entram na casca

### DIFF
--- a/content/visualizers/BacktrackingPoda.tsx
+++ b/content/visualizers/BacktrackingPoda.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 // ---------------------------------------------------------------------------
 // BacktrackingPoda, a otimização que não muda o algoritmo, muda quando ele
 // desiste.
@@ -22,6 +24,19 @@ import { useMemo, useState } from "react";
 // assunto do visualizador de passo a passo, e aqui o que interessa é o total.
 // Por isso é interativo sem linha do tempo: a variável é o tamanho do
 // tabuleiro.
+//
+// Sobre a casca (contrato em `content/visualizers/README.md`):
+//   · `total: 1` — não há linha do tempo, então somem o contador de passo, os
+//     atalhos e a barra de progresso. O que resume o estado (quantas rainhas,
+//     quantas soluções, a razão) entra como `children` do `VizHeader`, no lugar
+//     onde ficaria o "passo N de M", com o rótulo junto.
+//   · `collapsible: false` — não existe bloco dispensável. O tabuleiro, as
+//     barras e os chips SÃO o conteúdo; inventar um bloco só para ganhar o
+//     botão é o que a §2 do contrato proíbe. Por isso `measureOn` também fica
+//     de fora: sem bloco para recolher não há decisão a medir.
+//   · os chips de tamanho e de solução ficam no MIOLO, não no rodapé: eles não
+//     são reprodução, e com `total: 1` o `VizFooter` sem `children` some
+//     inteiro — que é o caso em que a casca DEVOLVE altura no artigo (§9).
 // ---------------------------------------------------------------------------
 
 type Resultado = { nos: number; solucoes: number[][]; podas: number };
@@ -103,26 +118,26 @@ export function BacktrackingPoda() {
   const com = useMemo(() => comPoda(n), [n]);
   const [qual, setQual] = useState(0);
 
+  const viz = useVisualizer({
+    title: "Visualizador · a poda: mesma resposta, uma fração do trabalho",
+    total: 1,
+    collapsible: false,
+  });
+
   const mesmasSolucoes =
     sem.solucoes.map((s) => s.join(",")).sort().join("|") === com.solucoes.map((s) => s.join(",")).sort().join("|");
   const razao = sem.nos / com.nos;
   const sol = com.solucoes.length > 0 ? com.solucoes[Math.min(qual, com.solucoes.length - 1)] : [];
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a poda: mesma resposta, uma fração do trabalho</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            {n} rainhas · {com.solucoes.length} soluções · {razao.toFixed(1)}x menos nós com poda
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          {n} rainhas · {com.solucoes.length} soluções · {razao.toFixed(1)}x menos nós com poda
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {TAMANHOS.map((t) => (
             <button
@@ -255,6 +270,10 @@ export function BacktrackingPoda() {
           com um nome diferente: em vez de cortar o ramo impossível, guardar o resultado do ramo já calculado.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o `VizFooter` não desenha nada.
+          Fica declarado para o próximo leitor ver que a ausência é escolha. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/BuscaBinariaOverflow.tsx
+++ b/content/visualizers/BuscaBinariaOverflow.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 // ---------------------------------------------------------------------------
 // BuscaBinariaOverflow, o bug que ficou nove anos dentro da biblioteca do Java.
 //
@@ -16,6 +18,18 @@ import { useMemo, useState } from "react";
 // sendo a certa, e no momento em que a busca binária deixa de ser sobre índices
 // e passa a ser sobre um espaço de respostas (onde os limites podem ser
 // qualquer número), o problema volta em qualquer linguagem.
+//
+// Sobre a casca (contrato em `content/visualizers/README.md`):
+//   · `total: 1` — não há linha do tempo. O eixo é a ENTRADA (esq, dir e o tipo
+//     do inteiro), não um passo a passo, e o resumo do estado ("as duas
+//     concordam" / "as duas discordam") entra como `children` do `VizHeader`.
+//   · `collapsible: false` — as duas fórmulas e a fita de bits são o conteúdo,
+//     não um bloco dispensável. Sem bloco para recolher, `measureOn` não teria
+//     efeito nenhum e fica de fora.
+//   · os dois campos numéricos são o motivo de esta peça agradecer o `total: 1`
+//     por um segundo caminho: o hook só sequestra seta e espaço quando há linha
+//     do tempo, então digitar em `esq` e `dir` dentro do painel continua sendo
+//     digitar.
 // ---------------------------------------------------------------------------
 
 const INT_MAX = 2147483647;
@@ -78,6 +92,12 @@ export function BuscaBinariaOverflow() {
   const [dir, setDir] = useState(2000000000);
   const [limitado, setLimitado] = useState(true);
 
+  const viz = useVisualizer({
+    title: "Visualizador · as duas formas de achar o meio, e por que só uma serve",
+    total: 1,
+    collapsible: false,
+  });
+
   const aplicar = (p: Preset) => {
     setPresetKey(p.key);
     setEsq(p.esq);
@@ -98,19 +118,13 @@ export function BuscaBinariaOverflow() {
   const valido = esq >= 0 && dir >= esq;
   const bits = bits32(conta.soma);
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · as duas formas de achar o meio, e por que só uma serve</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">{conta.iguais ? "as duas concordam" : "as duas discordam"}</span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz}>
+        <span className="viz-step">{conta.iguais ? "as duas concordam" : "as duas discordam"}</span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((p) => (
             <button key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => aplicar(p)} aria-pressed={presetKey === p.key}>
@@ -308,6 +322,9 @@ export function BuscaBinariaOverflow() {
           enormes desde a primeira linha. A fórmula segura custa a mesma coisa: use ela sempre.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o `VizFooter` não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/HeapIndicesVisualizer.tsx
+++ b/content/visualizers/HeapIndicesVisualizer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 
 // ---------------------------------------------------------------------------
 // HeapIndicesVisualizer, a aritmética que substitui os ponteiros.
@@ -71,9 +71,21 @@ export function HeapIndicesVisualizer() {
   // Só encolher o array tira a seleção do intervalo válido: os índices vão de 0 a
   // n - 1 seja qual for o k. Trocar k muda quem é pai e quem é filho, nunca
   // quantas posições existem.
-  useEffect(() => {
+  //
+  // O ajuste roda na FASE DE RENDER e não num `useEffect`, que é o padrão
+  // documentado do React para estado derivado de outro estado — o mesmo que o
+  // §9 do contrato usa para o passo inicial. Com o efeito, o React pintava um
+  // quadro com a seleção fora da faixa antes de corrigir.
+  //
+  // O `Math.min` abaixo é rede, não a regra: é ele que segura o quadro em que o
+  // ajuste ainda não rodou. Quem apagar o bloco acima achando que o `Math.min`
+  // já resolve troca o comportamento sem nenhum erro aparecer — a seleção
+  // deixaria de ser fixada e voltaria sozinha ao encolher e crescer de novo.
+  const [nAnterior, setNAnterior] = useState(n);
+  if (nAnterior !== n) {
+    setNAnterior(n);
     if (sel >= n) setSel(Math.max(0, n - 1));
-  }, [n, sel]);
+  }
   const i = Math.min(sel, n - 1);
 
   const pai = i === 0 ? -1 : Math.floor((i - 1) / k);

--- a/content/visualizers/HeapIndicesVisualizer.tsx
+++ b/content/visualizers/HeapIndicesVisualizer.tsx
@@ -97,14 +97,16 @@ export function HeapIndicesVisualizer() {
   // quadro com a seleção fora da faixa antes de corrigir.
   //
   // O `Math.min` abaixo é rede, não a regra: é ele que segura o quadro em que o
-  // ajuste ainda não rodou. Quem apagar o bloco acima achando que o `Math.min`
+  // ajuste ainda não rodou. Quem apagar a linha abaixo achando que o `Math.min`
   // já resolve troca o comportamento sem nenhum erro aparecer — a seleção
   // deixaria de ser fixada e voltaria sozinha ao encolher e crescer de novo.
-  const [nAnterior, setNAnterior] = useState(n);
-  if (nAnterior !== n) {
-    setNAnterior(n);
-    if (sel >= n) setSel(Math.max(0, n - 1));
-  }
+  //
+  // A condição basta sozinha, sem guardar o `n` anterior: nenhum outro caminho
+  // põe `sel` fora da faixa (o clique nasce de um índice que existe, e o teclado
+  // já é limitado por `n` em `aoTeclar`), então ela só é verdadeira no render
+  // seguinte a um `n` menor. E ela termina: o `n` vem de um `range` de 3 a 16,
+  // então `n - 1 >= 2` e a escrita sempre deixa `sel < n`.
+  if (sel >= n) setSel(Math.max(0, n - 1));
   const i = Math.min(sel, n - 1);
 
   const pai = i === 0 ? -1 : Math.floor((i - 1) / k);

--- a/content/visualizers/HeapIndicesVisualizer.tsx
+++ b/content/visualizers/HeapIndicesVisualizer.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 // ---------------------------------------------------------------------------
 // HeapIndicesVisualizer, a aritmética que substitui os ponteiros.
 //
@@ -17,6 +19,17 @@ import { useMemo, useState } from "react";
 // O painel marca explicitamente os filhos que CAIRIAM FORA do array. É a mesma
 // checagem de limite que toda implementação de sift down precisa ter, e é o
 // erro mais comum de quem escreve heap pela primeira vez.
+//
+// Sobre a casca (contrato em `content/visualizers/README.md`):
+//   · `total: 1` — não há linha do tempo. O eixo é a SELEÇÃO (o nó clicado), e
+//     o resumo do estado ("índice 4 de 0 a 11") entra como `children` do
+//     `VizHeader`, no lugar do "passo N de M". Ele já vem com o rótulo junto.
+//   · `collapsible: false` — a árvore, o array e as fórmulas são o conteúdo, e
+//     não existe bloco dispensável. Sem bloco, `measureOn` não faria nada.
+//   · o `total: 1` também é o que preserva o teclado PRÓPRIO desta peça: os nós
+//     do SVG respondem a setas, Home e End, e o hook só sequestra seta e espaço
+//     quando há linha do tempo. Com passos, o `stepBy` do painel andaria por
+//     cima de cada seta do aluno navegando a árvore.
 // ---------------------------------------------------------------------------
 
 const VALORES = [10, 21, 14, 35, 27, 19, 42, 51, 38, 44, 33, 22, 60, 47, 55, 29];
@@ -65,6 +78,12 @@ export function HeapIndicesVisualizer() {
   const [k, setK] = useState(2);
   const [n, setN] = useState(12);
   const [sel, setSel] = useState(4);
+
+  const viz = useVisualizer({
+    title: "Visualizador · clique num nó e veja de onde saem pai e filhos",
+    total: 1,
+    collapsible: false,
+  });
 
   const arr = useMemo(() => construir(n, k), [n, k]);
 
@@ -154,21 +173,15 @@ export function HeapIndicesVisualizer() {
     })),
   ];
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · clique num nó e veja de onde saem pai e filhos</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            índice {i} de 0 a {n - 1}
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          índice {i} de 0 a {n - 1}
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="viz-inputs">
           <div className="viz-field">
             <span>Filhos por nó (k)</span>
@@ -297,6 +310,9 @@ export function HeapIndicesVisualizer() {
           razão pela qual build-heap custa O(n) e não O(n log n).
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o `VizFooter` não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/QuickSortPivo.tsx
+++ b/content/visualizers/QuickSortPivo.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 // ---------------------------------------------------------------------------
 // QuickSortPivo, a escolha que decide se o algoritmo é O(n log n) ou O(n²).
 //
@@ -23,6 +25,16 @@ import { useMemo, useState } from "react";
 //
 // Interativo sem linha do tempo: a variável é a estratégia e a entrada, e o
 // passo a passo do algoritmo é assunto do visualizador principal.
+//
+// Sobre a casca (contrato em `content/visualizers/README.md`):
+//   · `total: 1` — sem linha do tempo. O que resume o estado ("com n = 8,
+//     profundidade 4 é o ideal e 8 é o pior caso") entra como `children` do
+//     `VizHeader`, com o rótulo junto, no lugar do "passo N de M".
+//   · `collapsible: false` — as quatro linhas da corrida SÃO o conteúdo. Não há
+//     bloco dispensável, e por isso `measureOn` também fica de fora.
+//   · as quatro estratégias são constantes do arquivo, e os quatro presets têm
+//     oito elementos cada: a contagem de linhas não é eixo de altura aqui, só a
+//     prosa (a dica do preset e as legendas das barras).
 // ---------------------------------------------------------------------------
 
 type Estrategia = "ultimo" | "primeiro" | "meio" | "mediana3";
@@ -147,6 +159,12 @@ export function QuickSortPivo() {
   const preset = useMemo(() => PRESETS.find((p) => p.key === presetKey) ?? PRESETS[0], [presetKey]);
   const n = preset.valores.length;
 
+  const viz = useVisualizer({
+    title: "Visualizador · a escolha do pivô decide entre n log n e n²",
+    total: 1,
+    collapsible: false,
+  });
+
   const linhas = useMemo(
     () => ESTRATEGIAS.map((e) => ({ e, ...rodar(preset.valores, e) })),
     [preset]
@@ -158,21 +176,15 @@ export function QuickSortPivo() {
   const idealProf = Math.ceil(Math.log2(n + 1));
   const piorProf = n;
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a escolha do pivô decide entre n log n e n²</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            com n = {n}, profundidade {idealProf} é o ideal e {piorProf} é o pior caso
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          com n = {n}, profundidade {idealProf} é o ideal e {piorProf} é o pior caso
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
@@ -247,6 +259,9 @@ export function QuickSortPivo() {
           meio da execução, trocando velocidade por uma garantia.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o `VizFooter` não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/ShellSortGaps.tsx
+++ b/content/visualizers/ShellSortGaps.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 // ---------------------------------------------------------------------------
 // ShellSortGaps, onde a conta vira e o que a sequência de gaps muda.
 //
@@ -24,6 +26,15 @@ import { useMemo, useState } from "react";
 // As entradas são geradas por fórmula determinística, nunca por Math.random:
 // além de a hidratação quebrar, um número que muda a cada visita não pode ser
 // citado no artigo nem verificado por teste.
+//
+// Sobre a casca (contrato em `content/visualizers/README.md`):
+//   · `total: 1` — sem linha do tempo. O eixo é a ENTRADA (o tamanho e a
+//     forma), e o resumo do estado entra como `children` do `VizHeader`.
+//   · `collapsible: false` — as cinco linhas da corrida são o conteúdo; não há
+//     bloco dispensável, e por isso `measureOn` fica de fora.
+//   · o que move a altura aqui não é a contagem de linhas (são cinco, fixas em
+//     `SEQUENCIAS`) e sim a legenda `gaps: …`, que cresce com n, e a nota, que
+//     tem três redações. Os dois chips de controle ficam no miolo.
 // ---------------------------------------------------------------------------
 
 type Seq = { key: string; nome: string; gaps: (n: number) => number[]; nota: string };
@@ -178,6 +189,12 @@ export function ShellSortGaps() {
   const [forma, setForma] = useState<Forma>("embaralhado");
   const [n, setN] = useState(32);
 
+  const viz = useVisualizer({
+    title: "Visualizador · a partir de que tamanho o gap compensa",
+    total: 1,
+    collapsible: false,
+  });
+
   const entrada = useMemo(() => entradaDe(forma, n), [forma, n]);
   const linhas = useMemo(
     () =>
@@ -204,22 +221,16 @@ export function ShellSortGaps() {
   const shellPunida = n >= 16 && shell.comp > melhorGap.comp * 2;
   const formaAtual = FORMAS.find((f) => f.key === forma)!;
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · a partir de que tamanho o gap compensa</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            n = {n} · melhor com gap: {melhorGap.s.nome}, {melhorGap.comp} comparações · insertion sort:{" "}
-            {insertion.comp}
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          n = {n} · melhor com gap: {melhorGap.s.nome}, {melhorGap.comp} comparações · insertion sort:{" "}
+          {insertion.comp}
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {TAMANHOS.map((t) => (
             <button key={t} className={`bigo-chip${n === t ? " on" : ""}`} onClick={() => setN(t)} aria-pressed={n === t}>
@@ -311,6 +322,9 @@ export function ShellSortGaps() {
           deduzida.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o `VizFooter` não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/content/visualizers/ShellSortSubsequencias.tsx
+++ b/content/visualizers/ShellSortSubsequencias.tsx
@@ -2,6 +2,8 @@
 
 import { useMemo, useState } from "react";
 
+import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
+
 // ---------------------------------------------------------------------------
 // ShellSortSubsequencias, o que uma rodada de gap h realmente faz.
 //
@@ -19,6 +21,19 @@ import { useMemo, useState } from "react";
 // de a propriedade ser prometida num parágrafo.
 //
 // Interativo sem linha do tempo: a variável é a RODADA, não o passo dentro dela.
+//
+// Sobre a casca (contrato em `content/visualizers/README.md`):
+//   · `total: 1`, e a tentação era passar `total: 3`, uma por rodada. Seria
+//     errado por dois motivos: a rodada não é um passo da animação (ela mostra
+//     antes e depois de uma vez, não um instante), e o contador do hook
+//     escreveria "passo N de 3" onde hoje está o selo de gap. Rótulo que mente
+//     ensina errado, então o resumo do estado continua sendo `children` do
+//     `VizHeader` e os chips de rodada continuam no miolo.
+//   · `collapsible: false` — as fitas SÃO o conteúdo, e sem bloco para recolher
+//     `measureOn` não faria nada.
+//   · o eixo de altura é o GAP, não a contagem de elementos: `subs` tem uma
+//     fila por resto, então a rodada 1 (gap 4) desenha quatro subsequências e a
+//     rodada 3 (gap 1) desenha uma só.
 // ---------------------------------------------------------------------------
 
 const ENTRADA = [5, 3, 21, 13, 1, 7, 6, 15];
@@ -63,6 +78,13 @@ const ESTADOS = (() => {
 
 export function ShellSortSubsequencias() {
   const [rodadaIdx, setRodadaIdx] = useState(0);
+
+  const viz = useVisualizer({
+    title: "Visualizador · uma rodada de gap h são h insertion sorts entrelaçados",
+    total: 1,
+    collapsible: false,
+  });
+
   const gap = GAPS[rodadaIdx];
   const antes = ESTADOS[rodadaIdx];
   const depois = ESTADOS[rodadaIdx + 1];
@@ -80,22 +102,16 @@ export function ShellSortSubsequencias() {
 
   const mudou = useMemo(() => antes.some((v, k) => v !== depois[k]), [antes, depois]);
 
-  return (
-    <figure className="viz" style={{ margin: 0 }}>
-      <div className="viz-head">
-        <div className="viz-head-title">
-          <span className="dot" />
-          <span>Visualizador · uma rodada de gap h são h insertion sorts entrelaçados</span>
-        </div>
-        <div className="viz-head-right">
-          <span className="viz-step">
-            gap {gap} · {gap} subsequência{gap === 1 ? "" : "s"} de {Math.ceil(n / gap)} elemento
-            {Math.ceil(n / gap) === 1 ? "" : "s"}
-          </span>
-        </div>
-      </div>
+  return viz.inPanel(
+    <figure {...viz.figureProps} style={{ margin: 0 }}>
+      <VizHeader viz={viz}>
+        <span className="viz-step">
+          gap {gap} · {gap} subsequência{gap === 1 ? "" : "s"} de {Math.ceil(n / gap)} elemento
+          {Math.ceil(n / gap) === 1 ? "" : "s"}
+        </span>
+      </VizHeader>
 
-      <div className="viz-body">
+      <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {GAPS.map((g, k) => (
             <button
@@ -207,6 +223,9 @@ export function ShellSortSubsequencias() {
           estabilidade como preço.
         </p>
       </div>
+
+      {/* Sem linha do tempo e sem botões extras, o `VizFooter` não desenha nada. */}
+      <VizFooter viz={viz} />
     </figure>
   );
 }

--- a/tests/viz-backtracking.spec.ts
+++ b/tests/viz-backtracking.spec.ts
@@ -30,9 +30,30 @@ async function abrirPagina(page: Page, w: number, h: number) {
   await expect(page.locator("article figure.viz")).toHaveCount(3);
 }
 
+/** O título de cada uma das três, na ordem dos índices acima. */
+const TITULOS = [
+  "backtracking: escolher, explorar, desfazer",
+  "o mesmo backtracking resolvendo sudoku",
+  "a poda: mesma resposta, uma fração do trabalho",
+];
+
 /** A figura da peça, com as contagens afirmadas nos dois níveis. */
 async function figura(page: Page, i: number): Promise<Locator> {
   const fig = page.locator("article figure.viz").nth(i);
+  // O índice diz ONDE, e esta linha diz QUAL. Nenhuma das asserções abaixo
+  // separa as duas peças — árvore e sudoku têm as duas a casca, o contador de
+  // passo e o bloco recolhível —, então sem ela o helper devolve a figura
+  // errada calado.
+  //
+  // Medido, e o resultado corrige o que eu ia escrever aqui: trocando ARVORE e
+  // SUDOKU de índice, a suíte reprova COM e SEM esta linha. Os testes lá
+  // embaixo são específicos o bastante (`passo 1 de 32` contra `passo 1 de 60`)
+  // para pegar a troca. O que esta linha muda é ONDE a reprovação acontece: no
+  // helper, dizendo qual peça veio, em vez de três arquivos de asserção adiante
+  // com um número que não explica nada.
+  await expect(fig.locator(".viz-head-title"), `a figura ${i} é a peça certa`).toContainText(
+    TITULOS[i]
+  );
   await expect(fig).toHaveClass(/viz-fit/);
   // Na página `.viz-step` casa TRÊS, e o terceiro não é um contador de passo: o
   // `BacktrackingPoda` usa a mesma classe para dizer "6 rainhas · 4 soluções ·
@@ -44,9 +65,11 @@ async function figura(page: Page, i: number): Promise<Locator> {
   // `not.toContainText` num locator vazio REPROVA (`element(s) not found`) em
   // vez de passar. O que continua verdade — e é o que importa — é que o
   // `.viz-step` da poda não é um contador de passo.
-  await expect(
-    page.locator("article figure.viz").nth(PODA).locator(".viz-step")
-  ).not.toContainText("passo");
+  const poda = page
+    .locator("article figure.viz")
+    .filter({ has: page.locator(".viz-head-title", { hasText: TITULOS[PODA] }) });
+  await expect(poda).toHaveCount(1);
+  await expect(poda.locator(".viz-step")).not.toContainText("passo");
   await expect(fig.locator(".viz-step")).toHaveCount(1);
   await expect(fig.locator(".viz-step")).toContainText("passo");
   // O bloco recolhível existe só nas duas peças adaptadas.

--- a/tests/viz-backtracking.spec.ts
+++ b/tests/viz-backtracking.spec.ts
@@ -1,10 +1,11 @@
 import { test, expect, type Locator, type Page } from "@playwright/test";
 
-// A casca adaptativa nas duas peças de `backtracking`: a árvore de decisão e o
-// sudoku. A terceira figura da página (`BacktrackingPoda`) não tem overlay e
-// ficou fora — por isso todo seletor daqui é escopado na figura, e as contagens
-// são afirmadas nos dois níveis (página e figura). Sem isso, `.viz-step` casa
-// duas figuras e a leitura sai da peça errada.
+// A casca adaptativa nas duas peças de `backtracking` com linha do tempo: a
+// árvore de decisão e o sudoku. A terceira figura da página
+// (`BacktrackingPoda`) também está na casca, mas sem passo a passo — por isso
+// todo seletor daqui é escopado na figura, e as contagens são afirmadas nos
+// dois níveis (página e figura). Sem isso, `.viz-step` casa três figuras e a
+// leitura sai da peça errada.
 //
 // Medido antes de escrever: no expandido a figura inteira rolava, e o
 // `▶ Rodar` era desenhado 335px (árvore, 1512x900) e 590px (sudoku, 1440x600)
@@ -16,6 +17,8 @@ const URL = "/topico/backtracking/";
 
 const ARVORE = 0;
 const SUDOKU = 1;
+/** A peça sem linha do tempo, que usa `.viz-step` para outra coisa. */
+const PODA = 2;
 
 /** Folga de subpixel, igual à do hook. */
 const SLACK = 8;
@@ -36,7 +39,14 @@ async function figura(page: Page, i: number): Promise<Locator> {
   // 2.6x menos nós com poda". Escopar na figura não é preciosismo — sem isso a
   // leitura sai da peça errada e o teste fica verde medindo outra coisa.
   await expect(page.locator("article figure.viz .viz-step")).toHaveCount(3);
-  await expect(page.locator("article figure.viz:not(.viz-fit) .viz-step")).not.toContainText("passo");
+  // Escopado por QUAL figura, e não por `:not(.viz-fit)` como já foi: as três
+  // estão na casca agora, aquele seletor passou a casar ZERO, e
+  // `not.toContainText` num locator vazio REPROVA (`element(s) not found`) em
+  // vez de passar. O que continua verdade — e é o que importa — é que o
+  // `.viz-step` da poda não é um contador de passo.
+  await expect(
+    page.locator("article figure.viz").nth(PODA).locator(".viz-step")
+  ).not.toContainText("passo");
   await expect(fig.locator(".viz-step")).toHaveCount(1);
   await expect(fig.locator(".viz-step")).toContainText("passo");
   // O bloco recolhível existe só nas duas peças adaptadas.

--- a/tests/viz-binary-heap-indices.spec.ts
+++ b/tests/viz-binary-heap-indices.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// O `HeapIndicesVisualizer` fixa a seleção quando o array ENCOLHE, e continua
+// fixando depois que o ajuste saiu de um `useEffect` para a fase de render.
+//
+// Por que este arquivo existe: o ajuste era
+//
+//     useEffect(() => { if (sel >= n) setSel(Math.max(0, n - 1)); }, [n, sel]);
+//
+// um `setState` dentro de efeito que dá para derivar durante o render, e o
+// único caso do arquivo na lista do `react-hooks/set-state-in-effect`. Ele
+// nunca teve teste, e é por isso que trocá-lo é arriscado: a linha seguinte
+// (`const i = Math.min(sel, n - 1)`) parece tornar o bloco redundante, e quem
+// simplesmente apagar o ajuste troca o comportamento SEM nenhum erro aparecer —
+// a seleção deixa de ser fixada e volta sozinha ao encolher e crescer de novo.
+//
+// Arquivo próprio, e não uma seção de `viz-binary-heap.spec.ts`: aquele arquivo
+// tem PR aberto em cima (#51) e cobre o `BinaryHeapVisualizer`, que é a outra
+// figura da mesma página.
+
+const URL = "/topico/binary-heap/";
+
+/** A figura do visualizador de índices, que NÃO é a do passo a passo. */
+async function abrir(page: Page): Promise<Locator> {
+  await page.goto(URL);
+  await page.evaluate(() => document.fonts.ready);
+  const fig = page
+    .locator("article figure.viz")
+    .filter({ hasText: "clique num nó e veja de onde saem pai e filhos" });
+  await expect(fig).toHaveCount(1);
+  // A página tem duas figuras e as duas têm `.viz-step`, com sentidos
+  // diferentes: aqui é "índice N de 0 a M", lá é "passo N de M". Sem escopar,
+  // a leitura sai da peça errada e o teste fica verde medindo outra coisa.
+  await expect(page.locator("article .viz-step")).toHaveCount(2);
+  await expect(fig.locator(".viz-step")).toHaveCount(1);
+  return fig;
+}
+
+const rotulo = (fig: Locator) => fig.locator(".viz-step");
+const slider = (fig: Locator) => fig.locator("input[type=range]");
+/** A célula do array. Escopada no `.hp-arr` porque o MESMO `aria-label` está
+ *  também no nó da árvore em SVG: `getByRole("button", …)` casa dois. */
+const celula = (fig: Locator, idx: number) => fig.locator(".hp-arr .hp-cel").nth(idx);
+
+test.describe("binary heap · a seleção do visualizador de índices", () => {
+  test("encolher o array fixa a seleção, e crescer de volta NÃO a devolve", async ({ page }) => {
+    const fig = await abrir(page);
+
+    // O array cheio, com o último índice selecionado. O rótulo é lido junto com
+    // o valor: "índice 15" sozinho não diria de que faixa ele é o último.
+    await slider(fig).fill("16");
+    await expect(celula(fig, 15)).toHaveAttribute("aria-label", "Índice 15, valor 51");
+    await celula(fig, 15).click();
+    await expect(rotulo(fig)).toHaveText("índice 15 de 0 a 15");
+
+    // Encolhe: 15 sai da faixa e o ajuste fixa a seleção no último válido.
+    await slider(fig).fill("4");
+    await expect(rotulo(fig)).toHaveText("índice 3 de 0 a 3");
+
+    // E cresce de volta. Esta é a asserção que carrega o sentido: o ajuste é
+    // uma ESCRITA de estado, não um `clamp` de leitura, então a seleção fica
+    // onde foi fixada. Apagar o bloco de ajuste e confiar no `Math.min` faria
+    // esta linha ler "índice 15 de 0 a 15".
+    await slider(fig).fill("16");
+    await expect(rotulo(fig)).toHaveText("índice 3 de 0 a 15");
+  });
+
+  test("a seleção fixada é a mesma que a árvore e o array acendem", async ({ page }) => {
+    const fig = await abrir(page);
+
+    await slider(fig).fill("16");
+    await celula(fig, 12).click();
+    await expect(rotulo(fig)).toHaveText("índice 12 de 0 a 15");
+
+    await slider(fig).fill("5");
+    await expect(rotulo(fig)).toHaveText("índice 4 de 0 a 4");
+
+    // Comportamento certo com rótulo certo não basta: o que o aluno vê é a
+    // célula acesa. Exatamente uma no array, e é a do índice 4.
+    const acesas = fig.locator(".hp-arr .hp-cel.on");
+    await expect(acesas).toHaveCount(1);
+    await expect(acesas).toHaveAttribute("aria-label", /^Índice 4, valor /);
+
+    // E a fórmula do pai lê o índice fixado, não o antigo.
+    await expect(fig.locator(".hp-formula.pai .hp-formula-conta")).toHaveText("(4 - 1) // 2 = 1");
+  });
+
+  test("trocar só o k não mexe na seleção: quem tem faixa é o n", async ({ page }) => {
+    const fig = await abrir(page);
+
+    await slider(fig).fill("16");
+    await celula(fig, 15).click();
+    await expect(rotulo(fig)).toHaveText("índice 15 de 0 a 15");
+
+    // `k` muda quem é pai e quem é filho, nunca quantas posições existem — o
+    // ajuste não pode disparar aqui. Se ele dependesse de `k`, a seleção cairia.
+    await fig.locator(".sub-modo-btn", { hasText: /^4$/ }).click();
+    await expect(rotulo(fig)).toHaveText("índice 15 de 0 a 15");
+    await expect(fig.locator(".hp-formula.pai .hp-formula-conta")).toHaveText("(15 - 1) // 4 = 3");
+  });
+});

--- a/tests/viz-binary-heap.spec.ts
+++ b/tests/viz-binary-heap.spec.ts
@@ -54,8 +54,15 @@ const TOTAL_PADRAO = 21;
 // `.viz-step`, `.bigo-stat` e `input[type=range]`. Medido: `.viz-step` casa 2 na
 // página e 1 dentro da peça. Todo seletor daqui é escopado por isso — um
 // seletor ambíguo não dá erro, devolve o PRIMEIRO elemento.
+//
+// E o escopo diz QUAL peça é, não quantas têm a casca: `article figure.viz-fit`
+// era o seletor daqui e virou armadilha quando o vizinho entrou na casca — ele
+// passou a casar 2 e derrubou os 8 testes do arquivo. Contar `.viz-fit` é
+// afirmar o cronograma da migração, não o produto.
 function noArtigo(page: Page): Locator {
-  return page.locator("article figure.viz-fit");
+  return page
+    .locator("article figure.viz")
+    .filter({ hasText: "a árvore e o array do heap se movendo juntos" });
 }
 
 /** A peça depois de expandida: ela é portada para fora do artigo. */

--- a/tests/viz-busca-binaria-overflow.spec.ts
+++ b/tests/viz-busca-binaria-overflow.spec.ts
@@ -1,0 +1,203 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// A casca adaptativa no `BuscaBinariaOverflow` — a terceira peça do tópico
+// `busca-binaria`, e a única das três que não tem linha do tempo.
+//
+// Arquivo próprio, e não uma seção de `viz-busca-binaria.spec.ts`: aquele
+// arquivo cobre as DUAS peças com passo a passo, tem PR aberto em cima, e o
+// padrão da skill é um arquivo novo por rodada para N agentes não brigarem
+// pelo mesmo diff.
+//
+// O que muda o formato dos testes daqui em relação aos das peças com linha do
+// tempo, e vem direto da §8 do contrato:
+//
+//   · com `collapsible: false` não existem os itens 2, 3 e 4 do mínimo (os três
+//     que falam do bloco recolhível). No lugar deles a prova é a do rótulo:
+//     NENHUM botão pode prometer esconder um bloco que a peça não tem;
+//   · com `total: 1` não existe rodapé nenhum — `VizFooter` sem `children` some
+//     inteiro —, então a camada 1 não pode ser provada pela posição do
+//     `▶ Rodar`. Aqui o único cromo parado é o cabeçalho, e é a posição DELE,
+//     comparada com ela mesma, que carrega o sentido.
+//
+// Medido antes de escrever, nos 8 estados (4 presets x 2 tipos de inteiro) e
+// nas três réguas, com `document.fonts.ready` cumprido:
+//
+//   artigo, antes ....... 848..886 (1512x900) / 881..902 (1440x700) / 1768..1920 (390x844)
+//   artigo, depois ...... 856..894             / 889..910           / 1788..1940
+//   ou seja +8, +8 e +20, e a aritmética fecha: o `.viz-body` devolve os 4px do
+//   `padding-bottom` (18 -> 14) previstos na §9, e o cabeçalho cobra 12px a
+//   1512 (41 -> 53, o botão é mais alto que o texto) e 24px a 390 (73 -> 97).
+//   Nenhum estado desta peça faz a linha do cabeçalho QUEBRAR, que é o que
+//   custa 40px nas peças vizinhas desta mesma rodada.
+
+const URL = "/topico/busca-binaria/";
+
+/** Índice desta peça entre as três `figure.viz` da página, como no arquivo irmão. */
+const OVERFLOW = 1;
+const TITULO = "Visualizador · as duas formas de achar o meio, e por que só uma serve";
+
+/** Folga de subpixel, igual à do hook. */
+const SLACK = 8;
+
+async function abrir(page: Page, w: number, h: number): Promise<Locator> {
+  await page.setViewportSize({ width: w, height: h });
+  expect(page.viewportSize(), "a janela pedida é a janela medida").toEqual({ width: w, height: h });
+  await page.goto(URL);
+  await page.evaluate(() => document.fonts.ready);
+  const fig = page.locator("article figure.viz").nth(OVERFLOW);
+  await expect(fig).toHaveClass(/viz-fit/);
+  await expect(fig.locator(".viz-head-title")).toContainText("as duas formas de achar o meio");
+  return fig;
+}
+
+/** Expande e espera o painel estar PRONTO PARA O TECLADO, não só visível: o
+ *  `keydown` nasce num efeito, e a tecla enviada antes some sem erro nenhum.
+ *  O foco tendo entrado na figura é o sinal de que o efeito rodou. */
+async function expandir(page: Page, fig: Locator): Promise<Locator> {
+  await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+  const dialogo = page.getByRole("dialog", { name: TITULO });
+  await expect(dialogo).toHaveCount(1);
+  const painel = dialogo.locator("figure.viz-fit");
+  await expect(painel).toBeFocused();
+  return painel;
+}
+
+test.describe("busca binária · o estouro de 32 bits entra na casca", () => {
+  test("é a peça certa, e as contagens fecham nos dois níveis", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+
+    // A ambiguidade é da PÁGINA: três figuras, três `.viz-step` com sentidos
+    // diferentes. Afirmar só no nível da figura deixaria passar o dia em que
+    // um seletor de página começasse a casar com o irmão errado.
+    await expect(page.locator("article figure.viz")).toHaveCount(3);
+    await expect(page.locator("article figure.viz-fit")).toHaveCount(3);
+    await expect(page.locator("article .viz-step")).toHaveCount(3);
+    await expect(fig.locator(".viz-step")).toHaveCount(1);
+
+    // O número do cabeçalho vem COM o rótulo — sem o "passo N de M" ao lado, um
+    // número solto perderia o contexto que o explicava (contrato §6).
+    await expect(fig.locator(".viz-step")).toHaveText(/^as duas (concordam|discordam)$/);
+
+    // Um botão só no cabeçalho, e é o de expandir.
+    const botoes = fig.locator(".viz-head-right button");
+    await expect(botoes).toHaveCount(1);
+    await expect(botoes).toHaveText("⤢ Expandir");
+  });
+
+  test("sem bloco recolhível, nenhum botão promete esconder o que não existe", async ({ page }) => {
+    const fig = await abrir(page, 1512, 900);
+
+    // A premissa do `collapsible: false`: a peça REALMENTE não tem bloco.
+    await expect(fig.locator(".viz-code")).toHaveCount(0);
+    await expect(fig.locator(".viz-code-slot")).toHaveCount(0);
+
+    // E a promessa que não pode existir. Rótulo que mente ensina errado do
+    // mesmo jeito que comportamento errado.
+    await expect(fig.getByRole("button", { name: /Mostrar|Ocultar/ })).toHaveCount(0);
+    await expect(fig.locator(".viz-toggle-codigo")).toHaveCount(0);
+    await expect(fig.locator("[aria-expanded]")).toHaveCount(0);
+  });
+
+  test("sem linha do tempo, o rodapé some inteiro em vez de virar uma linha vazia", async ({
+    page,
+  }) => {
+    const fig = await abrir(page, 1512, 900);
+
+    await expect(fig.locator(".viz-step")).not.toContainText("passo");
+    await expect(fig.locator(".viz-foot")).toHaveCount(0);
+    await expect(fig.locator(".viz-controls")).toHaveCount(0);
+    await expect(fig.locator(".viz-progress")).toHaveCount(0);
+    await expect(fig.locator(".viz-atalhos")).toHaveCount(0);
+    await expect(fig.getByRole("button", { name: /Rodar|Pausar|Anterior|Próximo/ })).toHaveCount(0);
+
+    // Os controles desta peça não sumiram junto: eles são do MIOLO, porque não
+    // são reprodução. Se tivessem ido para o rodapé, sumiriam com ele.
+    await expect(fig.locator(".viz-body .bigo-chip")).toHaveCount(4);
+    await expect(fig.locator(".viz-body input[type=number]")).toHaveCount(2);
+  });
+
+  test("no painel o cabeçalho fica parado enquanto o miolo rola", async ({ page }) => {
+    const fig = await abrir(page, 1440, 700);
+    const painel = await expandir(page, fig);
+
+    const topoDoCabecalho = () =>
+      painel.locator(".viz-head").evaluate((e) => Math.round(e.getBoundingClientRect().top));
+
+    const antes = await topoDoCabecalho();
+
+    // Rola OS DOIS candidatos. Se a camada 1 estiver desligada quem rola é a
+    // figura inteira (`.viz-overlay .viz` é `overflow: auto`), e é justamente
+    // esse caso que precisa reprovar — mandar rolar só o miolo faria o teste
+    // passar contra a quebra, porque aí o miolo não rola e nada se mexe.
+    await painel.evaluate((f) => {
+      const b = f.querySelector<HTMLElement>(".viz-body");
+      f.scrollTop = f.scrollHeight;
+      if (b) b.scrollTop = b.scrollHeight;
+    });
+
+    // A asserção que carrega o sentido, e ela vem ANTES das premissas: a quebra
+    // desfaz a situação que as premissas afirmam, então com elas na frente o
+    // teste reprovaria na linha errada (armadilha 9 do processo).
+    expect(await topoDoCabecalho(), "o cabeçalho não anda quando o miolo rola").toBe(antes);
+
+    // Premissas, agora que já se sabe qual asserção trabalha: tem sobra para
+    // rolar, quem rolou foi o miolo, e a figura não rolou.
+    const medidas = await painel.evaluate((f) => {
+      const b = f.querySelector<HTMLElement>(".viz-body")!;
+      return {
+        sobraDoMiolo: b.scrollHeight - b.clientHeight,
+        miolo: Math.round(b.scrollTop),
+        figura: Math.round(f.scrollTop),
+      };
+    });
+    expect(medidas.sobraDoMiolo, "o miolo tem o que rolar").toBeGreaterThan(SLACK);
+    expect(medidas.miolo, "quem rolou foi o miolo").toBeGreaterThan(0);
+    expect(medidas.figura, "a figura não rola").toBe(0);
+  });
+
+  test("o diálogo é rotulado por ESTA peça, o foco entra nele e o Esc fecha", async ({ page }) => {
+    const fig = await abrir(page, 1440, 700);
+    const expandir3 = fig.getByRole("button", { name: "⤢ Expandir" });
+
+    await expandir3.click();
+    // Com três figuras na mesma página, um `aria-label` genérico deixaria o
+    // leitor de tela sem saber qual das três abriu.
+    await expect(page.getByRole("dialog", { name: TITULO })).toHaveCount(1);
+    await expect(page.getByRole("dialog")).toHaveCount(1);
+    await expect(page.locator(".viz-overlay figure.viz-fit")).toBeFocused();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByRole("dialog")).toHaveCount(0);
+
+    // A outra metade da promessa do contrato §5 — "o foco volta para onde
+    // estava ao fechar" — NÃO é afirmada aqui de propósito, porque hoje ela não
+    // acontece: o foco cai no `<body>`. Não é desta peça, é do hook, e vale
+    // para as três figuras desta página, incluindo as duas adaptadas há
+    // rodadas: o `previous?.focus?.()` do `useVisualizer` guarda o botão que
+    // estava em foco, e o nó morre quando o `createPortal` recolhe a figura de
+    // volta para o artigo, então o `focus()` sai num nó solto.
+    // Reportado como defeito de plataforma; o conserto é no hook e não cabe
+    // numa adaptação de peça (skill §1).
+  });
+
+  test("no painel o Tab circula dentro, e não escapa para os links do artigo", async ({ page }) => {
+    const fig = await abrir(page, 1440, 700);
+    const painel = await expandir(page, fig);
+
+    // Uma volta inteira e mais um pouco: o que prova a trava é o foco NUNCA
+    // sair, não ele estar dentro depois de um Tab só.
+    const focaveis = await painel
+      .locator('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])')
+      .count();
+    expect(focaveis, "há foco para circular").toBeGreaterThan(2);
+
+    for (let i = 0; i < focaveis + 3; i++) {
+      await page.keyboard.press("Tab");
+      const dentro = await page.evaluate(() => {
+        const p = document.querySelector(".viz-overlay figure.viz-fit");
+        return !!p && (p === document.activeElement || p.contains(document.activeElement));
+      });
+      expect(dentro, `o foco continua no painel depois de ${i + 1} Tabs`).toBe(true);
+    }
+  });
+});

--- a/tests/viz-busca-binaria-overflow.spec.ts
+++ b/tests/viz-busca-binaria-overflow.spec.ts
@@ -32,8 +32,6 @@ import { test, expect, type Locator, type Page } from "@playwright/test";
 
 const URL = "/topico/busca-binaria/";
 
-/** Índice desta peça entre as três `figure.viz` da página, como no arquivo irmão. */
-const OVERFLOW = 1;
 const TITULO = "Visualizador · as duas formas de achar o meio, e por que só uma serve";
 
 /** Folga de subpixel, igual à do hook. */
@@ -44,9 +42,15 @@ async function abrir(page: Page, w: number, h: number): Promise<Locator> {
   expect(page.viewportSize(), "a janela pedida é a janela medida").toEqual({ width: w, height: h });
   await page.goto(URL);
   await page.evaluate(() => document.fonts.ready);
-  const fig = page.locator("article figure.viz").nth(OVERFLOW);
+  // Escolhida por QUAL peça é, e não por posição entre as três figuras da
+  // página: `.nth(1)` é uma afirmação sobre a ordem do artigo, e o dia em que
+  // ela mudar esta suíte mede outra peça. O `toHaveCount(1)` é a outra metade —
+  // sem ele, um título ambíguo devolveria duas figuras.
+  const fig = page
+    .locator("article figure.viz")
+    .filter({ has: page.locator(".viz-head-title", { hasText: "as duas formas de achar o meio" }) });
+  await expect(fig, `a peça "${TITULO}" tem que ser única em ${URL}`).toHaveCount(1);
   await expect(fig).toHaveClass(/viz-fit/);
-  await expect(fig.locator(".viz-head-title")).toContainText("as duas formas de achar o meio");
   return fig;
 }
 

--- a/tests/viz-casca-sem-linha-do-tempo.spec.ts
+++ b/tests/viz-casca-sem-linha-do-tempo.spec.ts
@@ -1,0 +1,205 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// A casca adaptativa nas cinco peças `total: 1` + `collapsible: false` desta
+// rodada, em quatro tópicos. Elas são o mesmo perfil, e por isso o arquivo é
+// uma tabela: o que o contrato exige delas é idêntico, e escrever cinco vezes
+// o mesmo teste em cinco arquivos esconderia justamente o que elas têm em
+// comum. O `BuscaBinariaOverflow`, que é a sexta do perfil, tem arquivo
+// próprio porque entrou antes destas.
+//
+// O que muda o formato em relação a uma peça com linha do tempo, e vem da §8
+// do contrato:
+//
+//   · com `collapsible: false` não existem os itens 2, 3 e 4 do mínimo (os três
+//     que falam do bloco recolhível). No lugar deles vale a prova do rótulo:
+//     NENHUM botão pode prometer esconder um bloco que a peça não tem;
+//   · com `total: 1` e sem `children` o `VizFooter` some inteiro, então não há
+//     `▶ Rodar` cuja posição comparar. O único cromo parado é o cabeçalho, e é
+//     a posição DELE, comparada com ela mesma, que carrega o sentido.
+//
+// Todo seletor sai da figura, e a figura é achada por QUAL peça ela é. Nenhum
+// teste daqui conta quantas figuras da página têm a casca: essa é uma afirmação
+// sobre o cronograma da migração, não sobre o produto, e ela nasce condenada —
+// foi exatamente o que derrubou 39 testes quando estas cinco entraram.
+
+type Peca = {
+  slug: string;
+  nome: string;
+  /** Trecho do título que identifica a figura na página. */
+  titulo: string;
+  /** O título inteiro, que vira o `aria-label` do diálogo. */
+  tituloCompleto: string;
+  /** O resumo do estado que entra no lugar do "passo N de M". */
+  resumo: RegExp;
+  /** Quantas figuras a página tem, para a contagem do nível de cima. */
+  figurasNaPagina: number;
+};
+
+const PECAS: Peca[] = [
+  {
+    slug: "backtracking",
+    nome: "BacktrackingPoda",
+    titulo: "a poda: mesma resposta",
+    tituloCompleto: "Visualizador · a poda: mesma resposta, uma fração do trabalho",
+    resumo: /^\d+ rainhas · \d+ soluções · [\d.]+x menos nós com poda$/,
+    figurasNaPagina: 3,
+  },
+  {
+    slug: "quick-sort",
+    nome: "QuickSortPivo",
+    titulo: "a escolha do pivô decide",
+    tituloCompleto: "Visualizador · a escolha do pivô decide entre n log n e n²",
+    resumo: /^com n = \d+, profundidade \d+ é o ideal e \d+ é o pior caso$/,
+    figurasNaPagina: 3,
+  },
+  {
+    slug: "shell-sort",
+    nome: "ShellSortGaps",
+    titulo: "a partir de que tamanho o gap",
+    tituloCompleto: "Visualizador · a partir de que tamanho o gap compensa",
+    resumo: /^n = \d+ · melhor com gap: .+, \d+ comparações · insertion sort: \d+$/,
+    figurasNaPagina: 3,
+  },
+  {
+    slug: "shell-sort",
+    nome: "ShellSortSubsequencias",
+    titulo: "uma rodada de gap h são h insertion",
+    tituloCompleto: "Visualizador · uma rodada de gap h são h insertion sorts entrelaçados",
+    resumo: /^gap \d+ · \d+ subsequências? de \d+ elementos?$/,
+    figurasNaPagina: 3,
+  },
+  {
+    slug: "binary-heap",
+    nome: "HeapIndicesVisualizer",
+    titulo: "clique num nó e veja de onde saem",
+    tituloCompleto: "Visualizador · clique num nó e veja de onde saem pai e filhos",
+    resumo: /^índice \d+ de 0 a \d+$/,
+    figurasNaPagina: 2,
+  },
+];
+
+/** Folga de subpixel, igual à do hook. */
+const SLACK = 8;
+
+async function abrir(page: Page, peca: Peca, w: number, h: number): Promise<Locator> {
+  await page.setViewportSize({ width: w, height: h });
+  expect(page.viewportSize(), "a janela pedida é a janela medida").toEqual({ width: w, height: h });
+  await page.goto(`/topico/${peca.slug}/`);
+  await page.evaluate(() => document.fonts.ready);
+  const fig = page.locator("article figure.viz").filter({ hasText: peca.titulo });
+  await expect(fig, "o seletor casa uma figura, e é a desta peça").toHaveCount(1);
+  await expect(fig).toHaveClass(/viz-fit/);
+  return fig;
+}
+
+for (const peca of PECAS) {
+  test.describe(`${peca.nome} · casca sem linha do tempo`, () => {
+    test("o resumo do estado ocupa o lugar do contador, com o rótulo junto", async ({ page }) => {
+      const fig = await abrir(page, peca, 1512, 900);
+
+      // Nível de cima: a página inteira. É aqui que um seletor não escopado
+      // começaria a ler a peça errada, sem erro nenhum.
+      await expect(page.locator("article figure.viz")).toHaveCount(peca.figurasNaPagina);
+      await expect(page.locator("article .viz-step")).toHaveCount(peca.figurasNaPagina);
+      // Nível de baixo: a figura.
+      await expect(fig.locator(".viz-step")).toHaveCount(1);
+
+      // O número vem COM o rótulo: sem o "passo N de M" ao lado, um número solto
+      // perde o contexto que o explicava (contrato §6).
+      await expect(fig.locator(".viz-step")).toHaveText(peca.resumo);
+
+      // Um botão só no cabeçalho, e é o de expandir.
+      const botoes = fig.locator(".viz-head-right button");
+      await expect(botoes).toHaveCount(1);
+      await expect(botoes).toHaveText("⤢ Expandir");
+    });
+
+    test("nenhum botão promete esconder um bloco que a peça não tem", async ({ page }) => {
+      const fig = await abrir(page, peca, 1512, 900);
+
+      // A premissa do `collapsible: false`: a peça REALMENTE não tem bloco.
+      await expect(fig.locator(".viz-code")).toHaveCount(0);
+      await expect(fig.locator(".viz-code-slot")).toHaveCount(0);
+
+      // E a promessa que não pode existir. Rótulo que mente ensina errado do
+      // mesmo jeito que comportamento errado.
+      await expect(fig.getByRole("button", { name: /Mostrar|Ocultar/ })).toHaveCount(0);
+      await expect(fig.locator(".viz-toggle-codigo")).toHaveCount(0);
+      await expect(fig.locator("[aria-expanded]")).toHaveCount(0);
+    });
+
+    test("o rodapé some inteiro em vez de virar uma linha vazia", async ({ page }) => {
+      const fig = await abrir(page, peca, 1512, 900);
+
+      await expect(fig.locator(".viz-step")).not.toContainText("passo");
+      await expect(fig.locator(".viz-foot")).toHaveCount(0);
+      await expect(fig.locator(".viz-controls")).toHaveCount(0);
+      await expect(fig.locator(".viz-progress")).toHaveCount(0);
+      await expect(fig.locator(".viz-atalhos")).toHaveCount(0);
+      await expect(fig.getByRole("button", { name: /Rodar|Pausar|Anterior|Próximo/ })).toHaveCount(
+        0
+      );
+
+      // Os controles da peça não sumiram junto: eles são do MIOLO, porque não
+      // são reprodução. No rodapé teriam sumido com ele.
+      expect(await fig.locator(".viz-body button").count()).toBeGreaterThan(0);
+    });
+
+    test("no painel o cabeçalho fica parado enquanto o miolo rola", async ({ page }) => {
+      const fig = await abrir(page, peca, 1440, 700);
+      await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+      const painel = page.getByRole("dialog", { name: peca.tituloCompleto }).locator("figure.viz-fit");
+      await expect(painel).toBeFocused();
+
+      const topoDoCabecalho = () =>
+        painel.locator(".viz-head").evaluate((e) => Math.round(e.getBoundingClientRect().top));
+      const antes = await topoDoCabecalho();
+
+      // Rola OS DOIS candidatos. Se a camada 1 estiver desligada quem rola é a
+      // figura inteira (`.viz-overlay .viz` é `overflow: auto`), e é esse caso
+      // que precisa reprovar — mandar rolar só o miolo faria o teste passar
+      // contra a quebra, porque aí o miolo não rola e nada se mexe.
+      await painel.evaluate((f) => {
+        const b = f.querySelector<HTMLElement>(".viz-body");
+        f.scrollTop = f.scrollHeight;
+        if (b) b.scrollTop = b.scrollHeight;
+      });
+
+      // A asserção que carrega o sentido vem ANTES das premissas: a quebra
+      // desfaz a situação que elas afirmam, e com elas na frente o teste
+      // reprovaria na linha errada.
+      expect(await topoDoCabecalho(), "o cabeçalho não anda quando o miolo rola").toBe(antes);
+
+      const medidas = await painel.evaluate((f) => {
+        const b = f.querySelector<HTMLElement>(".viz-body")!;
+        return {
+          sobraDoMiolo: b.scrollHeight - b.clientHeight,
+          miolo: Math.round(b.scrollTop),
+          figura: Math.round(f.scrollTop),
+        };
+      });
+      expect(medidas.sobraDoMiolo, "o miolo tem o que rolar").toBeGreaterThan(SLACK);
+      expect(medidas.miolo, "quem rolou foi o miolo").toBeGreaterThan(0);
+      expect(medidas.figura, "a figura não rola").toBe(0);
+    });
+
+    test("o diálogo é rotulado por ESTA peça, e o Esc fecha", async ({ page }) => {
+      const fig = await abrir(page, peca, 1440, 700);
+      await fig.getByRole("button", { name: "⤢ Expandir" }).click();
+
+      // Com mais de uma figura na página, um `aria-label` genérico deixaria o
+      // leitor de tela sem saber qual delas abriu.
+      await expect(page.getByRole("dialog", { name: peca.tituloCompleto })).toHaveCount(1);
+      await expect(page.getByRole("dialog")).toHaveCount(1);
+
+      await page.keyboard.press("Escape");
+      await expect(page.getByRole("dialog")).toHaveCount(0);
+
+      // A outra metade da promessa do contrato §5 — "o foco volta para onde
+      // estava ao fechar" — NÃO é afirmada aqui de propósito, porque hoje ela
+      // não acontece: o foco cai no `<body>`. É defeito do hook, vale para
+      // todas as peças da casca, e está reportado no PR #51. Gravar o
+      // comportamento errado num teste seria pior que não ter o teste.
+    });
+  });
+}

--- a/tests/viz-quick-sort.spec.ts
+++ b/tests/viz-quick-sort.spec.ts
@@ -7,13 +7,17 @@ import { test, expect, type Page, type Locator } from "@playwright/test";
 // `.viz-step` casa 3 na página e 1 nesta figura, `.viz-note` idem. Por isso
 // todo seletor daqui é escopado na figura, nunca na página.
 //
-// Só o visualizador da partição recebeu a casca, então `figure.viz-fit` o
-// identifica sozinho — e o primeiro teste confere isso em vez de supor.
+// `figure.viz-fit` já identificou esta peça sozinho, e não identifica mais: o
+// comparador de pivôs entrou na casca e o seletor passou a casar 2, derrubando
+// os 8 testes do arquivo por strict mode violation. O seletor daqui agora diz
+// QUAL peça é, e não quantas têm a casca — contar `.viz-fit` é afirmar o
+// cronograma da migração, não o produto.
 
 const SLACK = 8;
 
 /** A figura adaptada, no fluxo do artigo. */
-const figArtigo = (page: Page) => page.locator("article figure.viz-fit");
+const figArtigo = (page: Page) =>
+  page.locator("article figure.viz").filter({ hasText: "quick sort: a partição e o pivô" });
 /** A mesma figura depois de expandida: ela vai para o portal, fora do <article>. */
 const figPainel = (page: Page) => page.locator(".viz-overlay figure.viz-fit");
 
@@ -55,14 +59,18 @@ async function passo(fig: Locator): Promise<{ atual: number; total: number }> {
 }
 
 test.describe("quick sort", () => {
-  test("a figura adaptada é a única com a casca, e os irmãos não contaminam os seletores", async ({
+  test("o seletor acha a peça da partição, e os irmãos não contaminam a leitura", async ({
     page,
   }) => {
     await abrirPagina(page, 1512, 900);
-    // Se um irmão ganhasse a casca, os seletores deste arquivo passariam a
-    // casar com ele e todos os outros testes mediriam a peça errada.
+    // O que precisa ser verdade não é "só uma tem a casca" — isso envelhece a
+    // cada peça que entra —, e sim "o meu seletor casa uma, e é a minha". O
+    // `toHaveCount(1)` do `abrirPagina` é essa garantia; aqui ficam as
+    // contagens dos irmãos, que é o que faz um seletor de página mentir.
     await expect(page.locator("article figure.viz")).toHaveCount(3);
-    await expect(page.locator("article figure.viz-fit")).toHaveCount(1);
+    await expect(figArtigo(page).locator(".viz-head-title")).toContainText(
+      "quick sort: a partição e o pivô que fica pronto"
+    );
     await expect(page.locator(".viz-step")).toHaveCount(3);
     await expect(figArtigo(page).locator(".viz-step")).toHaveCount(1);
     await expect(figArtigo(page).locator(".bigo-stat")).toHaveCount(4);

--- a/tests/viz-shell-sort.spec.ts
+++ b/tests/viz-shell-sort.spec.ts
@@ -3,7 +3,7 @@ import { test, expect, type Locator, type Page } from "@playwright/test";
 // Casca adaptativa do ShellSortVisualizer.
 //
 // A página tem TRÊS `figure.viz` (o passo a passo, as subsequências e a corrida
-// de sequências de gap) e só uma delas é `.viz-fit`. As outras duas têm
+// de sequências de gap), e as três estão na casca. As outras duas têm
 // `.viz-step` com outro sentido ("gap 4 · 4 subsequências...", "n = 32 ·
 // melhor com gap..."), então todo seletor aqui é escopado na figura certa e o
 // primeiro teste confere as contagens.
@@ -19,9 +19,16 @@ import { test, expect, type Locator, type Page } from "@playwright/test";
 
 const ORCAMENTO = (h: number) => h - 60 - 24;
 
-/** A figura adaptada, no fluxo do artigo. */
-const noArtigo = (page: Page) => page.locator("article figure.viz-fit");
-/** A figura adaptada, dentro do painel expandido. */
+/**
+ * A figura DESTE arquivo, no fluxo do artigo. Escopada por QUAL peça ela é, e
+ * não por quantas têm a casca: `article figure.viz-fit` já foi o seletor daqui
+ * e virou armadilha no dia em que as duas irmãs entraram na casca — ele casava
+ * 3 e derrubava os 11 testes do arquivo por strict mode violation. Contar
+ * `.viz-fit` é afirmar o cronograma da migração, não o produto.
+ */
+const noArtigo = (page: Page) =>
+  page.locator("article figure.viz").filter({ hasText: "shell sort: o insertion sort com gap" });
+/** A mesma figura no painel: o overlay só tem uma figura de cada vez. */
 const noPainel = (page: Page) => page.locator(".viz-overlay figure.viz-fit");
 
 /** Espera a casca terminar a medição: `data-anim` só vira "on" depois dela. */
@@ -93,7 +100,7 @@ async function ateOGap(fig: Locator, gap: number) {
 test.describe("shell sort · a figura certa", () => {
   test.use({ viewport: { width: 1512, height: 900 } });
 
-  test("a casca alcança um dos três visualizadores, e é o do passo a passo", async ({ page }) => {
+  test("o seletor deste arquivo acha o do passo a passo, e só ele", async ({ page }) => {
     const fig = await abrir(page);
     expect(page.viewportSize()).toEqual({ width: 1512, height: 900 });
 


### PR DESCRIPTION
As **seis peças mudas** que sobravam em cinco tópicos entram na casca
adaptativa, mais um defeito latente que estava no caminho. Elas vestiam
`<figure className="viz">` — a mesma moldura das peças adaptadas — sem
"⤢ Expandir", sem diálogo, sem trava de rolagem, sem `Esc` e sem foco. Em
quatro das cinco páginas o aluno encontrava **duas peças mudas para uma que
expande**: aparência idêntica, afordância diferente. Ele aprende que o botão
não existe e para de procurar, inclusive nas que o têm.

| peça | tópico |
|---|---|
| `BuscaBinariaOverflow` | `busca-binaria` |
| `BacktrackingPoda` | `backtracking` |
| `QuickSortPivo` | `quick-sort` |
| `ShellSortGaps`, `ShellSortSubsequencias` | `shell-sort` |
| `HeapIndicesVisualizer` | `binary-heap` |

As seis são o mesmo perfil: **`total: 1` + `collapsible: false`**, os dois casos
que o contrato já prevê. Não há linha do tempo (o eixo é a entrada ou a seleção)
nem bloco dispensável. O resumo do estado vira `children` do `VizHeader` **com o
rótulo junto**, e os controles ficam no miolo, porque no rodapé só entra
reprodução — e sem `children` o `VizFooter` some inteiro.

## Placar da casca: ela fecha

```
87  arquivos .tsx em content/visualizers/
61  na casca na main   ->   67 com este PR
17  mudas na main      ->   11 com este PR
```

**As 11 que sobram têm todas PR aberto**: 1 no #47 (`BigOChartVisualizer`), 1 no
#55 (`QuickSortTresVias`), 4 no #58 (os binários) e 5 no #56 (Ordenação). Com
esses quatro e este mergeados são **78 de 87, e nenhuma muda**. As outras 9 não
vestem a moldura — são cartaz estático e ficam de fora com razão.

## Medição da altura no artigo

Máximos por peça, varridos estado a estado nas três réguas, com
`document.fonts.ready` cumprido:

| peça | 1512x900 | 1440x700 | 390x844 |
|---|---|---|---|
| `BuscaBinariaOverflow` | 886 → 894 (**+8**) | 902 → 910 (+8) | 1920 → 1940 (+20) |
| `HeapIndicesVisualizer` | 930 → 938 (**+8**) | 930 → 938 (+8) | 1523 → 1559 (+36) |
| `BacktrackingPoda` | 1014 → 1050 (**+36**) | 1048 → 1068 (+20) | 1735 → 1795 (+60) |
| `QuickSortPivo` | 957 → 993 (**+36**) | 971 → 1007 (+36) | 1953 → 1997 (+44) |
| `ShellSortGaps` | 1045 → 1065 (**+20**) | 1078 → 1098 (+20) | 2014 → 2058 (+44) |
| `ShellSortSubsequencias` | 1058 → 1094 (**+36**) | 1090 → 1126 (+36) | 1749 → 1794 (+45) |

### O mecanismo, e ele corrige a expectativa da §9 do contrato

A §9 mede **−4px** em duas peças `total: 1` sem rodapé (`BinaryTreeFormatos`,
`GrafoRepresentacao`) e conclui que a casca **devolve** altura quando não há
rodapé. Medi as seis, e o −4 está lá ao pixel nas seis — mas quase nunca é o
saldo:

> **Δfigura = Δcabeçalho − 4px**, ao pixel, nas seis peças e nas três réguas.

O −4 é o `padding-bottom` do `.viz-body` (18 → 14). O resto é **100% a linha do
cabeçalho**, porque o botão "⤢ Expandir" entra num `.viz-head-right` que é
`flex-wrap: wrap`. A 1512x900:

| `.viz-head` | quando | Δfigura |
|---|---|---|
| 41 → 53px | o botão cabe na linha (é mais alto que o texto que estava sozinho) | **+8** |
| 41 → 81px | a linha **quebra** | **+36** |

A §9 já registra esse eixo, medido no `AStarVisualizer` como caso raro (19 de
514 estados, só a 1440px). Nestas peças ele é o **termo dominante** e
**incondicional**: é o estado de repouso, não um estado de borda. E há uma
tensão dentro do contrato que vale escrever: a §6 manda pôr o número que resume
o estado no cabeçalho **com o rótulo junto**, e é justamente esse texto longo
que, somado ao botão, garante a quebra da linha. **A peça que mais segue a §6 é
a que mais paga na §9.** Quem citar o "−4px" numa peça assim escreve o
contrário do que ela faz.

## As quatro asserções corrigidas, e por que elas eram o custo escondido

Adaptar estas peças reprovava **39 testes que já existiam** — não por conflito
de merge, por semântica. Quatro specs afirmavam, de um jeito ou de outro, que a
peça **vizinha** não estava na casca, e é exatamente isso que a adaptação
desfaz:

| spec | linha | a forma condenada | reprovações |
|---|---|---|---|
| `viz-shell-sort` | 23 | `const noArtigo = p.locator("article figure.viz-fit")` | 11 |
| `viz-quick-sort` | 16, 65 | idem, mais um `toHaveCount(1)` explícito | 8 |
| `viz-binary-heap` | 58 | idem | 8 |
| `viz-backtracking` | 39 | o espelho: `figure.viz:not(.viz-fit) .viz-step` | 12 |

**Contar `.viz-fit` é uma afirmação sobre o cronograma da migração, não sobre o
produto**, e nasce condenada: vira falsa no dia em que a peça do lado entra, e
leva junto todo teste do arquivo por strict mode violation.

O quarto merece a linha, porque contraria a intuição: com as três figuras na
casca, `figure.viz:not(.viz-fit) .viz-step` casa **zero** elementos, e
`not.toContainText` num locator vazio **reprova** com `element(s) not found` em
vez de passar.

O conserto é o que o `viz-busca-binaria.spec.ts` já fazia — e é por isso que ele
foi **o único dos cinco a sobreviver**: escopar por **qual** peça é, com
`nth(idx)` ou `filter({ hasText })`. Nenhuma asserção nova conta quantas figuras
têm a casca. Só as quatro linhas invalidadas foram tocadas; asserção fraca ao
lado ficou como está, é do #48.

## Provas de quebra

Todas com o build **visível**, restauração por `cp` (nunca `git checkout --`),
substituição exigindo casamento único, e `out/` reconstruído antes da suíte
cheia.

**As seis peças novas** (`tests/viz-casca-sem-linha-do-tempo.spec.ts` e
`tests/viz-busca-binaria-overflow.spec.ts`):

| a quebra | onde | resultado |
|---|---|---|
| `collapsible: false` → `true` | componente | **2 failed** — o botão que promete "Mostrar código" num bloco que não existe |
| `total: 1` → `2` | componente | **3 failed** — voltam contador, rodapé e atalhos |
| `viz-overlay viz-overlay-fit` → `viz-overlay` | hook | **5 failed**, uma por peça, todas em *"o cabeçalho não anda quando o miolo rola"* |
| `aria-label={title}` → genérico | hook | **10 failed** — o diálogo perde o nome desta peça |
| `e.key !== "Tab"` → outra tecla | hook | **1 failed** — *"o foco continua no painel depois de 10 Tabs"* |

**As quatro asserções corrigidas**, revertendo cada seletor ao condenado:

| a quebra | resultado |
|---|---|
| `viz-shell-sort` volta a `article figure.viz-fit` | **11 failed** (`resolved to 3 elements`) |
| `viz-quick-sort` idem | **8 failed** |
| `viz-binary-heap` idem | **8 failed** (`resolved to 2 elements`) |
| `viz-backtracking` volta a `:not(.viz-fit)` | **12 failed** (`element(s) not found`) |

11 + 8 + 8 + 12 = **39**, exatamente as 39 que a adaptação causava. A correção é
carregada pelo seletor, não por sorte.

**E o `HeapIndicesVisualizer:75`**, que é o commit de defeito latente: apagar o
ajuste de seleção reprova com `índice 15 de 0 a 15` onde devia ler
`índice 3 de 0 a 15`.

### Sobre a camada 1 numa peça sem rodapé

Com `total: 1` e sem `children` não existe `▶ Rodar` cuja posição comparar. O
único cromo parado é o cabeçalho, e o teste rola **os dois** candidatos (a
figura e o miolo) antes de medir — mandar rolar só o miolo faria o teste passar
contra a quebra do overlay, porque com ela o miolo não rola e nada se mexe. A
asserção vem **antes** das premissas, porque a quebra desfaz a situação que elas
afirmam.

## O defeito latente que veio junto

`HeapIndicesVisualizer.tsx:75` era um `setState` dentro de `useEffect` que dá
para derivar durante o render, e o único caso do arquivo na lista do
`react-hooks/set-state-in-effect` do #54. Virou ajuste em fase de render, em
**commit próprio**.

O detalhe que quase custou caro: a linha seguinte é
`const i = Math.min(sel, n - 1)`, que faz o bloco **parecer** redundante. Não é.
O ajuste é escrita de estado, o `Math.min` é leitura, e a diferença aparece ao
encolher e crescer de volta. Apagá-lo troca o comportamento sem nenhum erro
aparecer. Os outros 7 avisos estão em arquivos de outras frentes e ficaram de
fora de propósito.

## O que não mudou

- **Nenhum texto de tela.** O texto renderizado do build, comparado com a
  `origin/main` linha a linha nas cinco páginas, não perde uma palavra: as
  únicas diferenças são **seis** linhas `⤢ Expandir`, uma por peça.
- **`guarda-idioma.py`** nas seis: só nomes de classe que o hook passou a ser
  dono (`viz-head`, `viz-body`, `dot`…) e o import novo. No
  `HeapIndicesVisualizer`, o commit do efeito sai com `SUMIRAM: nenhuma /
  APARECERAM: nenhuma`.
- **Nenhum arquivo compartilhado.** `src/lib/visualizer.tsx`,
  `src/app/globals.css`, `content/visualizers/README.md`, `mdx-components.tsx`,
  `content/roadmap.ts`, `content/topics/`, `playwright.config.ts` e `scripts/`
  intocados. **Nenhuma linha de CSS nova** — o `data-anim` só controla
  transições de `.viz-split` e `.viz-code-slot`, que estas peças não têm.

## Verificação

- `npm run build` ✓, `npx tsc --noEmit` ✓
- suíte inteira: **493 passed, 0 failed** (eram 459 na `main`; 34 testes novos
  em 3 arquivos), com a máquina livre e uma porta só
- nenhuma reprovação da família de flake de 1px de rolagem nesta leva

## Um defeito reportado e NÃO consertado

**O foco não volta ao fechar o painel** (`src/lib/visualizer.tsx:334`). O
contrato §5 promete "volta para onde estava ao fechar"; medido nas três figuras
de `busca-binaria`, incluindo duas adaptadas há rodadas e intocadas aqui, o foco
cai no `<body>`. O `previous` guardado é o botão da figura **inline**, e o
`createPortal` destrói esse nó ao expandir, então o `focus()` sai num nó solto.
Vale para todas as peças da casca e nenhum teste do repo cobre. É do hook, e
está com o dono do arquivo no #51.

Os testes daqui afirmam só o que é verdade (o foco **entra** no painel, o `Esc`
fecha) e deixam a outra metade comentada apontando para o defeito — cimentar o
comportamento errado num teste seria pior que não ter o teste.
