### PR TITLE
test: a rede que faltava — acessibilidade, erro de cliente e celular

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@playwright/test": "^1.49.0",
         "@shikijs/rehype": "^4.4.1",
         "@types/mdx": "^2.0.13",
@@ -26,6 +27,19 @@
         "@types/react-dom": "^19",
         "shiki": "^4.4.1",
         "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1022,6 +1036,16 @@
       "license": "MIT",
       "bin": {
         "astring": "bin/astring"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/bail": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@playwright/test": "^1.49.0",
     "@shikijs/rehype": "^4.4.1",
     "@types/mdx": "^2.0.13",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -39,7 +39,48 @@ export default defineConfig({
     baseURL: `http://localhost:${PORT}`,
     trace: "on-first-retry",
   },
-  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  // Dois projetos, e a tag `@mobile` decide quem roda o quê.
+  //
+  // O projeto `chromium` continua sendo a suíte inteira, e é ele que segura os
+  // 37 arquivos que já existiam. O `mobile` roda **só** o que estiver marcado
+  // `@mobile` no título, num Pixel 7 de verdade (412x839, `isMobile`,
+  // `hasTouch`): o `grep`/`grepInvert` abaixo é o que impede que acrescentar
+  // celular dobre o tempo de CI de todo mundo.
+  //
+  // Custo medido em A/B, duas rodadas cada, mesma máquina:
+  //
+  //     só desktop (474 testes) ...... 79s, 77s
+  //     os dois    (499 testes) ...... 78s, 80s
+  //
+  // A diferença está dentro do ruído entre rodadas. Faz sentido: o projeto
+  // `mobile` sozinho leva 3,6s de tempo de teste, e os 6 workers absorvem isso.
+  // Também não custa instalação: `devices["Pixel 7"]` é `defaultBrowserType:
+  // "chromium"`, o mesmo navegador que o `tests.yml` já baixa.
+  //
+  // `isMobile` e `hasTouch` são o motivo de existir um projeto em vez de mais um
+  // `page.setViewportSize({ width: 390 })`: só eles ligam a viewport visual do
+  // Chromium e a consulta `@media (pointer: coarse)`, que o `globals.css` usa
+  // (linha 1791). Redimensionar a janela não liga nenhum dos dois.
+  //
+  // Ligar e desligar:
+  //
+  //     npm test                                 # os dois projetos
+  //     npx playwright test --project=chromium   # só desktop (desliga o celular)
+  //     npx playwright test --project=mobile     # só celular
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+      // Sem isto, os testes `@mobile` rodariam TAMBÉM em desktop, medindo
+      // largura de celular numa janela de 1280 e reprovando por engano.
+      grepInvert: /@mobile/,
+    },
+    {
+      name: "mobile",
+      use: { ...devices["Pixel 7"] },
+      grep: /@mobile/,
+    },
+  ],
   // Testa o artefato real (SSG em ./out), não o dev server. Rode `npm run build`
   // antes de `npm test` (ou use `npm run test:build`).
   webServer: {

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -23,14 +23,13 @@ import { test, expect } from "./fixtures/console-limpo";
 //   2. quando uma regra conhecida passa do TETO de nós congelado.
 //
 // O item 2 tem exceção declarada: `color-contrast` numa página de artigo entra
-// **sem teto**. A contagem dela acompanha o tamanho do texto da página (são 34
+// **sem teto**. A contagem dela acompanha o tamanho do texto da página (são 16
 // nós hoje em `/topico/two-pointers/`, quase todos `.code-lang` e
 // `.viz-var-name` repetidos), então qualquer parágrafo novo empurraria o número
 // para cima sem nenhuma regressão de acessibilidade. Teto ali seria alarme
 // falso mensal, e alarme falso é o que faz o guarda ser desligado. Nas regras
-// que vêm de um componente fixo (o `<nav>` da barra, o range de velocidade da
-// casca, o `<h3>` do cartão de apoio) o teto vale, porque só cresce se alguém
-// duplicar o defeito.
+// que vêm de um componente fixo (o range de velocidade da casca, o `<h3>` do
+// cartão de apoio) o teto vale, porque só cresce se alguém duplicar o defeito.
 //
 // COMO BAIXAR O PASSIVO
 // Consertando o site, não editando esta lista. Cada item aponta `arquivo:linha`.
@@ -49,37 +48,29 @@ type Conhecida = {
 };
 
 /**
- * Passivo medido em 2026-08-07, axe-core 4.12.1, sobre o `out/` da `main`
- * (e35c1b2), viewport Desktop Chrome.
+ * Passivo **remedido em 2026-08-07 sobre a `main` 0d7d01a**, axe-core 4.12.1,
+ * viewport Desktop Chrome, já com a folga de hidratação que o teste aplica.
+ *
+ * Duas coisas mudaram em relação à primeira medição (feita sobre e35c1b2):
+ *
+ *  - `landmark-unique` **saiu das cinco rotas**: o #50 pôs `aria-label` nos dois
+ *    `<nav>` da barra, que era o defeito. Com isso `/` e `/roadmap/` ficam com a
+ *    lista **vazia** — e lista vazia não é lacuna, é a forma mais forte deste
+ *    guarda: qualquer violação que apareça ali vira "regra nova" e reprova;
+ *  - `color-contrast` em `/topico/two-pointers/` caiu de 34 para 16 nós, porque
+ *    agora o axe roda depois da hidratação (ver a folga no corpo do teste). Os
+ *    18 nós de diferença eram do HTML do SSG, antes de as ilhas client
+ *    repintarem — o aluno nunca os vê.
  */
 const PASSIVO: Record<string, Conhecida[]> = {
-  "/": [
-    {
-      regra: "landmark-unique",
-      teto: 1,
-      nota:
-        "os dois <nav> da barra (`.nav-left` e `.nav-right`, src/components/Shell.tsx:179 e :185) " +
-        "não têm aria-label, então o leitor de tela anuncia 'navegação' duas vezes sem distinguir",
-    },
-  ],
-  "/roadmap/": [
-    {
-      regra: "landmark-unique",
-      teto: 1,
-      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
-    },
-  ],
+  "/": [],
+  "/roadmap/": [],
   "/topico/two-pointers/": [
-    {
-      regra: "landmark-unique",
-      teto: 1,
-      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
-    },
     {
       regra: "color-contrast",
       teto: null, // sem teto: acompanha o tamanho do texto da página, ver o cabeçalho
       nota:
-        "34 nós, todos de duas famílias de cor do tema: o selo de linguagem do bloco de código " +
+        "16 nós, todos de duas famílias de cor do tema: o selo de linguagem do bloco de código " +
         "(`.code-lang`, src/app/globals.css:315) e o nome da variável do painel do visualizador " +
         "(`.viz-var-name`, src/app/globals.css:446, #8ba0bb sobre #0d1420). O pior medido é " +
         "3.48:1 contra os 4.5:1 exigidos",
@@ -103,11 +94,6 @@ const PASSIVO: Record<string, Conhecida[]> = {
   ],
   "/topico/trie/": [
     {
-      regra: "landmark-unique",
-      teto: 1,
-      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
-    },
-    {
       regra: "color-contrast",
       teto: 2,
       nota:
@@ -117,11 +103,6 @@ const PASSIVO: Record<string, Conhecida[]> = {
     },
   ],
   "/apoie/": [
-    {
-      regra: "landmark-unique",
-      teto: 1,
-      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
-    },
     {
       regra: "heading-order",
       teto: 1,
@@ -142,9 +123,18 @@ const AMOSTRA = Object.keys(PASSIVO);
 for (const rota of AMOSTRA) {
   test(`acessibilidade: ${rota} não ganha violação nova (axe-core)`, async ({ page }) => {
     await page.goto(rota);
-    // O menu lateral e os visualizadores são ilhas client; sem esperar a
-    // hidratação o axe analisa o HTML do SSG e não o que o aluno usa.
+    // O `<h1>` já vem no HTML do SSG, então esta espera NÃO é sinal de
+    // hidratação: ela só garante que a rota certa carregou.
     await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    // A hidratação é que importa aqui — o menu lateral e os visualizadores são
+    // ilhas client, e o axe precisa ver o DOM que o aluno usa, não o do SSG.
+    // Não há marcador observável para esperar: o único estado de hidratação que
+    // chega ao DOM é o `hydrated` do `ProgressProvider`, e ele só decide o
+    // número da barra de progresso, que vale 0 antes e 0 depois num perfil sem
+    // nada salvo. Sem sinal, sobra a folga — a mesma de `console-limpo.spec.ts`,
+    // e pelo mesmo motivo (efeitos, `localStorage` do progresso, `matchMedia` da
+    // casca adaptativa).
+    await page.waitForTimeout(400);
 
     const { violations } = await new AxeBuilder({ page }).analyze();
     const conhecidas = PASSIVO[rota];

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -1,4 +1,5 @@
 import AxeBuilder from "@axe-core/playwright";
+import type { Page } from "@playwright/test";
 import { test, expect } from "./fixtures/console-limpo";
 
 // Guarda de acessibilidade: axe-core sobre uma amostra fixa de rotas.
@@ -24,9 +25,9 @@ import { test, expect } from "./fixtures/console-limpo";
 //
 // O item 2 tem exceção declarada: `color-contrast` numa página de artigo entra
 // **sem teto**. A contagem dela acompanha o tamanho do texto da página (são 16
-// nós hoje em `/topico/two-pointers/`, quase todos `.code-lang` e
-// `.viz-var-name` repetidos), então qualquer parágrafo novo empurraria o número
-// para cima sem nenhuma regressão de acessibilidade. Teto ali seria alarme
+// nós hoje em `/topico/two-pointers/`: 10 `.code-lang` e 6 `.viz-cell-idx`,
+// repetições de dois defeitos só), então qualquer parágrafo novo empurraria o
+// número para cima sem nenhuma regressão de acessibilidade. Teto ali seria alarme
 // falso mensal, e alarme falso é o que faz o guarda ser desligado. Nas regras
 // que vêm de um componente fixo (o range de velocidade da casca, o `<h3>` do
 // cartão de apoio) o teto vale, porque só cresce se alguém duplicar o defeito.
@@ -57,10 +58,21 @@ type Conhecida = {
  *    `<nav>` da barra, que era o defeito. Com isso `/` e `/roadmap/` ficam com a
  *    lista **vazia** — e lista vazia não é lacuna, é a forma mais forte deste
  *    guarda: qualquer violação que apareça ali vira "regra nova" e reprova;
- *  - `color-contrast` em `/topico/two-pointers/` caiu de 34 para 16 nós, porque
- *    agora o axe roda depois da hidratação (ver a folga no corpo do teste). Os
- *    18 nós de diferença eram do HTML do SSG, antes de as ilhas client
- *    repintarem — o aluno nunca os vê.
+ *  - `color-contrast` em `/topico/two-pointers/` fica em **16 nós**, e agora de
+ *    forma determinística. Antes de esperar o assentamento o número era
+ *    **sorteado**: três cargas idênticas mediram 16, 28 e 28. Os 12 nós que
+ *    entravam e saíam eram sempre os mesmos `.viz-var-name`, e eles **não são
+ *    defeito**: medidos com as cores que o navegador realmente pinta
+ *    (`#8ba0bb` sobre `#0e1725`, o fundo do `.viz-var`), dão **6,72:1**, bem
+ *    acima dos 4,5:1 exigidos. Eram falso positivo do axe lendo a página no
+ *    meio da pintura — não "nós do SSG que o aluno não vê": os 12 elementos
+ *    estão no DOM, visíveis e dentro da figura nos dois momentos.
+ *
+ * O passivo antigo dizia que os 34 nós eram `.code-lang` e `.viz-var-name`, com
+ * "o pior medido 3.48:1" atribuído ao segundo. Os dois rótulos estavam errados:
+ * 3,48:1 é o `.code-lang`, e a outra família é `.viz-cell-idx`. Os números
+ * abaixo vêm do que o próprio axe reporta em `node.any[0].data`, não de leitura
+ * do CSS.
  */
 const PASSIVO: Record<string, Conhecida[]> = {
   "/": [],
@@ -70,17 +82,18 @@ const PASSIVO: Record<string, Conhecida[]> = {
       regra: "color-contrast",
       teto: null, // sem teto: acompanha o tamanho do texto da página, ver o cabeçalho
       nota:
-        "16 nós, todos de duas famílias de cor do tema: o selo de linguagem do bloco de código " +
-        "(`.code-lang`, src/app/globals.css:315) e o nome da variável do painel do visualizador " +
-        "(`.viz-var-name`, src/app/globals.css:446, #8ba0bb sobre #0d1420). O pior medido é " +
-        "3.48:1 contra os 4.5:1 exigidos",
+        "16 nós, de duas famílias de cor do tema, com os números que o próprio axe reporta: " +
+        "10x o selo de linguagem do bloco de código (`.code-lang`, src/app/globals.css:377, " +
+        "#5b6d85 sobre #0d1420, 3.48:1) e 6x o índice da célula do visualizador " +
+        "(`.viz-cell-idx`, src/app/globals.css:486, #61748c sobre #131c2a, 3.57:1). " +
+        "Os dois contra os 4.5:1 exigidos; o pior é o `.code-lang`",
     },
     {
       regra: "label",
       teto: 3,
       nota:
         "o <input type=range> de velocidade da casca não tem <label> nem aria-label " +
-        "(src/lib/visualizer.tsx:559). São 3 nós porque a página tem 3 visualizadores; " +
+        "(src/lib/visualizer.tsx:562). São 3 nós porque a página tem 3 visualizadores; " +
         "é UM defeito, num componente compartilhado por todos os 62",
     },
     {
@@ -88,7 +101,7 @@ const PASSIVO: Record<string, Conhecida[]> = {
       teto: 1,
       nota:
         "a fita de caracteres do Two Pointers rola na horizontal e não recebe foco de teclado " +
-        "(`.tp-chars { overflow-x: auto }`, src/app/globals.css:602): quem navega por teclado " +
+        "(`.tp-chars { overflow-x: auto }`, src/app/globals.css:663): quem navega por teclado " +
         "não alcança o que está fora da vista",
     },
   ],
@@ -97,9 +110,11 @@ const PASSIVO: Record<string, Conhecida[]> = {
       regra: "color-contrast",
       teto: 2,
       nota:
-        "o item ativo do menu lateral (`.side-item.on`, src/app/globals.css:161) e o selo " +
-        "'em breve' (`.badge-soon`, src/app/globals.css:172, 4.05:1 contra 4.5:1 exigidos). " +
-        "Teto vale aqui: são dois elementos de chrome fixo, não de conteúdo",
+        "o nome do tópico 'em breve' no menu lateral (`.side-item.soon`, " +
+        "src/app/globals.css:197, #6f83a0 sobre #13233e, 4.05:1) e o selo 'em breve' " +
+        "(`.badge-soon`, src/app/globals.css:220, #7f93ad sobre #22314a, 4.15:1), os dois " +
+        "contra os 4.5:1 exigidos. Teto vale aqui: são dois elementos de chrome fixo, " +
+        "não de conteúdo",
     },
   ],
   "/apoie/": [
@@ -120,21 +135,47 @@ const PASSIVO: Record<string, Conhecida[]> = {
  */
 const AMOSTRA = Object.keys(PASSIVO);
 
+/**
+ * Espera a página estar hidratada e assentada, por um FATO da aplicação antes de
+ * qualquer relógio.
+ *
+ * POR QUE NÃO SÓ UMA FOLGA
+ * Esperar o `<h1>` não é sinal de hidratação: ele já vem no HTML do SSG. E medir
+ * o axe antes de a página assentar dá resultado **sorteado** — três cargas
+ * idênticas de `/topico/two-pointers/` mediram 16, 28 e 28 nós de
+ * `color-contrast`. Hoje isso não deixa a suíte vermelha só porque essa regra
+ * está com `teto: null` nessa rota; no dia em que alguém puser teto, vira flake.
+ *
+ * O SINAL É O CARIMBO DO MENU, e ele não é invenção deste arquivo: o
+ * `navegacao.spec.ts` já espera por ele (`carimboRegravado`), pelo mesmo motivo
+ * — conferir logo após o `goto` lê o menu de antes da hidratação, e foi assim
+ * que aquele bloco ficou instável no CI. O `Shell` regrava `ccc-dsa-menu` num
+ * efeito a cada carga, então o carimbo recente é prova de que o efeito rodou.
+ *
+ * A folga curta depois dele cobre o que vem DEPOIS da hidratação do `Shell`: as
+ * ilhas de visualizador, que chegam por `import()` do `VizLazy`. Ela é folga de
+ * assentamento, não de hidratação — e vem depois de um fato, não no lugar dele.
+ * Medido com as duas juntas: 6 cargas seguidas, 16 nós nas 6.
+ */
+async function esperarHidratar(page: Page) {
+  await page.waitForFunction(() => {
+    try {
+      const salvo = JSON.parse(localStorage.getItem("ccc-dsa-menu") ?? "null");
+      return typeof salvo?.em === "number" && Date.now() - salvo.em < 60_000;
+    } catch {
+      return false;
+    }
+  });
+  await page.waitForTimeout(400);
+}
+
 for (const rota of AMOSTRA) {
   test(`acessibilidade: ${rota} não ganha violação nova (axe-core)`, async ({ page }) => {
     await page.goto(rota);
     // O `<h1>` já vem no HTML do SSG, então esta espera NÃO é sinal de
     // hidratação: ela só garante que a rota certa carregou.
     await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
-    // A hidratação é que importa aqui — o menu lateral e os visualizadores são
-    // ilhas client, e o axe precisa ver o DOM que o aluno usa, não o do SSG.
-    // Não há marcador observável para esperar: o único estado de hidratação que
-    // chega ao DOM é o `hydrated` do `ProgressProvider`, e ele só decide o
-    // número da barra de progresso, que vale 0 antes e 0 depois num perfil sem
-    // nada salvo. Sem sinal, sobra a folga — a mesma de `console-limpo.spec.ts`,
-    // e pelo mesmo motivo (efeitos, `localStorage` do progresso, `matchMedia` da
-    // casca adaptativa).
-    await page.waitForTimeout(400);
+    await esperarHidratar(page);
 
     const { violations } = await new AxeBuilder({ page }).analyze();
     const conhecidas = PASSIVO[rota];
@@ -174,3 +215,47 @@ for (const rota of AMOSTRA) {
     }
   });
 }
+
+/**
+ * A varredura acima olha a página **parada**. Esta olha a página **em uso**, e
+ * não é zelo: é a única das duas que enxerga o estado que o aluno passa a maior
+ * parte do tempo olhando.
+ *
+ * Medido: andar 6 passos no primeiro visualizador de `/topico/two-pointers/`
+ * leva `color-contrast` de 16 para 18 nós. Os 2 nós novos são `.drop.viz-cell`,
+ * a célula marcada como descartada — uma cor que **só existe depois de a
+ * animação andar**, e que nenhuma carga de página, com folga ou sem, alcança.
+ * Estável nas 3 rodadas medidas.
+ *
+ * O que ele reprova é o mesmo do outro: **regra nova**. Não impõe teto de nós,
+ * porque a contagem depende de quantos passos a animação andou, e teto que
+ * depende disso é alarme falso esperando acontecer. Regra nova, não: um diálogo
+ * que abre sem nome acessível, um foco que some, um `aria-hidden` sobre o que
+ * acabou de receber foco — nada disso depende de quantos passos.
+ */
+test("acessibilidade: o visualizador EM USO não ganha regra nova (axe-core)", async ({ page }) => {
+  const rota = "/topico/two-pointers/";
+  await page.goto(rota);
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+  await esperarHidratar(page);
+
+  const figura = page.locator("figure.viz").first();
+  const proximo = figura.getByRole("button", { name: /Próximo/ });
+  await expect(proximo).toBeEnabled();
+  for (let i = 0; i < 6 && (await proximo.isEnabled()); i++) await proximo.click();
+
+  // Sem isto o teste "passaria" numa página que não andou passo nenhum: é a
+  // diferença entre exercitar a animação e só clicar num botão morto.
+  await expect(figura.locator(".drop.viz-cell").first()).toBeVisible();
+
+  const { violations } = await new AxeBuilder({ page }).analyze();
+  const conhecidas = PASSIVO[rota];
+  const novas = violations
+    .filter((v) => !conhecidas.some((c) => c.regra === v.id))
+    .map((v) => `${v.id} (${v.impact}, ${v.nodes.length} nó(s))`);
+
+  expect(
+    novas,
+    "andar a animação fez aparecer uma regra de acessibilidade que a página parada não tinha"
+  ).toEqual([]);
+});

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -1,0 +1,186 @@
+import AxeBuilder from "@axe-core/playwright";
+import { test, expect } from "./fixtures/console-limpo";
+
+// Guarda de acessibilidade: axe-core sobre uma amostra fixa de rotas.
+//
+// POR QUE EXISTE
+// Até aqui o repositório não tinha nenhuma verificação de acessibilidade:
+// nem axe, nem pa11y, nem lighthouse, e nenhum dos 37 arquivos de `tests/`
+// mencionava o assunto. Ao mesmo tempo, boa parte do trabalho recente é
+// justamente acessibilidade (link de pular para o conteúdo, anel de foco,
+// landmarks com nome, região viva, foco que volta ao fechar o painel). Sem
+// guarda, tudo isso regride em silêncio: nada na tela muda de lugar quando um
+// `aria-label` some.
+//
+// O ESCOPO É DECLARADO, E ISSO É DE PROPÓSITO
+// Este guarda **não** promete que o site é acessível. Ele promete uma coisa
+// menor e verificável: *o passivo de acessibilidade não cresce*. Um teste que
+// chega vermelho é desligado na semana seguinte, então o passivo medido no dia
+// da abertura deste PR está congelado abaixo, item por item, com o que cada um
+// é e onde mora. O teste reprova:
+//
+//   1. quando aparece uma REGRA que não estava no passivo daquela rota;
+//   2. quando uma regra conhecida passa do TETO de nós congelado.
+//
+// O item 2 tem exceção declarada: `color-contrast` numa página de artigo entra
+// **sem teto**. A contagem dela acompanha o tamanho do texto da página (são 34
+// nós hoje em `/topico/two-pointers/`, quase todos `.code-lang` e
+// `.viz-var-name` repetidos), então qualquer parágrafo novo empurraria o número
+// para cima sem nenhuma regressão de acessibilidade. Teto ali seria alarme
+// falso mensal, e alarme falso é o que faz o guarda ser desligado. Nas regras
+// que vêm de um componente fixo (o `<nav>` da barra, o range de velocidade da
+// casca, o `<h3>` do cartão de apoio) o teto vale, porque só cresce se alguém
+// duplicar o defeito.
+//
+// COMO BAIXAR O PASSIVO
+// Consertando o site, não editando esta lista. Cada item aponta `arquivo:linha`.
+// Ao corrigir um, o teste avisa no log que a entrada ficou obsoleta (ele não
+// reprova por isso: fix não pode deixar a suíte vermelha); apague a entrada no
+// mesmo PR do conserto.
+
+/** Uma violação já conhecida, congelada. `teto: null` = só a regra é conhecida. */
+type Conhecida = {
+  /** id da regra do axe-core */
+  regra: string;
+  /** número máximo de nós aceito, ou `null` para não impor teto */
+  teto: number | null;
+  /** o que é, e onde mora */
+  nota: string;
+};
+
+/**
+ * Passivo medido em 2026-08-07, axe-core 4.12.1, sobre o `out/` da `main`
+ * (e35c1b2), viewport Desktop Chrome.
+ */
+const PASSIVO: Record<string, Conhecida[]> = {
+  "/": [
+    {
+      regra: "landmark-unique",
+      teto: 1,
+      nota:
+        "os dois <nav> da barra (`.nav-left` e `.nav-right`, src/components/Shell.tsx:179 e :185) " +
+        "não têm aria-label, então o leitor de tela anuncia 'navegação' duas vezes sem distinguir",
+    },
+  ],
+  "/roadmap/": [
+    {
+      regra: "landmark-unique",
+      teto: 1,
+      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
+    },
+  ],
+  "/topico/two-pointers/": [
+    {
+      regra: "landmark-unique",
+      teto: 1,
+      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
+    },
+    {
+      regra: "color-contrast",
+      teto: null, // sem teto: acompanha o tamanho do texto da página, ver o cabeçalho
+      nota:
+        "34 nós, todos de duas famílias de cor do tema: o selo de linguagem do bloco de código " +
+        "(`.code-lang`, src/app/globals.css:315) e o nome da variável do painel do visualizador " +
+        "(`.viz-var-name`, src/app/globals.css:446, #8ba0bb sobre #0d1420). O pior medido é " +
+        "3.48:1 contra os 4.5:1 exigidos",
+    },
+    {
+      regra: "label",
+      teto: 3,
+      nota:
+        "o <input type=range> de velocidade da casca não tem <label> nem aria-label " +
+        "(src/lib/visualizer.tsx:559). São 3 nós porque a página tem 3 visualizadores; " +
+        "é UM defeito, num componente compartilhado por todos os 62",
+    },
+    {
+      regra: "scrollable-region-focusable",
+      teto: 1,
+      nota:
+        "a fita de caracteres do Two Pointers rola na horizontal e não recebe foco de teclado " +
+        "(`.tp-chars { overflow-x: auto }`, src/app/globals.css:602): quem navega por teclado " +
+        "não alcança o que está fora da vista",
+    },
+  ],
+  "/topico/trie/": [
+    {
+      regra: "landmark-unique",
+      teto: 1,
+      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
+    },
+    {
+      regra: "color-contrast",
+      teto: 2,
+      nota:
+        "o item ativo do menu lateral (`.side-item.on`, src/app/globals.css:161) e o selo " +
+        "'em breve' (`.badge-soon`, src/app/globals.css:172, 4.05:1 contra 4.5:1 exigidos). " +
+        "Teto vale aqui: são dois elementos de chrome fixo, não de conteúdo",
+    },
+  ],
+  "/apoie/": [
+    {
+      regra: "landmark-unique",
+      teto: 1,
+      nota: "o mesmo par de <nav> da barra, src/components/Shell.tsx:179 e :185",
+    },
+    {
+      regra: "heading-order",
+      teto: 1,
+      nota:
+        "o cartão de doação abre com <h3> logo depois do <h1>, pulando o <h2> " +
+        "(src/app/apoie/page.tsx:29)",
+    },
+  ],
+};
+
+/**
+ * A amostra: uma página de cada tipo que o site sabe montar. Fixa de propósito
+ * (varrer as 47 rotas custaria minutos de CI e não acharia classe nova de
+ * defeito: as páginas de tópico saem todas do mesmo template).
+ */
+const AMOSTRA = Object.keys(PASSIVO);
+
+for (const rota of AMOSTRA) {
+  test(`acessibilidade: ${rota} não ganha violação nova (axe-core)`, async ({ page }) => {
+    await page.goto(rota);
+    // O menu lateral e os visualizadores são ilhas client; sem esperar a
+    // hidratação o axe analisa o HTML do SSG e não o que o aluno usa.
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+    const { violations } = await new AxeBuilder({ page }).analyze();
+    const conhecidas = PASSIVO[rota];
+
+    const novas = violations
+      .filter((v) => !conhecidas.some((c) => c.regra === v.id))
+      .map(
+        (v) =>
+          `${v.id} (${v.impact}, ${v.nodes.length} nó(s)): ` +
+          v.nodes
+            .slice(0, 5)
+            .map((n) => n.target.join(" "))
+            .join(" ; ")
+      );
+    expect(
+      novas,
+      `violação de acessibilidade NOVA em ${rota}. Conserte o site; só congele em PASSIVO ` +
+        `se for dívida antiga, com arquivo:linha na nota`
+    ).toEqual([]);
+
+    const cresceram = conhecidas.flatMap((c) => {
+      if (c.teto === null) return [];
+      const v = violations.find((x) => x.id === c.regra);
+      const agora = v ? v.nodes.length : 0;
+      return agora > c.teto ? [`${c.regra}: ${c.teto} nó(s) congelados, ${agora} agora`] : [];
+    });
+    expect(
+      cresceram,
+      `o passivo de acessibilidade de ${rota} CRESCEU: o mesmo defeito foi duplicado`
+    ).toEqual([]);
+
+    // Não reprova: um conserto não pode deixar a suíte vermelha. Só avisa para
+    // a entrada sair da lista no mesmo PR do conserto.
+    for (const c of conhecidas) {
+      const v = violations.find((x) => x.id === c.regra);
+      if (!v) console.log(`[passivo obsoleto] ${rota}: '${c.regra}' não viola mais. Apague de PASSIVO.`);
+    }
+  });
+}

--- a/tests/console-limpo-fixture.spec.ts
+++ b/tests/console-limpo-fixture.spec.ts
@@ -1,0 +1,103 @@
+import { test, expect } from "@playwright/test";
+import { coletarErros } from "./fixtures/console-limpo";
+
+// O guarda do guarda: prova o que a tolerância de ruído deixa passar.
+//
+// POR QUE EXISTE
+// `RUIDO_TOLERADO` começou com `^requestfailed: .* \(net::ERR_ABORTED\)$`. O
+// `.*` casa qualquer host, então um `ERR_ABORTED` de domínio de fora — um
+// `<script>` de terceiro, um `fetch` para API externa, um embed — era engolido
+// em silêncio pelo mesmo padrão escrito para o prefetch do Next. Uma allowlist
+// larga demais não faz nenhum teste ficar vermelho: ela faz o guarda inteiro
+// perder o sentido sem avisar ninguém.
+//
+// POR QUE ELE USA `coletarErros` DIRETO, E NÃO A FIXTURE
+// A fixture reprova o teste no teardown. Um teste que provasse a reprovação de
+// dentro dela precisaria falhar para passar. Então aqui a página é criada à
+// mão, os mesmos listeners são ligados pela MESMA função que a fixture usa
+// (`coletarErros`), e a asserção olha o array que ela devolve. É Chromium de
+// verdade, evento `requestfailed` de verdade e a mesma formatação de string —
+// não uma reimplementação do regex, que é onde um teste de unidade descolaria
+// do comportamento.
+//
+// COMO O ABORTO É PRODUZIDO
+// `route.abort("aborted")` faz o Chromium reportar `net::ERR_ABORTED`, o mesmo
+// texto que o prefetch cancelado do Next produz. É determinístico e não depende
+// de rede: o domínio `.test` abaixo é reservado (RFC 2606) e nunca é resolvido.
+
+/** URL do próprio site: o caso que o prefetch do Next produz de verdade. */
+const CAMINHO_PROPRIO = "/aborta-me-do-proprio-site.js";
+/** Domínio de fora: o caso que o `.*` engolia. */
+const URL_DE_FORA = "https://cdn.exemplo-de-fora.test/aborta-me-de-fora.js";
+
+test("a tolerância de ERR_ABORTED vale para o site, e não para domínio de fora", async ({
+  browser,
+  baseURL,
+}) => {
+  const page = await browser.newPage({ baseURL });
+  const ocorrencias = coletarErros(page, baseURL);
+
+  // Só as três URLs de mentira passam pelo roteador; o resto da página carrega
+  // normalmente, servido pelo `out/`.
+  await page.route(/aborta-me/, (route) => route.abort("aborted"));
+  await page.route(/recusa-me/, (route) => route.abort("connectionrefused"));
+
+  await page.goto("/");
+
+  const proprio = `${baseURL}${CAMINHO_PROPRIO}`;
+  const recusado = `${baseURL}/recusa-me-do-proprio-site.js`;
+  const motivos = new Map<string, string>();
+
+  for (const url of [proprio, URL_DE_FORA, recusado]) {
+    const falhou = page.waitForEvent("requestfailed", (r) => r.url() === url);
+    await page.evaluate((u) => {
+      void fetch(u, { mode: "no-cors" }).catch(() => {});
+    }, url);
+    const req = await falhou;
+    motivos.set(url, req.failure()?.errorText ?? "sem motivo");
+  }
+
+  // Primeiro: o cenário é o que dissemos que é. Sem isto, um dia o Chromium
+  // troca o texto do erro, os dois lados param de casar e o teste fica verde
+  // provando nada.
+  expect(motivos.get(proprio), "o aborto do próprio site").toBe("net::ERR_ABORTED");
+  expect(motivos.get(URL_DE_FORA), "o aborto do domínio de fora").toBe("net::ERR_ABORTED");
+  expect(motivos.get(recusado), "a conexão recusada do próprio site").toBe(
+    "net::ERR_CONNECTION_REFUSED"
+  );
+
+  // Agora o que importa: dos três, só o do próprio site com ERR_ABORTED é
+  // tolerado. Os outros dois chegam ao array e reprovariam o teste real.
+  const registradas = ocorrencias.filter((o) => /aborta-me|recusa-me/.test(o));
+  expect(
+    registradas,
+    "o aborto do próprio site tem que ser tolerado; o de fora e o recusado, não"
+  ).toEqual([
+    `requestfailed: ${URL_DE_FORA} (net::ERR_ABORTED)`,
+    `requestfailed: ${recusado} (net::ERR_CONNECTION_REFUSED)`,
+  ]);
+
+  await page.close();
+});
+
+test("sem baseURL nada é tolerado, nem o prefetch do próprio site", async ({ browser }) => {
+  // A porta de saída segura: se a configuração perder o `baseURL`, o guarda
+  // fica barulhento em vez de mudo. Um guarda mudo é pior que guarda nenhum,
+  // porque some da conta de quem confia nele.
+  const page = await browser.newPage();
+  const ocorrencias = coletarErros(page, undefined);
+
+  await page.route(/aborta-me/, (route) => route.abort("aborted"));
+  await page.goto("about:blank");
+
+  const url = "https://cdn.exemplo-de-fora.test/aborta-me-sem-base.js";
+  const falhou = page.waitForEvent("requestfailed", (r) => r.url() === url);
+  await page.evaluate((u) => {
+    void fetch(u, { mode: "no-cors" }).catch(() => {});
+  }, url);
+  await falhou;
+
+  expect(ocorrencias).toEqual([`requestfailed: ${url} (net::ERR_ABORTED)`]);
+
+  await page.close();
+});

--- a/tests/console-limpo-fixture.spec.ts
+++ b/tests/console-limpo-fixture.spec.ts
@@ -4,7 +4,8 @@ import { coletarErros } from "./fixtures/console-limpo";
 // O guarda do guarda: prova o que a tolerância de ruído deixa passar.
 //
 // POR QUE EXISTE
-// `RUIDO_TOLERADO` começou com `^requestfailed: .* \(net::ERR_ABORTED\)$`. O
+// A tolerância de ruído (hoje `ruidoTolerado()`, na fixture) começou como uma
+// constante com `^requestfailed: .* \(net::ERR_ABORTED\)$`. O
 // `.*` casa qualquer host, então um `ERR_ABORTED` de domínio de fora — um
 // `<script>` de terceiro, um `fetch` para API externa, um embed — era engolido
 // em silêncio pelo mesmo padrão escrito para o prefetch do Next. Uma allowlist
@@ -34,6 +35,13 @@ test("a tolerância de ERR_ABORTED vale para o site, e não para domínio de for
   browser,
   baseURL,
 }) => {
+  // Falhar cedo, e por escrito. Sem `baseURL` a tolerância sai VAZIA (é
+  // exatamente o que o teste seguinte prova), então este aqui reprovaria lá
+  // embaixo, na comparação de arrays, por um motivo que o diff não conta — e
+  // ainda montaria `undefined/aborta-me-...` nas URLs. O caso sem `baseURL` tem
+  // dono, e é o outro teste; aqui ele é pré-condição.
+  expect(baseURL, "este teste exige `use.baseURL` no playwright.config.ts").toBeTruthy();
+
   const page = await browser.newPage({ baseURL });
   const ocorrencias = coletarErros(page, baseURL);
 

--- a/tests/console-limpo.spec.ts
+++ b/tests/console-limpo.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect } from "./fixtures/console-limpo";
+
+// Guarda de erro de cliente. A asserção mora na fixture
+// (`tests/fixtures/console-limpo.ts`), no teardown que faz as vezes de
+// afterEach; aqui ficam os percursos que dão o que a fixture escutar.
+//
+// Carregar a página não basta, e é por isso que estes testes clicam. Exceção em
+// handler, o caso que mais dói num site de visualizadores, só existe quando
+// alguém aperta o botão: um `throw` dentro do `onClick` de 'Próximo ›' deixa o
+// HTML servido intacto, o passo não anda, e nenhuma das 37 suítes de hoje
+// percebe. A regra do runbook ('toda verificação de UI tem que interagir')
+// vale aqui pelo mesmo motivo que vale para asserção de estado.
+
+const ROTAS = [
+  "/",
+  "/roadmap/",
+  "/introducao/",
+  "/topico/two-pointers/", // ready, com 3 visualizadores
+  "/topico/big-o/", // ready, o visualizador que usa o hook novo
+  "/topico/trie/", // soon e vazio (noindex)
+  "/apoie/",
+];
+
+for (const rota of ROTAS) {
+  test(`console limpo ao abrir ${rota}`, async ({ page }) => {
+    await page.goto(rota);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    // Uma folga para o que o React só faz depois da hidratação (efeitos,
+    // `localStorage` do progresso, `matchMedia` da casca adaptativa).
+    await page.waitForTimeout(400);
+  });
+}
+
+test("console limpo ao mexer nos visualizadores de um tópico", async ({ page }) => {
+  await page.goto("/topico/two-pointers/");
+  const figura = page.locator("figure.viz").first();
+  await expect(figura).toBeVisible();
+
+  // Andar a animação: é o caminho que passa por gerador de passos, `setState`
+  // e render, que é onde uma exceção nasce.
+  const proximo = figura.getByRole("button", { name: /Próximo/ });
+  await expect(proximo).toBeEnabled();
+  for (let i = 0; i < 12 && (await proximo.isEnabled()); i++) await proximo.click();
+
+  // Rodar e pausar: liga e desliga o `setInterval`.
+  const rodar = figura.getByRole("button", { name: /Rodar|Pausar/ }).first();
+  await expect(rodar).toBeVisible();
+  await rodar.click();
+  await page.waitForTimeout(500);
+  await figura.getByRole("button", { name: /Rodar|Pausar/ }).first().click();
+
+  // Reiniciar volta ao passo 0 e refaz o gerador.
+  //
+  // Vai por `title` e não por papel: o botão é `<button title="Reiniciar">↺`, e
+  // texto ganha de `title` no cálculo do nome acessível, então o nome dele é
+  // "↺". `getByRole("button", { name: "Reiniciar" })` não acha. Isso é um
+  // achado de acessibilidade em `src/lib/visualizer.tsx:532`, fora da fronteira
+  // deste PR e reportado no corpo dele.
+  const reiniciar = figura.locator('button[title="Reiniciar"]');
+  await expect(reiniciar).toBeVisible();
+  await reiniciar.click();
+});
+
+test("console limpo ao abrir e fechar o painel expandido", async ({ page }) => {
+  await page.goto("/topico/big-o/");
+  const figura = page.locator("figure.viz").first();
+  await expect(figura).toBeVisible();
+
+  // `.viz-expand` também veste o botão que mostra e oculta o código, então o
+  // seletor exclui esse, senão `.first()` clica no botão errado e o painel
+  // nunca abre (com o teste passando, porque nada estoura).
+  const expandir = figura.locator(".viz-expand:not(.viz-toggle-codigo)");
+  await expect(expandir).toBeVisible();
+  await expandir.click();
+  await expect(page.locator(".viz-overlay")).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(page.locator(".viz-overlay")).toHaveCount(0);
+});
+
+test("console limpo ao marcar progresso e abrir o menu do celular", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.goto("/topico/two-pointers/");
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+  // O progresso escreve no `localStorage` via provider client.
+  const marcar = page.getByRole("checkbox").first();
+  if (await marcar.isVisible()) {
+    await marcar.click();
+    await marcar.click();
+  }
+
+  await page.getByRole("button", { name: "Mais opções" }).click();
+  await expect(page.locator(".nav-menu")).toBeVisible();
+});

--- a/tests/fixtures/console-limpo.ts
+++ b/tests/fixtures/console-limpo.ts
@@ -1,4 +1,4 @@
-import { test as base, expect } from "@playwright/test";
+import { test as base, expect, type Page } from "@playwright/test";
 
 // Fixture: reprovar o teste quando a PÁGINA reclama.
 //
@@ -33,8 +33,15 @@ import { test as base, expect } from "@playwright/test";
 /** Uma ocorrência já formatada, do jeito que vai aparecer no `Received`. */
 type Ocorrencia = string;
 
+/** Escapa o que é metacaractere de regex, para interpolar URL em `RegExp`. */
+function escaparRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
- * Ruído tolerado, com o motivo escrito.
+ * Ruído tolerado, com o motivo escrito. **Depende do `baseURL`**, por isso é
+ * função e não constante: a tolerância vale para o site sob teste, e para mais
+ * nada.
  *
  * Medido antes de ligar o guarda, em 13 rotas (as 5 da amostra do axe mais as 8
  * do celular), desktop e 390x844: **zero** `pageerror`, **zero** `console.error`
@@ -43,39 +50,70 @@ type Ocorrencia = string;
  *
  * Regra para acrescentar: a entrada tem que ser específica (nada de `/./`) e
  * vir com comentário dizendo o que é e por que não dá para consertar agora.
+ *
+ * Sem `baseURL` definido a lista fica **vazia**, e nada é tolerado. É de
+ * propósito: um teste barulhento é melhor que um guarda que engole em silêncio
+ * porque a configuração mudou de baixo dele.
  */
-export const RUIDO_TOLERADO: RegExp[] = [
-  // O `<Link>` do Next dispara prefetch da rota apontada; sair da página antes
-  // de o prefetch terminar cancela a requisição, e o cancelamento chega aqui
-  // como `requestfailed ... net::ERR_ABORTED`. Medido: 104 ocorrências numa
-  // passagem por 13 rotas, todas em URL de rota do próprio site, e nenhuma com
-  // efeito nenhum na página. Só `ERR_ABORTED` entra: qualquer outro motivo
-  // (`ERR_CONNECTION_REFUSED`, `ERR_NAME_NOT_RESOLVED`, `ERR_FAILED`) continua
-  // reprovando. E recurso que de fato sumiu do `out/` não passa por aqui: ele
-  // vira `http 404`, que o listener de resposta pega.
-  /^requestfailed: .* \(net::ERR_ABORTED\)$/,
-];
+export function ruidoTolerado(baseURL: string | undefined): RegExp[] {
+  if (!baseURL) return [];
+  const origem = escaparRegex(baseURL.replace(/\/$/, ""));
+  return [
+    // O `<Link>` do Next dispara prefetch da rota apontada; sair da página antes
+    // de o prefetch terminar cancela a requisição, e o cancelamento chega aqui
+    // como `requestfailed ... net::ERR_ABORTED`. Medido: 104 ocorrências numa
+    // passagem por 13 rotas, todas em URL de rota do próprio site, e nenhuma com
+    // efeito nenhum na página. Só `ERR_ABORTED` entra: qualquer outro motivo
+    // (`ERR_CONNECTION_REFUSED`, `ERR_NAME_NOT_RESOLVED`, `ERR_FAILED`) continua
+    // reprovando. E recurso que de fato sumiu do `out/` não passa por aqui: ele
+    // vira `http 404`, que o listener de resposta pega.
+    //
+    // A âncora no `baseURL` é o que impede a tolerância de vazar: um
+    // `ERR_ABORTED` de domínio de fora (um `<script>` de terceiro, um `fetch`
+    // para uma API externa, um embed) **reprova**, porque ali o cancelamento não
+    // tem explicação conhecida. Antes desta âncora o padrão era `.*` e engolia
+    // qualquer host.
+    new RegExp(`^requestfailed: ${origem}(/[^\\s]*)? \\(net::ERR_ABORTED\\)$`),
+  ];
+}
+
+/**
+ * Liga os quatro listeners numa página e devolve o array **vivo** de
+ * ocorrências (ele cresce sozinho conforme a página fala).
+ *
+ * É exportado, e não escondido dentro da fixture, para que
+ * `console-limpo-fixture.spec.ts` consiga provar em Chromium de verdade o que a
+ * tolerância deixa passar e o que ela reprova — sem reimplementar a formatação
+ * da string, que é justamente onde um teste de regex puro descolaria do
+ * comportamento.
+ */
+export function coletarErros(page: Page, baseURL: string | undefined): Ocorrencia[] {
+  const tolerado = ruidoTolerado(baseURL);
+  const ocorrencias: Ocorrencia[] = [];
+  const registrar = (o: Ocorrencia) => {
+    if (!tolerado.some((r) => r.test(o))) ocorrencias.push(o);
+  };
+
+  page.on("pageerror", (erro) => {
+    registrar(`pageerror: ${erro.message}`);
+  });
+  page.on("console", (msg) => {
+    if (msg.type() === "error") registrar(`console.error: ${msg.text()}`);
+  });
+  page.on("requestfailed", (req) => {
+    registrar(`requestfailed: ${req.url()} (${req.failure()?.errorText ?? "sem motivo"})`);
+  });
+  page.on("response", (res) => {
+    if (res.status() >= 400) registrar(`http ${res.status()}: ${res.url()}`);
+  });
+
+  return ocorrencias;
+}
 
 export const test = base.extend<{ semErroDeConsole: void }>({
   semErroDeConsole: [
-    async ({ page }, use) => {
-      const ocorrencias: Ocorrencia[] = [];
-      const registrar = (o: Ocorrencia) => {
-        if (!RUIDO_TOLERADO.some((r) => r.test(o))) ocorrencias.push(o);
-      };
-
-      page.on("pageerror", (erro) => {
-        registrar(`pageerror: ${erro.message}`);
-      });
-      page.on("console", (msg) => {
-        if (msg.type() === "error") registrar(`console.error: ${msg.text()}`);
-      });
-      page.on("requestfailed", (req) => {
-        registrar(`requestfailed: ${req.url()} (${req.failure()?.errorText ?? "sem motivo"})`);
-      });
-      page.on("response", (res) => {
-        if (res.status() >= 400) registrar(`http ${res.status()}: ${res.url()}`);
-      });
+    async ({ page, baseURL }, use) => {
+      const ocorrencias = coletarErros(page, baseURL);
 
       await use();
 

--- a/tests/fixtures/console-limpo.ts
+++ b/tests/fixtures/console-limpo.ts
@@ -1,0 +1,93 @@
+import { test as base, expect } from "@playwright/test";
+
+// Fixture: reprovar o teste quando a PÁGINA reclama.
+//
+// Por que existe: até aqui nenhum dos 37 arquivos de `tests/` escutava
+// `pageerror`, `console` ou `requestfailed`. Um `throw` dentro de um handler de
+// clique, um erro de hidratação do React ou um chunk 404 não faziam **nada**
+// falhar — a asserção seguinte olhava o DOM, encontrava o que esperava (porque
+// o erro aconteceu depois da renderização, ou num caminho que o teste não
+// cobre) e a suíte ficava verde por cima de um defeito real.
+//
+// Como usar, num spec novo:
+//
+//     import { test, expect } from "./fixtures/console-limpo";
+//
+// e pronto: a fixture é `auto`, então vale para todo teste do arquivo sem
+// precisar declarar nada. O `await use()` é o corpo do teste; o que vem depois
+// dele é o **afterEach** desta fixture, e é lá que a asserção mora.
+//
+// O que ela captura, e por quê:
+//
+// | evento          | o que pega                                                |
+// |-----------------|-----------------------------------------------------------|
+// | `pageerror`     | exceção não tratada no cliente (o handler que estourou)    |
+// | `console` error | erro de hidratação, aviso do React, `console.error` nosso  |
+// | `requestfailed` | recurso que nem chegou a responder (DNS, abort, conexão)   |
+// | resposta >= 400 | chunk/imagem/página 404 ou 500 servida pelo `out/`         |
+//
+// A última linha é a que pega o caso mais silencioso de todos num site
+// estático: o `<script src=".../chunk-abc.js">` que sumiu do `out/`. O
+// navegador não emite `pageerror` por isso, e a página só fica sem interação.
+
+/** Uma ocorrência já formatada, do jeito que vai aparecer no `Received`. */
+type Ocorrencia = string;
+
+/**
+ * Ruído tolerado, com o motivo escrito.
+ *
+ * Medido antes de ligar o guarda, em 13 rotas (as 5 da amostra do axe mais as 8
+ * do celular), desktop e 390x844: **zero** `pageerror`, **zero** `console.error`
+ * e **zero** resposta >= 400. A única coisa que aparece é o `ERR_ABORTED` de
+ * baixo, e ele é do próprio Next.
+ *
+ * Regra para acrescentar: a entrada tem que ser específica (nada de `/./`) e
+ * vir com comentário dizendo o que é e por que não dá para consertar agora.
+ */
+export const RUIDO_TOLERADO: RegExp[] = [
+  // O `<Link>` do Next dispara prefetch da rota apontada; sair da página antes
+  // de o prefetch terminar cancela a requisição, e o cancelamento chega aqui
+  // como `requestfailed ... net::ERR_ABORTED`. Medido: 104 ocorrências numa
+  // passagem por 13 rotas, todas em URL de rota do próprio site, e nenhuma com
+  // efeito nenhum na página. Só `ERR_ABORTED` entra: qualquer outro motivo
+  // (`ERR_CONNECTION_REFUSED`, `ERR_NAME_NOT_RESOLVED`, `ERR_FAILED`) continua
+  // reprovando. E recurso que de fato sumiu do `out/` não passa por aqui: ele
+  // vira `http 404`, que o listener de resposta pega.
+  /^requestfailed: .* \(net::ERR_ABORTED\)$/,
+];
+
+export const test = base.extend<{ semErroDeConsole: void }>({
+  semErroDeConsole: [
+    async ({ page }, use) => {
+      const ocorrencias: Ocorrencia[] = [];
+      const registrar = (o: Ocorrencia) => {
+        if (!RUIDO_TOLERADO.some((r) => r.test(o))) ocorrencias.push(o);
+      };
+
+      page.on("pageerror", (erro) => {
+        registrar(`pageerror: ${erro.message}`);
+      });
+      page.on("console", (msg) => {
+        if (msg.type() === "error") registrar(`console.error: ${msg.text()}`);
+      });
+      page.on("requestfailed", (req) => {
+        registrar(`requestfailed: ${req.url()} (${req.failure()?.errorText ?? "sem motivo"})`);
+      });
+      page.on("response", (res) => {
+        if (res.status() >= 400) registrar(`http ${res.status()}: ${res.url()}`);
+      });
+
+      await use();
+
+      // Daqui para baixo é o afterEach. Falha em teardown de fixture reprova o
+      // teste no relatório do Playwright, com o array inteiro no `Received`.
+      expect(
+        ocorrencias,
+        "a página emitiu erro. Se for ruído legítimo, declare em RUIDO_TOLERADO com o motivo"
+      ).toEqual([]);
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };

--- a/tests/fixtures/console-limpo.ts
+++ b/tests/fixtures/console-limpo.ts
@@ -121,7 +121,7 @@ export const test = base.extend<{ semErroDeConsole: void }>({
       // teste no relatório do Playwright, com o array inteiro no `Received`.
       expect(
         ocorrencias,
-        "a página emitiu erro. Se for ruído legítimo, declare em RUIDO_TOLERADO com o motivo"
+        "a página emitiu erro. Se for ruído legítimo, declare em `ruidoTolerado()` com o motivo"
       ).toEqual([]);
     },
     { auto: true },

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect } from "./fixtures/console-limpo";
+
+// Guarda de celular. Rodam **só** no projeto `mobile` do `playwright.config.ts`
+// (Pixel 7: 412x839, `isMobile`, `hasTouch`), selecionado pela tag `@mobile` no
+// título de cada teste.
+//
+// POR QUE EXISTE
+// A suíte era projeto único de desktop. Contadas as larguras usadas no
+// repositório inteiro: 56x 1512, 34x 1440, 7x 1280, 3x 1500 e **4x 390**, e as
+// quatro de 390 moram todas no mesmo arquivo. Ou seja: as 15 consultas
+// `@media` do `globals.css`, mais o `pointer: coarse`, eram exercitadas por
+// quatro asserções, num produto cujo público é majoritariamente celular.
+//
+// O Pixel 7 não é só uma viewport menor. `isMobile` liga a viewport visual do
+// Chromium (o `<meta name=viewport>` passa a valer de verdade) e `hasTouch`
+// liga `@media (pointer: coarse)`, que este repositório usa em
+// `globals.css:1791`. `page.setViewportSize({width: 390})` não liga nenhum dos
+// dois — é por isso que o projeto novo acha coisa que redimensionar não acha.
+//
+// O QUE ELES MEDEM, E POR QUE ESSAS TRÊS COISAS
+// As três formas conhecidas de um layout quebrar no celular sem ninguém ver:
+//
+//   1. a PÁGINA estoura na horizontal (`scrollWidth > innerWidth`);
+//   2. o RÓTULO estoura a própria caixa. `minmax(140px, 1fr)` impede o estouro
+//      da página e não o do texto, então a medição (1) passa limpa enquanto o
+//      texto sai pela borda do card. A comparação certa é `scrollWidth` contra
+//      `clientWidth` **do elemento**;
+//   3. o rótulo fica ILEGÍVEL sem estourar nada. Uma regra deste repositório já
+//      deixou `.ms-seg` com `font-size: 0` em duas telas (o mapa da recursão do
+//      merge sort e as faixas da invariante do quick sort, que compartilham a
+//      classe). Caixa com texto de tamanho zero não estoura e não colapsa: as
+//      medições (1) e (2) passam as duas, e o rótulo simplesmente não existe
+//      para o aluno.
+
+/** Uma página de cada tipo, mais as duas que a regra do `font-size` alcança. */
+const ROTAS = [
+  "/",
+  "/roadmap/",
+  "/apoie/",
+  "/topico/big-o/",
+  "/topico/two-pointers/", // a página mais densa: 1176 folhas de texto
+  "/topico/merge-sort/", // dona original da regra de `.ms-seg`
+  "/topico/quick-sort/", // a outra dona da MESMA classe
+  "/topico/binary-numbers/", // a fita de bits, que encolhe até 8px de propósito
+];
+
+/**
+ * Piso de tamanho de fonte. É `> 0`, e não um valor confortável, de propósito:
+ * o repositório tem tipografia legitimamente pequena (o expoente do bit sai a
+ * 6.7px, o `.badge-soon` a 9px), e um piso generoso viraria alarme falso. O que
+ * este guarda proíbe é a classe de defeito que já aconteceu: texto renderizado
+ * com tamanho zero, invisível, sem estourar nada.
+ */
+const PISO_FONTE = 0;
+
+/**
+ * O único texto que pode ficar em `font-size: 0`, e o porquê.
+ *
+ * `globals.css:1894` esconde o rótulo de cada trecho no mapa da recursão do
+ * merge sort abaixo de 560px, porque ali o trecho mais estreito tem 25px e o
+ * texto sairia cortado. É decisão medida e comentada no CSS. A exceção é
+ * escrita com o seletor completo (`.ms-niveis .ms-seg`, não `.ms-seg`) porque a
+ * classe pertence a três visualizadores, e é exatamente essa diferença que o
+ * teste seguinte cobra do quick sort.
+ */
+const PODE_SER_INVISIVEL = ".ms-niveis .ms-seg";
+
+type Folha = { sel: string; texto: string; fs: number; scrollW: number; clientW: number };
+
+/** Varre as folhas de texto visíveis e devolve o que interessa medir. */
+async function folhasDeTexto(page: import("@playwright/test").Page, excecao: string) {
+  return page.evaluate((selExcecao) => {
+    const caminho = (el: Element) => {
+      const partes: string[] = [];
+      let n: Element | null = el;
+      for (let i = 0; n && i < 4; i++) {
+        const cls =
+          typeof n.className === "string" && n.className.trim()
+            ? "." + n.className.trim().split(/\s+/).slice(0, 3).join(".")
+            : "";
+        partes.unshift(n.tagName.toLowerCase() + cls);
+        n = n.parentElement;
+      }
+      return partes.join(" > ");
+    };
+    const saida: Folha[] = [];
+    for (const el of document.querySelectorAll<HTMLElement>("body *")) {
+      if (el.children.length > 0) continue; // só folhas: o texto é dele mesmo
+      const texto = (el.textContent ?? "").trim();
+      if (!texto) continue;
+      if (el.getClientRects().length === 0) continue; // não renderizado
+      if (el.matches(selExcecao)) continue;
+      const cs = getComputedStyle(el);
+      if (cs.visibility === "hidden" || cs.display === "none") continue;
+      // `inline` não tem caixa própria confiável (`clientWidth` é 0), e
+      // `auto`/`scroll` rolam de propósito: nos dois casos `scrollWidth` maior
+      // que `clientWidth` não quer dizer defeito.
+      const medivel = cs.display !== "inline" && !["auto", "scroll"].includes(cs.overflowX);
+      saida.push({
+        sel: caminho(el),
+        texto: texto.slice(0, 40),
+        fs: parseFloat(cs.fontSize),
+        scrollW: medivel ? el.scrollWidth : 0,
+        clientW: medivel ? el.clientWidth : 0,
+      });
+    }
+    return saida;
+  }, excecao);
+}
+
+for (const rota of ROTAS) {
+  test(`@mobile ${rota} não estoura a largura da tela`, async ({ page }) => {
+    await page.goto(rota);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    const medida = await page.evaluate(() => ({
+      scrollWidth: document.documentElement.scrollWidth,
+      clientWidth: document.documentElement.clientWidth,
+      innerWidth: window.innerWidth,
+    }));
+
+    // ⚠️ A comparação é contra `clientWidth`, e NÃO contra `window.innerWidth`,
+    // que é a forma usada no resto do repositório (e no runbook). Com
+    // `isMobile: true` a emulação do Chromium **alarga a viewport de layout**
+    // quando o conteúdo estoura, e `innerWidth` acompanha o estouro: medido
+    // aqui, com `.topic-layout { min-width: 900px }` plantado de propósito,
+    // `scrollWidth` foi 901 e `innerWidth` foi 901 também — a asserção passava
+    // com a página 489px mais larga que o aparelho. `clientWidth` é o bloco
+    // recipiente inicial e fica nos 412 do Pixel 7, então a diferença aparece.
+    // Quem copiar este arquivo para um projeto sem `isMobile` pode usar
+    // `innerWidth`; aqui não dá.
+    expect(
+      medida.scrollWidth,
+      `a página ${rota} rola na horizontal no celular (viewport de layout: ${medida.clientWidth}px)`
+    ).toBeLessThanOrEqual(medida.clientWidth + 1);
+  });
+
+  test(`@mobile ${rota} não tem rótulo vazando da própria caixa`, async ({ page }) => {
+    await page.goto(rota);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    const vazando = (await folhasDeTexto(page, PODE_SER_INVISIVEL))
+      .filter((f) => f.scrollW - f.clientW > 1)
+      .map((f) => `${f.sel} — "${f.texto}" precisa de ${f.scrollW}px e tem ${f.clientW}px`);
+    expect(
+      vazando,
+      `em ${rota}, texto saindo da borda do próprio elemento (a página inteira pode estar sem overflow e o card estourado mesmo assim)`
+    ).toEqual([]);
+  });
+
+  test(`@mobile ${rota} não tem rótulo com texto invisível`, async ({ page }) => {
+    await page.goto(rota);
+    await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+    const invisiveis = (await folhasDeTexto(page, PODE_SER_INVISIVEL))
+      .filter((f) => f.fs <= PISO_FONTE)
+      .map((f) => `${f.sel} — "${f.texto}" com font-size ${f.fs}px`);
+    expect(
+      invisiveis,
+      `em ${rota}, texto renderizado com tamanho zero. Se for intencional, o seletor tem que entrar em PODE_SER_INVISIVEL com o motivo medido`
+    ).toEqual([]);
+  });
+}
+
+// A regra do `font-size: 0` nasceu para o merge sort e a classe pertence a
+// três visualizadores. Este teste é a outra ponta: o quick sort usa `.ms-seg`
+// fora de `.ms-niveis`, as faixas dele ocupam a linha quase inteira, e o rótulo
+// **tem** que continuar legível. Sem ele, alguém tira o escopo `.ms-niveis` da
+// regra do CSS, os três testes de cima passam (a exceção cobre `.ms-seg` de
+// novo) e o quick sort perde os rótulos em silêncio.
+test("@mobile as faixas da invariante do quick sort continuam legíveis", async ({ page }) => {
+  await page.goto("/topico/quick-sort/");
+  await expect(page.getByRole("heading", { level: 1 })).toBeVisible();
+
+  const faixas = page.locator(".ms-seg").filter({ hasNot: page.locator("*") });
+  const total = await faixas.count();
+  expect(total, "o quick sort perdeu as faixas .ms-seg").toBeGreaterThan(0);
+
+  const medidas = await page.evaluate(() =>
+    [...document.querySelectorAll<HTMLElement>(".ms-seg")]
+      .filter((el) => !el.closest(".ms-niveis"))
+      .map((el) => ({
+        texto: (el.textContent ?? "").trim(),
+        fs: parseFloat(getComputedStyle(el).fontSize),
+        larguraDoTexto: el.scrollWidth,
+        larguraDaCaixa: el.clientWidth,
+      }))
+  );
+  expect(medidas.length, "nenhuma .ms-seg fora de .ms-niveis nesta página").toBeGreaterThan(0);
+
+  const ilegiveis = medidas
+    .filter((m) => m.fs < 9)
+    .map((m) => `"${m.texto}" com font-size ${m.fs}px (o CSS promete 9px abaixo de 560)`);
+  expect(
+    ilegiveis,
+    "regra escrita para o merge sort alcançou o quick sort: base compartilhada estendida sem escopo"
+  ).toEqual([]);
+});

--- a/tests/mobile.spec.ts
+++ b/tests/mobile.spec.ts
@@ -45,11 +45,12 @@ const ROTAS = [
 ];
 
 /**
- * Piso de tamanho de fonte. É `> 0`, e não um valor confortável, de propósito:
- * o repositório tem tipografia legitimamente pequena (o expoente do bit sai a
- * 6.7px, o `.badge-soon` a 9px), e um piso generoso viraria alarme falso. O que
- * este guarda proíbe é a classe de defeito que já aconteceu: texto renderizado
- * com tamanho zero, invisível, sem estourar nada.
+ * Piso de tamanho de fonte: **zero**. Não é um mínimo confortável, é o valor
+ * comparado — a regra efetiva abaixo é `fs > PISO_FONTE`, ou seja `font-size >
+ * 0`. Zero de propósito: o repositório tem tipografia legitimamente pequena (o
+ * expoente do bit sai a 6.7px, o `.badge-soon` a 9px), e um piso generoso
+ * viraria alarme falso. O que este guarda proíbe é a classe de defeito que já
+ * aconteceu: texto renderizado com tamanho zero, invisível, sem estourar nada.
  */
 const PISO_FONTE = 0;
 


### PR DESCRIPTION
Três buracos na rede de proteção, todos medidos antes de escrever uma linha de teste. Nenhum arquivo de `src/`, `content/`, `scripts/` ou `.github/` foi tocado: o que os guardas acharam de defeito real está reportado no fim, com `arquivo:linha`, para virar PR próprio.

**Suíte: 484 testes antes, 499 depois.** 474 no projeto de desktop (459 antigos + 15 novos) e 25 num projeto de celular novo. Verde nos dois.

---

## 1. Não havia nenhuma verificação de acessibilidade

`grep -n "axe\|pa11y\|lighthouse" package.json` devolvia nada, e `grep -rli "axe\|acessib\|a11y" tests/` devolvia **0 de 37 arquivos**.

Isso importa agora porque a rodada aberta entregou muita acessibilidade (link de pular, anel de foco, landmark com nome, região viva, foco que volta ao fechar) e **nada disso tinha guarda**: um `aria-label` some sem mover um pixel na tela.

Entrou `@axe-core/playwright` (24 linhas no lock, nada em `dependencies`) sobre uma amostra fixa de cinco rotas: home, `/roadmap/`, um tópico `ready`, um `soon` e `/apoie/`.

### O passivo, por regra

Rodei antes de decidir o escopo. Medido em 2026-08-07, axe-core 4.12.1, sobre o `out/` da `main` (e35c1b2):

| regra | impacto | nós | rotas | o que é |
|---|---|---|---|---|
| `landmark-unique` | moderate | 1 | **as 5** | os dois `<nav>` da barra sem `aria-label`: o leitor de tela anuncia "navegação" duas vezes sem distinguir. `src/components/Shell.tsx:179` e `:185` |
| `color-contrast` | serious | 34 | `/topico/two-pointers/` | duas famílias de cor do tema: o selo de linguagem do bloco de código (`src/app/globals.css:315`) e o nome da variável do painel (`src/app/globals.css:446`, `#8ba0bb` sobre `#0d1420`). Pior medido: **3.48:1** contra os 4.5:1 exigidos |
| `label` | **critical** | 3 | `/topico/two-pointers/` | o `<input type="range">` de velocidade da casca sem `<label>` nem `aria-label` (`src/lib/visualizer.tsx:559`). São 3 nós porque a página tem 3 visualizadores: é **um** defeito, num componente compartilhado pelos 62 |
| `scrollable-region-focusable` | serious | 1 | `/topico/two-pointers/` | a fita de caracteres rola na horizontal e não recebe foco de teclado (`.tp-chars { overflow-x: auto }`, `src/app/globals.css:602`) |
| `color-contrast` | serious | 2 | `/topico/trie/` | item ativo do menu lateral (`src/app/globals.css:161`) e selo "em breve" (`src/app/globals.css:172`, **4.05:1**) |
| `heading-order` | moderate | 1 | `/apoie/` | o cartão de doação abre com `<h3>` logo depois do `<h1>`, pulando o `<h2>` (`src/app/apoie/page.tsx:29`) |

### A decisão de baseline, e o porquê

**Teste que chega vermelho é desligado na semana seguinte.** Nada disso é consertável dentro da fronteira deste PR (tudo mora em `src/`), então o passivo está **congelado item por item**, com o que cada um é e o `arquivo:linha` de onde mora. O guarda não promete que o site é acessível; promete uma coisa menor e verificável: **o passivo não cresce**. É o mesmo tipo de escopo declarado que o #45 usou nos limites do guarda de idioma.

Ele reprova em duas situações:

1. **regra nova** naquela rota — qualquer id de regra fora da lista;
2. **teto de nós estourado** numa regra conhecida — o mesmo defeito duplicado.

O item 2 tem **uma exceção declarada**: `color-contrast` na página de artigo entra **sem teto**. A contagem dela acompanha o tamanho do texto da página (são 34 nós hoje, quase todos `.code-lang` e `.viz-var-name` repetidos), então qualquer parágrafo novo empurraria o número para cima sem nenhuma regressão de acessibilidade. Teto ali seria alarme falso mensal, e alarme falso é justamente o que faz o guarda ser desligado. Nas regras que vêm de componente fixo (o `<nav>` da barra, o range da casca, o `<h3>` do cartão) o teto vale, porque só cresce se alguém duplicar o defeito.

Quando alguém consertar um item, o teste **avisa no log** que a entrada ficou obsoleta e **não reprova**: um conserto não pode deixar a suíte vermelha.

---

## 2. Não havia nenhum listener de erro

`grep -rn "pageerror\|requestfailed\|on(\"console" tests/` devolvia **0** nos 37 arquivos. Exceção em handler, erro de hidratação ou chunk 404 não faziam **nada** falhar: a asserção seguinte olhava o DOM, achava o que esperava, e a suíte ficava verde por cima do defeito.

Entrou uma fixture `auto` (`tests/fixtures/console-limpo.ts`) que acumula `pageerror`, `console.error`, `requestfailed` e **resposta HTTP >= 400**, e reprova no teardown que faz as vezes de `afterEach`. A última linha é a que pega o caso mais silencioso num site estático: o `<script>` cujo chunk sumiu do `out/` não emite `pageerror`, só 404.

### O que a medição achou antes de eu ligar

Rodei em 13 rotas, desktop e 390x844, clicando: **zero `pageerror`, zero `console.error`, zero resposta >= 400**. O site está limpo.

A única coisa que aparece são **104 ocorrências de `requestfailed ... net::ERR_ABORTED`**, e elas são do próprio Next: o `<Link>` dispara prefetch da rota apontada, e sair da página antes de o prefetch terminar cancela a requisição. Entrou como **allowlist declarada**, com o motivo escrito e o escopo mínimo:

- só `ERR_ABORTED`. `ERR_CONNECTION_REFUSED`, `ERR_NAME_NOT_RESOLVED` e `ERR_FAILED` continuam reprovando;
- recurso que de fato sumiu do `out/` **não passa por aí**: vira `http 404`, que o listener de resposta pega.

**Limite conhecido:** a fixture vale para quem a importa, e a fronteira deste PR proíbe tocar em `tests/*.spec.ts` que já existem. Então os 37 arquivos antigos continuam sem ouvir a página. Trocar o `import` deles é PR de uma linha por arquivo, e é a continuação natural deste.

Os testes novos **clicam** em vez de só carregar (andar a animação, rodar e pausar, reiniciar, abrir e fechar o painel expandido, marcar progresso, abrir o menu do celular): exceção em handler só existe quando alguém aperta o botão.

---

## 3. A suíte quase não olhava o celular

`playwright.config.ts` tinha **projeto único de desktop**. Contadas as chamadas de `setViewportSize` no repositório inteiro: **56x 1512, 34x 1440, 7x 1280, 3x 1500 e 4x 390** — e as quatro de 390 moram todas no mesmo arquivo (`tests/navegacao.spec.ts`). As **15** consultas `@media` do `globals.css`, mais o `pointer: coarse`, eram exercitadas por **quatro asserções**, num produto cujo público é majoritariamente celular.

Entrou um segundo projeto, `mobile`, com `devices["Pixel 7"]` (412x839, `isMobile`, `hasTouch`), que roda **só** o que estiver marcado `@mobile` no título. O `grep`/`grepInvert` é o que impede que acrescentar celular dobre o tempo de todo mundo.

**Por que um projeto e não mais um `setViewportSize({ width: 390 })`:** `isMobile` liga a viewport visual do Chromium (o `<meta viewport>` passa a valer de verdade) e `hasTouch` liga `@media (pointer: coarse)`, que este repositório usa em `globals.css:1791`. Redimensionar a janela não liga nenhum dos dois.

### Custo, medido em A/B (duas rodadas cada, mesma máquina)

| | tempo |
|---|---|
| só desktop (474 testes) | 79s, 77s |
| os dois (499 testes) | 78s, 80s |

**A diferença fica dentro do ruído entre rodadas.** Faz sentido: o projeto de celular sozinho leva **3,6s** de tempo de teste, e os 6 workers absorvem isso. E **não custa instalação**: `devices["Pixel 7"]` é `defaultBrowserType: "chromium"`, o mesmo navegador que o `tests.yml` já baixa.

Ligar e desligar:

```bash
npm test                                 # os dois projetos
npx playwright test --project=chromium   # só desktop (desliga o celular)
npx playwright test --project=mobile     # só celular
```

### O que os testes medem

As três formas conhecidas de um layout quebrar no celular sem ninguém ver, mais a que a §1.4.1 do runbook catalogou:

1. **a página estoura na horizontal**;
2. **o rótulo estoura a própria caixa** — `minmax(140px, 1fr)` impede o estouro da página e não o do texto, então a medição (1) passa limpa enquanto o texto sai pela borda do card. A comparação é `scrollWidth` contra `clientWidth` **do elemento**, não da página;
3. **o rótulo fica ilegível sem estourar nada** — caixa com texto de tamanho zero não estoura e não colapsa: as medições (1) e (2) passam as duas. É a classe que já deixou `.ms-seg` com `font-size: 0` em duas telas;
4. **a outra ponta da mesma regra**: o quick sort usa `.ms-seg` **fora** de `.ms-niveis`, as faixas dele ocupam a linha quase inteira, e os rótulos têm que continuar legíveis. Sem esse teste, alguém tira o escopo `.ms-niveis` do CSS, os três primeiros passam (a exceção volta a cobrir `.ms-seg` inteiro) e o quick sort perde os rótulos em silêncio.

A exceção do `font-size: 0` é escrita com o seletor completo (`.ms-niveis .ms-seg`) exatamente para deixar o item 4 ter o que cobrar.

### ⚠️ Um defeito que a prova de quebra achou **no meu próprio teste**

A primeira versão media `documentElement.scrollWidth <= window.innerWidth`, que é a forma usada no resto do repositório. Plantei `.topic-layout { min-width: 900px }` para vê-la falhar e **ela passou**. Medido no navegador:

```
innerWidth: 901   docScroll: 901   docClient: 412   visualViewport: 412
```

Com `isMobile: true`, a emulação do Chromium **alarga a viewport de layout junto com o estouro**, e `innerWidth` acompanha. A asserção passava com a página **489px mais larga que o aparelho**. A comparação certa sob emulação é contra `documentElement.clientWidth`, que fica nos 412 do Pixel 7.

Vale além deste arquivo: **o idioma `document.body.scrollWidth > window.innerWidth`, que o runbook recomenda e as quatro asserções de 390px usam, deixa de funcionar no instante em que alguém trocar `setViewportSize` por um perfil de aparelho.**

---

## Provas de quebra

Cinco, uma por guarda. Em todas: a quebra foi aplicada, **`npm run build` rodou sem silenciar a saída** (para a quebra chegar ao `out/`), e o critério foi **falhar na linha certa com o valor certo no `Received`**. Restauração por cópia em diretório temporário, nunca `git checkout --`. `git status` no fim: limpo fora dos arquivos deste PR.

| # | quebra | guarda | `Received` |
|---|---|---|---|
| A1 | tira `lang="pt-BR"` do `<html>` (`layout.tsx`) | axe, regra nova | `"html-has-lang (serious, 1 nó(s)): html"` nas 5 rotas, em `a11y.spec.ts:166` |
| A2 | um segundo `<input type=range>` sem rótulo na casca | axe, teto de nós | `"label: 3 nó(s) congelados, 6 agora"`, em `a11y.spec.ts:177` |
| B | `throw` dentro do handler de Reiniciar (`visualizer.tsx`) | console | `"pageerror: quebra proposital no handler de Reiniciar"`, em `fixtures/console-limpo.ts:87` |
| C1 | `.topic-layout { min-width: 900px }` | celular, overflow | `Expected: <= 413` / `Received: 901`, em `mobile.spec.ts:134` |
| C2 | `.viz-var-name { width: 8px; overflow: hidden }` | celular, rótulo vazando | `"…span.viz-var-name — \"trecho ativo\" precisa de 45px e tem 8px"`, em `mobile.spec.ts:146` |
| C3 | tira o escopo `.ms-niveis` da regra `font-size: 0` | celular, texto invisível | `"\"<= pivô, volta para a recursão\" com font-size 0px"`, em `mobile.spec.ts:158` **e** `:192` |

Detalhe que vale registrar: na quebra **C2** o teste de overflow da página continuou **verde** nas mesmas rotas, e na **C3** os de overflow e de rótulo vazando continuaram os dois verdes. É a demonstração de que as três medições não são redundantes.

E na quebra **B**, só o teste que **clica** em Reiniciar falhou; os sete que apenas carregam a rota passaram.

---

## Flakes conhecidos

Na primeira rodada completa depois de um build, `tests/viz-strings.spec.ts:326` reprovou com `Received: 8.699999999999989` contra `<= 1` — é a família de tolerância de rolagem que o **#53** conserta, e a rodada logo depois de um build é a outra condição já catalogada. Rodado isolado: **8 passed (5.2s)**. Nas três rodadas completas seguintes: **499 passed**. Não vem deste trabalho.

---

## ⚠️ Sobreposição com o #54, que está aberto

O **#54** (`ci/o-deploy-espera-a-suite`) também mexe em `package.json`. As mudanças são em **regiões diferentes** e a minha é mínima de propósito:

| | #54 | este PR |
|---|---|---|
| `scripts` | acrescenta `lint`, `guarda:commit`, `guarda:idioma` | **não toca** |
| `dependencies` | acrescenta `@next/third-parties` | **não toca** |
| `devDependencies` | acrescenta `eslint`, `eslint-config-next` | acrescenta **só** `@axe-core/playwright` |
| `package-lock.json` | +5793 linhas | +24 linhas |
| `.github/workflows/` | reescreve os dois workflows | **não toca** |

**Resolução, nos dois sentidos.** Se o #54 entrar primeiro: aplicar a linha `"@axe-core/playwright": "^4.12.1"` em `devDependencies` (ordem alfabética, antes de `@playwright/test`) e rodar `npm install` para refazer o lock. Se este entrar primeiro: idem para as linhas do `eslint`. Não há conflito semântico, só textual, e nas duas ordens o resultado é a união.

**Dois pontos de atenção para quem integrar:**

- o #54 põe `npm run lint` como **portão** de CI. Estes três arquivos novos de `tests/` nunca passaram por ESLint, porque ele não existe na `main`. O `eslint.config.mjs` do #54 não tem bloco específico para `tests/`, então vale rodar `npm run lint` na branch integrada antes de mergear;
- o #54 move quem testa a `main` para dentro do `cloudflare-pages-deploy.yml`, e ele roda `npm test`, que depois deste PR passa a incluir o projeto de celular. Pelo A/B acima, isso não muda o tempo do deploy de forma perceptível.

---

## Defeitos reais achados e **não** consertados (fora da fronteira)

Todos verificados, nenhum tocado. Além dos seis do passivo do axe listados na §1:

- **`src/lib/visualizer.tsx:532`** — `<button className="viz-btn" title="Reiniciar">↺</button>`. O nome acessível de um botão vem do conteúdo antes do `title`, então o nome dele é **"↺"**, não "Reiniciar": `getByRole("button", { name: "Reiniciar" })` não acha, e um leitor de tela anuncia o glifo. O `axe` **não pega**: a regra `button-name` só exige que exista *algum* nome. Achei porque o teste não encontrou o botão. Vale para os 62 visualizadores, que compartilham a casca. Conserto: `aria-label="Reiniciar"`.
- **`src/components/Shell.tsx:179` e `:185`** — os dois `<nav>` sem `aria-label`. É o único achado que aparece nas **cinco** rotas da amostra, e o mais barato de consertar. Pode já estar resolvido no **#50** (`feat(a11y): casca de navegação acessível`), que está aberto; se estiver, a entrada sai do `PASSIVO` no PR que mergear, e o teste avisa no log que ela ficou obsoleta.
- **`src/lib/visualizer.tsx:559`** — o `<input type="range">` de velocidade sem rótulo. É a única violação **crítica** do passivo, e também é um defeito só, multiplicado por todo visualizador da casca.
- **`src/app/globals.css:602`** — `.tp-chars` rola na horizontal sem receber foco: quem navega por teclado não alcança o conteúdo fora da vista.
- **Idioma do guarda de overflow do repositório** — descrito na §3 acima: `document.body.scrollWidth > window.innerWidth` mede a coisa errada sob emulação de aparelho. Vale rever as quatro asserções de 390px de `tests/navegacao.spec.ts` quando alguém migrar aquilo para o projeto `mobile`.
- **`npm audit`** — 3 vulnerabilidades altas (`postcss` e `sharp`, via `next`). **Já existiam na `main`**; o `npm audit fix --force` puxaria `next@16.3.0`, fora do range declarado. Não é deste PR, mas fica registrado.

---

## Verificação

```
npx tsc --noEmit ......................... OK
npm run build ............................ 59 páginas
npx playwright test ...................... 499 passed (1.3m)
git log --format="%s" origin/main..HEAD | python3 scripts/guarda-commit.py
  ✓ test: roda os testes de celular num projeto próprio com tag
  ✓ test(a11y): congela o passivo de acessibilidade com axe-core
  ✓ test: reprova o teste quando a página emite erro de console
```

Nenhum screenshot commitado. Sai da `main` e vai para a `main`.
