### PR TITLE
chore: faxina de plataforma (frame, tema escuro e a conta de tópicos)

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -1214,6 +1214,17 @@ export const TOTAL_LEETCODE_PROBLEMS = ALL_TOPICS.reduce(
   (n, t) => n + (t.problems?.filter((p) => p.source === "LeetCode").length ?? 0),
   0
 );
+// Tópicos que já têm alguma coisa para o aluno abrir. É o mesmo rigor do
+// `TOTAL_LEETCODE_PROBLEMS` logo acima, aplicado à outra ponta: `TOTAL_TOPICS`
+// conta a trilha inteira, e a trilha inclui os tópicos que o próprio site marca
+// como "em breve" e tira do índice do Google por não terem vídeo, artigo nem
+// visualização. Prometer o total onde a frase descreve o que a página entrega
+// conta o que não existe.
+//
+// Deriva de `isEmptyTopic`, a MESMA função que decide o selo "em breve" no menu
+// e o `noindex` da página, e não de uma cópia da regra: o número sobe sozinho no
+// dia em que um tópico ganha material, sem ninguém lembrar de voltar aqui.
+export const TOTAL_TOPICS_PRONTOS = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).length;
 
 export function getTopic(slug: string): Topic | undefined {
   return ALL_TOPICS.find((t) => t.slug === slug);

--- a/public/_headers
+++ b/public/_headers
@@ -21,3 +21,30 @@
 
 /*/opengraph-image
   Content-Type: image/png
+
+# X-Frame-Options: por que DENY, e por que só ele.
+#
+# O risco aqui NÃO é sequestro de clique: o site é estático, não tem login, não
+# tem formulário e não tem ação destrutiva atrás de um clique. O risco é
+# republicação: envelopar o guia inteiro num iframe de um site com anúncios e
+# servir o nosso conteúdo como se fosse dele. A licença do repositório é
+# PolyForm Noncommercial 1.0.0, e esse uso a contraria. `DENY` é o único
+# cabeçalho que o navegador aplica sem depender de o outro site colaborar.
+#
+# Não quebra nada, e a direção é o que importa: o único iframe do projeto é de
+# SAÍDA (o embed do YouTube em `src/app/topico/[slug]/page.tsx`, que é a nossa
+# página carregando youtube-nocookie.com). `X-Frame-Options` só governa a
+# direção de ENTRADA, isto é, quem pode carregar as NOSSAS respostas dentro de
+# um frame. O embed continua igual.
+#
+# Dois cabeçalhos foram considerados e descartados de propósito, para o arquivo
+# não sugerir proteção nova onde não há:
+#
+# - `X-Content-Type-Options: nosniff` — o Pages já envia, em toda resposta. É o
+#   mesmo `nosniff` que o comentário do topo deste arquivo descreve como o
+#   motivo de as regras de Content-Type existirem.
+# - `Referrer-Policy: strict-origin-when-cross-origin` — é o padrão dos
+#   navegadores desde 2020. Escrever aqui não muda comportamento nenhum.
+
+/*
+  X-Frame-Options: DENY

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,6 +4,14 @@
    ========================================================================== */
 
 :root {
+  /* O tema é escuro e não tem alternância. Sem esta declaração, o navegador
+     assume claro para tudo que ele mesmo desenha: barra de rolagem, controles
+     de formulário e a cor de fundo antes do CSS chegar. As regras
+     `::-webkit-scrollbar` abaixo só maquiam o Chrome e o Safari; no Firefox,
+     que não as implementa, as barras saíam CLARAS sobre o fundo #0b111c,
+     inclusive a do menu lateral, que é o elemento mais rolado do produto.
+     Uma linha aqui resolve nos três, e é o gancho padrão para isso. */
+  color-scheme: dark;
   --ccc-accent: #3b82f6;
   --ccc-accent-soft: rgba(59, 130, 246, 0.14);
   --ccc-accent-2: #93bbfd;

--- a/tests/plataforma-faxina.spec.ts
+++ b/tests/plataforma-faxina.spec.ts
@@ -1,0 +1,174 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { join } from "node:path";
+import { ALL_TOPICS, TOTAL_TOPICS, TOTAL_TOPICS_PRONTOS, isEmptyTopic } from "../content/roadmap";
+import { SITE_URL } from "../src/lib/links";
+
+// Faxina de plataforma: três coisas que nenhum teste anterior olhava, cada uma
+// verificada onde ela existe de verdade.
+//
+// - `X-Frame-Options` mora no `_headers`, que não é HTML e não passa pelo
+//   navegador: a prova é o ARTEFATO do build (`out/_headers`), mais a
+//   confirmação de que o embed do YouTube, que é iframe de saída, continua de pé.
+// - `color-scheme` mora no CSS: a prova é o valor COMPUTADO na página servida,
+//   não o texto do arquivo. Ler o arquivo provaria que alguém digitou a linha,
+//   não que ela chega ao navegador.
+// - `TOTAL_TOPICS_PRONTOS` mora nos dados: a prova lê a fonte
+//   (`content/roadmap.ts`) e amarra o número ao que o site já faz com o mesmo
+//   critério, que é tirar do índice do Google quem não tem material. Teste que
+//   lê a fonte não envelhece quando um tópico é publicado.
+
+// ---------------------------------------------------------------- _headers
+
+const HEADERS_ARTEFATO = join(__dirname, "..", "out", "_headers");
+
+test("o `_headers` do build proíbe que o site seja embutido em frame de terceiro", () => {
+  const conteudo = readFileSync(HEADERS_ARTEFATO, "utf8");
+
+  // Sem comentários e sem linhas vazias: é o que o Cloudflare Pages de fato lê.
+  const regras = conteudo
+    .split("\n")
+    .filter((l) => l.trim() !== "" && !l.trimStart().startsWith("#"));
+
+  const i = regras.findIndex((l) => l.trim() === "/*");
+  expect(i, "o `_headers` do build não tem a regra `/*`").toBeGreaterThanOrEqual(0);
+
+  // O cabeçalho tem que estar DENTRO do bloco `/*`: uma linha indentada solta em
+  // outro bloco aplicaria a regra só àquela rota, e o arquivo pareceria certo.
+  const doBloco: string[] = [];
+  for (const linha of regras.slice(i + 1)) {
+    if (!linha.startsWith(" ") && !linha.startsWith("\t")) break;
+    doBloco.push(linha.trim());
+  }
+  expect(doBloco).toContain("X-Frame-Options: DENY");
+
+  // A faxina não pode ter atropelado o motivo original do arquivo: sem estas
+  // duas regras, o card de Open Graph volta a sair como binário anônimo.
+  expect(regras).toContain("/opengraph-image");
+  expect(regras).toContain("/*/opengraph-image");
+});
+
+test("o embed do YouTube, que é iframe de SAÍDA, continua de pé e ocupando a caixa", async ({ page }) => {
+  const comVideo = ALL_TOPICS.find((t) => t.youtube)!;
+  await page.goto(`/topico/${comVideo.slug}/`);
+
+  const frame = page.locator(".video-embed iframe");
+  await expect(frame).toHaveCount(1);
+  await expect(frame).toHaveAttribute("src", /youtube-nocookie\.com\/embed\//);
+
+  // Existência não basta: um iframe de 0px passaria na asserção acima. E o ponto
+  // do `X-Frame-Options` é a DIREÇÃO — ele governa quem embute as nossas
+  // respostas, não o que as nossas páginas embutem —, então o que prova isso é
+  // a caixa do embed continuar com tamanho de vídeo.
+  const caixa = await frame.boundingBox();
+  expect(caixa, "o iframe do vídeo não tem caixa").not.toBeNull();
+  expect(caixa!.width, "o embed do YouTube colapsou na largura").toBeGreaterThan(200);
+  expect(caixa!.height, "o embed do YouTube colapsou na altura").toBeGreaterThan(100);
+
+});
+
+test("todo iframe do site é de saída: nenhuma página do build embute o próprio site", () => {
+  // Esta é a asserção que sustenta o `DENY`. `X-Frame-Options` só recusa a
+  // direção de ENTRADA, então ele só quebraria alguma coisa se alguma página
+  // nossa embutisse outra página nossa. Varrer o HTML exportado responde isso
+  // sem depender de rede: um teste que espera o YouTube carregar de verdade
+  // vira flake de conectividade, e não mede o que interessa aqui.
+  const paginas = execFileSync("find", [join(__dirname, "..", "out"), "-name", "*.html"], {
+    encoding: "utf8",
+  })
+    .split("\n")
+    .filter(Boolean);
+  expect(paginas.length, "o build não gerou HTML; rode `npm run build` antes").toBeGreaterThan(40);
+
+  const entrada: string[] = [];
+  let saida = 0;
+  for (const arquivo of paginas) {
+    const html = readFileSync(arquivo, "utf8");
+    for (const m of html.matchAll(/<iframe\b[^>]*\bsrc="([^"]*)"/g)) {
+      const src = m[1];
+      // Relativo, ou apontando para o nosso domínio, é iframe de ENTRADA.
+      if (!/^https?:\/\//.test(src) || src.startsWith(SITE_URL)) entrada.push(`${arquivo}: ${src}`);
+      else saida++;
+    }
+  }
+
+  expect(entrada, "há iframe embutindo o próprio site; o DENY quebraria essa página").toEqual([]);
+  expect(saida, "nenhum iframe no build: a varredura não está achando nada").toBeGreaterThan(0);
+});
+
+// ------------------------------------------------------------ color-scheme
+
+test("o navegador sabe que o tema é escuro (`color-scheme` computado)", async ({ page }) => {
+  await page.goto("/");
+
+  // Valor computado, não o texto do CSS: é ele que decide a cor das barras de
+  // rolagem nativas (Firefox e Safari não implementam `::-webkit-scrollbar`) e
+  // dos controles que o próprio navegador desenha.
+  const computado = await page.evaluate(() => ({
+    root: getComputedStyle(document.documentElement).colorScheme,
+    // Herda do `:root`. Se o body sair "normal", alguma regra sobrescreveu.
+    body: getComputedStyle(document.body).colorScheme,
+  }));
+
+  expect(computado.root).toBe("dark");
+  expect(computado.body).toBe("dark");
+});
+
+test("a barra de rolagem escura vale para o menu lateral, que é o mais rolado", async ({ page }) => {
+  await page.goto("/topico/backtracking/");
+
+  // Quem rola é `.side-scroll`, não `.sidebar`: medido, a `.sidebar` tem
+  // `overflow-y: visible` e scrollHeight igual ao clientHeight. Apontar para o
+  // elemento errado daria um teste sempre verde que não olha barra nenhuma.
+  const menu = page.locator(".sidebar .side-scroll");
+  await expect(menu).toBeVisible();
+
+  const medido = await menu.evaluate((el) => ({
+    colorScheme: getComputedStyle(el).colorScheme,
+    // `overflow-y: auto` sozinho não diz que rola. O que diz é o conteúdo
+    // passar da caixa: sem isso, não há barra para pintar e o teste não
+    // testaria nada.
+    rola: el.scrollHeight > el.clientHeight,
+  }));
+
+  expect(medido.colorScheme, "o menu lateral não herdou o esquema escuro").toBe("dark");
+  expect(medido.rola, "o menu lateral não está rolando; escolha outro alvo").toBe(true);
+});
+
+// ------------------------------------------------- TOTAL_TOPICS_PRONTOS
+
+test("`TOTAL_TOPICS_PRONTOS` conta só quem tem material, pela mesma função do site", () => {
+  const prontos = ALL_TOPICS.filter((t) => !isEmptyTopic(t));
+
+  expect(TOTAL_TOPICS_PRONTOS).toBe(prontos.length);
+
+  // A constante só ganha razão de existir enquanto ela for MENOR que o total.
+  // No dia em que os dois números empatarem (todo tópico com material), esta
+  // asserção reprova e alguém decide conscientemente se a distinção ainda vale.
+  expect(TOTAL_TOPICS_PRONTOS).toBeLessThan(TOTAL_TOPICS);
+  expect(TOTAL_TOPICS).toBe(ALL_TOPICS.length);
+});
+
+test("o corte de `TOTAL_TOPICS_PRONTOS` é o mesmo que tira a página do índice", async ({ request }) => {
+  // Amarra o número ao comportamento do site: quem fica de fora da conta é
+  // exatamente quem o build marca `noindex`. Se alguém trocar a derivação por
+  // uma cópia da regra, as duas listas se separam e este teste reprova.
+  const semMaterial: string[] = [];
+  const comMaterial: string[] = [];
+
+  for (const t of ALL_TOPICS) {
+    const html = await (await request.get(`/topico/${t.slug}/`)).text();
+    const noindex = /<meta name="robots" content="noindex/.test(html);
+    (noindex ? semMaterial : comMaterial).push(t.slug);
+  }
+
+  expect(comMaterial.length, "páginas indexáveis != tópicos contados como prontos").toBe(
+    TOTAL_TOPICS_PRONTOS
+  );
+  expect(semMaterial.sort()).toEqual(
+    ALL_TOPICS.filter((t) => isEmptyTopic(t))
+      .map((t) => t.slug)
+      .sort()
+  );
+});


### PR DESCRIPTION
Quatro itens de faxina de plataforma. Três viraram mudança, **um virou a decisão de não mexer** — e a evidência de por que está aqui embaixo.

Diff: **220 linhas, todas de inserção, zero remoção**. O `globals.css` foi tocado só no bloco `:root` (linhas 6-7), bem acima das regiões dos PRs #50, #51 e #60.

---

## 1. `X-Frame-Options: DENY` (`public/_headers`)

**O risco não é sequestro de clique.** O site é estático, não tem login, não tem formulário e não tem nenhuma ação destrutiva atrás de um clique. O risco é **republicação**: envelopar o guia num iframe de um site com anúncios e servir o nosso conteúdo como se fosse dele, contra a **PolyForm Noncommercial 1.0.0**.

**Não quebra nada, e a direção é o argumento.** Varredura no projeto inteiro (`grep -rn iframe src/ content/ public/`):

| onde | direção | o que é |
|---|---|---|
| `src/app/topico/[slug]/page.tsx:126` | **saída** | a nossa página carregando `youtube-nocookie.com` |
| `src/app/globals.css:337` | — | só o CSS que dá caixa ao mesmo embed |

`X-Frame-Options` governa **exclusivamente a entrada** (quem pode carregar as *nossas* respostas num frame). O embed continua igual, medido depois da mudança: **812x456** em 1440x700, **842x473** em 1512x900 e **348x195** em 390x844.

### O que decidi NÃO acrescentar, e por quê

- **`X-Content-Type-Options: nosniff`** — o Cloudflare Pages **já envia**. É o mesmo `nosniff` que o comentário no topo do próprio `_headers` descreve como o motivo de as regras de `Content-Type` das imagens de Open Graph existirem. Repetir aqui não muda um byte na rede.
- **`Referrer-Policy: strict-origin-when-cross-origin`** — é o **padrão de navegador desde 2020**. Escrever a linha não muda comportamento nenhum.

Os dois entrariam como ruído que sugere proteção nova onde não há. O raciocínio ficou escrito no arquivo, para o próximo não refazer a pergunta.

## 2. `color-scheme: dark` (`src/app/globals.css`, bloco `:root`)

**Antes:** `grep -rn "color-scheme" src/` devolvia **0**, e `getComputedStyle(document.documentElement).colorScheme` devolvia `"normal"` em toda página. As barras de rolagem só existiam por `::-webkit-scrollbar`, que **o Firefox não implementa**.

**Depois:** `"dark"` no `:root` e herdado por `.side-scroll`, que é o elemento mais rolado do produto (`scrollHeight` 628 contra `clientHeight` 351 em 1280x720 — ele rola de verdade, e o teste confere isso antes de afirmar qualquer coisa sobre a barra).

### Consegui verificar no Firefox? Em parte, e vale a distinção

Rodei **Firefox 153 de verdade** (`playwright install firefox`) contra o build, na página `/topico/backtracking/`, com A/B na mesma sessão:

```
UA: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:153.0) Gecko/20100101 Firefox/153.0
ANTES  colorScheme=normal   canvas rgb(255,255,255)   luminância 255
DEPOIS colorScheme=dark     canvas rgb(28,27,34)      luminância 28
```

Isso é medição, não inferência: com o fundo explícito do site removido, quem pinta o canvas é o navegador, e a declaração nova troca **branco puro por escuro**. É a mesma chave de tema da UA que governa as barras nativas.

**O que eu NÃO consegui medir:** a cor da barra de rolagem em si. No macOS o Firefox usa **barra de sobreposição** (`offsetWidth - clientWidth` = **0px**), que só aparece durante a rolagem e que o headless não pinta — tentei com `ui.useOverlayScrollbars`, `ui.scrollbarDisplayMode`, `widget.non-native-theme.enabled` e captura durante a rolagem, e nas quatro a amostra continuou sendo o fundo do painel. Então: **o efeito no tema da UA está medido; o pixel exato da barra em Windows/Linux está inferido** a partir dele e do fato de o Firefox não implementar `::-webkit-scrollbar`.

## 3. `TOTAL_TOPICS_PRONTOS` (`content/roadmap.ts`)

`TOTAL_TOPICS` conta a trilha inteira, **47**, e a trilha inclui os **11** tópicos que o próprio site marca "em breve" e tira do índice do Google por não terem vídeo, artigo nem visualização.

É o mesmo rigor que **este arquivo já aplica** logo acima, no comentário do `TOTAL_LEETCODE_PROBLEMS` ("prometer o total seria contar duas fontes como uma"), e que o bloco de estatísticas da home já aplica ao separar "47 no roadmap" de "36 com visualização".

```ts
export const TOTAL_TOPICS_PRONTOS = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).length;
```

Deriva da **mesma** `isEmptyTopic` usada pelo `generateMetadata` da página de tópico e pelo selo do menu, não de uma cópia da regra: **o número sobe sozinho** quando um tópico ganha material. Hoje dá **36 de 47**.

### O que fica para depois

A frase que promete "47 tópicos com visualização passo a passo, código Python e problemas do LeetCode" mora em **`src/app/page.tsx:20`** (e o mesmo `TOTAL_TOPICS` aparece em `src/app/page.tsx:22` e `:35`), arquivo do **PR #49, aberto**. **Não toquei.** Ligar a copy à constante é o passo seguinte, depois que o #49 mergear.

## 4. Selo `isNew`: **decidi não mexer**, e a evidência é o histórico

O pedido dizia que `grep -c "isNew: true" content/roadmap.ts` devolve 4. Devolve — mas **três** são tópicos. A quarta ocorrência é a **linha 51, dentro do comentário** que documenta a própria convenção:

```
51:  // trilha recebe `isNew: true` no PR que publica o tópico, e perde a marca no
1070:        isNew: true,     backtracking
1139:        isNew: true,     binary-numbers
1168:        isNew: true,     negative-binary
```

`git log -S 'isNew: true' -- content/roadmap.ts` mostra que esses três foram marcados em **`c125d8d` (2026-08-04), "feat(topics): publica backtracking e os dois de números binários"** — e que **o mesmo commit tirou a marca dos quatro anteriores** (4 remoções, 3 adições no diff). O protocolo do runbook foi seguido à risca.

E não há publicação depois disso: `git log --diff-filter=A --name-only -- 'content/topics/*.mdx'` tem `c125d8d` como o commit mais recente a criar artigo. Tudo o que veio na `main` desde então (PRs #40 a #44) é casca adaptativa, teste e analytics.

**Conclusão: os três marcados são exatamente os últimos publicados. O selo está certo e não há marca velha para tirar.** Mexer aqui seria apagar informação correta. A pendência do runbook ("tirar o selo de backtracking, binary-numbers e negative-binary") continua válida **para o PR que publicar o próximo tópico**, que é onde ela está escrita.

---

## Provas de quebra

Cada uma com o fix **já commitado** antes de quebrar, restauração por `cp` (nunca `git checkout --`), build **nunca silenciado**, e `git diff --stat` vazio ao final.

| # | quebra | teste que reprovou | `Received` |
|---|---|---|---|
| A | `_headers` volta ao de antes (sem o bloco `/*`) | `plataforma-faxina.spec.ts:35` | `-1` (não achou a regra `/*`) |
| B | `globals.css` volta ao de antes (sem `color-scheme`) | `:114` e `:135` | `"normal"` nos dois |
| C | `TOTAL_TOPICS_PRONTOS = ALL_TOPICS.length` | `:144` e `:166` | **`47`** contra `36` esperado |
| D | injeta `<iframe src="/topico/strings/">` num HTML do `out/` | `:96` | o arquivo e o `src` do iframe de entrada, nomeados |

A quebra C é a que mais importa: o `Received: 47` é **exatamente o número que a home promete hoje**.

## Testes novos (`tests/plataforma-faxina.spec.ts`, 7 testes)

Cada um verifica onde a coisa existe de verdade:

- **o artefato**, não a fonte: o bloco `/*` é lido de `out/_headers`, conferindo que o cabeçalho está **dentro** do bloco (uma linha indentada solta em outro bloco valeria só para aquela rota e o arquivo pareceria certo) e que as duas regras de Open Graph continuam lá;
- **a direção de todo iframe do build**: varre os 54 HTML exportados, acha **34 iframes, todos de saída**, e reprova se algum embutir o próprio site (mais a asserção de que achou pelo menos um, senão a varredura estaria passando por não enxergar nada). É a asserção que sustenta o `DENY`, e não depende de rede — um teste que espera o YouTube carregar vira flake de conectividade e não mede o que interessa;
- **comportamento, não existência**: o embed é medido pela `boundingBox` (um iframe de 0px passaria numa asserção de presença);
- **o valor computado** do `color-scheme`, no `:root` e no `.side-scroll`, com asserção prévia de que o elemento **de fato rola** — senão não há barra para pintar e o teste não testaria nada;
- **a fonte de dados**: `TOTAL_TOPICS_PRONTOS` contra `ALL_TOPICS.filter(...)`, mais o amarre ao comportamento — quem fica de fora da conta é **exatamente** quem o build marca `noindex`.

## Verificação

- `npm run build` ✅ · `npx tsc --noEmit` ✅ · **suíte inteira: 466 passed em 1.3 min, sem nenhum flake** (nem o de rolagem do `viz-strings.spec.ts`, nem a família da primeira rodada pós-build).
- Conferência em **390x844**, **1440x700** e **1512x900**, com `?v=$(date +%s)` para furar o cache de CSS: `document.body.scrollWidth > innerWidth` **falso** nas três, `color-scheme` `dark` nas três, embed com caixa de vídeo nas três.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3BfAzcaMzDmPLn9xFnHVv
