### PR TITLE
fix: o CSS que cortava o rótulo da faixa e escondia o rodapé da gaveta

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1617,7 +1617,25 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 .ms-nivel { min-width: 0; }
 .ms-nivel-rot { display: block; margin-bottom: 2px; font-family: var(--mono); font-size: 10px; color: #4c5f79; }
 .ms-nivel-faixa { display: grid; gap: 3px; }
-.ms-seg { display: grid; place-items: center; min-width: 0; height: 22px; padding: 0 4px; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 5px; background: #0f1826; font-family: var(--mono); font-size: 10px; color: #6b7f99; white-space: nowrap; overflow: hidden; transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease; }
+/* O trecho QUEBRA LINHA e cresce em altura, e isso não é preferência de estilo.
+   A largura de um trecho é proporcional às posições do array que ele cobre — é
+   essa proporção que ensina "seis dos oito elementos são maiores que o pivô" —,
+   então um trecho de uma posição recebe 26px em 390px de tela e 31px em 1440,
+   por construção, e nenhuma redistribuição de largura muda isso sem apagar a
+   informação. Com `white-space: nowrap` mais `overflow: hidden` e SEM
+   `text-overflow`, o que sobrava era corte no meio da palavra e sem reticências:
+   medido com um Range sobre o conteúdo, `> pivô, volta para a recursão` pedia
+   174px e recebia 31px a 1440x700, e o aluno lia `> piv` achando que o rótulo
+   era aquilo. O caso mais caro é o `= pivô, N já resolvido(s)`: a concordância
+   escrita para o preset "Sem repetição" é justamente a que o corte comia.
+   Trocado por quebra de linha com `overflow-wrap: anywhere` (só ela chega a uma
+   coluna de 26px) e altura automática: medido, a faixa vai de 22px a 96px no
+   pior preset a 1440x700 e todo o texto passa a ser lido. As faixas do merge
+   sort não sentem nada — os rótulos delas (`0`, `10..15`) sempre couberam, e as
+   duas peças medem os mesmos 163 e 205px de antes em 390, 480, 561, 760, 1440 e
+   1512px. O `min-height` guarda o desenho de quem tem rótulo vazio ou
+   `font-size: 0` (a regra deliberada do celular, mais abaixo). */
+.ms-seg { display: grid; place-items: center; min-width: 0; min-height: 22px; padding: 2px 4px; border: 1px solid rgba(255, 255, 255, 0.1); border-radius: 5px; background: #0f1826; font-family: var(--mono); font-size: 10px; line-height: 1.2; text-align: center; color: #6b7f99; overflow-wrap: anywhere; overflow: hidden; transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease; }
 .ms-seg.folha { opacity: 0.6; }
 .ms-seg.pronto { border-color: rgba(52, 211, 153, 0.55); background: rgba(52, 211, 153, 0.13); color: #a7f3d0; }
 .ms-seg.ativo { border-color: var(--ccc-accent); background: rgba(59, 130, 246, 0.28); color: #fff; opacity: 1; }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1837,7 +1837,26 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
 @media (max-width: 1000px) {
   .shell { grid-template-columns: minmax(0, 1fr); }
   .sidebar { display: none; }
-  .sidebar.open { display: flex; position: fixed; top: var(--ccc-header-h); left: 0; right: 0; bottom: 0; z-index: 45; width: 100%; height: calc(100vh - var(--ccc-header-h)); }
+  /* A gaveta do celular tem duas alturas e as duas importam.
+     A primeira é a da JANELA: `100vh` é a viewport GRANDE, a de barra do
+     navegador recolhida, então numa barra visível a gaveta nasce mais alta que
+     o que se vê e o pé dela fica embaixo da barra. O arquivo já conhece o
+     remédio e usa duas linhas acima, no expandido do visualizador
+     (`max-height: calc(100vh…)` seguido de `calc(100dvh…)`); a gaveta tinha
+     ficado de fora. As duas declarações ficam: a de `vh` é o fallback de quem
+     não entende `dvh`.
+     A segunda é a do CONTEÚDO: o `.side-apoio` mora FORA do `.side-scroll`, e a
+     gaveta não rolava, então quando cabeçalho mais apoio passavam da altura o
+     card ficava inalcançável — não "mais embaixo", sem caminho. Medido em
+     844x300 e 390x260: o card terminava 35px e 111px abaixo da janela com 47 e
+     123px de sobra que ninguém conseguia rolar. `overflow-y: auto` é a rolagem
+     de último recurso; nas alturas normais a sobra é 0 e nada muda. */
+  .sidebar.open {
+    display: flex; position: fixed; top: var(--ccc-header-h); left: 0; right: 0; bottom: 0;
+    z-index: 45; width: 100%; overflow-y: auto;
+    height: calc(100vh - var(--ccc-header-h));
+    height: calc(100dvh - var(--ccc-header-h));
+  }
   .header-menu-toggle { display: grid; }
   .hero { padding: 48px 24px 40px; }
   .hero h1 { font-size: 40px; }

--- a/tests/regressao-css-celular.spec.ts
+++ b/tests/regressao-css-celular.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect, type Page, type Locator } from "@playwright/test";
+
+// Dois defeitos de CSS que uma suíte verde deixou passar, pelo mesmo motivo: as
+// verificações mediam OVERFLOW DA PÁGINA, e nenhum dos dois estoura a página.
+//
+//  1. `.ms-seg` cortava o rótulo no meio da palavra (`white-space: nowrap` mais
+//     `overflow: hidden`, sem `text-overflow`). Caixa com `overflow` escondido
+//     não estoura nada: o único número que pega o corte é a largura REAL do
+//     texto, medida com um `Range` sobre o conteúdo, contra a largura útil do
+//     elemento.
+//  2. A gaveta do celular media `100vh` — a viewport GRANDE, de barra do
+//     navegador recolhida — e o card de apoio mora FORA da área rolável, então
+//     ele podia ficar sem caminho nenhum: não "mais embaixo", inalcançável.
+//
+// Todas as asserções daqui comparam número com número e carregam o rótulo
+// junto. E a checagem de `font-size` computado está aqui porque o contrário do
+// defeito é o mesmo defeito: rótulo com fonte zerada também faz toda medição de
+// largura passar, e já deixou texto invisível neste repositório.
+
+const REGUAS = [
+  { w: 390, h: 844, nome: "390x844" },
+  { w: 1440, h: 700, nome: "1440x700" },
+  { w: 1512, h: 900, nome: "1512x900" },
+] as const;
+
+type Medida = { rotulo: string; precisa: number; recebe: number; linhas: number; fonte: string };
+
+/** A largura de cada linha do texto contra a largura útil da caixa.
+ *
+ *  `getClientRects()` de um `Range` devolve um retângulo por linha, então o
+ *  máximo é a linha mais larga — é assim que a medição continua valendo depois
+ *  que o rótulo passou a quebrar linha. `clientWidth` já desconta a borda, mas
+ *  não o padding: sem descontar, um rótulo encostado nos dois lados passaria.
+ *
+ *  Sem argumento mede a página inteira; com um elemento (que é o que o
+ *  `locator.evaluate` passa) mede só o que está dentro dele. */
+function medir(raiz?: Element): Medida[] {
+  const dono: Element | Document = raiz ?? document;
+  return [...dono.querySelectorAll(".ms-seg")].map((el) => {
+    const faixa = document.createRange();
+    faixa.selectNodeContents(el);
+    const linhas = [...faixa.getClientRects()];
+    const cs = getComputedStyle(el);
+    const padding = parseFloat(cs.paddingLeft) + parseFloat(cs.paddingRight);
+    return {
+      rotulo: (el.textContent ?? "").trim(),
+      precisa: Math.round((linhas.length ? Math.max(...linhas.map((l) => l.width)) : 0) * 10) / 10,
+      recebe: Math.round((el.clientWidth - padding) * 10) / 10,
+      linhas: linhas.length,
+      fonte: cs.fontSize,
+    };
+  });
+}
+
+const cortadas = (m: Medida[]) => m.filter((x) => x.precisa - x.recebe > 0.5);
+
+async function abrir(page: Page, url: string, w: number, h: number) {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto(url);
+  expect(page.viewportSize(), "a janela pedida é a janela medida").toEqual({ width: w, height: h });
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+}
+
+/** Troca de preset esperando o re-render, e não o tick seguinte ao clique:
+ *  medir no mesmo tick lê o preset anterior e a asserção vira decoração. */
+async function trocarPreset(fig: Locator, i: number): Promise<string> {
+  const chip = fig.locator(".bigo-chip").nth(i);
+  const rotulo = (await chip.innerText()).trim();
+  await chip.click();
+  await expect(chip).toHaveAttribute("aria-pressed", "true");
+  return rotulo;
+}
+
+// ---------------------------------------------------------------------------
+// Defeito 1 — o rótulo das faixas cabe na faixa
+// ---------------------------------------------------------------------------
+
+test.describe("faixas: o rótulo cabe no trecho", () => {
+  for (const r of REGUAS) {
+    test(`quick sort, os dois painéis de três vias, todos os presets (${r.nome})`, async ({ page }) => {
+      await abrir(page, "/topico/quick-sort/", r.w, r.h);
+      const fig = page.locator("figure.viz").filter({ hasText: "o que fazer com os iguais ao pivô" });
+      await expect(fig).toHaveCount(1);
+
+      const chips = fig.locator(".bigo-chip");
+      expect(await chips.count(), "os quatro presets do comparador").toBe(4);
+      // Os DOIS painéis de uma vez: eles usam a mesma classe e o corte apareceu
+      // nos dois, então medir um só mediria metade do defeito.
+      expect(await fig.locator(".ms-op").count(), "duas vias e três vias, lado a lado").toBe(2);
+
+      for (let i = 0; i < 4; i++) {
+        const preset = await trocarPreset(fig, i);
+        const medidas = await fig.evaluate(medir);
+        expect(medidas.length, `${preset}: há trechos para medir`).toBeGreaterThan(1);
+        expect(
+          cortadas(medidas),
+          `${r.nome}, preset ${JSON.stringify(preset)}: rótulo cortado (precisa x recebe, em px)`
+        ).toEqual([]);
+      }
+    });
+
+    test(`quick sort, a invariante da partição, passo a passo (${r.nome})`, async ({ page }) => {
+      test.slow();
+      await abrir(page, "/topico/quick-sort/", r.w, r.h);
+      const fig = page.locator("figure.viz-fit");
+      await expect(fig).toHaveCount(1);
+
+      const chips = fig.locator(".bigo-chip");
+      expect(await chips.count(), "os quatro presets da partição").toBe(4);
+
+      for (let i = 0; i < 4; i++) {
+        const preset = await trocarPreset(fig, i);
+        const contador = fig.locator(".viz-step");
+        const passos = Number((await contador.innerText()).match(/de (\d+)/)![1]);
+        expect(passos, `${preset}: a linha do tempo tem passos`).toBeGreaterThan(1);
+
+        const proximo = fig.getByRole("button", { name: /Próximo/ });
+        for (let s = 1; s <= passos; s++) {
+          await expect(contador).toHaveText(new RegExp(`passo ${s} de ${passos}`));
+          expect(
+            cortadas(await fig.evaluate(medir)),
+            `${r.nome}, preset ${JSON.stringify(preset)}, passo ${s} de ${passos}: rótulo cortado`
+          ).toEqual([]);
+          if (s < passos) await proximo.click();
+        }
+        // Sem isto o laço pode sair calado no meio, e as asserções acima teriam
+        // rodado num punhado de passos do começo.
+        await expect(proximo).toBeDisabled();
+      }
+    });
+
+    test(`merge sort, os quatro tamanhos, e a faixa continua de uma linha (${r.nome})`, async ({ page }) => {
+      await abrir(page, "/topico/merge-sort/", r.w, r.h);
+      // A varredura aqui é pelo TAMANHO da entrada, e não pelo passo: os
+      // rótulos do merge sort (`0`, `10..15`) não mudam ao longo da animação —
+      // o que muda é a cor. O tamanho é que muda a largura de cada trecho.
+      const niveis = page.locator("figure.viz").filter({ hasText: "o n log n desenhado" });
+      await expect(niveis).toHaveCount(1);
+      expect(await niveis.locator(".bigo-chip").count(), "os quatro tamanhos de entrada").toBe(4);
+
+      for (let i = 0; i < 4; i++) {
+        const tamanho = await trocarPreset(niveis, i);
+        // A página inteira: as duas peças de merge sort dividem a classe.
+        const medidas = await page.locator("body").evaluate(medir);
+        expect(cortadas(medidas), `${r.nome}, ${tamanho}: rótulo cortado no mapa da recursão`).toEqual([]);
+
+        // O mapa da recursão tem que continuar com UMA linha por trecho. Se ele
+        // passar a quebrar, a peça dobra de altura sem ninguém ter pedido.
+        expect(
+          medidas.filter((x) => x.linhas > 1),
+          `${r.nome}, ${tamanho}: trecho quebrou linha`
+        ).toEqual([]);
+      }
+    });
+  }
+
+  test("o rótulo continua legível: font-size computado nos dois donos da classe", async ({ page }) => {
+    // A regra `.ms-niveis .ms-seg { font-size: 0 }` no celular é DELIBERADA e
+    // escopada: ela vale para o mapa da recursão do merge sort, onde o trecho
+    // mais estreito tem 13px, e NÃO para as faixas do quick sort, que ocupam a
+    // linha quase inteira. Este teste guarda os dois lados — o que some de
+    // propósito e o que precisa continuar aparecendo.
+    const fonte = (sel: string) =>
+      page.evaluate((s) => {
+        const el = document.querySelector(s);
+        if (!el) throw new Error(`sem elemento para ${s}`);
+        return getComputedStyle(el).fontSize;
+      }, sel);
+
+    await abrir(page, "/topico/merge-sort/", 390, 844);
+    expect(await fonte(".ms-niveis .ms-seg"), "celular: o mapa da recursão esconde o rótulo, de propósito").toBe("0px");
+
+    // ...e escondê-lo não pode colapsar o desenho. O número não é digitado: sai
+    // do próprio `min-height` computado, então ele sobrevive a mudança de CSS
+    // sem deixar de testar o que importa.
+    const desenho = await page.evaluate(() => {
+      const seg = document.querySelector(".ms-niveis .ms-seg")!;
+      const faixa = seg.closest(".ms-nivel-faixa")!;
+      return {
+        faixa: Math.round(faixa.getBoundingClientRect().height),
+        minima: parseFloat(getComputedStyle(seg).minHeight),
+      };
+    });
+    expect(desenho.faixa, "a faixa continua desenhada mesmo com o rótulo escondido").toBe(desenho.minima);
+
+    await abrir(page, "/topico/quick-sort/", 390, 844);
+    expect(
+      await fonte("figure.viz-fit .ms-nivel-faixa .ms-seg"),
+      "celular: a invariante do quick sort continua legível"
+    ).toBe("9px");
+
+    await abrir(page, "/topico/merge-sort/", 1440, 700);
+    expect(await fonte(".ms-niveis .ms-seg"), "fora do celular o rótulo do merge sort volta").toBe("10px");
+  });
+});

--- a/tests/regressao-css-celular.spec.ts
+++ b/tests/regressao-css-celular.spec.ts
@@ -193,3 +193,94 @@ test.describe("faixas: o rótulo cabe no trecho", () => {
     expect(await fonte(".ms-niveis .ms-seg"), "fora do celular o rótulo do merge sort volta").toBe("10px");
   });
 });
+
+// ---------------------------------------------------------------------------
+// Defeito 2 — a gaveta do celular e o card que ficava sem caminho
+// ---------------------------------------------------------------------------
+
+async function abrirGaveta(page: Page, w: number, h: number) {
+  await abrir(page, "/topico/quick-sort/", w, h);
+  await page.getByRole("button", { name: "Abrir menu de tópicos" }).click();
+  await expect(page.locator(".sidebar.open")).toBeVisible();
+}
+
+/** Rola tudo o que a gaveta oferece para rolar. Se depois disto o card ainda
+ *  estiver fora da janela, ele é inalcançável — não é "fica mais embaixo". */
+async function rolarTudo(page: Page) {
+  await page.evaluate(() => {
+    document.querySelectorAll<HTMLElement>(".sidebar.open, .sidebar.open .side-scroll").forEach((e) => {
+      e.scrollTop = e.scrollHeight;
+    });
+  });
+  await page.waitForTimeout(100);
+}
+
+test.describe("gaveta do celular: o card de apoio é alcançável", () => {
+  for (const [w, h, porque] of [
+    [390, 844, "o celular em pé"],
+    [844, 390, "o celular deitado"],
+    // As duas últimas não são celulares: são a GEOMETRIA do caso em que
+    // cabeçalho mais apoio passam da altura da gaveta. Antes do conserto o card
+    // terminava 35px e 111px abaixo da janela, com 47 e 123px de sobra que
+    // ninguém conseguia rolar, porque o `.side-apoio` mora fora do
+    // `.side-scroll` e a gaveta não rolava.
+    [844, 300, "a gaveta apertada, onde o conteúdo passa da altura"],
+    [390, 260, "a gaveta muito apertada"],
+  ] as const) {
+    test(`${w}x${h}: ${porque}`, async ({ page }) => {
+      await abrirGaveta(page, w, h);
+      await rolarTudo(page);
+      const g = await page.evaluate(() => {
+        const gaveta = document.querySelector(".sidebar.open")!;
+        const card = document.querySelector(".side-apoio")!.lastElementChild!;
+        return {
+          rotulo: (card.textContent ?? "").trim().slice(0, 18),
+          topo: Math.round(card.getBoundingClientRect().top),
+          base: Math.round(card.getBoundingClientRect().bottom),
+          janela: window.innerHeight,
+          gavetaBase: Math.round(gaveta.getBoundingClientRect().bottom),
+        };
+      });
+
+      expect(g.rotulo, "é o card de apoio que está sendo medido").toContain("Seja um apoiador");
+      expect(
+        g.base - g.janela,
+        `${JSON.stringify(g.rotulo)} terminou em ${g.base}px numa janela de ${g.janela}px, depois de rolar tudo`
+      ).toBeLessThanOrEqual(0);
+      expect(g.topo, `o card começou em ${g.topo}px, acima do topo da janela`).toBeGreaterThanOrEqual(0);
+      // A gaveta termina onde a janela termina: é o que o `dvh` garante no
+      // celular de verdade, onde `100vh` é a viewport de barra recolhida.
+      expect(
+        g.gavetaBase - g.janela,
+        `a gaveta terminou em ${g.gavetaBase}px numa janela de ${g.janela}px`
+      ).toBeLessThanOrEqual(0);
+    });
+  }
+
+  test("a gaveta declara o fallback de viewport dinâmica", async ({ page }) => {
+    // Asserção de FOLHA DE ESTILO, e está aqui declarada como tal: em Chromium
+    // headless não existe barra de navegador dinâmica, então
+    // `100vh === 100dvh === innerHeight` e nenhuma medição de tela distingue as
+    // duas. O que dá para afirmar é que a regra da gaveta continua com as duas
+    // declarações — `vh` como fallback, `dvh` por cima —, que é o mesmo idioma
+    // que o expandido do visualizador já usa neste arquivo, e com a rolagem de
+    // último recurso que torna o card alcançável.
+    // A leitura é do ARQUIVO servido, não do CSSOM: `cssText` devolve uma
+    // declaração por propriedade e descarta a que foi sobrescrita, então ele
+    // mostra só o `dvh` e some justamente com o fallback que se quer garantir.
+    // Medido: o CSSOM devolve `height: calc(100dvh …)` sozinho enquanto o
+    // arquivo tem as duas linhas.
+    await abrir(page, "/topico/quick-sort/", 390, 844);
+    const folha = await page.evaluate(async () => {
+      const links = [...document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')].map((l) => l.href);
+      const partes = await Promise.all(links.map((h) => fetch(h).then((r) => r.text())));
+      return partes.join("\n");
+    });
+
+    const regra = folha.match(/\.sidebar\.open\s*\{[^}]*\}/)?.[0];
+    expect(regra, "a regra da gaveta aberta chegou ao arquivo servido").toBeTruthy();
+    expect(regra, "a altura da gaveta usa a viewport dinâmica").toContain("100dvh");
+    expect(regra, "e mantém o fallback de quem não entende dvh").toContain("100vh");
+    expect(regra, "e a gaveta rola quando o conteúdo não cabe").toMatch(/overflow-y:\s*auto/);
+  });
+});

--- a/tests/regressao-css-celular.spec.ts
+++ b/tests/regressao-css-celular.spec.ts
@@ -270,14 +270,28 @@ test.describe("gaveta do celular: o card de apoio é alcançável", () => {
     // mostra só o `dvh` e some justamente com o fallback que se quer garantir.
     // Medido: o CSSOM devolve `height: calc(100dvh …)` sozinho enquanto o
     // arquivo tem as duas linhas.
+    // E a leitura é só das folhas do PRÓPRIO app. A página também linka o CSS
+    // do Google Fonts (`src/app/layout.tsx`), que não tem uma linha da gaveta:
+    // baixá-lo poria a rede externa dentro de uma asserção sobre CSS local, e o
+    // dia em que ela caísse o teste reprovaria com um erro de `fetch` no lugar
+    // do que ele mede. Medido nesta página: 2 folhas, e só a de mesma origem
+    // (108.190 bytes) tem a regra — a do Google Fonts são 1.639 bytes com zero
+    // ocorrência de `sidebar`.
     await abrir(page, "/topico/quick-sort/", 390, 844);
     const folha = await page.evaluate(async () => {
-      const links = [...document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')].map((l) => l.href);
+      const links = [...document.querySelectorAll<HTMLLinkElement>('link[rel="stylesheet"]')]
+        .map((l) => new URL(l.href, location.href))
+        .filter((u) => u.origin === location.origin)
+        .map((u) => u.href);
       const partes = await Promise.all(links.map((h) => fetch(h).then((r) => r.text())));
-      return partes.join("\n");
+      return { folhas: partes.length, css: partes.join("\n") };
     });
 
-    const regra = folha.match(/\.sidebar\.open\s*\{[^}]*\}/)?.[0];
+    // Sem isto, um filtro que não casasse nada faria a asserção seguinte culpar
+    // o CSS por um problema que é do filtro.
+    expect(folha.folhas, "há folha de estilo do próprio app para ler").toBeGreaterThan(0);
+
+    const regra = folha.css.match(/\.sidebar\.open\s*\{[^}]*\}/)?.[0];
     expect(regra, "a regra da gaveta aberta chegou ao arquivo servido").toBeTruthy();
     expect(regra, "a altura da gaveta usa a viewport dinâmica").toContain("100dvh");
     expect(regra, "e mantém o fallback de quem não entende dvh").toContain("100vh");


### PR DESCRIPTION
Dois defeitos de CSS que uma suíte verde deixou passar pelo mesmo motivo: as
verificações mediam **overflow da página**, e nenhum dos dois estoura a página.

> ⚠️ **Este PR é o que faz o conserto do #55 chegar ao leitor.** O #55 acertou a
> concordância de `= pivô, N já resolvido(s)` porque "sem ela a tela dizia «1 já
> resolvidos» bem no exemplo que existe para mostrar o contraponto". Só que essa
> string nasce exatamente na faixa que o CSS cortava: medido, ela pedia **124,2px
> e recebia 26px** a 390x844 no preset "Sem repetição", que é o preset para o qual
> ela foi escrita. O aluno lia `= piv`. Os dois PRs andam juntos: o #55 conserta o
> texto, este conserta a caixa que o escondia.

---

## Defeito 1 — o rótulo cortado no meio da palavra

`.ms-seg` era `white-space: nowrap` mais `overflow: hidden` e **sem**
`text-overflow`. Caixa com overflow escondido não estoura nada, então o único
número que pega o corte é a largura real do texto, medida com um `Range` sobre o
conteúdo, contra a largura útil do elemento.

**O escopo era maior do que o relatado: 34 dos 75 estados medidos cortavam**, em
3 dos 4 presets, nos **dois** painéis do comparador de três vias, nas **três**
réguas (inclusive 1512x900), e também na invariante da partição.

| onde | precisa × recebe | corta |
|---|---|---|
| `<= pivô, volta para a recursão`, três vias, 1440x700 | 180px × 31px | **149px** |
| `> pivô, volta para a recursão`, três vias, 1440x700 | 174px × 31px | 143px |
| `= pivô, 1 já resolvidos`, três vias, 1440x700 | 138px × 31px | 107px |
| `= pivô, 1 já resolvidos`, três vias, 390x844 | 124,2px × 26px | 98,2px |
| `não vistos`, invariante da partição, 390x844, **nos 4 presets** | 54px × 26px | 28px |

### Por que a largura não é negociável, e o que foi feito

A largura de um trecho é **proporcional às posições do array que ele cobre** — é
essa proporção que ensina "seis dos oito elementos são maiores que o pivô". Um
trecho de uma posição recebe 26px em 390x844 e 31px em 1440x700 **por
construção**, e nenhuma redistribuição de largura muda isso sem apagar a
informação. Medi as alternativas antes de escolher:

| candidato | resultado medido |
|---|---|
| `text-overflow: ellipsis` | **34 de 75 continuam cortadas**; muda o corte de desonesto para honesto e o aluno segue sem ler. E o `title` que o tornaria acessível é JSX, fora da fronteira deste PR |
| quebra de linha **sem** `overflow-wrap: anywhere` | ainda corta: `recursão` sozinha pede 43,2px numa coluna de 22px |
| quebra de linha **com** `overflow-wrap: anywhere` | **0 de 75 cortadas** |

Ficou o último: `white-space` volta ao normal, `overflow-wrap: anywhere`,
`min-height` no lugar de `height` fixo, mais `line-height: 1.2` e
`text-align: center` para o texto de duas ou mais linhas.

**O preço, com número:** a faixa passa de 22px para até **96px** (1440x700 e
1512x900) e **99,2px** (390x844) no pior preset, e a peça de três vias vai de 662
para 735px a 1440x700. É o custo de o texto ser lido.

**As faixas do merge sort não sentem nada.** Os rótulos delas (`0`, `10..15`)
sempre couberam: as duas peças medem os mesmos **163 e 205px** de antes em 390,
480, 561, 760, 1440 e 1512px, e nenhum trecho quebra linha em nenhum dos quatro
tamanhos de entrada.

**A regra deliberada continua de pé.** `.ms-niveis .ms-seg { font-size: 0 }` no
celular é escopada de propósito, e o teste guarda os dois lados: 0px no mapa da
recursão do merge sort, **9px** na invariante do quick sort, 10px fora do celular.

---

## Defeito 2 — a gaveta do celular

`.sidebar.open` media `height: calc(100vh - var(--ccc-header-h))` sem fallback
`dvh`. `100vh` é a viewport **grande**, a de barra do navegador recolhida: com a
barra visível a gaveta nasce mais alta do que se vê. O arquivo já conhece o
idioma e usa duas linhas acima, no expandido do visualizador
(`max-height: calc(100vh…)` seguido de `calc(100dvh…)`); a gaveta tinha ficado
de fora. As duas declarações ficam, a de `vh` como fallback.

### O que eu NÃO consegui observar, e digo isso de propósito

Em Chromium headless **não existe barra dinâmica**: `100vh === 100dvh ===
innerHeight`, e as quatro asserções de geometria da gaveta **passam com e sem o
`dvh`**. Não vi o card sumir. O que está provado é (a) a inconsistência da folha
de estilo (o vizinho usa `dvh`, esta regra não) e (b) a geometria: a 390x844 o
card "Seja um apoiador" termina em **832px de 844**, com 12px de sobra, numa
gaveta com **0px para rolar**. Portanto o `dvh` entra aqui como **correção de
consistência de CSS**, não como conserto de bug observado.

### O que eu consegui observar, e foi consertado

O `.side-apoio` mora **fora** do `.side-scroll` (isso é JSX, fora da fronteira
deste PR) e a gaveta não rolava. Quando cabeçalho mais apoio passam da altura, o
card fica **sem caminho nenhum** — não "mais embaixo", inalcançável:

| régua | card × janela | sobra que ninguém rolava | depois |
|---|---|---|---|
| 844x300 | terminava em **335px** numa janela de 300 | 47px | dentro da janela |
| 390x260 | terminava em **371px** numa janela de 260 | 123px | dentro da janela |

O conserto CSS-only é `overflow-y: auto` na gaveta, uma rolagem de último
recurso. **Nas alturas normais nada muda**: a 390x844, 390x700, 844x390 e
1000x600 a sobra é 0, não aparece barra, e o card fica exatamente onde estava.

---

## Provas de quebra

Cada quebra foi aplicada no `globals.css`, **buildada sem silenciar o build**, e
confirmada no artefato (`out/_next/.../*.css`) antes de rodar o teste. Restauração
por cópia, nunca `git checkout --`.

| quebra | artefato conferido | resultado |
|---|---|---|
| **A** — volta `white-space: nowrap; height: 22px; overflow: hidden` | `.ms-seg{…white-space:nowrap…}` no CSS servido | **5 failed / 10 passed**, com `"precisa": 174, "recebe": 74` e `"precisa": 138, "recebe": 118` no `Received` da minha linha |
| **B** — tira `overflow-y: auto` da gaveta | `.sidebar.open{…}` sem `overflow-y` | **3 failed / 2 passed**, com `Received: 35` (844x300) e `Received: 111` (390x260) |
| **C** — tira a linha `height: calc(100dvh …)` | `.sidebar.open{…height:calc(100vh…)}` só | **1 failed / 4 passed**, com a regra inteira no `Received` |

A quebra **C** derruba **só** a asserção de folha de estilo: as quatro de
geometria continuam verdes, que é a medida exata do que o headless não enxerga.

Uma armadilha que apareceu escrevendo o teste, e vale para quem for repetir: o
**CSSOM colapsa declarações repetidas**. `regra.cssText` devolve
`height: calc(100dvh …)` sozinho e some justamente com o fallback que se quer
garantir — o arquivo servido tem as duas linhas. Por isso a asserção lê o
**arquivo CSS servido**, não o CSSOM.

## Verificação

- `npm run build` ✓, `npx tsc --noEmit` ✓
- `npm run test:build`: **474 passed**, 0 failed, na primeira rodada depois do
  build. Nenhum dos dois flakes conhecidos apareceu.
- Conferência em 390x844, 1440x700 e 1512x900 com `?v=$(date +%s)`: 0 overflow de
  página e 0 trechos com texto vazando, em `/topico/quick-sort/` e
  `/topico/merge-sort/`.

## Achado que NÃO foi consertado aqui

`content/visualizers/QuickSortTresVias.tsx:147-149` — os rótulos das regiões são
frases (`> pivô, volta para a recursão`, 174px) num desenho cujas caixas podem ter
26px. Com a quebra de linha o texto passa a ser lido inteiro, e num trecho de uma
posição ele vira uma torre estreita de duas ou três letras por linha. Encurtar o
rótulo, ou tirá-lo da faixa e pôr numa legenda, é **texto de tela e JSX** — fora da
fronteira deste PR, e reportado em vez de consertado de carona.
