### PR TITLE
fix(viz): o artigo não depende de ter assistido à gravação

### DIFF
--- a/content/topics/hash-table.mdx
+++ b/content/topics/hash-table.mdx
@@ -82,7 +82,7 @@ class TabelaHash:
 
 Repare que a soma dos códigos **não é** o índice: ela é só um número grande e determinístico. Quem transforma esse número num endereço é o módulo, e é por isso que o tamanho da tabela participa da conta. Guarde isso: quando o tamanho mudar, todos os endereços mudam junto.
 
-Rode o visualizador abaixo passo a passo. Ele começa exatamente com o quadro do encontro: cinco nomes, cinco buckets, encadeamento. Acompanhe os dois passos de cada chave, primeiro a soma ASCII e depois o módulo, e repare no painel de variáveis: `soma` é sempre um número na casa das centenas, e `indice` é sempre um número de 0 a 4.
+Rode o visualizador abaixo passo a passo. Ele começa no cenário **"Cinco chaves, cinco buckets"**, com encadeamento ligado. Acompanhe os dois passos de cada chave, primeiro a soma ASCII e depois o módulo, e repare no painel de variáveis: `soma` é sempre um número na casa das centenas, e `indice` é sempre um número de 0 a 4.
 
 Depois pare de assistir e mexa nele. Troque a lista de chaves pelo seu nome e o de quem estiver perto, clique em **Sortear**, mude a capacidade de 5 para 8, e antes de avançar cada passo tente prever em que bucket a chave vai cair. Errar a previsão é justamente o momento em que o módulo entra na cabeça.
 

--- a/content/topics/skip-list.mdx
+++ b/content/topics/skip-list.mdx
@@ -60,7 +60,7 @@ Quando você não puder mais descer (chegou ao nível 0), o único candidato pos
 
 <SkipListVisualizer />
 
-Comece pelo preset **"Do encontro: procurar o 73"**, que é o desenho que o pessoal usou na tela. A lista tem 12 elementos distribuídos em 4 níveis, na pirâmide exata da teoria: **12 nós no nível 0, 6 no nível 1, 3 no nível 2 e 1 no nível 3**. Rode passo a passo e acompanhe a linha azul, a escada. Ela sai do head lá em cima, pula direto para o 42, tenta seguir e não consegue, desce, desce de novo, anda até o 59 e só então cai no nível 0 para conferir o 73.
+Comece pelo preset **"A escada completa: procurar o 73"**. A lista tem 12 elementos distribuídos em 4 níveis, na pirâmide exata da teoria: **12 nós no nível 0, 6 no nível 1, 3 no nível 2 e 1 no nível 3**. Rode passo a passo e acompanhe a linha azul, a escada. Ela sai do head lá em cima, pula direto para o 42, tenta seguir e não consegue, desce, desce de novo, anda até o 59 e só então cai no nível 0 para conferir o 73.
 
 Agora olhe os dois contadores embaixo. A skip list gastou **6 comparações**. A mesma busca andando só pelo nível 0, que é exatamente o que uma lista encadeada comum faria, gastaria **10**. Com 12 elementos a diferença é uma curiosidade. Troque o preset para "Lá no fim: procurar o 92" e o placar fica **6 contra 12**: a skip list nem sentiu o alvo estar mais longe, e a lista comum sentiu tudo.
 
@@ -126,7 +126,7 @@ Basta anotar. É o vetor `update`, que a galera do encontro apelidou de *bread c
 
 <SkipListInsercao />
 
-Na aba **Inserir**, rode o preset **"Do encontro: inserir o 33 (altura 2)"** com calma e olhe o painel `update[]`. Ele já nasce inteiro apontando para o head, e cada descida da busca troca uma posição por um candidato de verdade. Ao fim da descida ele fica assim: `update[0] = 31`, `update[1] = 23`, `update[2] = 9`, `update[3] = head`, `update[4] = head`. Aí a moeda decide altura 2, e só os níveis 0 e 1 são religados: o 31 passa a apontar para o 33 no nível 0, o 23 passa a apontar para o 33 no nível 1. **Quatro ponteiros mudaram de lugar. Mais nada na lista se mexeu.**
+Na aba **Inserir**, rode o preset **"Caso comum: inserir o 33 (altura 2)"** com calma e olhe o painel `update[]`. Ele já nasce inteiro apontando para o head, e cada descida da busca troca uma posição por um candidato de verdade. Ao fim da descida ele fica assim: `update[0] = 31`, `update[1] = 23`, `update[2] = 9`, `update[3] = head`, `update[4] = head`. Aí a moeda decide altura 2, e só os níveis 0 e 1 são religados: o 31 passa a apontar para o 33 no nível 0, o 23 passa a apontar para o 33 no nível 1. **Quatro ponteiros mudaram de lugar. Mais nada na lista se mexeu.**
 
 ```python
 def inserir(self, valor):
@@ -178,7 +178,7 @@ O `break` no meio merece atenção, porque não é óbvio. Se o candidato de um 
 
 Troque para a aba **Remover** do visualizador e rode os quatro presets nesta ordem, prevendo cada um antes:
 
-- **"Do encontro: remover o 59"**. O `update` fica `[50, 42, 42, 42, head]`, e o 59 vive só nos níveis 0 e 1. Repare que o desligamento para no nível 2: ali quem vem depois do 42 é o 73, não o 59, e o `break` dispara. **Dois ponteiros reescritos**, embora o `update` tenha guardado um candidato nos quatro níveis: guardar é de graça, usar é que depende da altura do nó.
+- **"Caso comum: remover o 59 (altura 2)"**. O `update` fica `[50, 42, 42, 42, head]`, e o 59 vive só nos níveis 0 e 1. Repare que o desligamento para no nível 2: ali quem vem depois do 42 é o 73, não o 59, e o `break` dispara. **Dois ponteiros reescritos**, embora o `update` tenha guardado um candidato nos quatro níveis: guardar é de graça, usar é que depende da altura do nó.
 - **"O mais alto: remover o 42"**. Este é o único nó do nível 3. Os quatro níveis são desligados, o laço termina sem `break`, e aí o `while` do fim entra em ação: `head.forward[3]` virou `None`, então **`nivel_max` cai de 3 para 2** e a lista inteira ficou um andar mais baixa. Sem nenhuma rotação, sem nenhum vizinho promovido para tapar o buraco.
 - **"Só no nível 0: remover o 3"**. Todo o `update` é o head, e o `break` dispara já no nível 1.
 - **"Não existe: remover o 33"**. A busca roda inteira, o candidato do nível 0 é o 42, `42 != 33`, e a função devolve `False` sem tocar em ponteiro nenhum. Remover o que não existe custa exatamente uma busca.

--- a/content/topics/two-pointers.mdx
+++ b/content/topics/two-pointers.mdx
@@ -90,7 +90,7 @@ def dois_ponteiros(nums, alvo):
 
 <TwoPointersVisualizer />
 
-Rode o visualizador passo a passo e acompanhe dois números do painel de baixo ao mesmo tempo: **somas avaliadas** e **pares na força bruta**. Com o preset do encontro ele termina em 6 contra 28. Depois experimente:
+Rode o visualizador passo a passo e acompanhe dois números do painel de baixo ao mesmo tempo: **somas avaliadas** e **pares na força bruta**. Com o preset **"Alvo 16: os dois ponteiros andam"** ele termina em 6 contra 28. Depois experimente:
 
 - **Acerta de cara: alvo 22.** O par está exatamente nas duas pontas, então uma única soma resolve. É o melhor caso, O(1).
 - **Sem solução: alvo 100.** Nenhum par existe e, mesmo assim, foram só **7 somas**, ou seja `n - 1`. Esse é o **pior caso** da técnica: cada soma queima um índice de vez, e depois de `n - 1` delas os ponteiros se encontram. A força bruta teria feito as 28 do mesmo jeito.

--- a/content/visualizers/HashTableVisualizer.tsx
+++ b/content/visualizers/HashTableVisualizer.tsx
@@ -348,7 +348,7 @@ type Preset = {
 };
 
 const PRESETS: Preset[] = [
-  { label: "Quadro do encontro", keys: "Ana, Bob, Lia, Leo, Eva", cap: 5, chained: true, resizes: false },
+  { label: "Cinco chaves, cinco buckets", keys: "Ana, Bob, Lia, Leo, Eva", cap: 5, chained: true, resizes: false },
   { label: "Sondagem linear", keys: "Ana, Bob, Lia, Leo, Eva", cap: 5, chained: false, resizes: false },
   { label: "Rehash acontecendo", keys: "Ana, Bob, Lia, Leo, Eva", cap: 4, chained: true, resizes: true },
   { label: "Anagramas: o pior caso", keys: "Lia, Ali, Ila, Lai", cap: 5, chained: true, resizes: false },

--- a/content/visualizers/LinkedListReversao.tsx
+++ b/content/visualizers/LinkedListReversao.tsx
@@ -107,7 +107,7 @@ const VB_HEIGHT = 140;
 
 type Preset = { key: string; label: string; nodes: string[] };
 const PRESETS: Preset[] = [
-  { key: "encontro", label: "Do encontro: a b c d", nodes: ["a", "b", "c", "d"] },
+  { key: "encontro", label: "Quatro nós: a b c d", nodes: ["a", "b", "c", "d"] },
   { key: "cinco", label: "Cinco nós: 1 a 5", nodes: ["1", "2", "3", "4", "5"] },
   { key: "dois", label: "Só dois nós", nodes: ["a", "b"] },
   { key: "um", label: "Um nó só", nodes: ["a"] },

--- a/content/visualizers/PrefixSumVisualizer.tsx
+++ b/content/visualizers/PrefixSumVisualizer.tsx
@@ -66,7 +66,7 @@ const DEFAULT_NUMS = [10, 30, 20, 45, 60, 40, 50];
 type Preset = { label: string; nums: number[]; i: number; j: number };
 
 const PRESETS: Preset[] = [
-  { label: "Encontro: soma(1, 4)", nums: DEFAULT_NUMS, i: 1, j: 4 },
+  { label: "O exemplo do artigo: soma(1, 4)", nums: DEFAULT_NUMS, i: 1, j: 4 },
   { label: "Miolo: soma(2, 3)", nums: DEFAULT_NUMS, i: 2, j: 3 },
   { label: "Do início: soma(0, 2)", nums: DEFAULT_NUMS, i: 0, j: 2 },
   { label: "Um elemento: soma(3, 3)", nums: DEFAULT_NUMS, i: 3, j: 3 },

--- a/content/visualizers/SkipListInsercao.tsx
+++ b/content/visualizers/SkipListInsercao.tsx
@@ -497,13 +497,13 @@ function buildRemove(
 type Preset = { key: string; label: string; value: number; height: number };
 const PRESETS: Record<Mode, Preset[]> = {
   inserir: [
-    { key: "meio", label: "Do encontro: inserir o 33 (altura 2)", value: 33, height: 2 },
+    { key: "meio", label: "Caso comum: inserir o 33 (altura 2)", value: 33, height: 2 },
     { key: "raso", label: "Só no nível 0: inserir o 80 (altura 1)", value: 80, height: 1 },
     { key: "teto", label: "Andar novo: inserir o 33 (altura 5)", value: 33, height: 5 },
     { key: "menor", label: "Menor que todos: inserir o 1 (altura 3)", value: 1, height: 3 },
   ],
   remover: [
-    { key: "r-meio", label: "Do encontro: remover o 59 (altura 2)", value: 59, height: 2 },
+    { key: "r-meio", label: "Caso comum: remover o 59 (altura 2)", value: 59, height: 2 },
     { key: "r-alto", label: "O mais alto: remover o 42 (altura 4)", value: 42, height: 4 },
     { key: "r-raso", label: "Só no nível 0: remover o 3", value: 3, height: 1 },
     { key: "r-nao", label: "Não existe: remover o 33", value: 33, height: 1 },

--- a/content/visualizers/SkipListVisualizer.tsx
+++ b/content/visualizers/SkipListVisualizer.tsx
@@ -209,7 +209,7 @@ type Preset = { key: string; label: string; target: number; values: number[]; he
 const PRESETS: Preset[] = [
   {
     key: "encontro",
-    label: "Do encontro: procurar o 73",
+    label: "A escada completa: procurar o 73",
     target: 73,
     values: DEFAULT_VALUES,
     heights: defaultHeights(DEFAULT_VALUES.length),

--- a/content/visualizers/SlidingWindowVisualizer.tsx
+++ b/content/visualizers/SlidingWindowVisualizer.tsx
@@ -269,7 +269,7 @@ const PRESETS: Record<Variant, Preset[]> = {
   // vezes seguidas, a borda do elemento que sozinho estoura k, e o caso em que
   // nada estoura (a janela nunca encolhe).
   dynamic: [
-    { key: "encontro", label: "Do encontro: soma ≤ 15", nums: [2, 3, 4, 5, 6, 7, 9], k: 15 },
+    { key: "encontro", label: "Padrão: soma ≤ 15", nums: [2, 3, 4, 5, 6, 7, 9], k: 15 },
     { key: "encolhe", label: "Encolhe em série: soma ≤ 8", nums: [3, 1, 2, 7, 4, 2, 1, 1, 5], k: 8 },
     { key: "estoura", label: "Um elemento maior que k", nums: [1, 2, 20, 1, 1], k: 5 },
     { key: "nunca", label: "Nada estoura: k folgado", nums: [1, 1, 1, 1, 1], k: 9 },

--- a/content/visualizers/TailRecursionForma.tsx
+++ b/content/visualizers/TailRecursionForma.tsx
@@ -101,7 +101,7 @@ const CASES: Case[] = [
     recursive: true,
     pending: "nada",
     reading:
-      "É a função do encontro. O caso base virou uma cláusula separada por pattern matching, e [head | tail] decompõe a lista sem copiar nada: tail é um ponteiro para o resto, não uma cópia como o nums[1:] do Python.",
+      "É a forma idiomática em Elixir. O caso base virou uma cláusula separada por pattern matching, e [head | tail] decompõe a lista sem copiar nada: tail é um ponteiro para o resto, não uma cópia como o nums[1:] do Python.",
     fix: "A BEAM aplica a otimização sozinha, sem anotação nenhuma: lista de 1.000 elementos, 1 frame.",
     stack: "O(1), a BEAM otimiza",
   },
@@ -115,7 +115,7 @@ const CASES: Case[] = [
     recursive: false,
     pending: "nada",
     reading:
-      "Chamada de cauda não precisa ser recursiva. Aqui a última instrução chama outra função, e o frame de validar também não serve mais para nada depois disso. Foi exatamente a pergunta do Giovani no encontro, e a resposta é sim: a otimização vale igual.",
+      "Chamada de cauda não precisa ser recursiva. Aqui a última instrução chama outra função, e o frame de validar também não serve mais para nada depois disso. A pergunta natural é se a otimização vale nesse caso, e a resposta é sim: vale igual.",
     fix: "Nada a consertar. Só repare no vocabulário: isto é tail call, e tail recursion é o caso em que a função chamada é ela mesma.",
     stack: "O(1) com TCO",
   },
@@ -169,7 +169,7 @@ const CASES: Case[] = [
     recursive: true,
     pending: "[nums[0] * 2] + ?",
     reading:
-      "Mesmo formato da soma comum, só que juntando listas em vez de números. E é o caso que o Tiago mediu no encontro: aqui a versão de cauda saiu mais lenta, porque ela monta a lista ao contrário e precisa de um reverse no fim.",
+      "Mesmo formato da soma comum, só que juntando listas em vez de números. E é o caso em que a medição surpreende: aqui a versão de cauda sai mais lenta, porque ela monta a lista ao contrário e precisa de um reverse no fim.",
     fix: "Dá para transformar (acc=[] e reverse no fim), só que o conserto custa uma passada extra. Nem toda recursão quer virar de cauda.",
     stack: "O(n) sempre",
   },

--- a/content/visualizers/TailRecursionTrampolim.tsx
+++ b/content/visualizers/TailRecursionTrampolim.tsx
@@ -168,7 +168,7 @@ const DEFAULT_LIST = [1, 2, 3, 4];
 
 type Preset = { key: string; label: string; nums: number[] };
 const PRESETS: Preset[] = [
-  { key: "encontro", label: "Do encontro: [1, 2, 3, 4]", nums: DEFAULT_LIST },
+  { key: "encontro", label: "Quatro números: [1, 2, 3, 4]", nums: DEFAULT_LIST },
   { key: "sete", label: "Sete números", nums: [5, 3, 8, 1, 9, 2, 7] },
   { key: "um", label: "Um elemento só", nums: [7] },
   { key: "vazia", label: "Lista vazia", nums: [] },

--- a/content/visualizers/TailRecursionVisualizer.tsx
+++ b/content/visualizers/TailRecursionVisualizer.tsx
@@ -225,7 +225,7 @@ const DEFAULT_LIST = [1, 2, 3, 4];
 
 type Preset = { key: string; label: string; nums: number[] };
 const PRESETS: Preset[] = [
-  { key: "encontro", label: "Do encontro: [1, 2, 3, 4]", nums: DEFAULT_LIST },
+  { key: "encontro", label: "Quatro números: [1, 2, 3, 4]", nums: DEFAULT_LIST },
   { key: "sete", label: "Sete números", nums: [5, 3, 8, 1, 9, 2, 7] },
   { key: "um", label: "Um elemento só", nums: [7] },
   { key: "vazia", label: "Lista vazia", nums: [] },

--- a/content/visualizers/TwoPointersVisualizer.tsx
+++ b/content/visualizers/TwoPointersVisualizer.tsx
@@ -84,7 +84,7 @@ const DEFAULT_TARGET = 16;
 // par, n-1 somas) e uma borda em que todo elemento é igual.
 type Preset = { key: string; label: string; nums: number[]; target: number };
 const PRESETS: Preset[] = [
-  { key: "encontro", label: "Do encontro: alvo 16", nums: DEFAULT_NUMS, target: DEFAULT_TARGET },
+  { key: "encontro", label: "Alvo 16: os dois ponteiros andam", nums: DEFAULT_NUMS, target: DEFAULT_TARGET },
   { key: "pontas", label: "Acerta de cara: alvo 22", nums: DEFAULT_NUMS, target: 22 },
   { key: "sem", label: "Sem solução: alvo 100", nums: DEFAULT_NUMS, target: 100 },
   { key: "iguais", label: "Tudo igual: alvo 11", nums: [5, 5, 5, 5], target: 11 },

--- a/tests/rotulo-de-preset-e-artigo.spec.ts
+++ b/tests/rotulo-de-preset-e-artigo.spec.ts
@@ -117,7 +117,20 @@ const ANCORA = /(?:\b(?:do|no|da|na)\s+(?:encontro|aula|v[ií]deo|gravação)|\b
 /** O "nó do encontro" do ciclo de Floyd é termo técnico, não procedência. */
 const FALSO_POSITIVO = /n[oó]\s+do\s+encontro|desencontro/i;
 
-const CAMPO_DE_TELA = /(?:label|rotulo|title|reading|leitura|note|nota)\s*:\s*\n?\s*"((?:[^"\\]|\\.)*)"/g;
+// As TRÊS formas de escrever uma string em TypeScript, e não só a primeira.
+//
+// A versão anterior só reconhecia aspas duplas, e a conta explica por que isso é
+// guarda que passou disfarçado de guarda que olhou: nos 87 visualizadores são
+// 855 campos de tela, dos quais 542 com aspas duplas e 313 com template ou
+// aspas simples. O guarda enxergava 63,4% e afirmava cobrir tudo. Só de rótulo
+// de botão (`label`/`rotulo`/`title`) eram 23 fora do alcance dele.
+//
+// A alternância é uma só, com três grupos, e o texto é o primeiro não-nulo: com
+// três regexes separadas, um `label: "diz 'oi'"` casaria também na varredura de
+// aspas simples e o mesmo campo entraria duas vezes, com o recorte errado.
+// Aqui quem abre a string decide qual grupo captura, e cada campo casa uma vez.
+const CAMPO_DE_TELA =
+  /(?:label|rotulo|title|reading|leitura|note|nota)\s*:\s*\n?\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`)/g;
 
 test("nenhum texto de tela de visualizador se ancora na gravação", () => {
   const achados: string[] = [];
@@ -125,7 +138,10 @@ test("nenhum texto de tela de visualizador se ancora na gravação", () => {
   for (const arquivo of readdirSync(VIZ_DIR).filter((f) => f.endsWith(".tsx"))) {
     const fonte = readFileSync(path.join(VIZ_DIR, arquivo), "utf-8");
     for (const m of fonte.matchAll(CAMPO_DE_TELA)) {
-      const texto = m[1];
+      // `??` e não `||`: string vazia é um campo de tela legítimo (e vazio não
+      // tem âncora), mas trocar por `||` faria o grupo seguinte responder por
+      // ela e o recorte sair de outro campo.
+      const texto = m[1] ?? m[2] ?? m[3];
       if (!ANCORA.test(texto) || FALSO_POSITIVO.test(texto)) continue;
       achados.push(`${arquivo}: "${texto.slice(0, 90)}"`);
     }

--- a/tests/rotulo-de-preset-e-artigo.spec.ts
+++ b/tests/rotulo-de-preset-e-artigo.spec.ts
@@ -1,0 +1,179 @@
+import { test, expect, type Page } from "@playwright/test";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// O guarda que faltava: o rótulo do preset e o artigo são UMA coisa só.
+//
+// Os artigos instruem o aluno pelo TEXTO DO BOTÃO («rode o preset "Caso comum:
+// remover o 59 (altura 2)"»). Renomear o rótulo sem mexer no artigo não quebra
+// build, não quebra teste e não quebra tipo: quebra em silêncio, na frente do
+// aluno, que procura um botão que não existe mais. Antes deste arquivo eram 81
+// citações literais em 12 artigos e nenhuma asserção ligando as duas pontas.
+//
+// Cada caso aqui amarra TRÊS pontas, e é a terceira que dá a garantia:
+//
+//   1. dado    · o rótulo começa pelo texto que o artigo manda procurar;
+//   2. artigo  · a página renderizada contém essa instrução;
+//   3. tela    · existe um botão de preset com o rótulo inteiro.
+//
+// Sem a 3, renomear o rótulo passa verde. Sem a 2, reescrever o artigo passa
+// verde. A asserção da 3 é sobre a LISTA de rótulos, e não `toBeVisible()` de
+// propósito: quando ela reprova, o `Received` mostra os rótulos que estão de
+// fato na tela, então o relatório já diz qual virou qual.
+// ---------------------------------------------------------------------------
+
+type Caso = {
+  /** Slug do artigo, que também é a URL. */
+  slug: string;
+  /** Seletor da fileira de botões de preset dentro da peça certa da página. */
+  botoes: string;
+  /** O rótulo inteiro, como está no botão. */
+  rotulo: string;
+  /** O que o artigo manda o aluno procurar. Prefixo do rótulo. */
+  citacao: string;
+  /** Alguns presets moram atrás de uma aba. */
+  antes?: (page: Page) => Promise<void>;
+};
+
+const CASOS: Caso[] = [
+  {
+    slug: "skip-list",
+    botoes: "article figure.viz >> nth=0 >> .bigo-chip",
+    rotulo: "A escada completa: procurar o 73",
+    citacao: "A escada completa: procurar o 73",
+  },
+  {
+    slug: "skip-list",
+    botoes: "article figure.viz >> nth=1 >> .bigo-chip",
+    rotulo: "Caso comum: inserir o 33 (altura 2)",
+    citacao: "Caso comum: inserir o 33 (altura 2)",
+  },
+  {
+    slug: "skip-list",
+    botoes: "article figure.viz >> nth=1 >> .bigo-chip",
+    rotulo: "Caso comum: remover o 59 (altura 2)",
+    citacao: "Caso comum: remover o 59 (altura 2)",
+    // Os presets de remoção só existem depois da aba, e é a aba que o artigo
+    // manda abrir («Troque para a aba Remover»).
+    antes: async (page) => {
+      await page.locator("article figure.viz").nth(1).getByRole("button", { name: "Remover", exact: true }).click();
+    },
+  },
+  {
+    slug: "two-pointers",
+    botoes: "article figure.viz >> nth=0 >> .bigo-chip",
+    rotulo: "Alvo 16: os dois ponteiros andam",
+    citacao: "Alvo 16: os dois ponteiros andam",
+  },
+  {
+    slug: "hash-table",
+    botoes: "article .ht-presets .viz-btn",
+    rotulo: "Cinco chaves, cinco buckets",
+    citacao: "Cinco chaves, cinco buckets",
+  },
+];
+
+for (const caso of CASOS) {
+  test(`${caso.slug}: o artigo cita «${caso.citacao}» e o botão existe`, async ({ page }) => {
+    // 1 · a citação é mesmo um pedaço do rótulo, e não um texto parecido.
+    expect(
+      caso.rotulo.startsWith(caso.citacao),
+      `a citação do artigo não é prefixo do rótulo: «${caso.citacao}» vs «${caso.rotulo}»`
+    ).toBe(true);
+
+    await page.goto(`/topico/${caso.slug}/`);
+
+    // 2 · a instrução está no artigo que o aluno lê, não só no arquivo fonte.
+    await expect(page.locator("article")).toContainText(caso.citacao);
+
+    if (caso.antes) await caso.antes(page);
+
+    // 3 · e existe um botão de preset com esse rótulo, inteiro.
+    const rotulos = (await page.locator(caso.botoes).allTextContents()).map((t) => t.trim());
+    expect(rotulos, `os rótulos de preset na tela de ${caso.slug}`).toContain(caso.rotulo);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// A varredura, e ela é do FONTE de propósito.
+//
+// Os testes acima cobrem os cinco casos que este PR tocou. Esta parte cobre os
+// 87 visualizadores de uma vez, inclusive os que nem página têm ainda, porque
+// o defeito não é de renderização: é uma string de tela ancorada numa gravação
+// que o leitor não viu. Guarda que só olha as páginas visitadas é opt-in
+// disfarçado de varredura, e este repositório já foi mordido por isso.
+//
+// Duas famílias de campo entram: `label`/`rotulo`/`title` (o rótulo do botão) e
+// `reading`/`leitura`/`note`/`nota` (a prosa do painel). A segunda existe
+// porque três âncoras dentro do `TailRecursionForma` passaram batido por um
+// grep que só olhava rótulo.
+// ---------------------------------------------------------------------------
+
+const VIZ_DIR = path.join(__dirname, "..", "content", "visualizers");
+
+/** "no encontro", "da aula", "do vídeo", "a galera" — e o Floyd de fora. */
+const ANCORA = /(?:\b(?:do|no|da|na)\s+(?:encontro|aula|v[ií]deo|gravação)|\ba galera\b|\bao vivo\b)/i;
+/** O "nó do encontro" do ciclo de Floyd é termo técnico, não procedência. */
+const FALSO_POSITIVO = /n[oó]\s+do\s+encontro|desencontro/i;
+
+const CAMPO_DE_TELA = /(?:label|rotulo|title|reading|leitura|note|nota)\s*:\s*\n?\s*"((?:[^"\\]|\\.)*)"/g;
+
+test("nenhum texto de tela de visualizador se ancora na gravação", () => {
+  const achados: string[] = [];
+
+  for (const arquivo of readdirSync(VIZ_DIR).filter((f) => f.endsWith(".tsx"))) {
+    const fonte = readFileSync(path.join(VIZ_DIR, arquivo), "utf-8");
+    for (const m of fonte.matchAll(CAMPO_DE_TELA)) {
+      const texto = m[1];
+      if (!ANCORA.test(texto) || FALSO_POSITIVO.test(texto)) continue;
+      achados.push(`${arquivo}: "${texto.slice(0, 90)}"`);
+    }
+  }
+
+  expect(
+    achados,
+    "texto de tela que só faz sentido para quem assistiu à gravação (o artigo é autocontido)"
+  ).toEqual([]);
+});
+
+// ---------------------------------------------------------------------------
+// E a mesma regra lida no navegador, porque fonte limpa não prova tela limpa.
+//
+// O classificador de recursão de cauda é onde as três âncoras de prosa moravam.
+// Aqui o teste CLICA em cada caso e LÊ o painel: é o par comportamento mais
+// rótulo que o repositório exige, e não a contagem de elementos que já deixou
+// passar visualizador sem botão nenhum.
+// ---------------------------------------------------------------------------
+
+test("recursão funcional: a prosa do classificador não cita a gravação", async ({ page }) => {
+  await page.goto("/topico/recursao-funcional/");
+
+  const peca = page.locator("article figure.viz").filter({ hasText: "está em posição de cauda" }).first();
+  const casos = peca.locator(".bigo-chip").filter({ hasNotText: "Modo treino" });
+  const quantos = await casos.count();
+  expect(quantos, "casos do classificador").toBeGreaterThan(5);
+
+  const lidos: string[] = [];
+  for (let i = 0; i < quantos; i++) {
+    await casos.nth(i).click();
+    const nota = peca.locator("p.viz-note").first();
+    await expect(nota).toBeVisible();
+    const texto = (await nota.textContent()) ?? "";
+    expect(texto.length, `a leitura do caso ${i} veio vazia`).toBeGreaterThan(40);
+    lidos.push(texto);
+  }
+
+  // Passou pelos sete casos e leu sete textos diferentes: sem isto o laço
+  // poderia estar lendo o mesmo painel o tempo todo e a asserção sairia vazia.
+  expect(new Set(lidos).size, "leituras distintas").toBe(quantos);
+
+  for (const texto of lidos) {
+    expect(texto, "prosa do painel ancorada na gravação").not.toMatch(ANCORA);
+    expect(texto, "prosa do painel citando pessoa pelo nome").not.toMatch(/\b(Giovani|Tiago|Eduardo|Nelson)\b/);
+  }
+
+  // E o conteúdo continua lá: o caso do Elixir e o contraexemplo do reverse.
+  expect(lidos.join(" ")).toContain("forma idiomática em Elixir");
+  expect(lidos.join(" ")).toContain("a versão de cauda sai mais lenta");
+});

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -229,11 +229,20 @@ test("o sitemap lista exatamente as rotas indexáveis, nem mais nem menos", () =
   expect(doSitemap).toEqual(esperadas);
 });
 
+// Um `git log` por caminho, e não por consulta: o teste pergunta a mesma data
+// até três vezes por rota (o guarda de capacidade, o `?` do fallback e a
+// agregação), e cada processo novo custa ~29ms.
+const cacheDoGit = new Map<string, string>();
+
 function dataDoGit(arquivo: string): string {
-  return execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
+  const emCache = cacheDoGit.get(arquivo);
+  if (emCache !== undefined) return emCache;
+  const iso = execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
   }).trim();
+  cacheDoGit.set(arquivo, iso);
+  return iso;
 }
 
 /** A data esperada de uma rota: o mais recente dos arquivos que a alimentam. */
@@ -299,17 +308,43 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   // essa diferença? Se não, ele está achatando o histórico e não serve de
   // referência — conferir contra ele acusaria o build de um erro que é do
   // ambiente de medição.
-  const datasDoGit = new Set(
-    ALL_TOPICS.filter((t) => !isEmptyTopic(t))
-      .slice(0, 8)
-      .map((t) => dataDoGit(`content/topics/${t.slug}.mdx`))
-      .filter(Boolean)
-  );
+  //
+  // A pergunta NÃO é "quantas datas distintas ele resolve", e a diferença
+  // custou uma CI vermelha inteira. Naquele job o git deste processo achatou 39
+  // dos 42 caminhos na data do merge da base (16:43:05Z) e resolveu a data de
+  // verdade para os TRÊS que o próprio PR tinha tocado, porque esses três estão
+  // no lado do histórico que o processo alcança. Um deles é `two-pointers.mdx`,
+  // o 5º artigo da lista: um caminho distinguível dentro de uma amostra de oito
+  // bastava para a contagem valer 2, o guarda concluir "o git enxerga" e o
+  // teste reprovar 37 URLs cujo `lastmod` estava certo.
+  //
+  // O sintoma do achatamento não é a contagem, é a CONCENTRAÇÃO: git cego
+  // devolve o MESMO segundo para quase tudo, porque devolve sempre o
+  // commit-fronteira. Então a medida é a fatia da moda, e sobre TODOS os
+  // caminhos que o teste vai comparar — amostra pequena é enviesável pelo PR da
+  // vez, que por definição mexeu em alguns desses arquivos.
+  //
+  // Margem medida: neste repositório com histórico de verdade são 42 caminhos,
+  // 22 datas distintas e moda de 6 (14,3%); no job achatado a moda era 39 de 42
+  // (92,9%). O corte em 50% fica longe dos dois, e cobre o caso antigo — git
+  // que resolve UMA data para tudo tem moda de 100%.
+  const caminhosConferidos = [
+    ...ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => `content/topics/${t.slug}.mdx`),
+    ...Object.values(CONTEUDO_DA_ROTA).flat(),
+  ];
+  const porData = new Map<string, number>();
+  for (const caminho of caminhosConferidos) {
+    const d = dataDoGit(caminho);
+    if (d) porData.set(d, (porData.get(d) ?? 0) + 1);
+  }
+  const resolvidos = [...porData.values()].reduce((a, b) => a + b, 0);
+  const moda = porData.size ? Math.max(...porData.values()) : 0;
   test.skip(
-    datasDoGit.size <= 1,
-    `o git deste processo resolve ${datasDoGit.size} data(s) distinta(s) para 8 artigos ` +
-      "diferentes, ou seja, achata o histórico por caminho e não pode servir de " +
-      "referência. As invariantes do artefato acima já foram conferidas."
+    resolvidos === 0 || moda / resolvidos > 0.5,
+    `o git deste processo devolve a mesma data para ${moda} dos ${resolvidos} caminhos ` +
+      `conferidos (${porData.size} data(s) distinta(s) ao todo): ele achata o histórico no ` +
+      "commit-fronteira e não pode servir de referência. As invariantes do artefato acima " +
+      "já foram conferidas."
   );
 
   // Daqui para baixo o git deste processo enxerga o histórico, então dá para


### PR DESCRIPTION
O artigo é autocontido: a gravação do encontro é insumo, e o leitor não viu o
vídeo. Este PR tira da tela o texto que só faz sentido para quem assistiu.

O link e o embed da gravação ficam onde estão. Eles são o reforço que a regra
promete a quem quiser assistir. O que sai é o texto que **exige** ter assistido.

## Os dez rótulos, antes e depois

| arquivo | antes | depois |
|---|---|---|
| `HashTableVisualizer.tsx` | Quadro do encontro | **Cinco chaves, cinco buckets** |
| `LinkedListReversao.tsx` | Do encontro: a b c d | **Quatro nós: a b c d** |
| `PrefixSumVisualizer.tsx` | Encontro: soma(1, 4) | **O exemplo do artigo: soma(1, 4)** |
| `SkipListInsercao.tsx` | Do encontro: inserir o 33 (altura 2) | **Caso comum: inserir o 33 (altura 2)** |
| `SkipListInsercao.tsx` | Do encontro: remover o 59 (altura 2) | **Caso comum: remover o 59 (altura 2)** |
| `SkipListVisualizer.tsx` | Do encontro: procurar o 73 | **A escada completa: procurar o 73** |
| `SlidingWindowVisualizer.tsx` | Do encontro: soma ≤ 15 | **Padrão: soma ≤ 15** |
| `TailRecursionTrampolim.tsx` | Do encontro: [1, 2, 3, 4] | **Quatro números: [1, 2, 3, 4]** |
| `TailRecursionVisualizer.tsx` | Do encontro: [1, 2, 3, 4] | **Quatro números: [1, 2, 3, 4]** |
| `TwoPointersVisualizer.tsx` | Do encontro: alvo 16 | **Alvo 16: os dois ponteiros andam** |

Cada rótulo passa a dizer **o que o preset ensina**. Nenhum preset mudou de
dado e **nenhum mudou de ordem**: existem artigos que citam preset por posição
("o segundo preset", "o caso degenerado"), e a varredura não pega esses.

Três escolhas que valem explicação:

- **Hash.** Não usei "Encadeamento" como prefixo porque as chaves de estratégia
  logo acima já são "Encadeamento" e "Sondagem linear", e o preset seguinte já
  se chama "Sondagem linear". Um terceiro botão com a mesma palavra deixaria
  três alvos ambíguos na mesma tela.
- **Prefix sum.** "O exemplo do artigo" é forma que o repositório já usa ("A
  árvore do artigo", em `tree-traversals` e `n-ary-trees`). Apontar para o
  artigo é o reforço que a regra promete; apontar para o encontro é o que ela
  proíbe.
- **Two pointers.** O inventário sugeria "Alvo 16: dois pares possíveis", e
  **é falso**: em `[1, 2, 3, 6, 8, 10, 20, 21]` existe **um** par que soma 16
  (`6 + 10`). A sugestão não tinha sido rodada contra os dados. O rótulo que
  entrou diz o que de fato acontece, e é o que separa esse preset do vizinho
  "Acerta de cara: alvo 22", onde nenhum ponteiro sai do lugar.

As `key` dos presets ficaram como estavam (`key: "encontro"` em oito arquivos).
`key` é identificador, não texto de tela: ninguém a referencia de fora do
componente, e ela sai junto do rename de idioma de cada tópico.

## As três linhas de prosa dentro do visualizador

`TailRecursionForma.tsx`, no campo `reading`, que é o que o aluno lê no painel
do classificador. As três citavam pessoa pelo nome ou pediam o contexto da
gravação. Um grep de rótulo não vê essa categoria, e foi assim que elas
sobreviveram a quatro rodadas de adaptação.

| antes | depois |
|---|---|
| É a função do encontro | **É a forma idiomática em Elixir** |
| Foi exatamente a pergunta do Giovani no encontro, e a resposta é sim | **A pergunta natural é se a otimização vale nesse caso, e a resposta é sim** |
| É o caso que o Tiago mediu no encontro: aqui a versão de cauda saiu mais lenta | **É o caso em que a medição surpreende: aqui a versão de cauda sai mais lenta** |

O ensino não perde nada: o caso do Elixir continua sendo o idiomático, a
resposta continua sendo sim, e o `map` continua sendo o contraexemplo em que a
versão de cauda perde. O verbo do terceiro saiu do passado, porque sem a
medição datada a frase é sobre a forma, não sobre um benchmark de um dia.

## As cinco citações de artigo que vieram junto

Este é o pedaço que define o tamanho do PR. Os artigos instruem o aluno **pelo
texto do botão**, e renomear um rótulo sem mexer no artigo quebra a instrução
**em silêncio**: não quebra build, não quebra tipo, não quebra teste, e o aluno
procura um botão que não existe.

| arquivo | o que dizia | o que diz |
|---|---|---|
| `skip-list.mdx:63` | Comece pelo preset "Do encontro: procurar o 73", que é o desenho que o pessoal usou na tela | Comece pelo preset **"A escada completa: procurar o 73"** |
| `skip-list.mdx:129` | rode o preset "Do encontro: inserir o 33 (altura 2)" | rode o preset **"Caso comum: inserir o 33 (altura 2)"** |
| `skip-list.mdx:181` | "Do encontro: remover o 59" | **"Caso comum: remover o 59 (altura 2)"** |
| `two-pointers.mdx:93` | Com o preset do encontro ele termina em 6 contra 28 | Com o preset **"Alvo 16: os dois ponteiros andam"** ele termina em 6 contra 28 |
| `hash-table.mdx:85` | Ele começa exatamente com o quadro do encontro: cinco nomes, cinco buckets, encadeamento | Ele começa no cenário **"Cinco chaves, cinco buckets"**, com encadeamento ligado |

Duas dessas **a varredura não pega**, e é o achado mais útil daqui:

- `two-pointers.mdx:93` e `hash-table.mdx:85` citam o preset **por descrição**
  ("o preset do encontro", "o quadro do encontro"), sem copiar o rótulo. O
  script das 81 citações procura literal e passa direto por elas. Foram
  encontradas lendo os sete artigos, um por um.
- Em `skip-list.mdx:181` a citação estava **incompleta** ("Do encontro: remover
  o 59", sem a altura). Agora cita o rótulo inteiro, e é isso que deixa o
  guarda novo comparar exato em vez de por prefixo.

Nos outros quatro tópicos não havia citação nenhuma, nem literal nem por
descrição: conferido lendo `listas-ligadas.mdx`, `prefix-sum.mdx`,
`sliding-window.mdx` e `recursao-funcional.mdx`.

## As varreduras, antes e depois

**Rótulo de preset ancorado (categoria A).** De 10 para 0.

```
$ grep -rnE '(rotulo|label|title|nome):\s*"[^"]*(ncontro|[Vv]ídeo|aula|galera|ao vivo|quadro)' content/visualizers/*.tsx

ANTES (10)
  HashTableVisualizer.tsx:351      { label: "Quadro do encontro", ...
  LinkedListReversao.tsx:110       { key: "encontro", label: "Do encontro: a b c d", ...
  PrefixSumVisualizer.tsx:69       { label: "Encontro: soma(1, 4)", ...
  SkipListInsercao.tsx:500         { key: "meio", label: "Do encontro: inserir o 33 (altura 2)", ...
  SkipListInsercao.tsx:506         { key: "r-meio", label: "Do encontro: remover o 59 (altura 2)", ...
  SkipListVisualizer.tsx:212       label: "Do encontro: procurar o 73",
  SlidingWindowVisualizer.tsx:272  { key: "encontro", label: "Do encontro: soma ≤ 15", ...
  TailRecursionTrampolim.tsx:171   { key: "encontro", label: "Do encontro: [1, 2, 3, 4]", ...
  TailRecursionVisualizer.tsx:228  { key: "encontro", label: "Do encontro: [1, 2, 3, 4]", ...
  TwoPointersVisualizer.tsx:87     { key: "encontro", label: "Do encontro: alvo 16", ...

DEPOIS (0)
  (nenhuma linha)
```

**Prosa dentro de visualizador (categoria C).** De 12 para 0 (as 3 de prosa
mais as 9 de rótulo que este grep também alcança).

```
$ grep -rnE '"[^"]*((do|no|No|Do) encontro|da aula|do v[ií]deo|a galera)' content/visualizers/*.tsx \
    | grep -vE 'n[oó] do encontro|desencontro'

ANTES: 12 linhas   (3 de prosa no TailRecursionForma + 9 rótulos já contados na A)
DEPOIS: 0 linhas
```

**Prosa de artigo (categoria B).** De 75 para 70, e **as cinco que saíram são
exatamente as cinco que o rename obrigou a tocar**:

```
$ diff <(varredura B em origin/main) <(varredura B agora)

content/topics/hash-table.mdx:85
content/topics/skip-list.mdx:63
content/topics/skip-list.mdx:129
content/topics/skip-list.mdx:181
content/topics/two-pointers.mdx:93
```

Nenhuma outra linha de B foi tocada.

**As 81 citações literais de rótulo.** De 81 para 84, e **as três a mais são
ganho, não perda**:

| artigo | antes | depois | por quê |
|---|---:|---:|---|
| `skip-list.mdx` | 11 | 12 | a citação de `:181` virou literal completa |
| `two-pointers.mdx` | 6 | 7 | `:93` deixou de citar por descrição |
| `hash-table.mdx` | 2 | 3 | `:85` deixou de citar por descrição |
| todos os outros | 62 | 62 | intocados |

**Nenhum artigo ficou citando rótulo que não existe mais.** Conferido com
`grep -rn "Do encontro\|Quadro do encontro\|Encontro: soma" tests/ src/ content/ scripts/`,
que sai vazio.

## O guarda que não existia

`tests/rotulo-de-preset-e-artigo.spec.ts`. Eram **81 citações literais em 12
artigos e nenhuma asserção ligando as duas pontas**. Este era o risco do PR
inteiro, e agora tem rede.

Três camadas:

1. **cinco casos amarram rótulo, artigo e tela.** A asserção da tela é sobre a
   **lista** de rótulos, não `toBeVisible()`, para o `Received` mostrar o que
   está de fato na página quando reprovar.
2. **uma varredura do fonte dos 87 visualizadores**, campos de rótulo e de
   prosa, com o "nó do encontro" do ciclo de Floyd de fora por ser termo
   técnico. É varredura de verdade, e não guarda que só olha página visitada.
3. **o classificador de recursão de cauda lido no navegador**, caso a caso,
   porque fonte limpa não prova tela limpa. O laço confere que leu sete textos
   **distintos** antes de concluir qualquer coisa, senão a asserção sai vazia
   lendo o mesmo painel sete vezes.

### O buraco que a revisão achou nele

A camada 2 nasceu **cega para 36,6% do que dizia varrer**: a regex só
reconhecia literal com **aspas duplas**.

| forma da string | campos de tela |
|---|---:|
| aspas duplas (o que ela via) | 542 |
| template literal | 312 |
| aspas simples | 1 |
| **total nos 87 visualizadores** | **855** |

Só de **rótulo de botão** (`label`/`rotulo`/`title`) eram **23 fora do
alcance**. Guarda que não olha tudo é indistinguível de guarda que passou, e
este afirmava, no próprio comentário, cobrir os 87 arquivos.

Agora é **uma alternância só, com três grupos**, e o texto é o primeiro
não-nulo. Três regexes separadas fariam `label: "diz 'oi'"` casar duas vezes,
com o recorte errado na segunda; e `??` em vez de `||` porque string vazia é
campo de tela legítimo e cairia para o grupo seguinte.

**Prova de quebra**, num template literal
(`IntervalsSobreposicaoVisualizer.tsx:229`):

```
guarda NOVO
  ✘ nenhum texto de tela de visualizador se ancora na gravação
    + Array [
    +   "IntervalsSobreposicaoVisualizer.tsx: \"A = ${fmtIv(a)} (o do encontro)\"",
    + ]
    > 153 |   ).toEqual([]);

guarda ANTIGO, com a MESMA quebra no lugar
  ✓ nenhum texto de tela de visualizador se ancora na gravação (23ms)
  1 passed (924ms)
```

Com a regex larga, os **855 campos dão 0 achados** hoje: o buraco era de
cobertura, não de sujeira escondida atrás de template literal.

## O CI vermelho, e por que ele era deste PR

Não era citação órfã. Era **uma** falha (as outras cinco do relatório eram
`flaky` e passaram no retry): `seo-estrutura.spec.ts:253 › o lastmod do sitemap
vem do Git, ou não existe`.

Aquele teste tem um guarda de capacidade porque **o processo do teste, na CI, às
vezes não enxerga o histórico**. O guarda amostrava **8 artigos** e pulava se
resolvessem **≤ 1 data distinta**.

No job, o git do processo de teste achatou **39 dos 42 caminhos** na data do
commit-fronteira (`bb8a63c`, `16:43:05Z`) e resolveu a data **de verdade** para
os **três arquivos que este PR tocou** — `hash-table.mdx`, `skip-list.mdx` e
`two-pointers.mdx` —, que estão do lado do histórico que o processo alcança. E
`two-pointers` é o **5º artigo da lista**: um caminho distinguível dentro da
amostra fez a contagem valer **2**, o guarda concluiu "o git enxerga", e o teste
reprovou **37 URLs cujo `lastmod` estava certo**. A lista de erros tinha
exatamente 37 entradas, e as três que **faltavam** nela eram justamente essas.

**O guarda foi derrubado pelo PR que ele deveria acompanhar**, e qualquer PR que
toque um dos oito primeiros artigos reproduz isso.

Reproduzido, não deduzido: clone `--shared` com o merge ref do PR em `HEAD` e o
commit-fronteira virado raiz por `git replace --graft`.

```
$ git log -1 --format=%cI -- content/topics/arrays.mdx
2026-08-07T13:43:05-03:00      ← achatado no commit-fronteira
$ git log -1 --format=%cI -- content/topics/two-pointers.mdx
2026-08-07T11:48:08-03:00      ← data de verdade (arquivo deste PR)

amostra de 8: big-o, arrays, strings, subarray-…, two-pointers, …
ANTIGO -> datas distintas: 2  | pula? false   ← reprova 37 URLs corretas
NOVO   -> moda 39 de 42 = 92,9% | pula? true
```

O sintoma de git cego **não é a contagem, é a concentração**: ele devolve o
**mesmo segundo** para quase tudo, porque devolve sempre o commit-fronteira.
Agora a medida é a **fatia da moda**, sobre **todos** os caminhos conferidos, e
não sobre uma amostra que o PR da vez enviesa.

| ambiente | caminhos | datas distintas | moda | decide |
|---|---:|---:|---:|---|
| repositório com histórico | 42 | 22 | 6 (**14,3%**) | confere |
| job achatado (reproduzido) | 42 | 4 | 39 (**92,9%**) | pula |

Corte em **50%**, longe dos dois, e ele cobre o caso antigo (moda de 100%). De
carona, memo no `dataDoGit`: o teste pergunta a mesma data até três vezes por
rota, e cada `git log` custa ~29ms de processo novo.

`tests/seo-estrutura.spec.ts` não estava na lista original deste PR. Medido
antes de tocar: **nenhum** dos outros PRs abertos (#67, #69, #70, #71) toca esse
arquivo. Foi a menor mudança que fecha o vermelho, e nenhum arquivo do escopo
original poderia consertá-lo.

## Prova de quebra

Duas quebras plantadas, cada uma com `npm run build` **sem silenciar** e o
teste rodando contra o `out/` novo. Restauração por `cp` de cópia salva antes,
nunca por `git checkout --`, e `git diff --stat` vazio no fim.

**A) rótulo revertido, artigo intocado** (`SkipListVisualizer.tsx:212` volta a
"Do encontro: procurar o 73"). Reprova na linha 94, com o valor antigo no
`Received`:

```
  2) rotulo-de-preset-e-artigo.spec.ts:78 › skip-list: o artigo cita
     «A escada completa: procurar o 73» e o botão existe

    Error: os rótulos de preset na tela de skip-list
    expect(received).toContain(expected)

    Expected value: "A escada completa: procurar o 73"
    Received array: ["Do encontro: procurar o 73", "Lá no fim: procurar o 92",
                     "Não existe: procurar o 44", "Azar total: ninguém passou
                     do nível 0", "Antes de todos: procurar o 1",
                     "Um elemento só: procurar o 42"]

    > 94 |     expect(rotulos, `os rótulos de preset na tela de ${caso.slug}`)
                 .toContain(caso.rotulo);
```

E a varredura do fonte pega a mesma quebra por outro caminho, na linha 137:

```
    + Array [
    +   "SkipListVisualizer.tsx: \"Do encontro: procurar o 73\"",
    + ]
```

**B) prosa do painel revertida** (`TailRecursionForma.tsx` volta a citar o
Tiago). Reprova na linha 172, lendo o painel no navegador:

```
  2) rotulo-de-preset-e-artigo.spec.ts:149 › recursão funcional: a prosa do
     classificador não cita a gravação

    Error: prosa do painel ancorada na gravação
    Received string: "Mesmo formato da soma comum, ... E é o caso que o Tiago
                      mediu no encontro: aqui a versão de cauda saiu mais
                      lenta, ..."

    > 172 |     expect(texto, "prosa do painel ancorada na gravação")
                   .not.toMatch(ANCORA);
```

Com tudo restaurado, `git diff --stat` sai vazio e os 7 testes voltam a passar.

## Conferência em celular

Rótulo novo pode ser mais longo que o antigo, então a medição é do **elemento**,
comparando `scrollWidth` com `clientWidth` de cada botão de preset, e a largura
da tela vem de `document.documentElement.clientWidth` (e não de `innerWidth`,
que mente sob perfil de aparelho).

Sete páginas, presets atrás de aba incluídos, nos dois tamanhos:

| tamanho | botões medidos | pior sobra | página estoura |
|---|---:|---:|---|
| Pixel 7 (412x839) | 127 | **0px** | não |
| 390x844 | 141 | **0px** | não |

Nenhum botão com fonte abaixo de 9px.

## Verificação

- `npm run build` passa.
- `npx tsc --noEmit` limpo.
- `npm run lint`: **6 problemas, 0 erros**, igual à baseline.
- Guarda de commit: **11 commits, uma linha `✓` para cada**.
- Suíte completa (`npm run test:build`, um agente sozinho na máquina):
  **674 passaram, 0 falharam, 0 puladas** em 1,8 min.

As **7 falhas** que este PR reportava antes **não existem mais**: eram
anteriores ao PR, e a `main` já as recalibrou no #68, que entrou aqui pelo
commit `41c1104`. Nenhuma delas era deste PR, e nenhuma sobrou.

Nada de string renderizada mudou nesta rodada — as duas correções são de
arquivo de teste —, então a conferência em celular acima continua valendo sem
reabrir.

## O que este PR NÃO faz

**A categoria B fica de fora: 70 linhas de prosa de artigo ancoradas na
gravação, em 11 artigos, 10 delas citando pessoa pelo nome.** É redação de
verdade, não conserto de linha, e o `recursao-funcional.mdx` inteiro é
**reescrita de seção**: a estrutura narrativa dele é "o que o Tiago mostrou e o
que o Giovani perguntou", com sete das quatorze linhas ancoradas presas a isso.
Vira PR próprio.

O número mudou de 87 para 70 porque **87 e 75 medem coisas diferentes**: 87 é o
total do inventário com as variações "a comunidade" e "ao vivo" incluídas; 75 é
o que o comando publicado no inventário devolve hoje, contra a `main` em
`0b2c87c`. Este PR baixou o segundo para 70. Quem for escrever o PR de B
precisa recontar com todos os artigos na mesa, e não confiar em nenhum dos
três números.

Duas linhas que ficaram e são vizinhas do que eu toquei, para o PR de B não
perder de vista:

- `hash-table.mdx:48` e `:60` continuam dizendo "a mesma do encontro" e "os
  cinco nomes do encontro", a dois parágrafos da linha 85 que este PR arrumou.
- `skip-list.mdx:11`, `:50` e `:125` continuam com "a própria galera no
  encontro", "a dúvida que mais rendeu no encontro" e "a galera do encontro
  apelidou de bread crumb".

Também ficou de fora, e não é violação: **`listas-ligadas.mdx` e
`two-pointers.mdx` falam do "nó do encontro" do algoritmo de Floyd**, que é o
ponto onde lebre e tartaruga se encontram. Termo técnico, nada a ver com a
gravação, e é o falso positivo mais fácil de cometer numa busca por "encontro".

Uma citação parcial que **já existia** e este PR não tocou:
`skip-list.mdx:182` cita **"O mais alto: remover o 42"** e o botão diz "O mais
alto: remover o 42 (altura 4)". Não está quebrado (o aluno acha o botão), e o
rótulo não é dos dez, então ficou fora do escopo.

