### PR TITLE
fix(ci): os guardas que saíam 0 sem ter olhado nada

### DIFF
--- a/scripts/guarda-commit.py
+++ b/scripts/guarda-commit.py
@@ -1,26 +1,99 @@
+#!/usr/bin/env python3
 """Guarda dos headers de commit: tamanho E caixa.
 
-    git log --format="%s" origin/main..HEAD | python3 guarda-commit.py
+    git log --format="%s" origin/main..HEAD | python3 scripts/guarda-commit.py
+
+O `|` NÃO é enfeite: o guarda lê de `stdin`. Chamado sem entrada ele não tem o
+que checar, e é justamente aí que a versão anterior saía **0 sem imprimir nada**
+— indistinguível de "olhei todos os commits e estão certos". Foi assim que dez
+agentes "rodaram o guarda" antes de cada push sem que nenhum guarda rodasse.
+Desde então ele sai 2 e diz o que faltou.
+
+Códigos de saída:
+
+    0   checou pelo menos UM header e todos passam
+    1   algum header reprova o commitlint
+    2   o guarda NÃO CHECOU NADA (`stdin` vazio, ou só commits de merge)
 
 O commitlint reprova por duas coisas que passam despercebidas:
   · header acima de 72 CARACTERES (não bytes: um `ê` vale 2 em `awk length`);
   · `subject-case` — o assunto não pode começar em maiúscula, e isso inclui
     sigla e nome de variável de ambiente (`PORT`, `CSS`, `SEO`).
 """
-import re, sys
+import re
+import sys
 
-ruim = False
-for linha in sys.stdin:
-    h = linha.rstrip()
-    if not h:
-        continue
-    n = len(h)
-    assunto = h.split(":", 1)[1].strip() if ":" in h else h
+# Commit de merge não é escrito por ninguém: o `git merge origin/main` gera
+# "Merge remote-tracking branch 'origin/main' into <branch>", que começa em
+# maiúscula e costuma passar de 72 caracteres — ou seja, reprovava pelas DUAS
+# regras acima. E o portão de verdade, o `wagoid/commitlint-github-action` do
+# `.github/workflows/commitlint.yml`, **ignora** essas mensagens (os
+# `defaultIgnores` do `@commitlint/is-ignored` casam `Merge pull request`,
+# `Merge remote-tracking branch` e `Merge <x> into <y>`). O guarda local
+# reprovava o que o CI aprova: falso alarme puro, e caro — dois agentes
+# reescreveram a mensagem do merge à mão para calar o guarda, e o histórico
+# guarda as duas cicatrizes ("chore: mescla a main e regenera o lock com o axe"
+# e "chore: traz a main nova para a branch do anúncio e da pausa").
+#
+# O padrão é ancorado, sensível à caixa e exige o espaço, porque a convenção
+# deste repositório é Conventional Commits em MINÚSCULA: `feat: merge sort
+# ganha visualizador` não casa (não está no começo e não tem maiúscula), e
+# `Merged` também não (falta o espaço). Conferido em 2026-08-07 sobre a
+# `origin/main` inteira: `^Merge ` casou 55 assuntos, TODOS commits de merge de
+# verdade (`git log --merges` devolve 57; os 2 a mais são os dois merges com a
+# mensagem reescrita à mão acima). Nenhum commit de trabalho casou.
+MERGE = re.compile(r"^Merge ")
+
+
+def problemas_de(header: str) -> list[str]:
+    """As duas regras do commitlint que este guarda antecipa."""
+    assunto = header.split(":", 1)[1].strip() if ":" in header else header
     problemas = []
-    if n > 72:
-        problemas.append(f"{n} caracteres (máx. 72)")
+    if len(header) > 72:
+        problemas.append(f"{len(header)} caracteres (máx. 72)")
     if assunto[:1].isupper():
         problemas.append(f"assunto começa em maiúscula ({assunto.split()[0]!r})")
-    print(("✖ " if problemas else "✓ ") + h + ("  → " + "; ".join(problemas) if problemas else ""))
-    ruim = ruim or bool(problemas)
-sys.exit(1 if ruim else 0)
+    return problemas
+
+
+def main() -> int:
+    ruim = False
+    checados = 0
+    merges = 0
+
+    for linha in sys.stdin:
+        h = linha.rstrip()
+        if not h:
+            continue
+        if MERGE.match(h):
+            merges += 1
+            print(f"↷ {h}  → commit de merge, ignorado (igual ao commitlint)")
+            continue
+        checados += 1
+        problemas = problemas_de(h)
+        marca = "✖ " if problemas else "✓ "
+        print(marca + h + ("  → " + "; ".join(problemas) if problemas else ""))
+        ruim = ruim or bool(problemas)
+
+    # A linha do fim existe para tirar a ambiguidade da saída vazia: quem roda
+    # precisa conseguir distinguir "passou" de "nem olhou" SEM contar as linhas
+    # de cima. Ela vai para o stdout mesmo no caminho feliz, de propósito.
+    if checados == 0:
+        sys.stdout.flush()   # senão o stderr sai ANTES das linhas `↷` e a leitura fica trocada
+        motivo = (f"as {merges} linha(s) que chegaram eram todas commits de merge"
+                  if merges else "não chegou nada em `stdin` — faltou o `|` do pipe?")
+        print(f"guarda-commit: NENHUM header foi checado ({motivo}).", file=sys.stderr)
+        print("guarda-commit: uso: "
+              'git log --format="%s" origin/main..HEAD | python3 scripts/guarda-commit.py',
+              file=sys.stderr)
+        return 2
+
+    resumo = f"{checados} header(s) checado(s)"
+    if merges:
+        resumo += f", {merges} commit(s) de merge ignorado(s)"
+    print(f"{'✖' if ruim else '✓'} {resumo}.")
+    return 1 if ruim else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/guarda-idioma.py
+++ b/scripts/guarda-idioma.py
@@ -12,6 +12,13 @@ guarda não conseguiu rodar. **Nunca sai 0 por não ter conseguido olhar**: o
 histórico deste arquivo é de passar verde com a aula estragada, e um guarda que
 falha calado é pior que nenhum.
 
+Isso vale para a ENTRADA também, e era o buraco que sobrava. Um diretório sem
+nenhum `.tsx` dentro — o `git archive` que falhou, o caminho digitado errado —
+saía `SUMIRAM: nenhuma / APARECERAM: nenhuma (0 arquivos)` **com código 0**, que
+é o mesmo veredito de "comparei o tópico inteiro e nada mudou". Hoje isso é
+código 2. A fronteira: *não conseguiu olhar* é erro do guarda (2); *olhou e não
+achou texto de tela* é resultado, e continua sendo 0.
+
 O QUE MUDOU NESTA VERSÃO, E POR QUÊ
 -----------------------------------
 As três versões anteriores casavam texto por expressão regular, e as três
@@ -142,12 +149,27 @@ def main() -> None:
             morrer(f"não existe: {p}")
     if a.is_dir() != d.is_dir():
         morrer("os dois lados têm que ser ambos arquivo ou ambos diretório.")
+    # Comparar um caminho com ele mesmo passa SEMPRE, e por construção: os dois
+    # lados saem da mesma leitura. É verde sem ter olhado duas versões de nada.
+    if a.resolve() == d.resolve():
+        morrer(f"os dois lados são o mesmo caminho ({a.resolve()}) — "
+               "nada seria comparado. Aponte a versão de ANTES e a de DEPOIS.")
 
     if a.is_file():
         dados = extrair([a, d])
-        raise SystemExit(1 if comparar(dados[str(a)], dados[str(d)]) else 0)
+        mudou = comparar(dados[str(a)], dados[str(d)])
+        # Quantos itens o guarda olhou. Sem isto, `SUMIRAM: nenhuma /
+        # APARECERAM: nenhuma` tem duas leituras — "conferi tudo e está igual" e
+        # "não achei texto nenhum para conferir" — e a segunda é a que engana.
+        print(f"({len(dados[str(a)]['tela'])} texto(s) de tela em {a}, "
+              f"{len(dados[str(d)]['tela'])} em {d})")
+        raise SystemExit(1 if mudou else 0)
 
     nomes = sorted(set(arquivos_de(a)) | set(arquivos_de(d)))
+    if not nomes:
+        morrer(f"nenhum arquivo {'/'.join(EXTENSOES)} em {a} nem em {d} — "
+               "o guarda não olhou NADA. Confira os caminhos (e, na CI, se o "
+               "`git archive` da base extraiu alguma coisa).")
     dados = extrair([a / n for n in nomes if (a / n).exists()]
                     + [d / n for n in nomes if (d / n).exists()])
     vazio = {"tela": [], "codigo": []}

--- a/scripts/testa-guarda-idioma.py
+++ b/scripts/testa-guarda-idioma.py
@@ -1,22 +1,39 @@
 #!/usr/bin/env python3
-"""Suíte do próprio guarda de idioma.
+"""Suíte dos guardas: o de idioma e o de header de commit.
 
-    python3 scripts/testa-guarda-idioma.py                 # roda o guarda atual
-    python3 scripts/testa-guarda-idioma.py --guarda <p>    # roda OUTRO guarda
-    python3 scripts/testa-guarda-idioma.py -v              # imprime a saída de cada caso
+    python3 scripts/testa-guarda-idioma.py                      # roda os guardas atuais
+    python3 scripts/testa-guarda-idioma.py --guarda <p>         # roda OUTRO guarda-idioma
+    python3 scripts/testa-guarda-idioma.py --guarda-commit <p>  # roda OUTRO guarda-commit
+    python3 scripts/testa-guarda-idioma.py -v                   # imprime a saída de cada caso
 
-O `--guarda` existe para a prova de quebra: aponte para uma cópia da versão
-anterior e veja os casos 4, 5 e 6 passarem verdes com a aula estragada. Um
-guarda que você nunca viu falhar não é guarda.
+Os `--guarda*` existem para a prova de quebra: aponte para uma cópia da versão
+anterior e veja os casos passarem verdes com a aula estragada (ou com o guarda
+cego). Um guarda que você nunca viu falhar não é guarda.
 
-Cada caso é um par de arquivos em `fixtures-guarda-idioma/<caso>/`, com
-extensão `.tsx.txt` de propósito: o `tsconfig.json` inclui `**/*.tsx`, então
-fixture com extensão de verdade entraria no `npx tsc --noEmit` e quebraria o
-typecheck com código que existe justamente para estar errado. O motor força
-`ScriptKind.TSX`, então o parser lê igual.
+**O nome do arquivo ficou menor que o conteúdo, e é de propósito.** Ele cobre os
+DOIS guardas porque é este caminho que o portão da CI chama
+(`.github/workflows/tests.yml`, passo "Suíte do próprio guarda de idioma");
+renomear exigiria mexer no workflow, e uma suíte que a CI não roda protege
+menos que um nome errado.
+
+A suíte tem dois blocos:
+
+  FIXTURES — pares de arquivo em `fixtures-guarda-idioma/<caso>/`, com extensão
+    `.tsx.txt` de propósito: o `tsconfig.json` inclui `**/*.tsx`, então fixture
+    com extensão de verdade entraria no `npx tsc --noEmit` e quebraria o
+    typecheck com código que existe justamente para estar errado. O motor força
+    `ScriptKind.TSX`, então o parser lê igual.
+
+  LINHA DE COMANDO — o guarda chamado errado, ou sem nada para olhar. É o bloco
+    que defende a regra que os dois guardas violavam: **ferramenta que sai 0 sem
+    receber entrada é indistinguível de ferramenta que sai 0 porque passou.**
+    O `guarda-commit.py` saía 0 e MUDO sem o pipe (dez agentes "rodaram o
+    guarda" e nenhum guarda rodou), e o `guarda-idioma.py` saía 0 com dois
+    diretórios sem um `.tsx` dentro.
 """
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 AQUI = Path(__file__).resolve().parent
@@ -58,31 +75,142 @@ CASOS = [
      "o MESMO `d`/`viewBox` num ELEMENTO HTML é código e não reprova"),
 ]
 
+# ---------------------------------------------------------------------------
+# Bloco 2: o guarda chamado errado, ou sem nada para olhar.
+#
+# Aqui o valor esperado é o CÓDIGO DE SAÍDA exato, não "reprova/passa", porque o
+# ponto destes casos é justamente a diferença entre 0 ("olhei e está tudo bem"),
+# 1 ("olhei e achei problema") e 2 ("não consegui olhar"). Um caso que só
+# checasse "não-zero" aprovaria a versão antiga do `guarda-commit.py` no caso
+# do merge, que reprovava — pelo motivo errado.
+#
+# `{tmp}` nos caminhos é substituído por um diretório temporário da rodada. Os
+# dois diretórios vazios não podem virar fixture: o git não versiona pasta
+# vazia, e uma pasta com `.gitkeep` dentro deixa de ser o caso que interessa.
+# ---------------------------------------------------------------------------
+# (nome, guarda, argumentos, stdin, código esperado, o que o caso prova)
+CASOS_CLI = [
+    # -- guarda-commit -------------------------------------------------------
+    ("commit-merge-no-meio-do-trabalho", "commit", [],
+     "fix(ci): pula commit de merge no guarda de header\n"
+     "Merge remote-tracking branch 'origin/main' into fix/os-guardas\n"
+     "test(ci): prova os dois guardas na suíte que a CI já roda\n", 0,
+     "merge do `git merge origin/main` não reprova (o commitlint também o ignora)"),
+    ("commit-sem-o-pipe", "commit", [], "", 2,
+     "`stdin` vazio NÃO é sucesso: 0 mudo era indistinguível de 'passou'"),
+    ("commit-so-merges", "commit", [],
+     "Merge pull request #63 from craft-code-club/test/a-rede-que-faltava\n", 2,
+     "pulou tudo = checou nada; nunca sai 0 sem ter olhado um header"),
+    ("commit-header-longo", "commit", [],
+     "feat(viz): o visualizador de heap ganha presets, legenda nova, teclado e foco\n", 1,
+     "header de 77 caracteres continua reprovando (não trocamos cegueira por silêncio)"),
+    ("commit-assunto-em-maiuscula", "commit", [],
+     "fix(test): PORT inválida falha alto\n", 1,
+     "`subject-case` continua reprovando sigla no começo do assunto"),
+    # O header abaixo tem 77 caracteres DE PROPÓSITO: se o `^Merge ` engolisse
+    # um commit de trabalho que fala de merge sort, o guarda sairia 0 e o caso
+    # não teria como perceber. Ele só sai 1 se o header foi de fato checado.
+    ("commit-merge-minusculo-e-checado", "commit", [],
+     "feat(viz): merge sort ganha visualizador com passo a passo, presets e legenda\n", 1,
+     "`^Merge ` é ancorado e sensível à caixa: commit de trabalho NÃO é pulado"),
+    ("commit-header-bom", "commit", [],
+     "fix(ci): o guarda de header ignora commit de merge\n", 0,
+     "o caminho feliz continua saindo 0 — e agora imprimindo quantos checou"),
+    # -- guarda-idioma -------------------------------------------------------
+    ("idioma-sem-argumento", "idioma", [], None, 2,
+     "sem argumento nenhum: sai 2, não 0 (é o `npm run guarda:idioma` pelado)"),
+    ("idioma-um-argumento-so", "idioma", ["{tmp}/a.tsx"], None, 2,
+     "meio par não é par: sai 2"),
+    ("idioma-caminho-inexistente", "idioma", ["{tmp}/a.tsx", "{tmp}/nao-existe.tsx"], None, 2,
+     "caminho errado sai 2 em vez de fingir comparação"),
+    ("idioma-diretorio-sem-fonte", "idioma", ["{tmp}/vazio-a", "{tmp}/vazio-b"], None, 2,
+     "dois diretórios sem um `.tsx` dentro: saía 0 '(0 arquivos)', agora 2"),
+    ("idioma-mesmo-caminho-dos-dois-lados", "idioma", ["{tmp}/a.tsx", "{tmp}/a.tsx"], None, 2,
+     "comparar um arquivo com ele mesmo passa por construção: vira erro"),
+    ("idioma-par-normal-ainda-reprova", "idioma",
+     [str(FIXTURES / "1-no-de-texto-jsx" / "antes.tsx.txt"),
+      str(FIXTURES / "1-no-de-texto-jsx" / "depois.tsx.txt")], None, 1,
+     "os guardas novos de entrada não engoliram o caminho que reprova"),
+    ("idioma-diretorio-com-fonte-passa", "idioma", ["{tmp}/dir-a", "{tmp}/dir-b"], None, 0,
+     "diretório COM fonte e sem mudança de tela continua saindo 0"),
+]
+
+FONTE_DE_TESTE = 'export const Rotulo = () => <span>passo 1 de 7</span>;\n'
+
+
+def preparar_tmp(tmp: Path) -> None:
+    """Monta o cenário dos casos de linha de comando."""
+    (tmp / "a.tsx").write_text(FONTE_DE_TESTE, encoding="utf-8")
+    (tmp / "vazio-a").mkdir()
+    (tmp / "vazio-b").mkdir()
+    # Um `.md` de cada lado: o diretório NÃO está vazio, e mesmo assim não há
+    # fonte nenhuma para o guarda olhar. É a forma realista do caso (um
+    # `git archive` que trouxe só o README do diretório).
+    (tmp / "vazio-a" / "README.md").write_text("nao sou fonte\n", encoding="utf-8")
+    (tmp / "vazio-b" / "README.md").write_text("nao sou fonte\n", encoding="utf-8")
+    for lado in ("dir-a", "dir-b"):
+        (tmp / lado).mkdir()
+        (tmp / lado / "Peca.tsx").write_text(FONTE_DE_TESTE, encoding="utf-8")
+
+
+def caminho_do_flag(argv: list[str], flag: str, atual: Path) -> Path:
+    """Lê `--flag <caminho>`. Erro de uso sai 2, nunca 1 (que é 'caso reprovou')."""
+    if flag not in argv:
+        return atual
+    i = argv.index(flag) + 1
+    if i >= len(argv):
+        raise SystemExit(2)
+    alvo = Path(argv[i])
+    if not alvo.is_file():
+        print(f"guarda não encontrado: {alvo}", file=sys.stderr)
+        raise SystemExit(2)
+    return alvo.resolve()
+
+
+def rodar_cli(guardas: dict, tmp: Path, verboso: bool) -> list[str]:
+    """Bloco 2. Devolve os nomes dos casos que falharam."""
+    print("  -- linha de comando (o guarda sem nada para olhar) --")
+    falhas = []
+    for nome, qual, args, entrada, esperado, oquê in CASOS_CLI:
+        cmd = [sys.executable, str(guardas[qual])] + [a.format(tmp=tmp) for a in args]
+        r = subprocess.run(cmd, input=entrada, capture_output=True, text=True)
+        ok = r.returncode == esperado
+        marca = "ok  " if ok else "FALHA"
+        print(f"  {marca}  {nome:<38} sai {esperado:<4} {oquê}")
+        if not ok:
+            print(f"         -> saiu {r.returncode}, esperado {esperado}")
+        if verboso or not ok:
+            for linha in (r.stdout + r.stderr).rstrip().splitlines():
+                print(f"         | {linha[:160]}")
+        if not ok:
+            falhas.append(nome)
+    return falhas
+
 
 def main() -> int:
     argv = sys.argv[1:]
     verboso = "-v" in argv or "--verbose" in argv
-    guarda = AQUI / "guarda-idioma.py"
-    if "--guarda" in argv:
-        # Sem o caminho depois do flag isto era um IndexError com traceback e
-        # código 1 — o MESMO código de "um caso reprovou". Erro de uso não pode
-        # ser confundido com resultado de teste, então sai 2.
-        i = argv.index("--guarda") + 1
-        if i >= len(argv):
-            print("uso: testa-guarda-idioma.py [--guarda <caminho>] [-v]", file=sys.stderr)
-            return 2
-        alvo = Path(argv[i])
-        if not alvo.is_file():
-            print(f"guarda não encontrado: {alvo}", file=sys.stderr)
-            return 2
-        guarda = alvo.resolve()
+    # Sem o caminho depois do flag isto era um IndexError com traceback e
+    # código 1 — o MESMO código de "um caso reprovou". Erro de uso não pode
+    # ser confundido com resultado de teste, então sai 2.
+    if any(f in argv and argv.index(f) + 1 >= len(argv) for f in ("--guarda", "--guarda-commit")):
+        print("uso: testa-guarda-idioma.py [--guarda <p>] [--guarda-commit <p>] [-v]",
+              file=sys.stderr)
+        return 2
+    guardas = {
+        "idioma": caminho_do_flag(argv, "--guarda", AQUI / "guarda-idioma.py"),
+        "commit": caminho_do_flag(argv, "--guarda-commit", AQUI / "guarda-commit.py"),
+    }
 
-    print(f"guarda: {guarda}\n")
+    print(f"guarda-idioma: {guardas['idioma']}")
+    print(f"guarda-commit: {guardas['commit']}\n")
     falhas = []
+    print("  -- fixtures (o texto de tela) --")
     for pasta, deve_reprovar, oquê in CASOS:
         base = FIXTURES / pasta
         r = subprocess.run(
-            [sys.executable, str(guarda), str(base / "antes.tsx.txt"), str(base / "depois.tsx.txt")],
+            [sys.executable, str(guardas["idioma"]),
+             str(base / "antes.tsx.txt"), str(base / "depois.tsx.txt")],
             capture_output=True, text=True,
         )
         # Código inesperado é o guarda NÃO TENDO RODADO, não um caso reprovado.
@@ -112,10 +240,18 @@ def main() -> int:
             falhas.append(pasta)
 
     print()
+    with tempfile.TemporaryDirectory(prefix="testa-guardas-") as bruto:
+        tmp = Path(bruto)
+        preparar_tmp(tmp)
+        falhas += rodar_cli(guardas, tmp, verboso)
+
+    total = len(CASOS) + len(CASOS_CLI)
+    print()
     if falhas:
-        print(f"{len(falhas)} de {len(CASOS)} casos FALHARAM: {', '.join(falhas)}")
+        print(f"{len(falhas)} de {total} casos FALHARAM: {', '.join(falhas)}")
         return 1
-    print(f"{len(CASOS)} de {len(CASOS)} casos ok")
+    print(f"{total} de {total} casos ok "
+          f"({len(CASOS)} fixtures + {len(CASOS_CLI)} de linha de comando)")
     return 0
 
 


### PR DESCRIPTION
## O que este PR conserta

Dois guardas em `scripts/` passavam **sem olhar nada**, e a regra que os dois
violavam é a mesma:

> **Ferramenta que sai 0 sem receber entrada é indistinguível de ferramenta que
> sai 0 porque passou.**

Foi assim que dez agentes rodaram `python3 scripts/guarda-commit.py` sem o pipe,
todos "rodaram o guarda", e nenhum guarda rodou.

Nada de `src/`, `content/`, `tests/`, `.github/`, `package.json` ou
`package-lock.json` foi tocado: o diff são **três arquivos Python em `scripts/`**.

---

## 1. `guarda-commit.py` reprovava commit de merge

`git merge origin/main` gera `Merge remote-tracking branch 'origin/main' into
<branch>` — começa em maiúscula e costuma passar de 72 caracteres, ou seja caía
nas **duas** regras do guarda.

**E o portão de verdade aprova essa mensagem.** O
`wagoid/commitlint-github-action` do check `Valida mensagens de commit` usa os
`defaultIgnores` do `@commitlint/is-ignored`, que casam `Merge pull request`,
`Merge remote-tracking branch` e `Merge <x> into <y>`. Medido com o
`@commitlint/cli` e o `config-conventional`, fora do repositório:

```
$ echo "Merge remote-tracking branch 'origin/main' into descartavel/prova-merge" | commitlint -x @commitlint/config-conventional
exit=0

$ echo "Merge pull request #63 from craft-code-club/test/a-rede-que-faltava" | commitlint -x @commitlint/config-conventional
exit=0

# controle, a MESMA forma sem ser merge — prova que o arnês funciona:
$ echo "Mescla remote-tracking branch 'origin/main' into descartavel/prova" | commitlint -x @commitlint/config-conventional
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]
exit=1
```

O guarda local reprovava o que a CI aprova. **Falso alarme puro, e caro:** dois
agentes reescreveram a mensagem do merge à mão só para calá-lo, e as duas
cicatrizes estão no histórico (`chore: mescla a main e regenera o lock com o
axe` e `chore: traz a main nova para a branch do anúncio e da pausa`).

### O regex, e por que `^Merge ` é seguro aqui

Ancorado, sensível à caixa, com o espaço obrigatório. Conferido sobre a
`origin/main` inteira em 2026-08-07:

| medida | valor |
|---|---|
| assuntos que casam `^Merge ` | **55** |
| commits de merge de verdade (`git log --merges`) | **57** |
| commits de **trabalho** que casaram | **0** |

Os 2 de diferença são justamente os dois merges com a mensagem reescrita à mão
acima — o guarda antigo os empurrou para fora do padrão. A convenção daqui é
Conventional Commits **em minúscula**, então `feat(viz): merge sort ganha
visualizador…` não casa (não está no começo e não tem maiúscula), e `Merged`
também não (falta o espaço). Há um caso na suíte para exatamente isso.

### Prova de quebra, com um commit de merge de verdade

Branch descartável em `origin/main~3`, um commit de trabalho, `git merge
origin/main`:

```
### ANTES (guarda da origin/main)
✖ Merge remote-tracking branch 'origin/main' into descartavel/prova-merge  → assunto começa em maiúscula ('Merge')
✓ chore(ci): arquivo descartavel da prova de quebra do guarda
exit=1

### DEPOIS (guarda deste PR)
↷ Merge remote-tracking branch 'origin/main' into descartavel/prova-merge  → commit de merge, ignorado (igual ao commitlint)
✓ chore(ci): arquivo descartavel da prova de quebra do guarda
✓ 1 header(s) checado(s), 1 commit(s) de merge ignorado(s).
exit=0
```

## 2. `guarda-commit.py` sem o pipe saía 0 e mudo

```
### ANTES
$ python3 scripts/guarda-commit.py < /dev/null
exit=0                       # e sem imprimir uma linha sequer

### DEPOIS
$ python3 scripts/guarda-commit.py < /dev/null
guarda-commit: NENHUM header foi checado (não chegou nada em `stdin` — faltou o `|` do pipe?).
guarda-commit: uso: git log --format="%s" origin/main..HEAD | python3 scripts/guarda-commit.py
exit=2
```

O caminho feliz agora **diz quantos olhou**, que é o outro lado da mesma regra:
saída vazia deixa de ser ambígua.

```
✓ fix(ci): guarda de idioma sai 2 quando não tem o que comparar
✓ 3 header(s) checado(s).
```

**Contrato de saída:** `0` checou ao menos um header e passou · `1` algum
reprova · `2` não checou nada (`stdin` vazio, **ou só commits de merge**). É o
mesmo `0/1/2` do `guarda-idioma.py`.

## 3. `guarda-idioma.py` sem argumento — o defeito relatado **não existe mais**

Medido antes de mexer, na `origin/main`:

```
$ python3 scripts/guarda-idioma.py
guarda-idioma: uso: python3 scripts/guarda-idioma.py <antes> <depois>  (arquivo ou diretório)
exit=2
```

O PR #45 já resolveu isso quando reescreveu o guarda. `npm run guarda:idioma`
pelado sai 2, com a mensagem certa — **problema menor, e já consertado**. Fica
uma trava de regressão na suíte para não voltar.

## 4. O que sobrava no `guarda-idioma.py`, e era silencioso

A mesma classe, pela **entrada**:

```
### ANTES
$ python3 scripts/guarda-idioma.py /tmp/antes/content/visualizers content/visualizers
SUMIRAM: nenhuma / APARECERAM: nenhuma  (0 arquivos)
exit=0

### DEPOIS
guarda-idioma: nenhum arquivo .tsx/.ts/.jsx/.js em /tmp/antes/... nem em ... —
o guarda não olhou NADA. Confira os caminhos (e, na CI, se o `git archive` da
base extraiu alguma coisa).
exit=2
```

Dois diretórios sem um `.tsx` dentro — o `git archive` da base que não extraiu
nada, o caminho digitado errado — davam o **mesmo veredito** de "comparei o
tópico inteiro e nada mudou". O passo _"O que mudou na tela dos visualizadores"_
do `tests.yml` lê exatamente esse código e escreveria **"Nada mudou na tela"**
sobre zero arquivo olhado.

Junto veio o irmão dele: **os dois lados apontando para o mesmo caminho** saía 0,
e passava por construção, não por mérito. Agora sai 2.

E, no modo arquivo, a última linha diz quantos textos de tela havia de cada lado:

```
(1 texto(s) de tela em .../antes.tsx.txt, 1 em .../depois.tsx.txt)
```

**A fronteira, escrita no docstring:** *não conseguiu olhar* é erro do guarda
(2); *olhou e não achou texto de tela* é resultado (0).

---

## A suíte: 27 casos, 13 antigos + 14 novos

Somados ao `scripts/testa-guarda-idioma.py` que já existe, **não numa segunda
suíte** — é este caminho que o portão da CI chama (`tests.yml`, passo _"Suíte do
próprio guarda de idioma"_), e renomear o arquivo exigiria mexer no workflow,
que está fora da fronteira deste PR. Uma suíte que a CI não roda protege menos
que um nome que ficou menor que o conteúdo.

O bloco novo compara o **código de saída exato**, não "reprova/passa". A
diferença é o ponto: um caso que só exigisse não-zero aprovaria o guarda antigo
no caso do merge, que reprovava — pelo motivo errado.

### Prova de quebra: a suíte nova contra os guardas da `origin/main`

`--guarda` e `--guarda-commit` apontados para as versões antigas:

```
5 de 27 casos FALHARAM:
  commit-merge-no-meio-do-trabalho      saiu 1, esperado 0
  commit-sem-o-pipe                     saiu 0, esperado 2   ← o grave
  commit-so-merges                      saiu 1, esperado 2
  idioma-diretorio-sem-fonte            saiu 0, esperado 2   ← o silencioso
  idioma-mesmo-caminho-dos-dois-lados   saiu 0, esperado 2
```

São **exatamente os cinco defeitos consertados**. Os outros 22 passam com o
guarda velho **e** com o novo — é o lado do trade: não trocamos cegueira por
alarme falso. Os 13 fixtures de texto de tela seguem verdes nas duas versões
(este PR não toca o motor de comparação).

Com os guardas deste PR: **27 de 27 ok (13 fixtures + 14 de linha de comando)**.

Um detalhe que a própria suíte pegou enquanto eu a escrevia: o caso
`commit-merge-minusculo-e-checado` usa um header de **77** caracteres de
propósito. Com um header de 68 ele saía 0 tanto com o guarda que checa quanto
com um que engolisse o commit — o caso não teria como perceber. Só sai 1 se o
header foi de fato checado.

---

## Verificação

| passo | resultado |
|---|---|
| `python3 scripts/testa-guarda-idioma.py` | **27/27 ok** |
| a mesma suíte contra os guardas da `origin/main` | 5 falham (os cinco defeitos) |
| `npm run lint` | **6 problems, 0 errors** — igual ao baseline |
| `npx tsc --noEmit` | limpo; `--listFiles` conta **0** arquivos de `scripts/` |
| `npm run build` | `✓ Compiled successfully`; `grep -rl guarda out/` não acha nada |
| `git log --format=%s origin/main..HEAD \| python3 scripts/guarda-commit.py` | `✓ 3 header(s) checado(s)` |

---

## O que os guardas **continuam** não pegando

1. **`guarda-commit.py` só antecipa duas das regras do commitlint** (72
   caracteres e `subject-case`). `type-enum`, `subject-empty` e o resto continuam
   só na CI. Verde local não é verde no portão.
2. **Os outros `defaultIgnores` do commitlint continuam divergindo.** Este PR
   alinhou só o merge. `Revert "feat: …"`, `fixup!`, `squash!`, `Merged … into
   …`, `Automatic merge…` e `Auto-merged … into …` são ignorados pelo commitlint
   e ainda reprovam aqui. `Revert` é o que mais dói, porque o `git revert` gera a
   mensagem sozinho — mesma classe, escopo deixado de fora de propósito para o
   diff continuar revisável.
3. **`guarda-commit.py` lê `%s`, não o corpo.** `body-max-line-length` está
   desligado na config, mas o footer e o `BREAKING CHANGE` passam sem ninguém
   olhar localmente.
4. **`guarda-idioma.py` continua sem saber se você apontou o par certo.**
   Comparar `antes/` com `antes-de-ontem/` é verde e não prova nada. O guarda
   sabe dizer "não olhei"; não sabe dizer "olhei a coisa errada".
5. **Um arquivo que existe e não tem texto de tela nenhum continua saindo 0.**
   É deliberado (um `.ts` de lógica pura é legítimo), e a contagem na última
   linha existe para isso ficar visível em vez de virar silêncio.
6. **Nenhum dos dois roda em `pre-commit`.** Não há `.husky/`, então continuam
   dependendo de alguém lembrar — só a suíte deles é que é portão na CI.

## Encontrado e **não** consertado (fora da fronteira deste PR)

`npm test` na branch reprova **7 casos**, todos em `tests/regressao-css-celular.spec.ts`
— arquivo que este PR não toca e que `git diff origin/main..HEAD` mostra
intacto. Não é flake: reprova igual com `--workers=1`, e as duas causas estão no
`out/` recém-buildado. **São regressões de merge já na `origin/main`:**

- **`tests/regressao-css-celular.spec.ts:106`** — `expect(page.locator("figure.viz-fit")).toHaveCount(1)`
  em `/topico/quick-sort/`. O HTML gerado tem **2** (`merge-sort` tem 3). É a
  armadilha catalogada do seletor que virou ambíguo quando a casca chegou ao
  segundo visualizador da página. Reprova nos três viewports (390x844, 1440x700,
  1512x900).
- **`tests/regressao-css-celular.spec.ts:203`** —
  `getByRole("button", { name: "Abrir menu de tópicos" })`. Essa string **só
  existe no arquivo de teste**: não está em `src/`, não está no `out/`. O botão
  real é `aria-label="Menu de tópicos"`, em **`src/components/Shell.tsx:192`**,
  renomeado em `862700a feat(a11y): dá nome à busca, ao botão do menu e aos
  landmarks`. Reprova nos quatro viewports da gaveta.

Os dois exigem editar `tests/*.spec.ts`, que está fora da fronteira. Ficam
reportados — e valem um PR próprio, porque hoje a `main` tem sete testes que não
podem passar.
