### PR TITLE
Cartões que ensinavam o oposto: o rótulo do heap sort, a legenda do grafo e o guarda dos três números

### DIFF
--- a/content/visualizers/GrafoRepresentacao.tsx
+++ b/content/visualizers/GrafoRepresentacao.tsx
@@ -283,7 +283,23 @@ export function GrafoRepresentacao() {
           <div className="bigo-stat"><span>arestas (E)</span><strong>{E} de {maxE}</strong></div>
           <div className="bigo-stat"><span>memória da matriz</span><strong>{matrixCost} células</strong></div>
           <div className="bigo-stat"><span>memória da lista</span><strong>{listCost} entradas</strong></div>
-          <div className="bigo-stat"><span>células em zero</span><strong>{matrixCost - (directed ? E : 2 * E) - V}</strong></div>
+          {/* Sem o `- V` que descontava a diagonal. Ela é DESENHADA: cada
+              célula dela é um botão com `0` dentro (`:250-257`), só com
+              `opacity: .35` — apagada, e perfeitamente legível. Descontá-la
+              fazia o cartão dizer 16 com 22 zeros na tela, e dizer 0 no preset
+              Completo com 6 zeros à vista, logo abaixo de um cartão que cobra
+              as 36 células da matriz.
+
+              Entre mudar o número e mudar o rótulo, o número: é ele que o
+              aluno consegue CONFERIR contando a tela, e é ele que fecha a
+              conta com o cartão vizinho (36 células menos 22 em zero = as 14
+              ocupadas). E a diagonal não é ruído a descontar, é o argumento:
+              são V posições que a matriz reserva para sempre e que nenhuma
+              aresta pode ocupar, porque vértice não é vizinho de si mesmo. O
+              desperdício de V² é o assunto da peça, e essa é a parte dele que
+              nunca tem chance. O rótulo continua "células em zero" porque
+              agora é literalmente isso que o número conta. */}
+          <div className="bigo-stat"><span>células em zero</span><strong>{matrixCost - (directed ? E : 2 * E)}</strong></div>
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>

--- a/content/visualizers/GrafoRepresentacao.tsx
+++ b/content/visualizers/GrafoRepresentacao.tsx
@@ -289,8 +289,9 @@ export function GrafoRepresentacao() {
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
           A matriz custa V² sempre, ligada ou não a aresta. A lista custa{" "}
           {directed ? "V + E (dirigido: cada aresta aparece uma vez só)" : "V + 2E (não dirigido: cada aresta aparece nos dois vizinhos)"},
-          então ela só perde quando o grafo é quase completo. Com 6 vértices a diferença é pequena;
-          com 1 milhão de vértices, a matriz pediria 10¹² células e simplesmente não cabe.
+          e no grafo completo isso dá exatamente V²: os dois empatam, e é o mais caro que a lista
+          chega a ficar. Com 6 vértices a diferença é pequena; com 1 milhão de vértices, a matriz
+          pediria 10¹² células e simplesmente não cabe.
         </p>
       </div>
 

--- a/content/visualizers/HeapSortVisualizer.tsx
+++ b/content/visualizers/HeapSortVisualizer.tsx
@@ -34,7 +34,16 @@ type Step = {
   arr: number[];
   n: number; // tamanho do heap ativo: as posições >= n já estão ordenadas
   focus: number;
-  pair: number;
+  // Dois campos, e não um. Eles já foram um `pair` só, e o painel de variáveis
+  // chamava os três significados dele de "maior candidato": o maior filho (o
+  // único que o rótulo descrevia), a origem da subida depois de uma troca, e a
+  // posição que ACABOU DE SAIR do heap. Medido no gerador, nos quatro presets:
+  // dos 156 passos que mostravam um número, 95 mostravam um que não era
+  // candidato a nada. No passo 27 do preset padrão o cartão dizia "9" com a
+  // célula 9 pintada de verde, que é a cor de "resolvida para sempre" — o
+  // oposto exato da fronteira que esta peça existe para ensinar.
+  largest: number; // índice do maior entre pai e filhos; -1 quando o passo não compara
+  swapWith: number; // índice do parceiro da troca; -1 quando o passo não troca
   swapped: boolean;
   phase: Phase;
   comp: number;
@@ -108,7 +117,9 @@ function buildSteps(values: number[]): Step[] {
   let swaps = 0;
   let n = total;
   let phase: Phase = "build";
-  const base = () => ({ arr: [...a], n, focus: -1, pair: -1, swapped: false, phase, comp, swaps });
+  const base = () => ({
+    arr: [...a], n, focus: -1, largest: -1, swapWith: -1, swapped: false, phase, comp, swaps,
+  });
 
   // sift down com limite: tudo de `n` para a frente é resultado final e não existe
   // para o algoritmo. Empurrar os passos aqui dentro mantém o gerador puro.
@@ -137,12 +148,14 @@ function buildSteps(values: number[]): Step[] {
         text += `. A direita seria ${right}, que já caiu na parte ordenada, então nem olho`;
       }
       out.push({
-        ...base(), focus: i, pair: largest === i ? -1 : largest, line: right < n ? 14 : 13,
+        ...base(), focus: i, largest, line: right < n ? 14 : 13,
         note: `${text}. O maior da tríade é ${a[largest]}.`,
       });
       if (largest === i) {
         out.push({
-          ...base(), focus: i, line: 15, ok: true,
+          // `largest: i` é o `maior == i` da linha 16 do código na tela: o
+          // maior da tríade é o próprio pai, e é por isso que a descida para.
+          ...base(), focus: i, largest: i, line: 15, ok: true,
           note: `${a[i]} já é o maior entre pai e filhos: ${context} está válido daqui para baixo e paro a descida.`,
         });
         return;
@@ -153,7 +166,11 @@ function buildSteps(values: number[]): Step[] {
       const previous = i;
       i = largest;
       out.push({
-        ...base(), focus: i, pair: previous, swapped: true, line: 16,
+        // Sem `largest` aqui de propósito: a troca já aconteceu, e a posição
+        // que era a do maior passou a guardar o MENOR dos dois. Manter o
+        // rótulo aceso mostraria um índice cujo valor acabou de deixar de ser
+        // o maior. O fato deste passo é a troca, e é ela que tem rótulo.
+        ...base(), focus: i, swapWith: previous, swapped: true, line: 16,
         note: `${raised} sobe para ${previous} e ${a[i]} desce para ${i}. Sigo só por este ramo: o outro filho e a subárvore dele já estavam válidos e continuam.`,
       });
     }
@@ -187,14 +204,17 @@ function buildSteps(values: number[]): Step[] {
   // ---- fase 2 -------------------------------------------------------------
   phase = "sort";
   for (let end = total - 1; end > 0; end--) {
-    const largest = a[0];
+    // `topValue` é um VALOR (a raiz do heap), enquanto o `largest` do `siftDown`
+    // é um ÍNDICE. Eles se chamavam igual, e é dessa confusão que nasceu o
+    // rótulo mentindo: `end` entrava no mesmo campo do maior filho.
+    const topValue = a[0];
     const swappedOut = a[end];
     [a[0], a[end]] = [a[end], a[0]];
     swaps++;
     n = end;
     out.push({
-      ...base(), focus: 0, pair: end, swapped: true, line: 7,
-      note: `${largest} é o maior do heap, então o lugar dele é a última posição livre, a ${end}. Troco com ${swappedOut} e a posição ${end} está resolvida para sempre.`,
+      ...base(), focus: 0, swapWith: end, swapped: true, line: 7,
+      note: `${topValue} é o maior do heap, então o lugar dele é a última posição livre, a ${end}. Troco com ${swappedOut} e a posição ${end} está resolvida para sempre.`,
     });
     out.push({
       ...base(), focus: 0, line: 8,
@@ -265,6 +285,13 @@ export function HeapSortVisualizer() {
   };
   const cy = (i: number) => TOP_Y + NODE_R + depth(i) * LEVEL_Y;
 
+  // O "outro" índice destacado no desenho não é um conceito só: num passo de
+  // comparação é o maior filho, num passo de troca é o parceiro dela. O
+  // destaque pode juntar os dois, porque a cor só diz "olhe aqui" — quem diz o
+  // QUE é o número é o painel de variáveis, e lá eles aparecem separados, cada
+  // um com o seu rótulo.
+  const partner = s.swapWith >= 0 ? s.swapWith : s.largest !== s.focus ? s.largest : -1;
+
   const sortedCount = s.arr.length - s.n;
   const phaseLabel =
     s.phase === "build" ? "fase 1 · virando max-heap" : s.phase === "sort" ? "fase 2 · arrancando o maior" : "pronto";
@@ -314,7 +341,7 @@ export function HeapSortVisualizer() {
                 .map((f) => (
                   <line
                     key={`${i}-${f}`}
-                    className={`tt-aresta${(s.focus === i && s.pair === f) || (s.focus === f && s.pair === i) ? " ativa" : ""}`}
+                    className={`tt-aresta${(s.focus === i && partner === f) || (s.focus === f && partner === i) ? " ativa" : ""}`}
                     x1={cx(i)}
                     y1={cy(i) + NODE_R}
                     x2={cx(f)}
@@ -325,7 +352,7 @@ export function HeapSortVisualizer() {
             {s.arr.slice(0, s.n).map((v, i) => {
               const cls = ["tt-no"];
               if (i === s.focus) cls.push("on");
-              else if (i === s.pair) cls.push("aux");
+              else if (i === partner) cls.push("aux");
               return (
                 <g key={i} className={cls.join(" ")}>
                   <circle cx={cx(i)} cy={cy(i)} r={NODE_R} />
@@ -352,8 +379,8 @@ export function HeapSortVisualizer() {
               const cls = ["hp-cel"];
               if (i >= s.n) cls.push("fixo");
               else if (i === s.focus) cls.push("foco");
-              else if (i === s.pair) cls.push("par");
-              if (s.swapped && (i === s.focus || i === s.pair)) cls.push("troca");
+              else if (i === partner) cls.push("par");
+              if (s.swapped && (i === s.focus || i === partner)) cls.push("troca");
               return (
                 <span key={i} className={cls.join(" ")}>
                   <i>{i}</i>
@@ -390,9 +417,19 @@ export function HeapSortVisualizer() {
               <span className="viz-var-name">i (foco)</span>
               <span className="viz-var-val">{s.focus >= 0 ? s.focus : "-"}</span>
             </div>
+            {/* Os dois rótulos que antes eram um. `maior (índice)` é o `maior`
+                do código ao lado, que é índice como o `i`; `trocou com` é a
+                outra ponta da troca deste passo. Cada um mostra "-" quando o
+                seu fato não acontece no passo, e esse traço também informa:
+                numa folha não há comparação, e num passo de comparação não há
+                troca. */}
             <div className="viz-var">
-              <span className="viz-var-name">maior candidato</span>
-              <span className="viz-var-val">{s.pair >= 0 ? s.pair : "-"}</span>
+              <span className="viz-var-name">maior (índice)</span>
+              <span className="viz-var-val">{s.largest >= 0 ? s.largest : "-"}</span>
+            </div>
+            <div className="viz-var">
+              <span className="viz-var-name">trocou com</span>
+              <span className="viz-var-val">{s.swapWith >= 0 ? s.swapWith : "-"}</span>
             </div>
           </div>
         </div>

--- a/tests/viz-cartoes-que-mentem.spec.ts
+++ b/tests/viz-cartoes-que-mentem.spec.ts
@@ -1,0 +1,259 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// Cartões que ensinavam o oposto do que a peça existe para ensinar.
+//
+// Todo teste daqui lê o RÓTULO junto do VALOR, no mesmo cartão. É a camada que
+// nenhum teste de estado alcança: comportamento certo com rótulo errado ensina
+// errado do mesmo jeito, e foi exatamente o que aconteceu no painel de
+// variáveis do heap sort. O campo `pair` recebia três coisas diferentes — o
+// maior filho, a origem da subida e a posição que ACABOU DE SAIR do heap — e o
+// painel chamava as três de "maior candidato". Medido no gerador, nos quatro
+// presets: dos 156 passos que mostravam um número, 95 mostravam um que não era
+// candidato a nada, e 34 apontavam uma célula VERDE, que é a cor de "resolvida
+// para sempre" e o oposto exato da fronteira que a peça ensina.
+//
+// Por isso a asserção central não é um número: é a INVARIANTE, varrida na
+// animação inteira dos quatro presets. Onde o rótulo `maior (índice)` acende, o
+// índice tem que estar dentro do heap e apontar o maior da tríade; onde `trocou
+// com` acende, a troca tem que ter acontecido de verdade.
+
+const HEAP = "/topico/heap-sort/";
+const GRAFOS = "/topico/grafos-intro/";
+
+// A página do heap sort tem três visualizadores, e `figure.viz-fit` só é único
+// nela enquanto os outros dois não vestirem a casca (é o que o PR #56 faz).
+// A âncora é o que só esta peça tem: a faixa de fase. Mesma ideia no grafo, com
+// a matriz — `.gr-matriz` também existe no BellmanFord, que mora noutra página.
+const FIG_HEAP = "article figure.viz:has(.hs-fase)";
+const FIG_GRAFO = "article figure.viz:has(.gr-matriz)";
+
+async function abrir(page: Page, url: string, sel: string): Promise<Locator> {
+  await page.goto(url);
+  await page.evaluate(() => document.fonts.ready);
+  const fig = page.locator(sel);
+  await expect(fig).toHaveCount(1);
+  await fig.scrollIntoViewIfNeeded();
+  return fig;
+}
+
+/**
+ * Uma linha do painel de variáveis, achada pelo RÓTULO — o valor é lido dentro
+ * dela. Ler o número por posição passaria verde com dois campos trocados de
+ * lugar: o conjunto de textos da tela fica idêntico e só a associação mente.
+ */
+const variavel = (fig: Locator, nome: string) =>
+  fig.locator(`.viz-var:has(.viz-var-name:text-is(${JSON.stringify(nome)}))`);
+
+const cartao = (fig: Locator, nome: string) =>
+  fig.locator(`.bigo-stat:has(span:text-is(${JSON.stringify(nome)}))`);
+
+const proximoDe = (fig: Locator) => fig.getByRole("button", { name: "Próximo ›" });
+
+/** Anda até o passo `alvo`, confirmando o contador a cada clique: leitura única
+ *  de estado do React mente, e clique rápido some se a asserção não fechar. */
+async function irAoPasso(fig: Locator, alvo: number) {
+  const contador = fig.locator(".viz-step");
+  await expect(contador).toContainText("passo 1 de ");
+  for (let i = 1; i < alvo; i++) {
+    await proximoDe(fig).click();
+    await expect(contador).toContainText(`passo ${i + 1} de `);
+  }
+}
+
+test.describe("cartões que ensinavam o oposto", () => {
+  test.use({ viewport: { width: 1440, height: 900 } });
+
+  // ------------------------------------------------------------------ heap sort
+  test.describe("heap sort · o painel de variáveis", () => {
+    test("os rótulos nomeiam dois fatos, em vez de um nome só para três", async ({ page }) => {
+      const fig = await abrir(page, HEAP, FIG_HEAP);
+
+      // O rótulo antigo, "maior candidato", descrevia um dos três significados
+      // que o campo carregava. Cada fato passa a ter o seu nome.
+      await expect(fig.locator(".viz-var-name")).toHaveText([
+        "n (heap ativo)",
+        "i (foco)",
+        "maior (índice)",
+        "trocou com",
+      ]);
+    });
+
+    test("os dois lados de cada rótulo: aceso quando o fato vale, traço quando não", async ({
+      page,
+    }) => {
+      const fig = await abrir(page, HEAP, FIG_HEAP);
+      const maior = variavel(fig, "maior (índice)").locator(".viz-var-val");
+      const trocou = variavel(fig, "trocou com").locator(".viz-var-val");
+
+      // Passo 4: compara os filhos de 4 e o maior da tríade está em 9. Há
+      // comparação e não há troca.
+      await irAoPasso(fig, 4);
+      await expect(fig.locator(".viz-note")).toContainText("O maior da tríade é 6.");
+      await expect(maior).toHaveText("9");
+      await expect(trocou).toHaveText("-");
+
+      // Passo 5: a troca aconteceu, e o que era o maior deixou de ser. Há troca
+      // e não há comparação — o traço em `maior (índice)` é informação.
+      await proximoDe(fig).click();
+      await expect(fig.locator(".viz-step")).toContainText("passo 5 de ");
+      await expect(maior).toHaveText("-");
+      await expect(trocou).toHaveText("4");
+    });
+
+    test("passo 27: a célula verde é 'trocou com', e nunca 'maior'", async ({ page }) => {
+      const fig = await abrir(page, HEAP, FIG_HEAP);
+      await irAoPasso(fig, 27);
+
+      // A cena exata do defeito. O cartão dizia "maior candidato: 9" com a
+      // célula 9 pintada de verde: candidata a nada, resolvida para sempre.
+      await expect(variavel(fig, "trocou com").locator(".viz-var-val")).toHaveText("9");
+      await expect(variavel(fig, "maior (índice)").locator(".viz-var-val")).toHaveText("-");
+
+      const celula = fig.locator(".hp-cel").nth(9);
+      await expect(celula).toHaveClass(/\bfixo\b/);
+      await expect(celula).toHaveClass(/\btroca\b/);
+      await expect(fig.locator(".viz-note")).toContainText(
+        "a posição 9 está resolvida para sempre"
+      );
+    });
+
+    test("a invariante dos dois rótulos vale na animação inteira dos quatro presets", async ({
+      page,
+    }) => {
+      test.slow();
+      const fig = await abrir(page, HEAP, FIG_HEAP);
+
+      const presets = ["Embaralhado", "Já ordenado", "Ao contrário", "Com repetidos"];
+      const varridos: { preset: string; passos: number; maior: number; trocou: number }[] = [];
+
+      for (const nome of presets) {
+        await fig.getByRole("button", { name: new RegExp(`^${nome}:`) }).click();
+        await expect(fig.locator(".viz-step")).toContainText("passo 1 de ");
+
+        const r = await page.evaluate(
+          (s) =>
+            new Promise<{
+              passos: number;
+              erros: string[];
+              maior: number;
+              trocou: number;
+            }>((resolve, reject) => {
+              const f = document.querySelector(s)!;
+              const prox = [...f.querySelectorAll("button")].find((b) =>
+                b.textContent!.includes("Próximo")
+              ) as HTMLButtonElement;
+
+              // Rótulo E valor do MESMO cartão, sempre.
+              const varDe = (nome: string) => {
+                const c = [...f.querySelectorAll(".viz-var")].find(
+                  (e) => e.querySelector(".viz-var-name")!.textContent!.trim() === nome
+                );
+                if (!c) throw new Error(`nao achei a variavel "${nome}"`);
+                return c.querySelector(".viz-var-val")!.textContent!.trim();
+              };
+              const num = (t: string) => (t === "-" ? -1 : parseInt(t, 10));
+
+              const erros: string[] = [];
+              let maior = 0;
+              let trocou = 0;
+              let k = 0;
+
+              const ler = () => {
+                const passo = parseInt(
+                  f.querySelector(".viz-step")!.textContent!.match(/passo (\d+)/)![1],
+                  10
+                );
+                const n = parseInt(varDe("n (heap ativo)"), 10);
+                const foco = num(varDe("i (foco)"));
+                const iMaior = num(varDe("maior (índice)"));
+                const iTrocou = num(varDe("trocou com"));
+
+                // O valor de cada célula vem do nó de texto, e o índice do <i>.
+                // `textContent` cola os dois ("46" é o índice 4 com o valor 6).
+                const celulas = [...f.querySelectorAll(".hp-cel")].map((c) => {
+                  const i = c.querySelector("i")!.textContent!;
+                  return {
+                    valor: parseInt(c.textContent!.slice(i.length), 10),
+                    troca: c.classList.contains("troca"),
+                    fixo: c.classList.contains("fixo"),
+                  };
+                });
+
+                if (iMaior >= 0 && iTrocou >= 0)
+                  erros.push(`passo ${passo}: os dois rotulos acesos (${iMaior} e ${iTrocou})`);
+
+                if (iMaior >= 0) {
+                  maior++;
+                  // Nunca um índice fora do heap: fora do heap é verde, e verde
+                  // é "resolvida para sempre", o oposto de candidata.
+                  if (iMaior >= n)
+                    erros.push(
+                      `passo ${passo}: "maior (indice)" = ${iMaior} esta fora do heap (n=${n})`
+                    );
+                  else if (celulas[iMaior].fixo)
+                    erros.push(`passo ${passo}: "maior (indice)" = ${iMaior} aponta celula verde`);
+                  else if (foco < 0)
+                    erros.push(`passo ${passo}: "maior (indice)" aceso sem foco`);
+                  else {
+                    // E é mesmo o maior entre o pai e os filhos dentro do heap.
+                    const triade = [foco, 2 * foco + 1, 2 * foco + 2].filter((x) => x < n);
+                    const topo = Math.max(...triade.map((x) => celulas[x].valor));
+                    if (celulas[iMaior].valor !== topo)
+                      erros.push(
+                        `passo ${passo}: "maior (indice)" = ${iMaior} vale ${celulas[iMaior].valor}, ` +
+                          `mas o maior da triade ${JSON.stringify(triade)} e ${topo}`
+                      );
+                  }
+                }
+
+                if (iTrocou >= 0) {
+                  trocou++;
+                  // Só acende onde houve troca, e as duas pontas dela estão
+                  // marcadas no array.
+                  if (!celulas[iTrocou].troca)
+                    erros.push(
+                      `passo ${passo}: "trocou com" = ${iTrocou}, mas a celula nao esta marcada como troca`
+                    );
+                  if (foco < 0 || !celulas[foco].troca)
+                    erros.push(`passo ${passo}: "trocou com" aceso e o foco (${foco}) sem troca`);
+                }
+              };
+
+              const tick = () => {
+                try {
+                  ler();
+                } catch (e) {
+                  return reject(e);
+                }
+                k++;
+                if (prox.disabled) return resolve({ passos: k, erros, maior, trocou });
+                if (k > 500) return reject(new Error("a animacao nao terminou em 500 passos"));
+                prox.click();
+                requestAnimationFrame(() => requestAnimationFrame(tick));
+              };
+              tick();
+            }),
+          FIG_HEAP
+        );
+
+        // O laço andou até o fim de verdade, e não parou no meio calado.
+        await expect(proximoDe(fig)).toBeDisabled();
+        expect(r.erros, `${nome}: os rotulos discordam do que a tela mostra`).toEqual([]);
+        expect(r.passos, `${nome}: a animacao encurtou demais para significar algo`).toBeGreaterThan(
+          50
+        );
+        varridos.push({ preset: nome, passos: r.passos, maior: r.maior, trocou: r.trocou });
+      }
+
+      // A varredura só vale se os dois rótulos tiverem mesmo acendido. Sem isto
+      // um `largest` sempre em -1 passaria com zero erro e zero significado.
+      expect(varridos).toEqual([
+        { preset: "Embaralhado", passos: 78, maior: 22, trocou: 27 },
+        { preset: "Já ordenado", passos: 84, maior: 25, trocou: 30 },
+        { preset: "Ao contrário", passos: 71, maior: 26, trocou: 21 },
+        { preset: "Com repetidos", passos: 56, maior: 18, trocou: 17 },
+      ]);
+    });
+  });
+
+});

--- a/tests/viz-cartoes-que-mentem.spec.ts
+++ b/tests/viz-cartoes-que-mentem.spec.ts
@@ -324,4 +324,43 @@ test.describe("cartões que ensinavam o oposto", () => {
     });
   });
 
+  // --------------------------------------------------------------------- grafo
+  test.describe("grafos-intro · o custo das duas representações", () => {
+    test("a legenda diz empate no completo, e os dois cartões empatam mesmo", async ({ page }) => {
+      const fig = await abrir(page, GRAFOS, FIG_GRAFO);
+      const matriz = cartao(fig, "memória da matriz").locator("strong");
+      const lista = cartao(fig, "memória da lista").locator("strong");
+
+      // Esparso: a lista custa bem menos, que é o argumento da peça.
+      await expect(matriz).toHaveText("36 células");
+      await expect(lista).toHaveText("20 entradas");
+
+      // Completo, não dirigido: V + 2E = V + V(V-1) = V². Os dois EMPATAM. A
+      // legenda dizia que a lista "só perde quando o grafo é quase completo", e
+      // ela nunca perde: o completo é o teto, e no teto os números se igualam.
+      await fig.getByRole("button", { name: "Completo", exact: true }).click();
+      await expect(fig.locator(".viz-step")).toHaveText("V = 6 · E = 15 · densidade 100%");
+      await expect(matriz).toHaveText("36 células");
+      await expect(lista).toHaveText("36 entradas");
+
+      // O outro lado da condicional da legenda: no dirigido a conta é V + E, e
+      // o empate acontece igual, com os 30 arcos do completo.
+      await fig.getByRole("button", { name: "dirigido", exact: true }).click();
+      await expect(fig.locator(".viz-step")).toHaveText("V = 6 · E = 30 · densidade 100%");
+      await expect(matriz).toHaveText("36 células");
+      await expect(lista).toHaveText("36 entradas");
+
+      await expect(fig.locator(".viz-caption")).toContainText("V + E (dirigido");
+      await expect(fig.locator(".viz-caption")).toContainText(
+        "no grafo completo isso dá exatamente V²: os dois empatam, e é o mais caro que a lista chega a ficar."
+      );
+
+      // E o lado não dirigido da mesma frase.
+      await fig.getByRole("button", { name: "não dirigido", exact: true }).click();
+      await expect(fig.locator(".viz-caption")).toContainText("V + 2E (não dirigido");
+      await expect(fig.locator(".viz-caption")).toContainText(
+        "no grafo completo isso dá exatamente V²: os dois empatam, e é o mais caro que a lista chega a ficar."
+      );
+    });
+  });
 });

--- a/tests/viz-cartoes-que-mentem.spec.ts
+++ b/tests/viz-cartoes-que-mentem.spec.ts
@@ -362,5 +362,60 @@ test.describe("cartões que ensinavam o oposto", () => {
         "no grafo completo isso dá exatamente V²: os dois empatam, e é o mais caro que a lista chega a ficar."
       );
     });
+
+    test("o cartão 'células em zero' conta os zeros que a matriz desenha", async ({ page }) => {
+      const fig = await abrir(page, GRAFOS, FIG_GRAFO);
+      const zeros = cartao(fig, "células em zero").locator("strong");
+
+      // A invariante que faltava, e a que teria pego o defeito: o número do
+      // cartão é a contagem dos botões que mostram `0`. A expressão descontava
+      // a diagonal (`- V`), mas a diagonal É DESENHADA, como botão com o zero
+      // dentro — `opacity: .35` deixa apagado, não invisível.
+      const naTela = () =>
+        fig.evaluate((f) => {
+          const cel = [...f.querySelectorAll(".gr-cel")];
+          return {
+            botoes: cel.length,
+            zeros: cel.filter((b) => b.textContent!.trim() === "0").length,
+            diagonalEmZero: cel.filter(
+              (b) => b.classList.contains("diag") && b.textContent!.trim() === "0"
+            ).length,
+          };
+        });
+
+      const presets = ["Esparso (rede social)", "Denso", "Completo", "Caminho (o mínimo conexo)"];
+      const visto: string[] = [];
+
+      for (const modo of ["não dirigido", "dirigido"]) {
+        await fig.getByRole("button", { name: modo, exact: true }).click();
+        for (const preset of presets) {
+          await fig.getByRole("button", { name: preset, exact: true }).click();
+          const t = await naTela();
+
+          // A matriz sempre desenha V² botões, e a diagonal inteira sempre em
+          // zero: é ela que o `- V` descontava, e é ela que o aluno vê.
+          expect(t.botoes, `${modo}/${preset}: a matriz deixou de ter V² botões`).toBe(36);
+          expect(t.diagonalEmZero, `${modo}/${preset}: a diagonal saiu do zero`).toBe(6);
+
+          await expect(zeros, `${modo}/${preset}: o cartão discorda da tela`).toHaveText(
+            String(t.zeros)
+          );
+          visto.push(`${modo}/${preset}: ${t.zeros}`);
+        }
+      }
+
+      // E os números medidos, presos: a invariante sozinha passaria com os dois
+      // lados errados do mesmo jeito, e é a tela que manda.
+      expect(visto).toEqual([
+        "não dirigido/Esparso (rede social): 22",
+        "não dirigido/Denso: 10",
+        "não dirigido/Completo: 6",
+        "não dirigido/Caminho (o mínimo conexo): 26",
+        "dirigido/Esparso (rede social): 29",
+        "dirigido/Denso: 23",
+        "dirigido/Completo: 21",
+        "dirigido/Caminho (o mínimo conexo): 31",
+      ]);
+    });
   });
 });

--- a/tests/viz-cartoes-que-mentem.spec.ts
+++ b/tests/viz-cartoes-que-mentem.spec.ts
@@ -60,6 +60,35 @@ async function irAoPasso(fig: Locator, alvo: number) {
   }
 }
 
+/**
+ * Anda a animação inteira dentro do navegador e fecha com `toBeDisabled`.
+ * Laço que não prova que chegou ao fim deixa a asserção seguinte vazia.
+ */
+async function irAoFim(page: Page, sel: string, fig: Locator): Promise<number> {
+  const andou = await page.evaluate(
+    (s) =>
+      new Promise<number>((resolve, reject) => {
+        const f = document.querySelector(s)!;
+        const prox = [...f.querySelectorAll("button")].find((b) =>
+          b.textContent!.includes("Próximo")
+        ) as HTMLButtonElement;
+        if (!prox) return reject(new Error("nao achei o botao Proximo"));
+        let k = 0;
+        const tick = () => {
+          if (prox.disabled) return resolve(k);
+          if (k > 500) return reject(new Error("a animacao nao terminou em 500 passos"));
+          prox.click();
+          k++;
+          requestAnimationFrame(() => requestAnimationFrame(tick));
+        };
+        tick();
+      }),
+    sel
+  );
+  await expect(proximoDe(fig)).toBeDisabled();
+  return andou;
+}
+
 test.describe("cartões que ensinavam o oposto", () => {
   test.use({ viewport: { width: 1440, height: 900 } });
 
@@ -253,6 +282,45 @@ test.describe("cartões que ensinavam o oposto", () => {
         { preset: "Ao contrário", passos: 71, maior: 26, trocou: 21 },
         { preset: "Com repetidos", passos: 56, maior: 18, trocou: 17 },
       ]);
+    });
+  });
+
+  // -------------------------------------------------- heap sort · os três números
+  test.describe("heap sort · os números prometidos", () => {
+    test("38, 41 e 35 são o que a peça produz, e é o que a legenda e o artigo dizem", async ({
+      page,
+    }) => {
+      test.slow();
+      const fig = await abrir(page, HEAP, FIG_HEAP);
+
+      // A peça. Igualdade exata: `toContainText("38")` passaria com 138.
+      for (const [preset, esperado] of [
+        ["Embaralhado", "38"],
+        ["Já ordenado", "41"],
+        ["Ao contrário", "35"],
+      ] as const) {
+        await fig.getByRole("button", { name: new RegExp(`^${preset}:`) }).click();
+        await expect(fig.locator(".viz-step")).toContainText("passo 1 de ");
+        await irAoFim(page, FIG_HEAP, fig);
+        await expect(
+          cartao(fig, "comparações").locator("strong"),
+          `${preset}: o total de comparacoes mudou`
+        ).toHaveText(esperado);
+      }
+
+      // A legenda da peça, que manda o aluno anotar os três.
+      await expect(fig.locator(".viz-caption")).toContainText(
+        "anote o total de comparações: 38, 41 e 35."
+      );
+
+      // E a terceira cópia: o artigo repete os mesmos números, em negrito. As
+      // três pontas amarradas num teste só — mexer no gerador reprova aqui em
+      // vez de apodrecer em silêncio nas outras duas.
+      const frase = page.locator("article p").filter({ hasText: "38 comparações" });
+      await expect(frase).toHaveCount(1);
+      await expect(frase).toContainText(
+        "38 comparações no embaralhado, 41 no já ordenado e 35 no invertido"
+      );
     });
   });
 

--- a/tests/viz-grafos-intro.spec.ts
+++ b/tests/viz-grafos-intro.spec.ts
@@ -176,17 +176,22 @@ test.describe("grafos-intro · casca adaptativa", () => {
     await expect(painel.locator(".viz-body .sub-modo button")).toHaveCount(2);
 
     // Rótulo e valor lidos no MESMO cartão. Esparso: a lista custa 20 entradas
-    // contra 36 células da matriz, e sobram 16 células em zero.
+    // contra 36 células da matriz, e sobram 22 células em zero — as 14 ligadas
+    // mais a diagonal, que a matriz desenha com o zero à mostra.
     await expect(cartao(painel, "memória da matriz").locator("strong")).toHaveText("36 células");
     await expect(cartao(painel, "memória da lista").locator("strong")).toHaveText("20 entradas");
-    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("16");
+    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("22");
 
-    // Completo: os dois custos empatam e não sobra célula nenhuma em zero.
+    // Completo: os dois custos empatam, e o que sobra em zero é exatamente a
+    // diagonal — as V células que nenhuma aresta pode ocupar, porque vértice
+    // não é vizinho de si mesmo. (Este comentário dizia "não sobra célula
+    // nenhuma em zero", e era falso: os 6 zeros da diagonal sempre estiveram
+    // na tela. O cartão é que os descontava.)
     await painel.getByRole("button", { name: "Completo", exact: true }).click();
     await expect(cartao(painel, "arestas (E)").locator("strong")).toHaveText("15 de 15");
     await expect(cartao(painel, "memória da matriz").locator("strong")).toHaveText("36 células");
     await expect(cartao(painel, "memória da lista").locator("strong")).toHaveText("36 entradas");
-    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("0");
+    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("6");
   });
 
   test("clicar numa célula dentro do painel liga a aresta, espelha a simétrica e atualiza cabeçalho, lista e custo", async ({
@@ -219,6 +224,6 @@ test.describe("grafos-intro · casca adaptativa", () => {
       "C",
       "F",
     ]);
-    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("14");
+    await expect(cartao(painel, "células em zero").locator("strong")).toHaveText("20");
   });
 });


### PR DESCRIPTION
## O que este PR conserta

Três cartões que ensinavam o **oposto** do que a peça existe para ensinar, mais o guarda dos três números que a legenda e o artigo prometem sem ninguém conferir.

Todo número aqui foi medido por mim: o gerador do heap sort reexecutado em Node, e os cartões do grafo lidos no HTML do build.

---

### 1. `HeapSortVisualizer` · "maior candidato" estava errado em **61%** dos passos

O painel de variáveis tinha um campo só, `pair`, sob o rótulo **maior candidato**. Esse campo recebia **três coisas diferentes**: o maior filho (o único que o rótulo descrevia), a origem da subida depois de uma troca, e a posição que acabara de **sair** do heap.

Reexecutando o gerador. **Medi os quatro presets, e não os três do enunciado** — o quarto sozinho acrescenta 17 passos errados e mostra que não é peculiaridade de um arranjo:

| preset | passos que mostravam um número | quantos o rótulo descrevia errado |
|---|---|---|
| Embaralhado | 45 | **27** |
| Já ordenado | 51 | **30** |
| Ao contrário | 33 | **21** |
| **Com repetidos** (fora do enunciado) | 27 | **17** |
| **total** | **156** | **95 (61%)** |

**Em 34 desses passos o índice apontava uma célula verde** — a cor que a própria peça usa para "resolvida para sempre". No **passo 27 de 78** do preset padrão o cartão dizia `maior candidato: 9` com `n = 9`, ou seja, a célula 9 já tinha saído do heap. A peça existe para ensinar a fronteira entre heap ativo e parte ordenada, e o cartão apontava justamente para o lado errado dela.

**Conserto.** Dois campos com dois rótulos, cada um ligado a um fato:

- `maior (índice)` — o `maior` do Python que aparece na tela (`if maior == i: return`), aceso só onde há comparação;
- `trocou com` — a outra ponta da troca, aceso só onde houve troca.

Cada um mostra `-` quando o seu fato não acontece no passo, e o traço também informa (numa folha não há comparação; num passo de comparação não há troca). O destaque do desenho passa a derivar dos dois, porque a cor só diz "olhe aqui" e não precisa distinguir os dois fatos.

**Depois:** 186 valores mostrados nos quatro presets, **0** incoerentes com a tela.

### 2. `GrafoRepresentacao` · "células em zero" contava 6 a menos que a tela mostra

A expressão era `V*V - arestas - V`, descontando a diagonal. Mas a diagonal **é desenhada**: cada célula dela é um botão com `0` dentro, só com `opacity: .35` — apagada, e perfeitamente legível.

Medido no HTML do build, preset **Esparso**: **36 botões, 22 mostrando `0`, e o cartão dizia 16**. No preset **Completo** o cartão dizia **0** com **6 zeros à vista**, logo abaixo de um cartão que cobra as 36 células da matriz.

**A escolha, e o porquê.** O enunciado admitia dois consertos: o número passar a contar o que a tela mostra, ou o rótulo passar a dizer o que o número conta. **Mudei o número**, por dois motivos didáticos:

- **É o número que o aluno consegue conferir.** Ele conta 36 botões e 22 zeros, e fecha a conta com o cartão vizinho: 36 células menos 22 em zero são as 14 ocupadas. Um rótulo do tipo "células em zero fora da diagonal" mantém o número exato e o torna **inverificável na tela** — pior, no preset Completo ele continuaria dizendo 0 com 6 zeros à vista.
- **A diagonal não é ruído a descontar, é o argumento.** São V posições que a matriz reserva para sempre e que nenhuma aresta pode ocupar, porque vértice não é vizinho de si mesmo. O desperdício de V² é o assunto da peça, e essa é a parte dele que nunca tem chance de ser usada.

O **rótulo fica** em "células em zero", porque agora é literalmente isso que o número conta. Como o rótulo não muda, o helper `cartao()` dos testes, que acha o cartão por `getByText(rotulo, { exact: true })`, segue valendo sem mudança.

O teste novo prende a **invariante que faltava**, em 4 presets x 2 modos: o cartão tem que bater com a contagem dos botões que mostram `0`, com a matriz sempre em 36 botões e a diagonal sempre em 6 zeros.

### 3. `GrafoRepresentacao` · a legenda dizia que a lista perde, e ela nunca perde

**Este não estava no enunciado: saiu da varredura de classe**, que é o modo de achar que este PR defende. A legenda afirmava que a lista de adjacência *"só perde quando o grafo é quase completo"*. Ela **nunca** perde: no grafo completo `V + 2E = V + V(V-1) = V²`, exatamente o custo da matriz, e o completo é o teto. No dirigido dá no mesmo, `V + E = V + V(V-1) = V²`.

**Os dois cartões da própria peça já provavam isso, logo acima da frase.** Medido no build, preset Completo: `memória da matriz` = **36 células**, `memória da lista` = **36 entradas**. Empate, não derrota — e o spec de grafos já dizia "os dois custos empatam" num comentário, ao lado da legenda que dizia o contrário.

A frase passa a dizer o empate, que é o que a tela mostra e o que a aula quer: a lista nunca custa mais, e o teto é onde os dois se encontram.

### 4. Os três números prometidos, agora com guarda

A legenda manda o aluno rodar três presets até o fim e anotar **"38, 41 e 35 comparações"**, e `content/topics/heap-sort.mdx:85` repete os mesmos três em negrito. `grep -rn '38, 41' tests/` voltava **vazio**.

Conferido reexecutando o gerador antes de escrever qualquer asserção: **38, 41 e 35 são mesmo o que a peça produz hoje** (e o quarto preset dá 24). Nada a ajustar, só a guardar.

O teste amarra as **três pontas** numa rodada só: percorre a animação inteira de cada preset, lê o cartão `comparações` pelo rótulo e afirma o valor com **igualdade exata** (`toContainText("38")` passaria com 138), confere a frase da legenda e confere a frase do artigo, que mora na mesma página.

---

## As provas de quebra

O critério não foi `1 failed`: foi **falhar na minha linha, com o valor antigo no `Received`**.

| quebra | o que reprovou | `Received` |
|---|---|---|
| **A.** os dois componentes de `origin/main`, com o teste novo por cima | 5 dos 6 testes de então | `"maior candidato"` no lugar dos dois rótulos novos; a legenda antiga do grafo inteira, com o *"só perde quando o grafo é quase completo"* |
| **B.** `swapWith: end` volta a ser `largest: end` na fase 2 (compila, reproduz o defeito exato) | a varredura da invariante | `passo 27: "maior (indice)" = 9 esta fora do heap (n=9)`, e mais 8 iguais nos passos 34, 41, 48, 55, 61, 66, 71 e 76 |
| **C.** um `comp++` a menos no gerador | o guarda dos três números | `Expected "38"` / `Received "18"` |
| **D.** o `- V` de volta no cartão do grafo | a invariante nova **e** as duas asserções ajustadas do spec de grafos | `Received "16"` no Esparso (nos dois testes) e `Received "14"` no estado com a aresta A-C ligada |

A quebra **A** deixa o guarda dos três números **passando**, e é o esperado: ele guarda comportamento que não mudou, então quem tem que reprová-lo é a quebra **C**.

O build nunca foi silenciado, e as quebras escolhidas **compilam** (troca de campo, remoção de um incremento, reintrodução de um termo), em vez de um `return` que o compilador rejeitaria calado.

## Sobre o `tests/viz-grafos-intro.spec.ts`

As três asserções de "células em zero" (`:182`, `:189`, `:222`) afirmavam o número antigo, e vão para **22**, **6** e **20** num **commit separado, encostado no do conserto**, para o histórico mostrar causa e efeito.

**O comentário do `:189` foi reescrito junto, e ele é o achado mais desconfortável daqui:** dizia *"não sobra célula nenhuma em zero"* sob um `toHaveText("0")` verde. Os 6 zeros da diagonal sempre estiveram na tela; era o cartão que os descontava. Uma asserção certificando uma frase falsa é pior que asserção nenhuma, porque o próximo leitor confia nela. O comentário passa a dizer o que sobra e por que sobra, com nota do que ele afirmava antes, para ninguém sair procurando um defeito que já saiu.

## A varredura de classe

Nos **dois arquivos**, para cada rótulo, selo e cartão, olhei a expressão que o alimenta:

**`HeapSortVisualizer`** — o selo de fase (`s.phase`), a faixa `heap ativo / já ordenado`, o título `verde = posição final`, as 4 linhas do painel de variáveis, os 4 cartões de estatística (`tamanho do array`, `comparações`, `trocas`, `memória extra`), o `aria-label` do SVG, as 4 dicas de preset e a legenda. Confirmei também que a dica do preset "já ordenado" (*"ficam na mesma faixa"*, 38 contra 41) e a do "ao contrário" (*"a fase 1 quase não faz nada"*) batem com o gerador.

**`GrafoRepresentacao`** — o `V = 6 · E = N · densidade N%` do cabeçalho, os 5 cartões de custo, os dois títulos de painel, o `aria-label` de cada célula da matriz, o fallback `sem vizinhos`, a dica de cada preset e a legenda. Nos **dois modos**, dirigido e não dirigido.

Dois dos quatro consertos deste PR (o 3 e parte do 1) vieram da varredura, não do apontamento inicial.

## O que achei e NÃO consertei

Os três esbarram em arquivo com dono, ou em decisão que não é minha.

1. **`content/visualizers/HeapSortVisualizer.tsx:298` — a faixa anuncia "posições 0 a 0" com o heap vazio.** No último passo `n = 0`, e `Math.max(s.n - 1, 0)` devolve `0`: o selo diz `heap ativo: posições 0 a 0` enquanto o SVG logo acima diz **"heap vazio: tudo virou resultado"** e a posição 0 já está verde. Mesma classe do achado 1 deste PR, no mesmo arquivo. O conserto reprova **`tests/viz-heap-sort.spec.ts:309`**, cujo regex exige o literal `heap ativo: posições 0 a (\d+)` em **todos** os passos — e esse arquivo é do **PR #56**, aberto.
2. **`tests/viz-heap-sort.spec.ts:333-336` — a asserção final é vazia.** O helper lê o valor da célula com `parseInt(c.textContent.replace(/^\d+/, ""), 10)`, mas o `textContent` cola índice e valor (`<i>4</i>6` vira `"46"`), então `^\d+` come os dois e sobra `""`. Todo valor sai **`NaN`**, e `expect(ultimoArr).toEqual([...ultimoArr].sort(...))` compara um array de `NaN` com ele mesmo: **"o heap sort terminou com o array fora de ordem" passa sem testar nada**. Verificado em Node. Também do PR #56.
3. **`content/visualizers/GrafoRepresentacao.tsx:63` e as outras três dicas de preset ignoram o modo dirigido.** A do Completo diz *"V(V-1)/2 = 15 arestas. É o teto"*, mas em dirigido o teto é **30**, e o cartão ao lado passa a dizer `15 de 30` enquanto a dica afirma que aquilo é o teto. Não é rótulo alimentado por expressão (é prosa estática por preset), e consertar direito é reescrever as quatro dicas para serem cientes do modo — decisão editorial própria.

## Verificação

- `npm run build`, `npx tsc --noEmit` e a **suíte inteira**: **466 passed (1.3m)**, sem flake.
- Os consertos mudam string renderizada, então **reabri a conferência em 390x844** depois de cada leva: sem overflow de página, os quatro rótulos do painel do heap sort cabem sem vazar (12,5px, o maior com 105px de 308 disponíveis), e os cinco cartões do grafo não vazam rótulo nem valor, com o "células em zero: 22" a 19px. Conferido nos **dois** estados do bloco recolhível.
- A quarta linha do painel de variáveis custa **0px** de altura à peça: recolhido, as 4 fichas ocupam 545px de 772 numa linha só (o painel segue com 36px); aberto, o `.viz-split` tem 510px e quem manda é o bloco de código, com o painel em 200px.
- `scripts/guarda-idioma.py` nos dois componentes: a única mudança de texto de tela no heap sort é `maior candidato` saindo e `maior (índice)` mais `trocou com` entrando.

Nenhum print commitado. Nenhum travessão em copy do site.
