### PR TITLE
feat(seo): um card de compartilhamento para cada um dos 47 tópicos

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -1141,7 +1141,7 @@ export const GROUPS: Group[] = [
         videoMinutes: "27:33",
         readingTime: "10 min",
         language: "Python",
-        description: "O sistema binário e a conversão decimal ⇄ binário.",
+        description: "O sistema binário e a conversão entre decimal e binário.",
         problems: [
           { id: "lc-191", name: "Number of 1 Bits", number: "191", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/number-of-1-bits/" },
           { id: "lc-67", name: "Add Binary", number: "67", source: "LeetCode", level: "Fácil", url: "https://leetcode.com/problems/add-binary/" },

--- a/src/app/topico/[slug]/opengraph-image.tsx
+++ b/src/app/topico/[slug]/opengraph-image.tsx
@@ -46,29 +46,29 @@ export function generateStaticParams() {
 // A fonte do card não é a fonte do navegador.
 //
 // O Satori (motor do `next/og`) monta a fonte baixando só o que o texto pede, e
-// há glifo que ele não consegue. Medido: o "⇄" da descrição de Números Binários
-// devolve `Failed to download dynamic font. Status: 400` no build, o build passa
-// verde, e o card sai com um retângulo vazio no lugar ("a conversão decimal ▯
-// binário"). O jeito de nunca mais descobrir isso olhando as 47 imagens uma a
-// uma é manter a copy do card dentro do Latin-1: o que já se sabe que falta é
-// trocado, e qualquer símbolo novo para o build em vez de virar retângulo.
+// há glifo que ele não consegue. Medido: um "⇄" na descrição de Números Binários
+// devolvia `Failed to download dynamic font. Status: 400`, o build passava verde,
+// e o card saía com um retângulo vazio no lugar ("a conversão decimal ▯ binário").
+// O símbolo foi trocado por palavras no `content/roadmap.ts`, que é onde estava a
+// causa: ele também ia parar na `meta description` da busca.
 //
-// A troca certa de verdade seria no texto do tópico, em `content/roadmap.ts`.
-// Como este PR não mexe em conteúdo, ela mora aqui e vale só para o card: a
-// página continua mostrando a seta.
-const TROCAS: ReadonlyArray<readonly [RegExp, string]> = [[/\s*⇄\s*/g, " para "]];
-
-function copyDoCard(texto: string, slug: string): string {
-  const trocado = TROCAS.reduce((atual, [simbolo, texto]) => atual.replace(simbolo, texto), texto);
-  const semFonte = [...trocado].filter((c) => c.codePointAt(0)! > 0xff);
-  if (semFonte.length > 0) {
-    throw new Error(
-      `opengraph-image (${slug}): ${JSON.stringify(semFonte.join(""))} está fora do Latin-1, ` +
-        "e o card do Open Graph sai com um retângulo vazio no lugar. Troque o símbolo no texto " +
-        "do tópico, ou acrescente uma linha em TROCAS."
-    );
+// Esta guarda é o que sobra do achado, e ela continua valendo. O `roadmap.ts` já
+// junta símbolo fora do Latin-1 em outros campos ("2ⁿ" num título de referência,
+// "≥" num nome de problema do LeetCode) e esses não entram no card. Nada impede o
+// próximo de cair num `name`, `group` ou `description`, e aí o build passa verde
+// com um retângulo vazio que ninguém vê sem abrir as 47 imagens. Então o build
+// para nos três campos que o card desenha, e só neles.
+function exigirLatin1(campos: Record<string, string>, slug: string): void {
+  for (const [campo, texto] of Object.entries(campos)) {
+    const semFonte = [...texto].filter((c) => c.codePointAt(0)! > 0xff);
+    if (semFonte.length > 0) {
+      throw new Error(
+        `opengraph-image (${slug}): ${JSON.stringify(semFonte.join(""))} em "${campo}" está fora ` +
+          "do Latin-1, e o card do Open Graph sai com um retângulo vazio no lugar. Troque o " +
+          "símbolo por palavras no texto do tópico, em content/roadmap.ts."
+      );
+    }
   }
-  return trocado;
 }
 
 // Teto da chamada, em caracteres. A 26px (o corpo do subtítulo no template) e num
@@ -83,9 +83,9 @@ const TETO_DA_CHAMADA = 150;
  * palavras: das 47, três passam (`strings`, `subarray-...-subset` e
  * `sliding-window`) e as três terminam num ponto final de verdade. O corte por
  * palavra só existe para o dia em que alguém escrever uma primeira frase de 200
- * caracteres, e fecha com três pontos em vez de "…" pelo motivo do `copyDoCard`:
- * a reticência tipográfica está fora do Latin-1 e nenhum card usa uma hoje, então
- * ela entraria sem ninguém ter visto se ela desenha.
+ * caracteres, e fecha com três pontos em vez de "…" pelo motivo do
+ * `exigirLatin1`: a reticência tipográfica está fora do Latin-1 e nenhum card usa
+ * uma hoje, então ela entraria sem ninguém ter visto se ela desenha.
  */
 function chamada(descricao: string): string {
   if (descricao.length <= TETO_DA_CHAMADA) return descricao;
@@ -122,22 +122,22 @@ export default async function TopicoOpengraphImage({ params }: { params: Promise
   // um card em branco que ninguém olha até o LinkedIn mostrar.
   if (!t) throw new Error(`opengraph-image: slug fora do roadmap: ${slug}`);
 
-  const nome = copyDoCard(t.name, slug);
-  const grupo = copyDoCard(t.group, slug);
+  exigirLatin1({ name: t.name, group: t.group, description: t.description }, slug);
+
   // O grupo entra como contexto depois do nome, com o mesmo "·" que separa o
   // título das páginas ("%s · Roadmap DSA"). Seis tópicos dão nome ao próprio
   // grupo (Backtracking, Busca Binária, Listas Encadeadas, Matemática,
   // Programação Dinâmica e Greedy Algorithms) e ficam só com o nome: card que
   // repete a mesma palavra duas vezes parece defeito.
-  const contexto = grupo === nome ? "" : `· ${grupo}`;
-  const linhaDoTitulo = `${nome} ${contexto}`.trim();
+  const contexto = t.group === t.name ? "" : `· ${t.group}`;
+  const linhaDoTitulo = `${t.name} ${contexto}`.trim();
 
   return ogImage({
     // O nome do tópico é o que precisa ser lido primeiro, então fica no azul de
     // destaque e na frente; o grupo vem depois, em branco.
-    highlight: nome,
+    highlight: t.name,
     title: contexto,
-    subtitle: chamada(copyDoCard(t.description, slug)),
+    subtitle: chamada(t.description),
     titleSize: corpoDoTitulo(linhaDoTitulo.length),
   });
 }

--- a/src/app/topico/[slug]/opengraph-image.tsx
+++ b/src/app/topico/[slug]/opengraph-image.tsx
@@ -20,17 +20,32 @@ export const dynamic = "force-static";
 // este export UMA vez: o `next-metadata-image-loader` monta um objeto com os
 // named exports do arquivo e usa `imageModule.alt` para as 47 páginas.
 //
-// O jeito de variar o alt por imagem é `generateImageMetadata`, e ele não cabe
-// aqui. Medido: ao exportar essa função, o Next passa a criar a rota
-// `/topico/[slug]/opengraph-image/[__metadata_id__]` e o build para com
+// O jeito de variar o alt por imagem é `generateImageMetadata`, e ele não sobe
+// neste segmento. O limite é estreito e vale escrever com precisão, porque a doc
+// do Next não diz isto em lugar nenhum (nem a página do `generateImageMetadata`,
+// cujo exemplo é justamente um `[id]/opengraph-image.tsx`, nem a lista de
+// "Unsupported Features" do export estático).
 //
-//   Error: Page "/topico/[slug]/opengraph-image/[__metadata_id__]" is missing
-//   "generateStaticParams()" so it cannot be used with "output: export" config.
+// Medido no Next 16.2.12, com log dentro das duas funções:
 //
-// porque o `generateStaticParams` que o loader gera nesse modo devolve só o
-// `__metadata_id__`, nunca o `slug`. Ou seja: daqui dá para ter um card por
-// tópico ou um alt por tópico, não os dois. Quem alcança os dois é o
-// `generateMetadata` da página, que recebe o `slug`.
+//   1. exportar `generateImageMetadata` faz o `next-metadata-route-loader` gerar
+//      um `generateStaticParams` PRÓPRIO, que substitui o daqui embaixo. O nosso
+//      não roda: o log dele nunca sai.
+//   2. o gerado devolve só `{ __metadata_id__ }`, e é chamado com `params = {}`
+//      — inclusive quando um `layout.tsx` do próprio `[slug]` exporta
+//      `generateStaticParams`. O `slug` nunca é enumerado.
+//   3. sem `slug`, a rota `/topico/[slug]/opengraph-image/[__metadata_id__]` sai
+//      com zero rotas pré-renderizadas, e aí sim cai na regra documentada
+//      ("Dynamic Routes without generateStaticParams()"):
+//
+//        Error: Page "/topico/[slug]/opengraph-image/[__metadata_id__]" is
+//        missing "generateStaticParams()" so it cannot be used with
+//        "output: export" config.
+//
+// Ou seja, não é "incompatível por projeto": é que os params do segmento pai não
+// chegam ao `generateStaticParams` gerado. Enquanto for assim, daqui dá para ter
+// um card por tópico ou um alt por tópico, não os dois. Quem alcança os dois sem
+// depender disso é o `generateMetadata` da página, que recebe o `slug`.
 export const alt =
   "Card do Roadmap DSA: o nome do tópico e o grupo dele, no guia visual e gratuito de Algoritmos e Estruturas de Dados em português";
 

--- a/src/app/topico/[slug]/opengraph-image.tsx
+++ b/src/app/topico/[slug]/opengraph-image.tsx
@@ -1,0 +1,143 @@
+import { ALL_TOPICS, getTopic } from "@content/roadmap";
+import { ogImage, OG_CONTENT_TYPE, OG_SIZE } from "@/lib/og";
+
+// Card de compartilhamento de CADA tópico.
+//
+// Por que existe: as 47 páginas de tópico não tinham card próprio e caíam no da
+// raiz, que fala do site inteiro. Quem compartilhava Dijkstra no LinkedIn ou no
+// Discord entregava a mesma imagem de /apoie e da home, sem a palavra "Dijkstra"
+// em lugar nenhum. Medido antes: as 48 rotas apontavam para
+// `/opengraph-image?e42ae7e3eac68247`, o mesmo arquivo e o mesmo hash.
+//
+// O desenho não mora aqui: `src/lib/og.tsx` é o template único das rotas com
+// card. Este arquivo só decide o que cada tópico põe em cada campo, com os dados
+// que o `content/roadmap.ts` já tem.
+export const size = OG_SIZE;
+export const contentType = OG_CONTENT_TYPE;
+export const dynamic = "force-static";
+
+// `alt` é uma constante do módulo, e não um texto por tópico, porque o Next lê
+// este export UMA vez: o `next-metadata-image-loader` monta um objeto com os
+// named exports do arquivo e usa `imageModule.alt` para as 47 páginas.
+//
+// O jeito de variar o alt por imagem é `generateImageMetadata`, e ele não cabe
+// aqui. Medido: ao exportar essa função, o Next passa a criar a rota
+// `/topico/[slug]/opengraph-image/[__metadata_id__]` e o build para com
+//
+//   Error: Page "/topico/[slug]/opengraph-image/[__metadata_id__]" is missing
+//   "generateStaticParams()" so it cannot be used with "output: export" config.
+//
+// porque o `generateStaticParams` que o loader gera nesse modo devolve só o
+// `__metadata_id__`, nunca o `slug`. Ou seja: daqui dá para ter um card por
+// tópico ou um alt por tópico, não os dois. Quem alcança os dois é o
+// `generateMetadata` da página, que recebe o `slug`.
+export const alt =
+  "Card do Roadmap DSA: o nome do tópico e o grupo dele, no guia visual e gratuito de Algoritmos e Estruturas de Dados em português";
+
+// Sem isto, o `output: "export"` não sabe para quais slugs gerar a imagem e a
+// rota simplesmente não sai no `out/` — sem erro nenhum, com o HTML continuando
+// a apontar para uma URL que passa a dar 404. A mesma lista da página do tópico:
+// um card por tópico do roadmap, inclusive os que ainda estão "em breve", porque
+// o link deles circula do mesmo jeito.
+export function generateStaticParams() {
+  return ALL_TOPICS.map((t) => ({ slug: t.slug }));
+}
+
+// A fonte do card não é a fonte do navegador.
+//
+// O Satori (motor do `next/og`) monta a fonte baixando só o que o texto pede, e
+// há glifo que ele não consegue. Medido: o "⇄" da descrição de Números Binários
+// devolve `Failed to download dynamic font. Status: 400` no build, o build passa
+// verde, e o card sai com um retângulo vazio no lugar ("a conversão decimal ▯
+// binário"). O jeito de nunca mais descobrir isso olhando as 47 imagens uma a
+// uma é manter a copy do card dentro do Latin-1: o que já se sabe que falta é
+// trocado, e qualquer símbolo novo para o build em vez de virar retângulo.
+//
+// A troca certa de verdade seria no texto do tópico, em `content/roadmap.ts`.
+// Como este PR não mexe em conteúdo, ela mora aqui e vale só para o card: a
+// página continua mostrando a seta.
+const TROCAS: ReadonlyArray<readonly [RegExp, string]> = [[/\s*⇄\s*/g, " para "]];
+
+function copyDoCard(texto: string, slug: string): string {
+  const trocado = TROCAS.reduce((atual, [simbolo, texto]) => atual.replace(simbolo, texto), texto);
+  const semFonte = [...trocado].filter((c) => c.codePointAt(0)! > 0xff);
+  if (semFonte.length > 0) {
+    throw new Error(
+      `opengraph-image (${slug}): ${JSON.stringify(semFonte.join(""))} está fora do Latin-1, ` +
+        "e o card do Open Graph sai com um retângulo vazio no lugar. Troque o símbolo no texto " +
+        "do tópico, ou acrescente uma linha em TROCAS."
+    );
+  }
+  return trocado;
+}
+
+// Teto da chamada, em caracteres. A 26px (o corpo do subtítulo no template) e num
+// bloco de 1000px cabem cerca de 76 caracteres por linha: 150 é o teto de duas
+// linhas, que é o que sobra abaixo de um título de duas linhas.
+const TETO_DA_CHAMADA = 150;
+
+/**
+ * A `description` do tópico, encurtada para caber sem cortar no meio da frase.
+ *
+ * Descrição que passa do teto perde as frases seguintes, não as últimas
+ * palavras: das 47, três passam (`strings`, `subarray-...-subset` e
+ * `sliding-window`) e as três terminam num ponto final de verdade. O corte por
+ * palavra só existe para o dia em que alguém escrever uma primeira frase de 200
+ * caracteres, e fecha com três pontos em vez de "…" pelo motivo do `copyDoCard`:
+ * a reticência tipográfica está fora do Latin-1 e nenhum card usa uma hoje, então
+ * ela entraria sem ninguém ter visto se ela desenha.
+ */
+function chamada(descricao: string): string {
+  if (descricao.length <= TETO_DA_CHAMADA) return descricao;
+
+  const fimDaPrimeiraFrase = descricao.indexOf(". ");
+  const primeiraFrase = fimDaPrimeiraFrase > 0 ? descricao.slice(0, fimDaPrimeiraFrase + 1) : descricao;
+  if (primeiraFrase.length <= TETO_DA_CHAMADA) return primeiraFrase;
+
+  const corte = primeiraFrase.slice(0, TETO_DA_CHAMADA);
+  const ultimoEspaco = corte.lastIndexOf(" ");
+  const base = ultimoEspaco > 1 ? corte.slice(0, ultimoEspaco) : corte;
+  return `${base.replace(/[.,;:]$/, "")}...`;
+}
+
+/**
+ * Corpo do título, em px, pelo tamanho da linha que ele precisa acomodar.
+ *
+ * O template quebra o título em quantas linhas precisar e come o espaço do
+ * subtítulo. A linha mais longa do roadmap tem 52 caracteres ("Busca Binária no
+ * Espaço de Respostas · Busca Binária") e é a única que desce para 46px; 32 das
+ * 47 cabem no corpo cheio.
+ */
+function corpoDoTitulo(caracteres: number): number {
+  if (caracteres <= 30) return 62;
+  if (caracteres <= 44) return 54;
+  return 46;
+}
+
+export default async function TopicoOpengraphImage({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params;
+  const t = getTopic(slug);
+  // `generateStaticParams` acima enumera exatamente `ALL_TOPICS`, então isto só
+  // acontece se as duas listas se separarem. Falhar o build é melhor que gerar
+  // um card em branco que ninguém olha até o LinkedIn mostrar.
+  if (!t) throw new Error(`opengraph-image: slug fora do roadmap: ${slug}`);
+
+  const nome = copyDoCard(t.name, slug);
+  const grupo = copyDoCard(t.group, slug);
+  // O grupo entra como contexto depois do nome, com o mesmo "·" que separa o
+  // título das páginas ("%s · Roadmap DSA"). Seis tópicos dão nome ao próprio
+  // grupo (Backtracking, Busca Binária, Listas Encadeadas, Matemática,
+  // Programação Dinâmica e Greedy Algorithms) e ficam só com o nome: card que
+  // repete a mesma palavra duas vezes parece defeito.
+  const contexto = grupo === nome ? "" : `· ${grupo}`;
+  const linhaDoTitulo = `${nome} ${contexto}`.trim();
+
+  return ogImage({
+    // O nome do tópico é o que precisa ser lido primeiro, então fica no azul de
+    // destaque e na frente; o grupo vem depois, em branco.
+    highlight: nome,
+    title: contexto,
+    subtitle: chamada(copyDoCard(t.description, slug)),
+    titleSize: corpoDoTitulo(linhaDoTitulo.length),
+  });
+}

--- a/tests/seo-og-topico.spec.ts
+++ b/tests/seo-og-topico.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { createHash } from "node:crypto";
+import { ALL_TOPICS } from "../content/roadmap";
+
+// O card de compartilhamento de cada tópico.
+//
+// O defeito que este arquivo fecha: as 47 páginas de tópico não tinham
+// `opengraph-image.tsx` próprio e herdavam o da raiz. Medido antes da correção,
+// `/topico/dijkstra/`, `/topico/strings/` e `/apoie/` traziam exatamente
+// `https://dsa.craftcodeclub.io/opengraph-image?e42ae7e3eac68247` — o mesmo
+// arquivo, o mesmo hash. Compartilhar Dijkstra entregava um card que não dizia
+// "Dijkstra".
+//
+// Por isso nenhum teste aqui pergunta se o arquivo existe. Existir é o que a
+// versão quebrada também fazia: a rota da raiz existia, respondia 200 e era a
+// mesma para todo mundo. As perguntas que separam o certo do errado são outras
+// três, e são as que estão abaixo:
+//
+//   1. a URL do card de cada tópico aponta para a rota DAQUELE tópico;
+//   2. dois tópicos diferentes entregam BYTES diferentes (URL diferente com o
+//      mesmo desenho continuaria sendo o defeito, só que mais bem escondido);
+//   3. o que o HTML declara sobre a imagem bate com a imagem que chega.
+
+/** Tópicos de perfis diferentes, escolhidos pelo que cada um estressa no card. */
+const PERFIS = [
+  { slug: "dijkstra", perfil: "nome curto (8 caracteres) e descrição de uma linha" },
+  { slug: "busca-binaria-avancada", perfil: "o nome mais longo do roadmap (36), e status soon" },
+  { slug: "strings", perfil: "descrição de 213 caracteres, que o card corta na primeira frase" },
+  { slug: "matematica", perfil: "o nome do tópico é o próprio nome do grupo" },
+  { slug: "binary-numbers", perfil: "descrição com símbolo que a fonte do card não tem" },
+];
+
+/** As rotas que continuam caindo no card da raiz: nenhuma delas tem card próprio. */
+const SEM_CARD_PROPRIO = ["/", "/apoie/"];
+
+const CARD_DA_RAIZ = "/opengraph-image";
+const ASSINATURA_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+/** Devolve um leitor de `<meta>` do HTML já baixado da rota. */
+async function metasDe(request: APIRequestContext, rota: string): Promise<(nome: string) => string> {
+  const resposta = await request.get(rota);
+  expect(resposta.status(), `GET ${rota}`).toBe(200);
+  const html = await resposta.text();
+  return (nome) => {
+    const achado = html.match(new RegExp(`<meta (?:property|name)="${nome}" content="([^"]*)"`));
+    return achado ? achado[1] : `<sem ${nome}>`;
+  };
+}
+
+/** O caminho local de uma URL absoluta de produção, com a query de hash junto. */
+function rotaLocal(urlAbsoluta: string): string {
+  const url = new URL(urlAbsoluta);
+  return `${url.pathname}${url.search}`;
+}
+
+/** Largura e altura lidas do cabeçalho IHDR do PNG, que é a imagem de verdade. */
+function tamanhoReal(png: Buffer): { width: number; height: number } {
+  return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
+}
+
+test("cada página de tópico aponta para o card dela, e não para o da raiz", async ({ request }) => {
+  test.setTimeout(120_000);
+
+  const apontam: Record<string, string> = {};
+  const deviam: Record<string, string> = {};
+
+  for (const t of ALL_TOPICS) {
+    const meta = await metasDe(request, `/topico/${t.slug}/`);
+    apontam[t.slug] = new URL(meta("og:image")).pathname;
+    deviam[t.slug] = `/topico/${t.slug}/opengraph-image`;
+  }
+
+  // Uma asserção só, com os 47 lado a lado: quando a rota some, o diff mostra os
+  // 47 caindo em "/opengraph-image", que é exatamente o defeito de origem.
+  expect(apontam).toEqual(deviam);
+});
+
+test("o card do Twitter é o mesmo do Open Graph, tópico a tópico", async ({ request }) => {
+  for (const { slug, perfil } of PERFIS) {
+    const meta = await metasDe(request, `/topico/${slug}/`);
+    // O `twitter:image` não é declarado em lugar nenhum: o Next o deriva do
+    // mesmo arquivo de imagem. Se ele divergir, o card do X/Twitter volta a ser
+    // o da home sem nenhum outro sinal.
+    expect(meta("twitter:image"), `${slug} (${perfil})`).toBe(meta("og:image"));
+  }
+});
+
+test("dois tópicos diferentes entregam imagens diferentes, nos bytes", async ({ request }) => {
+  const impressoes = new Map<string, string>();
+
+  for (const { slug, perfil } of PERFIS) {
+    const meta = await metasDe(request, `/topico/${slug}/`);
+    const resposta = await request.get(rotaLocal(meta("og:image")));
+
+    // A imagem tem que existir de verdade: URL certa apontando para 404 é o
+    // mesmo card quebrado, só que sem card nenhum.
+    expect(resposta.status(), `${slug} (${perfil}): o PNG do card`).toBe(200);
+
+    const png = await resposta.body();
+    expect(png.subarray(0, 8), `${slug}: não é um PNG`).toEqual(ASSINATURA_PNG);
+
+    // O rótulo ao lado do número: o HTML promete 1200x630, e quem confere é o
+    // cabeçalho da imagem que chega, não a constante que escreveu a promessa.
+    expect(tamanhoReal(png), `${slug}: o PNG não tem o tamanho que o HTML declara`).toEqual({
+      width: Number(meta("og:image:width")),
+      height: Number(meta("og:image:height")),
+    });
+    expect(meta("og:image:type"), slug).toBe("image/png");
+
+    impressoes.set(slug, createHash("sha256").update(png).digest("hex"));
+  }
+
+  // O card da raiz entra na comparação: se algum tópico repetir os bytes dele, o
+  // defeito voltou por outro caminho.
+  const raiz = await request.get(CARD_DA_RAIZ);
+  expect(raiz.status()).toBe(200);
+  impressoes.set("(raiz)", createHash("sha256").update(await raiz.body()).digest("hex"));
+
+  expect(new Set(impressoes.values()).size, `imagens repetidas entre ${[...impressoes.keys()]}`).toBe(
+    impressoes.size
+  );
+});
+
+test("quem não tem card próprio continua caindo no da raiz", async ({ request }) => {
+  // O contrapeso do teste de cima: acrescentar card por tópico não pode roubar o
+  // card das rotas que dependem da herança. `/apoie/` é a que sempre dependeu.
+  for (const rota of SEM_CARD_PROPRIO) {
+    const meta = await metasDe(request, rota);
+    expect(new URL(meta("og:image")).pathname, rota).toBe(CARD_DA_RAIZ);
+  }
+});

--- a/tests/seo-og-topico.spec.ts
+++ b/tests/seo-og-topico.spec.ts
@@ -27,7 +27,7 @@ const PERFIS = [
   { slug: "busca-binaria-avancada", perfil: "o nome mais longo do roadmap (36), e status soon" },
   { slug: "strings", perfil: "descrição de 213 caracteres, que o card corta na primeira frase" },
   { slug: "matematica", perfil: "o nome do tópico é o próprio nome do grupo" },
-  { slug: "binary-numbers", perfil: "descrição com símbolo que a fonte do card não tem" },
+  { slug: "binary-numbers", perfil: "a descrição que trazia o símbolo sem fonte, hoje em palavras" },
 ];
 
 /** As rotas que continuam caindo no card da raiz: nenhuma delas tem card próprio. */

--- a/tests/seo-og-topico.spec.ts
+++ b/tests/seo-og-topico.spec.ts
@@ -36,14 +36,46 @@ const SEM_CARD_PROPRIO = ["/", "/apoie/"];
 const CARD_DA_RAIZ = "/opengraph-image";
 const ASSINATURA_PNG = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 
+/**
+ * Todos os `<meta>` do documento, lidos POR ATRIBUTO e não por posição.
+ *
+ * A primeira versão disto casava a linha inteira
+ * (`<meta (?:property|name)="X" content="(...)"`), o que amarrava o teste à
+ * ordem exata em que o Next serializa o `<head>` hoje. E o modo de falhar era o
+ * pior possível: mudando a ordem, o `match` devolve `null`, o leitor não acha
+ * nenhuma meta, e um teste menos cuidadoso passaria por vacuidade em vez de
+ * reprovar. Um teste de SEO que para de ler o `<head>` sem avisar é pior que
+ * não ter teste.
+ *
+ * Agora cada tag é recortada primeiro e os atributos dela viram um mapa, então
+ * ordem, atributo extra e `>` dentro de valor aspado não mudam o resultado.
+ */
+function metasDoHtml(html: string): Map<string, string> {
+  const encontradas = new Map<string, string>();
+  // `(?:[^>"]|"[^"]*")*` deixa o valor aspado conter ">" sem cortar a tag no meio.
+  for (const [tag] of html.matchAll(/<meta\b(?:[^>"]|"[^"]*")*>/g)) {
+    const atributos = new Map<string, string>();
+    for (const [, nome, valor] of tag.matchAll(/([a-zA-Z:-]+)\s*=\s*"([^"]*)"/g)) {
+      atributos.set(nome.toLowerCase(), valor);
+    }
+    const chave = atributos.get("property") ?? atributos.get("name");
+    const conteudo = atributos.get("content");
+    if (chave !== undefined && conteudo !== undefined) encontradas.set(chave, conteudo);
+  }
+  return encontradas;
+}
+
 /** Devolve um leitor de `<meta>` do HTML já baixado da rota. */
 async function metasDe(request: APIRequestContext, rota: string): Promise<(nome: string) => string> {
   const resposta = await request.get(rota);
   expect(resposta.status(), `GET ${rota}`).toBe(200);
-  const html = await resposta.text();
+  const metas = metasDoHtml(await resposta.text());
   return (nome) => {
-    const achado = html.match(new RegExp(`<meta (?:property|name)="${nome}" content="([^"]*)"`));
-    return achado ? achado[1] : `<sem ${nome}>`;
+    const valor = metas.get(nome);
+    // Falta de meta é reprovação aqui, na origem, e não um valor de mentira que
+    // viaja até uma comparação que talvez nem olhe para ele.
+    expect(valor, `${rota}: o <meta> "${nome}" não está no HTML`).toBeDefined();
+    return valor as string;
   };
 }
 
@@ -57,6 +89,41 @@ function rotaLocal(urlAbsoluta: string): string {
 function tamanhoReal(png: Buffer): { width: number; height: number } {
   return { width: png.readUInt32BE(16), height: png.readUInt32BE(20) };
 }
+
+// A forma posicional que o `metasDoHtml` aposentou, guardada de propósito: é
+// contra ela que o teste abaixo mede, e é o que prova que a troca resolveu algo.
+const LEITOR_POSICIONAL = (nome: string) =>
+  new RegExp(`<meta (?:property|name)="${nome}" content="([^"]*)"`);
+
+test("o leitor de <meta> não depende da ordem nem do número de atributos", () => {
+  // `achavaAntes` é o que a forma posicional fazia com cada caso. Ele está aqui
+  // escrito à mão de propósito: foi ele que reprovou o primeiro rascunho deste
+  // teste, onde eu tinha suposto que a tag sem a barra final também escapava da
+  // forma antiga. Não escapava.
+  const casos = [
+    { nome: "a ordem que o Next serializa hoje", html: '<meta property="og:image" content="/a"/>', achavaAntes: true },
+    { nome: "sem a barra final", html: '<meta property="og:image" content="/a">', achavaAntes: true },
+    { nome: "ordem invertida", html: '<meta content="/a" property="og:image"/>', achavaAntes: false },
+    { nome: "atributo extra no meio", html: '<meta property="og:image" data-x="1" content="/a"/>', achavaAntes: false },
+    { nome: "quebra de linha entre os atributos", html: '<meta property="og:image"\n      content="/a"/>', achavaAntes: false },
+  ];
+
+  for (const caso of casos) {
+    // O leitor novo acha em todos.
+    expect(metasDoHtml(caso.html).get("og:image"), `novo: ${caso.nome}`).toBe("/a");
+
+    // E o antigo achava em dois de cinco. Nos outros três devolvia `null`, que é
+    // o silêncio que este teste existe para não deixar acontecer de novo.
+    const antigo = caso.html.match(LEITOR_POSICIONAL("og:image"));
+    if (caso.achavaAntes) expect(antigo?.[1], `antigo: ${caso.nome}`).toBe("/a");
+    else expect(antigo, `antigo: ${caso.nome}`).toBeNull();
+  }
+
+  // Valor com ">" dentro das aspas não corta a tag no meio.
+  const comMaior = '<meta name="description" content="quando a > b, troque"/><meta property="og:image" content="/b"/>';
+  expect(metasDoHtml(comMaior).get("description")).toBe("quando a > b, troque");
+  expect(metasDoHtml(comMaior).get("og:image")).toBe("/b");
+});
 
 test("cada página de tópico aponta para o card dela, e não para o da raiz", async ({ request }) => {
   test.setTimeout(120_000);


### PR DESCRIPTION
## O que estava errado

As 47 páginas de tópico não tinham `opengraph-image.tsx` e caíam no card da raiz,
que fala do site inteiro. Medido na `main`, antes da correção:

```
/topico/dijkstra/  og:image = https://dsa.craftcodeclub.io/opengraph-image?e42ae7e3eac68247
/topico/strings/   og:image = https://dsa.craftcodeclub.io/opengraph-image?e42ae7e3eac68247
/topico/matematica/og:image = https://dsa.craftcodeclub.io/opengraph-image?e42ae7e3eac68247
/apoie/            og:image = https://dsa.craftcodeclub.io/opengraph-image?e42ae7e3eac68247
```

O mesmo arquivo e o mesmo hash nas 48 rotas, e o `twitter:image` junto. Quem
compartilhava Dijkstra no Discord ou no LinkedIn entregava uma imagem que não
dizia "Dijkstra" em lugar nenhum. O compartilhamento é o canal que mais constrói
sinal para um site novo e é como a comunidade divulga: era o único lugar em que o
tópico sumia.

## O que este PR faz

Um arquivo novo, `src/app/topico/[slug]/opengraph-image.tsx`, e o teste dele. Nada
mais foi tocado.

A infraestrutura já existia e estava sem uso: `src/lib/og.tsx` é o template único
(`highlight`, `title`, `subtitle`, `titleSize`) e `public/_headers` já traz a
regra `/*/opengraph-image`, escrita "para qualquer rota que ganhe card próprio
depois". Este PR é a rota que ela esperava.

O card usa o que o tópico já tem: **nome** em azul e na frente, **grupo** depois
do mesmo `·` que separa o título das páginas, e a **descrição** como chamada.

| tópico | card |
|---|---|
| `dijkstra` | **Dijkstra** · Grafos / "Caminho mais curto com pesos não-negativos." |
| `busca-binaria-avancada` | **Busca Binária no Espaço de Respostas** · Busca Binária, em 46px porque é a linha mais longa do roadmap (52 caracteres) |
| `strings` | **Strings** · Arrays e Strings, com a descrição de 213 caracteres cortada na primeira frase |
| `matematica` | **Matemática** sozinho: seis tópicos dão nome ao próprio grupo, e card que repete a mesma palavra parece defeito |

## Os números medidos

Dois builds de cada lado, na mesma máquina, alternados, com `out/` apagado antes
de cada um:

| | build | `out/` | páginas | imagens |
|---|---|---|---|---|
| antes | 8,5s / 7,9s | 17064 KB | 59 | 3 |
| depois | 9,7s / 9,9s | 19916 KB | 106 | 50 |

**+47 imagens, +2852 KB (+16,7%) de export, cerca de +1,5s de build** (+18%). As
47 imagens novas somam 2,85 MB, uma média de 60 KB cada. O peso é do artefato
estático, não do que o leitor baixa: a página continua carregando zero byte a mais,
porque o card só é buscado por quem faz o scraping do link.

Os bytes são determinísticos: dois builds seguidos deram o **mesmo sha256** nas 50
imagens, então o `out/` não muda sozinho entre deploys.

## Um achado do caminho, consertado na fonte

A fonte do card não é a fonte do navegador. O Satori (motor do `next/og`) monta a
fonte baixando só o que o texto pede, e há glifo que ele não consegue: o `⇄` da
descrição de Números Binários devolvia
`Failed to download dynamic font. Status: 400`, **o build passava verde**, e o card
saía com um retângulo vazio: "a conversão decimal ▯ binário". Achado abrindo o PNG,
que é a única coisa que mostra isso.

A primeira versão deste PR contornava o glifo dentro do card. O Wilson, que é o
dono do conteúdo, decidiu o contrário e está certo: **o símbolo não precisava
existir**. Ele saiu da fonte, em `content/roadmap.ts:1144`:

```diff
- description: "O sistema binário e a conversão decimal ⇄ binário.",
+ description: "O sistema binário e a conversão entre decimal e binário.",
```

O ganho não é só do card. Essa string é também a `meta description`, a
`og:description` e a `twitter:description` da página do tópico: um `⇄` num
resultado de busca é ruído, e ninguém procura por ele. Com a causa resolvida, o
contorno (`TROCAS` e a substituição do `copyDoCard`) foi apagado, e o PR ficou
menor.

O card agora lê, conferido no PNG regenerado:

> **Números Binários** · Manipulação de Bits
> O sistema binário e a conversão entre decimal e binário.

Zero avisos de fonte no build (`Failed to load dynamic font` = 0 ocorrências).

**A guarda ficou**, que é o valor durável do achado: `exigirLatin1` para o build
quando `name`, `group` ou `description` trouxerem caractere acima de U+00FF,
dizendo o tópico, o campo e o símbolo. Que isso volta a acontecer não é
hipótese: o `roadmap.ts` já junta `2ⁿ` (U+207F) num título de referência e `≥` (U+2265)
num nome de problema do LeetCode. Nenhum dos dois entra no card, e é por isso que
a guarda olha os três campos que o card desenha, e só eles.

### Conferência em 390x844 (a frase ficou mais longa)

A descrição é renderizada em quatro lugares. Esta aparece no card do roadmap e nos
três metadados: a home só mostra os `FEATURED`, e o parágrafo da página do tópico
é do caminho sem artigo, que não é o caso deste tópico. Medido no card do roadmap,
com o texto antigo e o novo na mesma caixa:

| viewport | antes | depois |
|---|---|---|
| 390x844 | 1 linha, card 137px | **2 linhas, card 156px** |
| 768x1024 | 1 linha | 1 linha |
| 1440x900 | 2 linhas, card 156px | 2 linhas, card 156px |

Só o celular ganha uma linha, e ali os cards empilham em coluna única (os irmãos do
grupo medem 137 e 129, alturas livres, então não há linha para desalinhar). Nas
três viewports: nenhum texto vazando a própria caixa (`scrollWidth == clientWidth`),
nenhuma página vazando na horizontal, `font-size` de 12,5px em todas.


## Prova de quebra

Três quebras, nenhuma delas com `git checkout --`, e nenhum build silenciado.

**A) A rota inteira sai.** O build passa (59/59 páginas) e o teste reprova na
linha da asserção, com o valor de antes no `Received`:

```
> 75 |   expect(apontam).toEqual(deviam);
    - Expected  - 47
    + Received  + 47
    +   "dijkstra": "/opengraph-image",
    +   "strings": "/opengraph-image",
    ... os 47
```

**B) Só o `generateStaticParams` sai.** O teste nem chega a rodar, porque o Next
reprova o build sozinho:

```
Error: Page "/topico/[slug]/opengraph-image" is missing "generateStaticParams()"
so it cannot be used with "output: export" config.
```

**C) O `generateStaticParams` devolve 1 dos 47.** É o caso perigoso: o build
**passa**, gera 4 imagens, e o teste que confere a URL **passa também**, porque o
HTML continua apontando para a rota certa de cada tópico. Quem reprova é a
asserção que vai buscar o PNG:

```
> 97 |     expect(resposta.status(), `${slug} (${perfil}): o PNG do card`).toBe(200);
     Expected: 200
     Received: 404
```

É por isso que o teste não se contenta com a URL: 46 cards podiam não existir com
o HTML inteiro correto.

**D) O símbolo volta para uma `description`.** A guarda para o build, nomeando o
tópico, o campo e o caractere:

```
Error: opengraph-image (binary-numbers): "⇄" em "description" está fora do Latin-1,
e o card do Open Graph sai com um retângulo vazio no lugar. Troque o símbolo por
palavras no texto do tópico, em content/roadmap.ts.
```

**E) O mesmo símbolo num campo que o card não desenha** (um título de referência):
o build passa, 106/106. A guarda é escopada, não é uma proibição geral de símbolo
no `roadmap.ts`.

## Como isto se encaixa com o #49

O #49 está aberto e mexe em `src/lib/og.tsx`, `src/lib/seo.ts` e
`src/app/topico/[slug]/page.tsx`. Este PR **não toca em nenhum dos três**: só lê e
importa o `og.tsx`.

O #49 descobriu, na revisão, que definir `openGraph` na página **corta a herança**
da imagem da raiz, e contornou nomeando a imagem explicitamente
(`ogImage: "raiz"` → `images: [{ url: "/opengraph-image", ... }]`). **Este PR
resolve de vez o problema que ele contornou**: com card próprio no segmento, o
tópico não precisa mais herdar nada.

Só que o contorno não sai sozinho, e isso foi **medido, não deduzido**. Numa branch
descartável com os dois mergeados:

```
depois do merge, sem mudar nada:
  /topico/dijkstra/  og:image = https://dsa.craftcodeclub.io/opengraph-image
```

As 47 imagens continuam sendo geradas e **ninguém aponta para elas**: o `images`
explícito do `pageMetadata` vence o arquivo do segmento, e o defeito volta em
silêncio, agora com 2,85 MB de peso morto no `out/`. O teste deste PR reprova nessa
integração, que é como o conflito aparece em vez de passar batido:

```
Error: imagens repetidas entre dijkstra,busca-binaria-avancada,strings,matematica,binary-numbers,(raiz)
Expected: 6
Received: 1
```

**O conserto é uma linha, e ele é do #49**: apagar `ogImage: "raiz"` do
`generateMetadata` de `topico/[slug]/page.tsx` (o padrão já é `"segmento"`).
Verificado na mesma branch descartável:

```
/topico/dijkstra/  og:image = .../topico/dijkstra/opengraph-image?a3a160266d8c9470
/topico/strings/   og:image = .../topico/strings/opengraph-image?a3a160266d8c9470
/apoie/            og:image = .../opengraph-image          <- continua na raiz, como tem que ser
```

com `seo-og-topico.spec.ts`, `seo-estrutura.spec.ts` e `seo.spec.ts` passando
juntos (25 testes). O `/apoie/` continua precisando do `ogImage: "raiz"`, porque
ele não tem card próprio: a opção não some do `seo.ts`, só deixa de valer para
tópico.

Quem mergear por último faz a linha. Se for o #49, ele já entra sem o contorno.

## O limite que fica, medido e delimitado

**O `og:image:alt` é o mesmo texto nas 47 páginas.** O Next lê o `alt` do arquivo
de imagem **uma vez**: o `next-metadata-image-loader` monta um objeto com os named
exports e usa `imageModule.alt`. O jeito de variar por imagem é
`generateImageMetadata`, e ele não sobe neste segmento.

Vale escrever o limite com precisão, porque **a doc do Next não diz isso**: a
página do `generateImageMetadata` não menciona export estático, e o exemplo dela é
justamente um `app/products/[id]/opengraph-image.tsx`; a lista de *Unsupported
Features* do export estático não cita `generateImageMetadata` nem rota de imagem
de metadata (cita, sim, *"Dynamic Routes without `generateStaticParams()`"*).

Medido no **Next 16.2.12**, com log dentro das duas funções:

1. exportar `generateImageMetadata` faz o `next-metadata-route-loader` gerar um
   `generateStaticParams` **próprio**, que substitui o do arquivo. O nosso **não
   roda**: o log dele nunca sai.
2. o gerado devolve só `{ __metadata_id__ }` e é chamado com `params = {}`,
   **inclusive quando um `layout.tsx` do próprio `[slug]` exporta
   `generateStaticParams`** (testado). O `slug` nunca é enumerado.
3. sem `slug`, a rota `/topico/[slug]/opengraph-image/[__metadata_id__]` sai com
   zero rotas pré-renderizadas, e aí sim cai na regra documentada:

```
Error: Page "/topico/[slug]/opengraph-image/[__metadata_id__]" is missing
"generateStaticParams()" so it cannot be used with "output: export" config.
```

Ou seja: **não é "incompatível por projeto"**, é que os params do segmento pai não
chegam ao `generateStaticParams` gerado. Enquanto for assim, daqui dá para ter um
card por tópico ou um alt por tópico, não os dois. Descrito assim o limite é
reportável ao Next, e volta a valer sozinho se eles consertarem.

Quem alcança os dois hoje, sem depender disso, é o `generateMetadata` da página,
que recebe o `slug` e pode passar `openGraph.images[].alt`. Esse arquivo é o
`topico/[slug]/page.tsx`, do #49, e por isso não entra aqui. O `alt` atual
descreve o card sem mentir, e o card **mostra** o nome do tópico em 62px.

## Verificação

Refeita **depois de mesclar a `main`** (`0d7d01a`, que trouxe 13 PRs), sem
conflito e sem mudança em `package.json`/`package-lock.json`:

- `npm run build` ✅ (106/106 páginas)
- `npx tsc --noEmit` ✅
- suíte inteira ✅ **570 passed** (eram 476 antes do merge; os testes novos vieram da `main`)
- `guarda-commit.py` ✅ (um `✓` por commit, lido de `stdin`, com `--no-merges`)
- `npm run lint` ✅ **6 problemas, 0 erros**, todos em `ProgressProvider.tsx`,
  `Shell.tsx` e `visualizer.tsx` — arquivos que este PR não toca. O baseline caiu
  de 8 para 6 na própria `main`; este PR não acrescenta nenhum.
- conferência visual das imagens geradas em `dijkstra`, `busca-binaria-avancada`,
  `strings`, `matematica`, `hash-table` e `binary-numbers`, que é onde o retângulo
  vazio apareceu e onde o conserto foi confirmado
- conferência em 390x844, 768x1024 e 1440x900 do único lugar visível onde a
  descrição mudada é renderizada

