### PR TITLE
fix(home): a copy conta só os tópicos que têm material

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import {
   TOTAL_LEETCODE_PROBLEMS,
   TOTAL_PROBLEMS,
   TOTAL_TOPICS,
+  TOTAL_TOPICS_PRONTOS,
   TOTAL_VISUALIZERS,
 } from "@content/roadmap";
 import { LINKS } from "@/lib/links";
@@ -14,12 +15,20 @@ import { levelClass } from "@/lib/ui";
 
 // Os números saem do roadmap.ts (fonte única) em vez de escritos à mão: tópico
 // novo já entra no título e no card sem ninguém lembrar de atualizar o SEO.
+//
+// São DOIS números, e a escolha é frase a frase. `TOTAL_TOPICS` é o tamanho da
+// trilha, o que o roadmap mapeia: continua certo no título e no card de
+// estatística ("tópicos no roadmap"). `TOTAL_TOPICS_PRONTOS` é quem tem material
+// para o aluno abrir, e é ele que vale em toda frase que QUALIFICA os tópicos
+// pelo que eles entregam. Os 11 de diferença não têm vídeo, artigo nem
+// visualização: são exatamente os que o próprio site marca "em breve" e tira do
+// índice do Google, pela mesma `isEmptyTopic` de onde a constante deriva.
 export function generateMetadata(): Metadata {
   return pageMetadata({
     title: `Algoritmos e Estruturas de Dados: Guia Visual com ${TOTAL_TOPICS} Tópicos`,
-    description: `O guia mais completo de algoritmos e estruturas de dados em português: ${TOTAL_TOPICS} tópicos com visualização passo a passo, código Python e problemas do LeetCode para entrevistas. Grátis.`,
+    description: `O guia mais completo de algoritmos e estruturas de dados em português: ${TOTAL_TOPICS_PRONTOS} tópicos com visualização passo a passo, código Python e problemas do LeetCode para entrevistas. Grátis.`,
     ogTitle: "O maior guia visual de Algoritmos e Estruturas de Dados",
-    ogDescription: `${TOTAL_TOPICS} tópicos com o algoritmo rodando passo a passo, código em Python, vídeo e ${TOTAL_LEETCODE_PROBLEMS} problemas do LeetCode. Grátis, para sempre.`,
+    ogDescription: `${TOTAL_TOPICS_PRONTOS} tópicos com o algoritmo rodando passo a passo, código em Python, vídeo e ${TOTAL_LEETCODE_PROBLEMS} problemas do LeetCode. Grátis, para sempre.`,
     path: "/",
   });
 }
@@ -45,9 +54,9 @@ export default function Home() {
         <span className="hero-badge">Feito pela comunidade Craft &amp; Code Club · 100% grátis · open source</span>
         <h1><span className="accent">Visualização</span> e aprofundamento em cada estrutura</h1>
         <p>
-          O maior guia visual de algoritmos e estruturas de dados em português. Cada tópico traz o texto, o algoritmo
-          animado passo a passo com o código sincronizado, vídeo e uma lista de problemas do
-          LeetCode e do GeeksforGeeks.
+          O maior guia visual de algoritmos e estruturas de dados em português. Nos {TOTAL_TOPICS_PRONTOS} tópicos
+          já publicados você encontra o texto, o algoritmo animado passo a passo com o código
+          sincronizado, vídeo e uma lista de problemas do LeetCode e do GeeksforGeeks.
         </p>
         <div className="hero-actions">
           <Link href="/topico/big-o" className="btn btn-primary">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,12 +51,7 @@ export default function Home() {
   return (
     <>
       <section className="hero">
-        {/* "open source" saiu daqui e do rodapé: a licença é a PolyForm
-            Noncommercial, que proíbe uso comercial e por isso não é open source
-            pela definição da OSI. O que a frase queria dizer ao dev continua
-            verdade e continua dito, sem o rótulo errado: o código está no
-            GitHub, aberto para ler, aprender e contribuir. */}
-        <span className="hero-badge">Feito pela comunidade Craft &amp; Code Club · 100% grátis · código no GitHub</span>
+        <span className="hero-badge">Feito pela comunidade Craft &amp; Code Club · 100% grátis · open source</span>
         <h1><span className="accent">Visualização</span> e aprofundamento em cada estrutura</h1>
         <p>
           O maior guia visual de algoritmos e estruturas de dados em português. Nos {TOTAL_TOPICS_PRONTOS} tópicos
@@ -149,7 +144,7 @@ function Footer() {
       <div className="foot-text">
         <span>Feito <span className="heart">♥</span> pela comunidade, para a comunidade.</span>
         <span className="foot-sep">·</span>
-        <span>Código no GitHub · gratuito para sempre</span>
+        <span>Open source · gratuito para sempre</span>
       </div>
       <div className="foot-links">
         <a href={LINKS.github} target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -51,7 +51,12 @@ export default function Home() {
   return (
     <>
       <section className="hero">
-        <span className="hero-badge">Feito pela comunidade Craft &amp; Code Club · 100% grátis · open source</span>
+        {/* "open source" saiu daqui e do rodapé: a licença é a PolyForm
+            Noncommercial, que proíbe uso comercial e por isso não é open source
+            pela definição da OSI. O que a frase queria dizer ao dev continua
+            verdade e continua dito, sem o rótulo errado: o código está no
+            GitHub, aberto para ler, aprender e contribuir. */}
+        <span className="hero-badge">Feito pela comunidade Craft &amp; Code Club · 100% grátis · código no GitHub</span>
         <h1><span className="accent">Visualização</span> e aprofundamento em cada estrutura</h1>
         <p>
           O maior guia visual de algoritmos e estruturas de dados em português. Nos {TOTAL_TOPICS_PRONTOS} tópicos
@@ -144,7 +149,7 @@ function Footer() {
       <div className="foot-text">
         <span>Feito <span className="heart">♥</span> pela comunidade, para a comunidade.</span>
         <span className="foot-sep">·</span>
-        <span>Open source · gratuito para sempre</span>
+        <span>Código no GitHub · gratuito para sempre</span>
       </div>
       <div className="foot-links">
         <a href={LINKS.github} target="_blank" rel="noopener noreferrer">GitHub</a>

--- a/tests/copy-da-home.spec.ts
+++ b/tests/copy-da-home.spec.ts
@@ -1,11 +1,15 @@
 import { test, expect, type Page } from "@playwright/test";
 import { ALL_TOPICS, TOTAL_TOPICS, isEmptyTopic } from "../content/roadmap";
 
-// A copy da home prometia "47 tópicos com visualização passo a passo, código
-// Python e problemas do LeetCode", e 11 dos 47 não têm NENHUM dos três. É o
-// mesmo corte que o site usa para marcar "em breve" no menu e mandar `noindex`
-// para o Google, então a página afirmava, para quem busca, o contrário do que
-// ela própria declara para o buscador.
+// A copy da home prometia duas coisas que não eram verdade.
+//
+//  1. "47 tópicos com visualização passo a passo, código Python e problemas do
+//     LeetCode": 11 dos 47 não têm NENHUM dos três. É o mesmo corte que o site
+//     usa para marcar "em breve" no menu e mandar `noindex` para o Google, então
+//     a página afirmava, para quem busca, o contrário do que ela própria declara
+//     para o buscador.
+//  2. "open source": a licença é a PolyForm Noncommercial, que proíbe uso
+//     comercial e por isso não é open source pela definição da OSI.
 //
 // Os dois testes de número LEEM A FONTE (`content/roadmap.ts`) em vez de fixar
 // 36 e 47: no dia em que um tópico ganhar material eles continuam verdes, e o
@@ -84,3 +88,76 @@ test("o total da trilha continua onde ele é verdade: título e card do roadmap"
   await expect(cartao).toHaveCount(1);
   await expect(cartao.locator(".stat-n")).toHaveText(`${TOTAL_TOPICS}`);
 });
+
+test("a home não se chama open source, e diz onde o código está", async ({ page, request }) => {
+  await page.goto("/");
+
+  await expect(page.locator(".hero-badge")).toHaveText(
+    "Feito pela comunidade Craft & Code Club · 100% grátis · código no GitHub"
+  );
+  await expect(page.locator(".site-foot .foot-text")).toContainText(
+    "Código no GitHub · gratuito para sempre"
+  );
+
+  // O que o aluno lê...
+  const naTela = await page.locator("body").innerText();
+  expect(naTela, "'open source' voltou ao texto da home").not.toMatch(/open[\s-]?source/i);
+
+  // ...e o que o robô lê: título, descrição e card de compartilhamento saem no
+  // `<head>`, fora do `body`, e é por eles que a frase circula em link.
+  const html = await (await request.get("/")).text();
+  expect(html, "'open source' voltou ao HTML da home (head, meta ou payload)").not.toMatch(
+    /open[\s-]?source/i
+  );
+});
+
+const REGUAS = [
+  { w: 390, h: 844, nome: "390x844" },
+  { w: 1440, h: 700, nome: "1440x700" },
+  { w: 1512, h: 900, nome: "1512x900" },
+] as const;
+
+for (const regua of REGUAS) {
+  test(`o selo do topo cabe na caixa em ${regua.nome}`, async ({ page }) => {
+    await page.setViewportSize({ width: regua.w, height: regua.h });
+    await page.goto("/");
+
+    // "código no GitHub" é 30px mais largo que "open source" (medido em 1512:
+    // 411,2px -> 440,8px), e copy mais longa é a única forma de esta troca
+    // machucar alguém.
+    //
+    // O que se mede aqui é a CAIXA do selo contra a largura do aparelho. As duas
+    // medições mais naturais foram testadas e as duas são incapazes de reprovar,
+    // com uma palavra impossível de quebrar dentro do selo, em 390x844:
+    //
+    //   texto contra a caixa ..... a caixa é `inline-block` sem `max-width` e
+    //                              cresce junto: a linha nunca passa dela
+    //   página rolando de lado ... `documentElement.scrollWidth` continuou 390
+    //                              com o selo em 422,8px, porque ele é aparado
+    //                              em silêncio em vez de empurrar a página
+    //
+    // Sobra a caixa contra o aparelho, que reprovou por 32,8px no mesmo teste. E
+    // a comparação é com `documentElement.clientWidth`, a largura real: sob
+    // perfil de celular o Chromium alarga a viewport de layout junto com o
+    // estouro, e `innerWidth` mentiria junto.
+    const medida = await page.locator(".hero-badge").evaluate((el) => {
+      const faixa = document.createRange();
+      faixa.selectNodeContents(el);
+      return {
+        linhas: faixa.getClientRects().length,
+        caixa: el.getBoundingClientRect().width,
+        aparelho: document.documentElement.clientWidth,
+        fonte: parseFloat(getComputedStyle(el).fontSize),
+      };
+    });
+
+    expect(medida.fonte, "o selo ficou com fonte zerada").toBeGreaterThan(9);
+    expect(
+      Math.round((medida.caixa - medida.aparelho) * 10) / 10,
+      "a caixa do selo ficou mais larga que a tela"
+    ).toBeLessThanOrEqual(0);
+    // Uma linha no desktop, no máximo duas no celular (medido: já eram duas com
+    // a copy antiga, porque a quebra cai depois de "grátis ·").
+    expect(medida.linhas, "o selo ganhou linha demais").toBeLessThanOrEqual(regua.w < 500 ? 2 : 1);
+  });
+}

--- a/tests/copy-da-home.spec.ts
+++ b/tests/copy-da-home.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect, type Page } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { ALL_TOPICS, TOTAL_TOPICS, isEmptyTopic } from "../content/roadmap";
 
 // A copy da home prometia "47 tópicos com visualização passo a passo, código
@@ -83,4 +85,50 @@ test("o total da trilha continua onde ele é verdade: título e card do roadmap"
   const cartao = page.locator(".stat").filter({ hasText: "tópicos no roadmap" });
   await expect(cartao).toHaveCount(1);
   await expect(cartao.locator(".stat-n")).toHaveText(`${TOTAL_TOPICS}`);
+});
+
+// ---------------------------------------------------------------------------
+// "open source" é verdade, e por isso tem que continuar dito.
+//
+// Este guarda já existiu ao contrário. Enquanto a licença era a PolyForm
+// Noncommercial 1.0.0 — que proíbe uso comercial e por isso NÃO é open source
+// pela definição da OSI —, um teste afirmava que a palavra não aparecia na
+// home. O PR #71 relicenciou o CÓDIGO como MIT, a premissa caiu, e a asserção
+// virou de lado: agora o risco não é prometer demais, é esconder algo
+// verdadeiro por hábito.
+//
+// A palavra aparece em TRÊS lugares, e é por isso que o teste olha os três: se
+// alguém consertar um e esquecer os outros, o site passa a dizer duas coisas
+// diferentes sobre a mesma licença. O terceiro é o card de compartilhamento
+// (`src/lib/og.tsx`), que já foi inventariado como "pendência a corrigir" na
+// época da PolyForm — ele agora está CERTO, e este teste é o bilhete para quem
+// for "consertá-lo" depois.
+//
+// Nota para quando o #71 estiver na `main`: o guarda mais forte é amarrar esta
+// copy ao arquivo `LICENSE`, reprovando se o repositório voltar a uma licença
+// que a OSI não reconhece. Não dá para escrever aqui ainda, porque nesta branch
+// o `LICENSE` ainda é o antigo e o teste nasceria vermelho.
+// ---------------------------------------------------------------------------
+
+const OG = join(__dirname, "..", "src", "lib", "og.tsx");
+
+test("a home diz 'open source' nos três lugares em que faz a afirmação", async ({ page }) => {
+  await page.goto("/");
+
+  // 1. O selo do topo. Pelo RÓTULO renderizado, não pelo HTML da fonte.
+  const selo = page.locator(".hero-badge");
+  await expect(selo).toHaveCount(1);
+  await expect(selo).toContainText("open source");
+
+  // 2. O rodapé. `.site-foot` é a mesma caixa que leva o link do GitHub, e a
+  //    frase é a legenda dele.
+  const rodape = page.locator(".site-foot .foot-text");
+  await expect(rodape).toContainText(/open source/i);
+
+  // 3. O card de compartilhamento. A imagem é gerada em build, então não há
+  //    DOM para ler: a fonte é o único lugar onde dá para afirmar isso.
+  expect(
+    readFileSync(OG, "utf-8"),
+    "src/lib/og.tsx perdeu o selo 'open source'; com MIT ele está correto e deve ficar"
+  ).toContain('"open source"');
 });

--- a/tests/copy-da-home.spec.ts
+++ b/tests/copy-da-home.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type Page } from "@playwright/test";
+import { ALL_TOPICS, TOTAL_TOPICS, isEmptyTopic } from "../content/roadmap";
+
+// A copy da home prometia "47 tópicos com visualização passo a passo, código
+// Python e problemas do LeetCode", e 11 dos 47 não têm NENHUM dos três. É o
+// mesmo corte que o site usa para marcar "em breve" no menu e mandar `noindex`
+// para o Google, então a página afirmava, para quem busca, o contrário do que
+// ela própria declara para o buscador.
+//
+// Os dois testes de número LEEM A FONTE (`content/roadmap.ts`) em vez de fixar
+// 36 e 47: no dia em que um tópico ganhar material eles continuam verdes, e o
+// que eles protegem não é o valor, é a ESCOLHA entre os dois números. Por isso
+// vem junto a asserção do outro lado: a frase que fala do tamanho da trilha
+// ("tópicos no roadmap", o título) tem que continuar com o total. Trocar a
+// constante em toda ocorrência conserta a mentira e cria outra.
+
+const PRONTOS = ALL_TOPICS.filter((t) => !isEmptyTopic(t));
+
+/** O número que a frase usa, lido do texto que a página publicou. */
+function numeroDa(texto: string | null, padrao: RegExp, onde: string): number {
+  expect(texto, `${onde}: nada publicado`).toBeTruthy();
+  const achado = texto!.match(padrao);
+  expect(achado, `${onde}: a frase mudou e o guarda não achou o número em ${JSON.stringify(texto)}`)
+    .not.toBeNull();
+  return Number(achado![1]);
+}
+
+async function meta(page: Page, seletor: string): Promise<string | null> {
+  return page.locator(`head ${seletor}`).getAttribute("content");
+}
+
+test("a home só promete material nos tópicos que têm material", async ({ page }) => {
+  // O teste só sabe distinguir os dois números enquanto eles forem diferentes.
+  // Empatados (todo tópico com material), ele passaria sem testar nada.
+  expect(PRONTOS.length, "todo tópico tem material: reveja a copy e este guarda").toBeLessThan(
+    TOTAL_TOPICS
+  );
+
+  await page.goto("/");
+
+  const descricao = numeroDa(
+    await meta(page, 'meta[name="description"]'),
+    /(\d+) tópicos com visualização passo a passo/,
+    "meta description"
+  );
+  const cartao = numeroDa(
+    await meta(page, 'meta[property="og:description"]'),
+    /(\d+) tópicos com o algoritmo rodando passo a passo/,
+    "og:description"
+  );
+  const abertura = numeroDa(
+    (await page.locator(".hero > p").innerText()).replace(/\s+/g, " "),
+    /Nos (\d+) tópicos já publicados/,
+    "parágrafo de abertura"
+  );
+
+  expect({ descricao, cartao, abertura }).toEqual({
+    descricao: PRONTOS.length,
+    cartao: PRONTOS.length,
+    abertura: PRONTOS.length,
+  });
+
+  // A abertura diz "já publicados", e a conta é derivada de `isEmptyTopic`, que
+  // aceitaria um tópico `soon` com só um vídeo. Enquanto as duas listas forem a
+  // mesma, a palavra está certa; no dia em que se separarem, aqui reprova antes
+  // de a home passar a chamar de publicado quem não tem artigo.
+  expect(
+    PRONTOS.filter((t) => t.status !== "ready").map((t) => t.slug),
+    "a copy diz 'já publicados', mas há tópico contado sem artigo"
+  ).toEqual([]);
+});
+
+test("o total da trilha continua onde ele é verdade: título e card do roadmap", async ({ page }) => {
+  await page.goto("/");
+
+  // O título fala do tamanho do guia, não do que cada tópico entrega: 47 é o
+  // número certo aqui, e é o mesmo que o roadmap lista.
+  expect(await page.title()).toContain(`${TOTAL_TOPICS} Tópicos`);
+
+  // Pelo RÓTULO, não pela posição: o card vizinho mostra 36 hoje ("tópicos com
+  // visualização"), e um `.first()` daria um teste que passa lendo o número
+  // errado.
+  const cartao = page.locator(".stat").filter({ hasText: "tópicos no roadmap" });
+  await expect(cartao).toHaveCount(1);
+  await expect(cartao.locator(".stat-n")).toHaveText(`${TOTAL_TOPICS}`);
+});

--- a/tests/copy-da-home.spec.ts
+++ b/tests/copy-da-home.spec.ts
@@ -1,15 +1,11 @@
 import { test, expect, type Page } from "@playwright/test";
 import { ALL_TOPICS, TOTAL_TOPICS, isEmptyTopic } from "../content/roadmap";
 
-// A copy da home prometia duas coisas que não eram verdade.
-//
-//  1. "47 tópicos com visualização passo a passo, código Python e problemas do
-//     LeetCode": 11 dos 47 não têm NENHUM dos três. É o mesmo corte que o site
-//     usa para marcar "em breve" no menu e mandar `noindex` para o Google, então
-//     a página afirmava, para quem busca, o contrário do que ela própria declara
-//     para o buscador.
-//  2. "open source": a licença é a PolyForm Noncommercial, que proíbe uso
-//     comercial e por isso não é open source pela definição da OSI.
+// A copy da home prometia "47 tópicos com visualização passo a passo, código
+// Python e problemas do LeetCode", e 11 dos 47 não têm NENHUM dos três. É o
+// mesmo corte que o site usa para marcar "em breve" no menu e mandar `noindex`
+// para o Google, então a página afirmava, para quem busca, o contrário do que
+// ela própria declara para o buscador.
 //
 // Os dois testes de número LEEM A FONTE (`content/roadmap.ts`) em vez de fixar
 // 36 e 47: no dia em que um tópico ganhar material eles continuam verdes, e o
@@ -88,76 +84,3 @@ test("o total da trilha continua onde ele é verdade: título e card do roadmap"
   await expect(cartao).toHaveCount(1);
   await expect(cartao.locator(".stat-n")).toHaveText(`${TOTAL_TOPICS}`);
 });
-
-test("a home não se chama open source, e diz onde o código está", async ({ page, request }) => {
-  await page.goto("/");
-
-  await expect(page.locator(".hero-badge")).toHaveText(
-    "Feito pela comunidade Craft & Code Club · 100% grátis · código no GitHub"
-  );
-  await expect(page.locator(".site-foot .foot-text")).toContainText(
-    "Código no GitHub · gratuito para sempre"
-  );
-
-  // O que o aluno lê...
-  const naTela = await page.locator("body").innerText();
-  expect(naTela, "'open source' voltou ao texto da home").not.toMatch(/open[\s-]?source/i);
-
-  // ...e o que o robô lê: título, descrição e card de compartilhamento saem no
-  // `<head>`, fora do `body`, e é por eles que a frase circula em link.
-  const html = await (await request.get("/")).text();
-  expect(html, "'open source' voltou ao HTML da home (head, meta ou payload)").not.toMatch(
-    /open[\s-]?source/i
-  );
-});
-
-const REGUAS = [
-  { w: 390, h: 844, nome: "390x844" },
-  { w: 1440, h: 700, nome: "1440x700" },
-  { w: 1512, h: 900, nome: "1512x900" },
-] as const;
-
-for (const regua of REGUAS) {
-  test(`o selo do topo cabe na caixa em ${regua.nome}`, async ({ page }) => {
-    await page.setViewportSize({ width: regua.w, height: regua.h });
-    await page.goto("/");
-
-    // "código no GitHub" é 30px mais largo que "open source" (medido em 1512:
-    // 411,2px -> 440,8px), e copy mais longa é a única forma de esta troca
-    // machucar alguém.
-    //
-    // O que se mede aqui é a CAIXA do selo contra a largura do aparelho. As duas
-    // medições mais naturais foram testadas e as duas são incapazes de reprovar,
-    // com uma palavra impossível de quebrar dentro do selo, em 390x844:
-    //
-    //   texto contra a caixa ..... a caixa é `inline-block` sem `max-width` e
-    //                              cresce junto: a linha nunca passa dela
-    //   página rolando de lado ... `documentElement.scrollWidth` continuou 390
-    //                              com o selo em 422,8px, porque ele é aparado
-    //                              em silêncio em vez de empurrar a página
-    //
-    // Sobra a caixa contra o aparelho, que reprovou por 32,8px no mesmo teste. E
-    // a comparação é com `documentElement.clientWidth`, a largura real: sob
-    // perfil de celular o Chromium alarga a viewport de layout junto com o
-    // estouro, e `innerWidth` mentiria junto.
-    const medida = await page.locator(".hero-badge").evaluate((el) => {
-      const faixa = document.createRange();
-      faixa.selectNodeContents(el);
-      return {
-        linhas: faixa.getClientRects().length,
-        caixa: el.getBoundingClientRect().width,
-        aparelho: document.documentElement.clientWidth,
-        fonte: parseFloat(getComputedStyle(el).fontSize),
-      };
-    });
-
-    expect(medida.fonte, "o selo ficou com fonte zerada").toBeGreaterThan(9);
-    expect(
-      Math.round((medida.caixa - medida.aparelho) * 10) / 10,
-      "a caixa do selo ficou mais larga que a tela"
-    ).toBeLessThanOrEqual(0);
-    // Uma linha no desktop, no máximo duas no celular (medido: já eram duas com
-    // a copy antiga, porque a quebra cai depois de "grátis ·").
-    expect(medida.linhas, "o selo ganhou linha demais").toBeLessThanOrEqual(regua.w < 500 ? 2 : 1);
-  });
-}


### PR DESCRIPTION
> **⚠️ Reviravolta — este PR mudou de forma desde a abertura.** Ele nasceu com **dois** consertos. O primeiro (números) está de pé e é o que sobrou. O segundo (tirar "open source" da home) foi **revertido**, porque o Wilson decidiu resolver a contradição **pelo lado da licença**: o **PR #71** relicencia o código como **MIT**, e aí "open source" passa a ser **verdade**. O histórico deste PR conta essa história em vez de escondê-la, e por isso o revert vem em commit próprio.
>
> **Ordem de merge: o #71 primeiro.** Este PR devolve à home uma afirmação que só o #71 sustenta.

Duas frases da home não eram verdade. Uma prometia material que 11 tópicos não têm — e esse conserto continua aqui. A outra chamava de open source uma licença que não era; essa deixou de ser um problema de copy e virou um problema de licença, resolvido noutro lugar.

## 1. A home contava 47 tópicos com material que 11 não têm

**Antes**

| onde | frase |
|---|---|
| `description` | O guia mais completo (...): **47 tópicos com visualização passo a passo, código Python e problemas do LeetCode** para entrevistas. Grátis. |
| `ogDescription` | **47 tópicos com o algoritmo rodando passo a passo**, código em Python, vídeo e 192 problemas do LeetCode. |
| parágrafo de abertura | O maior guia visual (...). **Cada tópico traz** o texto, o algoritmo animado passo a passo com o código sincronizado, vídeo e uma lista de problemas do LeetCode e do GeeksforGeeks. |

**Depois**

| onde | frase |
|---|---|
| `description` | O guia mais completo (...): **36 tópicos com visualização passo a passo, código Python e problemas do LeetCode** para entrevistas. Grátis. |
| `ogDescription` | **36 tópicos com o algoritmo rodando passo a passo**, código em Python, vídeo e 192 problemas do LeetCode. |
| parágrafo de abertura | O maior guia visual (...). **Nos 36 tópicos já publicados você encontra** o texto, o algoritmo animado passo a passo com o código sincronizado, vídeo e uma lista de problemas do LeetCode e do GeeksforGeeks. |

O 36 é `TOTAL_TOPICS_PRONTOS`, a constante que o PR #61 derivou da **mesma** `isEmptyTopic` que decide o selo "em breve" no menu e o `noindex` da página. Ou seja: a home afirmava para quem busca exatamente o contrário do que ela declara para o buscador.

### Qual número em qual frase, e por quê

A regra que apliquei, frase a frase:

> quem fala do **tamanho da trilha** fica em 47, porque 47 é verdade; quem **qualifica os tópicos pelo que eles entregam** passa para 36.

| frase | número | por quê |
|---|---|---|
| `<title>` "Guia Visual com **47** Tópicos" | 47, **não mudou** | diz o tamanho do guia, a mesma afirmação do card "47 tópicos no roadmap", e é o que o /roadmap lista |
| card "**47** tópicos no roadmap" | 47, **não mudou** | é literalmente o total da trilha |
| `description` | **36** | enumera o que cada tópico entrega |
| `ogDescription` | **36** | idem |
| parágrafo de abertura | **36** | idem, e ainda dizia "Cada tópico traz" |

É o mesmo rigor que o `content/roadmap.ts` já aplica no comentário do `TOTAL_LEETCODE_PROBLEMS` ("não contar duas fontes como uma"), e o bloco de estatísticas já separava honestamente "47 no roadmap" de "36 com visualização". O card de estatística continua mostrando os dois números lado a lado, agora coerente com a abertura logo acima dele.

**"Cada tópico traz" era falso duas vezes**, e por isso virou "Nos 36 tópicos já publicados você encontra": além dos 11 tópicos sem nada, **vídeo existe em 34 dos 36**. Trocar o quantificador universal por uma leitura agregada resolve os dois casos sem perder nada da mensagem. Pelo mesmo motivo o "vídeo" da `ogDescription` ficou como está: ali a lista já é agregada por construção (os "192 problemas do LeetCode" nunca foram por tópico).

### O que eu conferi antes de escrever 36

Nos 36 tópicos que a constante conta, medido em `content/roadmap.ts` e nos MDX:

- 36 de 36 com visualização, com artigo MDX (`status: "ready"`) e com `language: "Python"`;
- 36 de 36 com ao menos um problema do LeetCode, e os **192** problemas do LeetCode do site estão **todos** dentro deles (nenhum mora num tópico vazio);
- 34 de 36 com vídeo (faltam `subarray-substring-subsequence-subset` e `intervals`), que é o motivo da redação agregada acima.

## 2. ~~"open source" com licença PolyForm~~ — revertido, e por quê

**O que este PR fazia:** trocava o selo do topo para `(...) · 100% grátis · código no GitHub` e o rodapé para `Código no GitHub · gratuito para sempre`, porque a licença era **PolyForm Noncommercial 1.0.0** — que proíbe uso comercial e por isso **não é open source pela definição da OSI**.

**O que mudou:** o raciocínio estava certo, e a **premissa** deixou de valer. O **#71** relicencia o repositório:

| dimensão | agora |
|---|---|
| **código** | **MIT** — open source pela definição da OSI |
| **conteúdo** (artigos MDX, textos) | **CC BY-NC-SA 4.0** |
| **visualizadores** | o componente é código (MIT); as strings didáticas são conteúdo (CC BY-NC-SA) |

Com MIT, "open source" não é mais uma promessa que a licença não sustenta: é **descrição verificável**. Apagar a palavra passaria a **esconder algo verdadeiro**, e um projeto que é open source e não diz isso perde contribuidor por timidez.

O revert é o commit `ea6dad8`, e desfaz **exatamente** o commit `34e9c63` — nada do commit dos números foi tocado.

### ⚠️ `src/lib/og.tsx:93` está CERTO. Não conserte.

O array `["100% grátis", "open source", "feito pela comunidade"]`, que desenha os selos do card de compartilhamento, estava inventariado neste PR como **pendência a corrigir**. Ele **agora está correto** e **não deve ser mexido**.

Para que ninguém o "conserte" por engano meses depois, isso não ficou só escrito aqui: **virou asserção de teste**, com uma mensagem de falha que explica o motivo.

Pelo mesmo motivo, as outras duas ocorrências que este PR havia reportado — `README.md:3` ("visual, gratuito e open source") e `CONTRIBUTING.md:4` ("gratuito e open source") — também estão corretas e ficam como estão.

### O teste virou de lado

O commit revertido trazia um teste que afirmava a **ausência** da palavra na home. Ele saiu junto no revert — se sobrevivesse, deixaria o PR vermelho, e com razão.

Deixar o lugar vazio seria pior do que antes, então entrou a **asserção contrária** (`7b807ac`), olhando os **três** lugares que fazem a afirmação, porque consertar um e esquecer os outros faz o site dizer duas coisas diferentes sobre a mesma licença:

1. o selo do topo (`.hero-badge`), pelo rótulo renderizado;
2. o rodapé (`.site-foot .foot-text`);
3. `src/lib/og.tsx` — a imagem é gerada em build e não tem DOM para ler, então a fonte é o único lugar onde dá para afirmar isso.

**Prova de quebra, uma por asserção**, cada uma vista reprovando **na sua linha, com o valor antigo no `Received`**, sem `git checkout`:

| o que quebrei | linha | `Received` |
|---|---|---|
| selo de volta a "código no GitHub" | `:121` | `"(...) · 100% grátis · código no GitHub"` |
| **só** o rodapé de volta | `:126` | `"(...)·Código no GitHub · gratuito para sempre"` |
| `"open source"` fora do `og.tsx` | `:133` | a fonte do arquivo, sem o selo |

Nas duas primeiras quebrei o HTML **já construído** em `out/`, que é o que a suíte serve, para provar cada asserção sem um build por caso. Na segunda, a asserção do selo **passou** antes de o rodapé reprovar — o que mostra que a primeira não estava mascarando a segunda.

**O guarda que ainda falta**, e fica anotado no comentário do teste: amarrar esta copy ao arquivo `LICENSE`, reprovando se o repositório voltar a uma licença que a OSI não reconhece. Não dá para escrever nesta branch, porque aqui o `LICENSE` ainda é o antigo e o teste nasceria vermelho. É o próximo passo natural depois de o #71 entrar na `main`.

## Medição no celular e nas outras duas réguas

A medição abaixo era do texto que **acabou revertido**. Fica registrada porque explica por que a troca era segura, e porque a copy atual é a **original**, que já estava medida e no ar:

O selo do topo era a única peça que ficava maior: **411,2px → 440,8px** de texto (+29,6px), medido em 1512x900. No celular ele **já ocupava duas linhas antes da mudança** (a quebra cai depois de "grátis ·"). Com o revert, o selo volta aos **411,2px** originais — ou seja, **menor** do que o que foi medido, dentro de tudo que já passava.

O parágrafo de abertura, que **fica**, ocupa 5 linhas em 1512x900 e 8 em 390x844, dentro da própria caixa nas três réguas.

## Provas de quebra do conserto que ficou

As três asserções dos números foram vistas reprovando **na própria linha, com o valor antigo no `Received`**, com `npm run build` antes de cada rodada:

| o que voltei a quebrar | linha | `Received` |
|---|---|---|
| as três frases de volta em `TOTAL_TOPICS` | `copy-da-home.spec.ts:61` | `{descricao: 47, cartao: 47, abertura: 47}` contra `{36, 36, 36}` |
| a constante trocada TAMBÉM no título | `:82` | `"(...) Guia Visual com 36 Tópicos"` |
| a constante trocada TAMBÉM no card do roadmap | `:89` | `"36"` |

Elas cobrem o erro simétrico, que é trocar a constante em toda ocorrência e passar a mentir para o outro lado.

## Testes

`tests/copy-da-home.spec.ts`, agora com 3 testes. Os de número **leem a fonte** (`ALL_TOPICS.filter(t => !isEmptyTopic(t))`, importado de `content/roadmap`) em vez de fixar 36 e 47: no dia em que um tópico ganhar material, o número sobe sozinho na página e o teste continua verde. O que eles protegem não é o valor, é a **escolha** entre os dois números, e por isso há asserção dos dois lados.

Dois guardas menores, do tipo "rótulo contra o valor que o alimenta":

- a abertura diz "já publicados", e a conta deriva de `isEmptyTopic`, que aceitaria um tópico `soon` só com vídeo. O teste reprova se as duas listas se separarem, antes de a home chamar de publicado quem não tem artigo.
- o teste só sabe distinguir 36 de 47 enquanto eles forem diferentes: se empatarem, ele reprova pedindo revisão em vez de passar sem testar nada.

## Verificação

- `npm run lint` ✅ — **6 problemas, 0 erros**, igual à baseline da `main`.
- `npx tsc --noEmit` ✅
- `PORT=4495 npm run test:build` ✅ — **670 passaram, 0 reprovaram**, a suíte **inteira** verde.
  As **7 falhas** que este PR reportava antes (em `regressao-css-celular.spec.ts`) **não existem mais**: elas eram da `main` daquele momento e foram resolvidas pela suíte recalibrada do #68, que entrou aqui em `7a6b2f2`.
- Guarda de commit, pelo `stdin`, com uma linha por commit:

```
$ git log --format="%s" origin/main..HEAD | python3 scripts/guarda-commit.py
✓ test: guarda que a home diz open source, agora que é verdade
✓ revert: devolve o rótulo open source, que a licença mit sustenta
✓ chore: traz a main com a suite recalibrada do #68
✓ fix(home): tira o rótulo open source que a licença não sustenta
✓ fix(home): conta na copy só os tópicos que têm material
✓ 5 header(s) checado(s).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3BfAzcaMzDmPLn9xFnHVv
