### PR TITLE
test: recalibrar as 21 asserções que barram o deploy da main

### DIFF
--- a/tests/console-limpo-fixture.spec.ts
+++ b/tests/console-limpo-fixture.spec.ts
@@ -95,8 +95,10 @@ test("a tolerância de ERR_ABORTED vale para o site, e não para domínio de for
 // uma tolerância escrita para "o beacon do Google Analytics" pode, se o regex
 // for largo, acabar engolindo QUALQUER coisa do domínio do Google — inclusive um
 // 404, que é justamente o sintoma de recurso que sumiu do `out/`. Este teste
-// fixa os quatro lados: o que passa, e os três vizinhos que continuam
-// reprovando.
+// fixa os cinco lados: o que passa, os três vizinhos do mesmo host que continuam
+// reprovando, e o SÓSIA — o host de fora que carrega `google-analytics.com` no
+// meio da URL e não pode ser confundido com o Google nem por quem tolera nem por
+// quem confere.
 // ---------------------------------------------------------------------------
 
 /** O beacon de verdade: `/g/collect` com a query que o gtag.js monta. */
@@ -108,6 +110,33 @@ const GA_404 = "https://www.google-analytics.com/g/collect?v=2&tid=G-EXEMPLO&cas
 const GA_RECUSADO = "https://www.google-analytics.com/g/collect?v=2&tid=G-EXEMPLO&caso=recusa";
 /** Mesmo host, OUTRO caminho: a tolerância é do endpoint de coleta, não do domínio. */
 const GA_OUTRO_CAMINHO = "https://www.google-analytics.com/analytics.js";
+/** O SÓSIA: `google-analytics.com` aparece inteiro na URL, e o host é outro, de
+ *  outro dono. `.test` é reservado (RFC 2606) e nunca é resolvido. */
+const GA_SOSIA = "https://google-analytics.com.dominio-de-fora.test/g/collect?v=2&tid=G-EXEMPLO";
+
+/** O host da URL que a ocorrência carrega, ou `null` quando ela não é de rede.
+ *
+ *  Existe porque `ocorrencia.includes("google-analytics.com")` **não é** teste de
+ *  host: a mesma substring aparece em `https://google-analytics.com.dominio-de-
+ *  fora.test/`, que é outro host, de outro dono. Aqui a troca não abriria buraco
+ *  (a comparação logo abaixo é contra um array EXATO, então uma entrada a mais
+ *  reprovaria alto em vez de passar), mas o teste cujo assunto é "a tolerância
+ *  nomeia o host, e não o pedaço de texto" não pode ele mesmo identificar host
+ *  por pedaço de texto. O `URL` faz a separação que o `includes` não faz.
+ *
+ *  As duas formas que `coletarErros` produz com URL dentro:
+ *      requestfailed: <url> (<motivo>)
+ *      http <status>: <url>
+ *  As outras (`pageerror:`, `console.error:`) devolvem `null` e ficam de fora. */
+function hostDa(ocorrencia: string): string | null {
+  const m = ocorrencia.match(/^(?:requestfailed|http \d{3}): (\S+)/);
+  if (!m) return null;
+  try {
+    return new URL(m[1]).host;
+  } catch {
+    return null;
+  }
+}
 
 test("a tolerância do GA vale para o beacon abortado, e não para o 404 nem para o resto do domínio", async ({
   browser,
@@ -129,6 +158,7 @@ test("a tolerância do GA vale para o beacon abortado, e não para o 404 nem par
   await page.route(/google-analytics\.com/, (route) => route.abort("aborted"));
   await page.route(GA_404, (route) => route.fulfill({ status: 404, body: "" }));
   await page.route(GA_RECUSADO, (route) => route.abort("connectionrefused"));
+  await page.route(GA_SOSIA, (route) => route.abort("aborted"));
 
   await page.goto("/");
 
@@ -142,7 +172,7 @@ test("a tolerância do GA vale para o beacon abortado, e não para o 404 nem par
   expect((await resposta404).status(), "o cenário do 404 é o que dissemos que é").toBe(404);
 
   const motivos = new Map<string, string>();
-  for (const url of [GA_BEACON, GA_RECUSADO, GA_OUTRO_CAMINHO]) {
+  for (const url of [GA_BEACON, GA_RECUSADO, GA_OUTRO_CAMINHO, GA_SOSIA]) {
     const falhou = page.waitForEvent("requestfailed", (r) => r.url() === url);
     await page.evaluate((u) => {
       void fetch(u, { mode: "no-cors" }).catch(() => {});
@@ -157,8 +187,9 @@ test("a tolerância do GA vale para o beacon abortado, e não para o 404 nem par
   expect(motivos.get(GA_BEACON), "o beacon abortado").toBe("net::ERR_ABORTED");
   expect(motivos.get(GA_OUTRO_CAMINHO), "o outro caminho, abortado").toBe("net::ERR_ABORTED");
   expect(motivos.get(GA_RECUSADO), "a conexão recusada").toBe("net::ERR_CONNECTION_REFUSED");
+  expect(motivos.get(GA_SOSIA), "o sósia, abortado").toBe("net::ERR_ABORTED");
 
-  const registradas = ocorrencias.filter((o) => o.includes("google-analytics.com"));
+  const registradas = ocorrencias.filter((o) => hostDa(o) === "www.google-analytics.com");
   expect(
     registradas,
     "só o beacon abortado é tolerado: o 404, a recusa e o outro caminho do mesmo host reprovam"
@@ -167,6 +198,22 @@ test("a tolerância do GA vale para o beacon abortado, e não para o 404 nem par
     `requestfailed: ${GA_RECUSADO} (net::ERR_CONNECTION_REFUSED)`,
     `requestfailed: ${GA_OUTRO_CAMINHO} (net::ERR_ABORTED)`,
   ]);
+
+  // O sósia fecha os dois lados de uma vez, e é o caso que `includes` erraria:
+  //   · a TOLERÂNCIA não o engole (ele está entre as ocorrências registradas),
+  //     porque o regex ancora `https://www.google-analytics.com/`;
+  //   · o FILTRO deste teste não o confunde com o GA (ele ficou de fora do
+  //     `registradas`), porque compara host e não pedaço de texto.
+  // Com `o.includes("google-analytics.com")` a segunda linha cairia, e a
+  // comparação de cima passaria a esperar uma entrada que não é do Google.
+  expect(
+    ocorrencias,
+    "o sósia reprova: `google-analytics.com` no meio da URL não é o host do Google"
+  ).toContain(`requestfailed: ${GA_SOSIA} (net::ERR_ABORTED)`);
+  expect(
+    registradas.join("\n"),
+    "e o sósia não entra na conta do GA"
+  ).not.toContain("dominio-de-fora.test");
 
   await page.close();
 });

--- a/tests/console-limpo-fixture.spec.ts
+++ b/tests/console-limpo-fixture.spec.ts
@@ -88,6 +88,89 @@ test("a tolerância de ERR_ABORTED vale para o site, e não para domínio de for
   await page.close();
 });
 
+// ---------------------------------------------------------------------------
+// A segunda tolerância: o beacon do GA4.
+//
+// Ela nasce com o mesmo risco da primeira, e por isso ganha o mesmo tratamento:
+// uma tolerância escrita para "o beacon do Google Analytics" pode, se o regex
+// for largo, acabar engolindo QUALQUER coisa do domínio do Google — inclusive um
+// 404, que é justamente o sintoma de recurso que sumiu do `out/`. Este teste
+// fixa os quatro lados: o que passa, e os três vizinhos que continuam
+// reprovando.
+// ---------------------------------------------------------------------------
+
+/** O beacon de verdade: `/g/collect` com a query que o gtag.js monta. */
+const GA_BEACON =
+  "https://www.google-analytics.com/g/collect?v=2&tid=G-EXEMPLO&en=page_view&_p=1";
+/** Mesmo endpoint, servido com 404: chunk sumido não pode virar ruído tolerado. */
+const GA_404 = "https://www.google-analytics.com/g/collect?v=2&tid=G-EXEMPLO&caso=404";
+/** Mesmo endpoint, outro motivo de falha. */
+const GA_RECUSADO = "https://www.google-analytics.com/g/collect?v=2&tid=G-EXEMPLO&caso=recusa";
+/** Mesmo host, OUTRO caminho: a tolerância é do endpoint de coleta, não do domínio. */
+const GA_OUTRO_CAMINHO = "https://www.google-analytics.com/analytics.js";
+
+test("a tolerância do GA vale para o beacon abortado, e não para o 404 nem para o resto do domínio", async ({
+  browser,
+  baseURL,
+}) => {
+  expect(baseURL, "este teste exige `use.baseURL` no playwright.config.ts").toBeTruthy();
+
+  const page = await browser.newPage({ baseURL });
+  const ocorrencias = coletarErros(page, baseURL);
+
+  // Nenhuma destas URLs sai da máquina: o roteador responde por todas antes de a
+  // requisição virar rede. É o que torna o teste determinístico e o que evita
+  // mandar pageview de mentira para o Google.
+  //
+  // A ordem importa, e é o contrário da intuição: no Playwright o handler
+  // registrado por ÚLTIMO é consultado primeiro. Por isso o pega-tudo vem antes
+  // dos dois casos específicos — invertido, ele responderia por todos e os dois
+  // `route` de baixo nunca rodariam, deixando o teste verde provando um caso só.
+  await page.route(/google-analytics\.com/, (route) => route.abort("aborted"));
+  await page.route(GA_404, (route) => route.fulfill({ status: 404, body: "" }));
+  await page.route(GA_RECUSADO, (route) => route.abort("connectionrefused"));
+
+  await page.goto("/");
+
+  // O 404 é o único que não chega por `requestfailed`: ele RESPONDE, e quem o
+  // registra é o listener de resposta. Esperar o evento certo para cada caso é o
+  // que impede o teste de medir uma corrida em vez do comportamento.
+  const resposta404 = page.waitForEvent("response", (r) => r.url() === GA_404);
+  await page.evaluate((u) => {
+    void fetch(u, { mode: "no-cors" }).catch(() => {});
+  }, GA_404);
+  expect((await resposta404).status(), "o cenário do 404 é o que dissemos que é").toBe(404);
+
+  const motivos = new Map<string, string>();
+  for (const url of [GA_BEACON, GA_RECUSADO, GA_OUTRO_CAMINHO]) {
+    const falhou = page.waitForEvent("requestfailed", (r) => r.url() === url);
+    await page.evaluate((u) => {
+      void fetch(u, { mode: "no-cors" }).catch(() => {});
+    }, url);
+    const req = await falhou;
+    motivos.set(url, req.failure()?.errorText ?? "sem motivo");
+  }
+
+  // Primeiro o cenário, como no teste de cima: se o Chromium trocar o texto do
+  // erro, é aqui que a gente descobre, e não numa comparação de arrays que
+  // passaria a provar outra coisa.
+  expect(motivos.get(GA_BEACON), "o beacon abortado").toBe("net::ERR_ABORTED");
+  expect(motivos.get(GA_OUTRO_CAMINHO), "o outro caminho, abortado").toBe("net::ERR_ABORTED");
+  expect(motivos.get(GA_RECUSADO), "a conexão recusada").toBe("net::ERR_CONNECTION_REFUSED");
+
+  const registradas = ocorrencias.filter((o) => o.includes("google-analytics.com"));
+  expect(
+    registradas,
+    "só o beacon abortado é tolerado: o 404, a recusa e o outro caminho do mesmo host reprovam"
+  ).toEqual([
+    `http 404: ${GA_404}`,
+    `requestfailed: ${GA_RECUSADO} (net::ERR_CONNECTION_REFUSED)`,
+    `requestfailed: ${GA_OUTRO_CAMINHO} (net::ERR_ABORTED)`,
+  ]);
+
+  await page.close();
+});
+
 test("sem baseURL nada é tolerado, nem o prefetch do próprio site", async ({ browser }) => {
   // A porta de saída segura: se a configuração perder o `baseURL`, o guarda
   // fica barulhento em vez de mudo. Um guarda mudo é pior que guarda nenhum,

--- a/tests/fixtures/console-limpo.ts
+++ b/tests/fixtures/console-limpo.ts
@@ -45,8 +45,8 @@ function escaparRegex(s: string): string {
  *
  * Medido antes de ligar o guarda, em 13 rotas (as 5 da amostra do axe mais as 8
  * do celular), desktop e 390x844: **zero** `pageerror`, **zero** `console.error`
- * e **zero** resposta >= 400. A única coisa que aparece é o `ERR_ABORTED` de
- * baixo, e ele é do próprio Next.
+ * e **zero** resposta >= 400. A única coisa que aparece é `ERR_ABORTED`, nos
+ * dois casos de baixo: o prefetch do próprio Next e o beacon do GA4.
  *
  * Regra para acrescentar: a entrada tem que ser específica (nada de `/./`) e
  * vir com comentário dizendo o que é e por que não dá para consertar agora.
@@ -74,6 +74,37 @@ export function ruidoTolerado(baseURL: string | undefined): RegExp[] {
     // tem explicação conhecida. Antes desta âncora o padrão era `.*` e engolia
     // qualquer host.
     new RegExp(`^requestfailed: ${origem}(/[^\\s]*)? \\(net::ERR_ABORTED\\)$`),
+
+    // O beacon de `page_view` do GA4. O `gtag.js` dispara o `/g/collect` e não
+    // espera resposta — é telemetria, o navegador cancela a requisição quando a
+    // página fecha, e o Chromium reporta isso como `net::ERR_ABORTED`. É o
+    // comportamento normal do GA, não erro do site: nenhuma medição depende da
+    // resposta, e a mesma requisição é reenviada na próxima visita.
+    //
+    // Por que só apareceu depois do #63: a entrada de cima passou a ser ancorada
+    // no `baseURL` (antes era `.*` e engolia qualquer host). O GA é host de
+    // fora, então deixou de ser tolerado — e, ao mesmo tempo, o CI de PR nunca
+    // viu isso, porque o `NEXT_PUBLIC_GA_ID` só é injetado no build da `main`
+    // (`.github/workflows/cloudflare-pages-deploy.yml`) e sem o ID o site não
+    // pede byte nenhum de analytics. Ou seja: é um caso que só existe no job
+    // que testa o artefato que vai ao ar.
+    //
+    // O que esta entrada NÃO tolera, de propósito:
+    //   · outro host — a tolerância nomeia o do GA e mais nenhum;
+    //   · outro caminho do próprio GA (`/analytics.js`, por exemplo): só o
+    //     endpoint de coleta, que é o único que é disparado sem esperar;
+    //   · outro motivo de falha (`ERR_CONNECTION_REFUSED`, `ERR_FAILED`...);
+    //   · resposta >= 400, que nem passa por aqui: ela vira `http 404: ...` no
+    //     listener de resposta e continua reprovando.
+    //
+    // Os endpoints regionais (`region1.google-analytics.com` e irmãos) entram
+    // porque o GA4 escolhe o host pela origem do tráfego: o runner de hoje bate
+    // no `www`, e um runner na Europa bateria no regional com exatamente o
+    // mesmo significado.
+    new RegExp(
+      "^requestfailed: https://(www|region\\d+)\\.google-analytics\\.com/g/collect" +
+        "(\\?[^\\s]*)? \\(net::ERR_ABORTED\\)$"
+    ),
   ];
 }
 

--- a/tests/regressao-css-celular.spec.ts
+++ b/tests/regressao-css-celular.spec.ts
@@ -218,9 +218,50 @@ test.describe("faixas: o rótulo cabe no trecho", () => {
 // Defeito 2 — a gaveta do celular e o card que ficava sem caminho
 // ---------------------------------------------------------------------------
 
+/** Clica num botão pelo rótulo acessível, e **diz o que houve** quando ele não
+ *  existe.
+ *
+ *  Por que não é `getByRole(...).click()` direto: quando o rótulo procurado não
+ *  existe em lugar nenhum, o Playwright reprova com `Test timeout of 30000ms
+ *  exceeded` — exatamente o mesmo texto de página que não carregou, de servidor
+ *  fora do ar, de elemento coberto por outro e de animação que nunca termina. O
+ *  relatório não distingue "o botão sumiu" de "a máquina está lenta", e a única
+ *  informação que resolveria o caso — quais rótulos EXISTEM — não aparece em
+ *  lugar nenhum.
+ *
+ *  Não é hipótese: `"Abrir menu de tópicos"` era procurado aqui e só existia
+ *  neste arquivo. O botão real nasceu `aria-label="Menu de tópicos"` no
+ *  `Shell.tsx`, e a renomeação passou por revisão sem que ninguém ligasse uma
+ *  coisa à outra, porque o que o CI mostrava eram quatro timeouts.
+ *
+ *  O guarda troca 30s de espera muda por 5s e uma mensagem que já traz a
+ *  resposta. Continua sendo espera de verdade (o botão do cabeçalho depende de
+ *  hidratação), só que com teto curto e desfecho falante. */
+async function clicarBotao(page: Page, nome: string) {
+  const alvo = page.getByRole("button", { name: nome, exact: true });
+  try {
+    await alvo.waitFor({ state: "visible", timeout: 5_000 });
+  } catch {
+    const presentes = await page
+      .getByRole("button")
+      .evaluateAll((bs) =>
+        bs.map((b) => (b.getAttribute("aria-label") ?? b.textContent ?? "").trim()).filter(Boolean)
+      );
+    throw new Error(
+      `nenhum botão visível com o rótulo acessível ${JSON.stringify(nome)}. ` +
+        `Se ele foi renomeado, o nome novo está nesta lista: ${JSON.stringify(presentes)}`
+    );
+  }
+  await alvo.click();
+}
+
 async function abrirGaveta(page: Page, w: number, h: number) {
   await abrir(page, "/topico/quick-sort/", w, h);
-  await page.getByRole("button", { name: "Abrir menu de tópicos" }).click();
+  // `aria-label="Menu de tópicos"`, em `src/components/Shell.tsx`. O texto de
+  // antes (`"Abrir menu de tópicos"`) não existia no produto: ele só existia
+  // aqui, e o `clicarBotao` acima é o que faz esse tipo de descolamento se
+  // anunciar em vez de virar timeout.
+  await clicarBotao(page, "Menu de tópicos");
   await expect(page.locator(".sidebar.open")).toBeVisible();
 }
 

--- a/tests/regressao-css-celular.spec.ts
+++ b/tests/regressao-css-celular.spec.ts
@@ -102,11 +102,26 @@ test.describe("faixas: o rótulo cabe no trecho", () => {
     test(`quick sort, a invariante da partição, passo a passo (${r.nome})`, async ({ page }) => {
       test.slow();
       await abrir(page, "/topico/quick-sort/", r.w, r.h);
-      const fig = page.locator("figure.viz-fit");
-      await expect(fig).toHaveCount(1);
+      // Escopado por QUAL figura, e nunca por QUANTAS têm a casca. Contar
+      // `figure.viz-fit` era afirmar o cronograma da migração: a peça alvo era a
+      // única adaptada em `/topico/quick-sort/` quando isto foi escrito, e a
+      // asserção passou a reprovar no dia em que a peça do pivô ganhou a mesma
+      // casca — sem que nada do que este teste mede tivesse mudado. O título é
+      // identidade; a contagem é data.
+      //
+      // E os dois modos de errar não custam o mesmo: título trocado reprova alto
+      // no `toHaveCount(1)`, contagem trocada mede a peça errada em silêncio.
+      const fig = page
+        .locator("figure.viz-fit")
+        .filter({ hasText: "a partição e o pivô que fica pronto" });
+      await expect(fig, "a peça da partição tem que ser única em /topico/quick-sort/").toHaveCount(1);
 
       const chips = fig.locator(".bigo-chip");
       expect(await chips.count(), "os quatro presets da partição").toBe(4);
+      // A faixa é o objeto do teste. Sem esta linha, apontar para a figura
+      // errada faria `medir` devolver zero trechos e a comparação com `[]`
+      // passaria em silêncio — verde provando nada.
+      expect(await fig.locator(".ms-nivel-faixa").count(), "a faixa da invariante").toBe(1);
 
       for (let i = 0; i < 4; i++) {
         const preset = await trocarPreset(fig, i);
@@ -117,8 +132,13 @@ test.describe("faixas: o rótulo cabe no trecho", () => {
         const proximo = fig.getByRole("button", { name: /Próximo/ });
         for (let s = 1; s <= passos; s++) {
           await expect(contador).toHaveText(new RegExp(`passo ${s} de ${passos}`));
+          const medidas = await fig.evaluate(medir);
           expect(
-            cortadas(await fig.evaluate(medir)),
+            medidas.length,
+            `${preset}, passo ${s}: há trecho para medir`
+          ).toBeGreaterThan(0);
+          expect(
+            cortadas(medidas),
             `${r.nome}, preset ${JSON.stringify(preset)}, passo ${s} de ${passos}: rótulo cortado`
           ).toEqual([]);
           if (s < passos) await proximo.click();


### PR DESCRIPTION
## O que está acontecendo

A `main` está com o deploy barrado. 21 testes reprovam, o job `Deploy to Cloudflare
Pages` sai `skipped`, e o portão do #54 está funcionando exatamente como projetado:
nada novo é publicado enquanto a suíte estiver vermelha. Todo PR aberto herda esse
CI vermelho.

**Nenhuma das 21 falhas é defeito de produto.** São três testes calibrados contra
uma `main` que deixou de existir — o preço de doze PRs em paralelo. Verifiquei as
três causas uma a uma antes de mexer em qualquer asserção, e a fronteira deste PR é
só `tests/`: nenhuma linha de `src/`, `content/`, `scripts/`, `package.json`,
`playwright.config.ts` ou `.github/`.

Reproduzi as falhas localmente contra o build da `main` — quer dizer, com
`NEXT_PUBLIC_GA_ID` injetado, que é o que o job de deploy faz e o CI de PR não faz.

---

## Grupo 1 — 14 falhas: o beacon do Google Analytics

`console-limpo.spec.ts`, `a11y.spec.ts` e o teste do visualizador em uso reprovavam
com *"a página emitiu erro. Se for ruído legítimo, declare em `ruidoTolerado()` com
o motivo"*. O conteúdo capturado, sempre o mesmo:

```
requestfailed: https://www.google-analytics.com/g/collect?v=2&tid=G-...&en=page_view&... (net::ERR_ABORTED)
```

**Causa confirmada.** É o beacon de `page_view` do GA4. O `gtag.js` dispara o
`/g/collect` e não espera resposta — é telemetria: o navegador cancela a requisição
quando a página fecha, e o Chromium reporta o cancelamento como `net::ERR_ABORTED`.
Nenhuma medição depende dessa resposta, e a requisição é reenviada na visita
seguinte. Comportamento normal do GA, não erro do site.

**Por que só aparece agora, e só na `main`.** Duas coisas se somaram:

1. A revisão do #63 escopou a allowlist ao `baseURL`, fechando o achado legítimo do
   Copilot de que `.*` tolerava aborto de **qualquer** domínio externo. O GA é
   externo, então deixou de ser tolerado.
2. O CI de PR não recebe `NEXT_PUBLIC_GA_ID` — `Analytics.tsx` devolve `null` e o
   site não pede byte nenhum de analytics. Só o build da `main` carrega o GA.

Ou seja: é um caso que só existe no job que testa o artefato que vai ao ar.

**Conserto.** A tolerância nomeia o host e o endpoint, e nada além disso:

```
^requestfailed: https://(www|region\d+)\.google-analytics\.com/g/collect(\?[^\s]*)? \(net::ERR_ABORTED\)$
```

Os hosts regionais entram porque o GA4 escolhe o host pela origem do tráfego: o
runner de hoje bate no `www`, e um na Europa bateria no regional com exatamente o
mesmo significado.

**Não voltamos para `.*`** — isso reabriria o achado do #63.

### O que a recalibração NÃO afrouxou

Fixado em `tests/console-limpo-fixture.spec.ts`, em Chromium de verdade e usando a
**mesma** `coletarErros()` da fixture (não uma reimplementação do regex, que é onde
um teste de unidade descolaria do comportamento):

| caso | desfecho |
|---|---|
| beacon `/g/collect` abortado | **tolerado** |
| `http 404` no mesmo `/g/collect` | **reprova** — chunk sumido não vira ruído |
| `ERR_CONNECTION_REFUSED` no mesmo endpoint | **reprova** |
| `/analytics.js`, outro caminho do mesmo host | **reprova** |
| `https://google-analytics.com.dominio-de-fora.test/g/collect` (o sósia) | **reprova** |
| aborto de qualquer outro domínio externo | **reprova** |
| sem `baseURL`, nada é tolerado | **reprova** |

**Prova de quebra.** Trocando o regex por `/google-analytics/` — a tolerância larga
que a gente quer impedir —, o teste novo reprova na linha da comparação:

```
Error: só o beacon abortado é tolerado: o 404, a recusa e o outro caminho do mesmo host reprovam
- Array [
-   "http 404: https://www.google-analytics.com/g/collect?v=2&tid=G-EXEMPLO&caso=404",
-   "requestfailed: ...&caso=recusa (net::ERR_CONNECTION_REFUSED)",
-   "requestfailed: https://www.google-analytics.com/analytics.js (net::ERR_ABORTED)",
- ]
+ Array []
```

### Achado do CodeQL, e o que ele virou

A primeira rodada de CI reprovou com um alerta **alto**,
`js/incomplete-url-substring-sanitization`, na linha que o teste novo usava para
filtrar as ocorrências do GA:

```ts
ocorrencias.filter((o) => o.includes("google-analytics.com"))
```

O CodeQL está certo, e o achado tem graça particular: o teste existe para provar
que a tolerância nomeia o **host** em vez de casar pedaço de texto, e ele mesmo
estava identificando host por pedaço de texto. `google-analytics.com` aparece
inteiro dentro de `https://google-analytics.com.dominio-de-fora.test/`, que é
outro host, de outro dono.

O filtro passa a extrair a URL e comparar `new URL(...).host`. E o caso virou
teste em vez de virar comentário: o sósia agora é abortado junto com os outros, e
o teste fixa os dois lados que o `includes` embaralhava — a **tolerância** não o
engole (ele aparece nas ocorrências registradas), e o **filtro** não o conta como
GA.

Prova de quebra: voltando o `includes`, o teste reprova na comparação de arrays
com o sósia no `Received`, ao lado dos três vizinhos legítimos.

---

## Grupo 2 — 3 falhas: o seletor que virou ambíguo

`tests/regressao-css-celular.spec.ts:106` fazia
`expect(page.locator("figure.viz-fit")).toHaveCount(1)` em `/topico/quick-sort/`.

**Causa confirmada**, contando no HTML entregue:

```
quick-sort -> figure.viz-fit: 2
merge-sort -> figure.viz-fit: 3
```

A segunda figura do quick sort é a do pivô (*"a escolha do pivô decide entre n log n
e n²"*), que ganhou a mesma casca adaptativa. Nada do que este teste mede mudou: o
que mudou foi o cronograma da migração. **Contar quantas figuras têm a casca é
asserção sobre o cronograma, não sobre o produto.** Contagem é data; título é
identidade.

**Conserto.** Escopar por QUAL figura, com o padrão que já existe no repositório
(`tests/viz-hook.spec.ts`):

```ts
const fig = page
  .locator("figure.viz-fit")
  .filter({ hasText: "a partição e o pivô que fica pronto" });
await expect(fig, "a peça da partição tem que ser única em /topico/quick-sort/").toHaveCount(1);
```

E os dois modos de errar não custam o mesmo: título trocado reprova alto, no próprio
`toHaveCount(1)`; contagem trocada mede a peça errada em silêncio.

### A asserção continua provando o que provava

O teste existe para garantir que o rótulo do quick sort cabe no trecho, medindo a
largura real do texto com um `Range`. Injetei `max-width: 24px` com `nowrap` no
`.ms-seg` da faixa — o formato exato do defeito original — e ele reprova na linha do
`cortadas(medidas)`, com a medição real no `Received`:

```
Error: 390x844, preset "Embaralhado: 5 3 13 1 7 6 21 3", passo 1 de 52: rótulo cortado
+   Object {
+     "fonte": "9px",
+     "linhas": 1,
+     "precisa": 156.6,
+     "recebe": 18,
+     "rotulo": "nenhuma partição em andamento",
+   },
```

Falhou na linha certa, com o valor real no `Received` — não por timeout de locator.

**Duas asserções que faltavam** vão junto, porque apontar para a figura errada tinha
como passar verde provando nada: a faixa da invariante tem que existir (`toBe(1)`), e
cada passo tem que ter pelo menos um trecho para medir. Sem elas, `medir` devolveria
lista vazia e `toEqual([])` passaria em silêncio.

---

## Grupo 3 — 4 falhas: o rótulo renomeado

`tests/regressao-css-celular.spec.ts:203` procurava
`getByRole("button", { name: "Abrir menu de tópicos" })`.

**Causa confirmada lendo o `Shell.tsx` de hoje**, e não o commit da renomeação: o
botão real é `aria-label="Menu de tópicos"`, em `src/components/Shell.tsx:192`,
renomeado em `862700a`. A string `"Abrir menu de tópicos"` não existe no produto —
ela só existia no arquivo de teste. O menu abre normalmente, e o rótulo novo é melhor
que o antigo.

### O guarda: teste que procura rótulo inexistente tem que dizer isso

Cabia, e era barato. `getByRole(...).click()` num rótulo que não existe reprova com
`Test timeout of 30000ms exceeded` — exatamente o mesmo texto de página que não
carregou, de servidor fora do ar, de elemento coberto por outro e de animação que
nunca termina. O relatório do CI não distinguia *"o botão sumiu"* de *"a máquina está
lenta"*, e a única informação que resolveria o caso — quais rótulos **existem** — não
aparecia em lugar nenhum. Foi por isso que a renomeação passou por revisão sem que
ninguém ligasse uma coisa à outra.

`clicarBotao()` espera 5s pelo botão visível (continua sendo espera de verdade: o
botão do cabeçalho depende de hidratação) e, se ele não vier, levanta a lista de
rótulos presentes.

**Prova**, rodando de propósito com o nome antigo:

```
Error: nenhum botão visível com o rótulo acessível "Abrir menu de tópicos".
Se ele foi renomeado, o nome novo está nesta lista:
["Menu de tópicos","Mais opções","Marcar como concluído","Mostrar código",...]
```

O nome certo vem em primeiro lugar, e a reprovação leva 10,5s em vez de 30s.

---

## Verificação

`npm run test:build`, suíte inteira, **nos dois projetos** (`chromium` e `mobile`):

| build | rodada | resultado |
|---|---|---|
| com `NEXT_PUBLIC_GA_ID` (o do deploy da `main`) | 1 | **667 passed** (1,9 min) |
| com `NEXT_PUBLIC_GA_ID` | 2 | **667 passed** (1,9 min) |
| sem `NEXT_PUBLIC_GA_ID` (o do CI de PR) | 1 | 666 passed, 1 flake de carga — ver abaixo |
| sem `NEXT_PUBLIC_GA_ID` | 2 | **667 passed** (2,5 min) |
| com `NEXT_PUBLIC_GA_ID`, já com o conserto do CodeQL | 1 | **667 passed** (2,4 min) |
| idem | 2 | **667 passed** (2,5 min), com a máquina a load 32 |

Rodei nos **dois** ambientes de propósito: o defeito do Grupo 1 só existe com o GA
ligado, e a recalibração não podia quebrar o ambiente onde ele nunca carrega. O
build sem o ID sai com **0** ocorrências do `G-...` no `out/` inteiro.

**Sobre a única falha das quatro rodadas**, e ela não é minha: 
`viz-skip-list.spec.ts:166` ("no expandido dos níveis, a pirâmide gigante rola
sozinha sob o cabeçalho parado") estourou o timeout numa rodada em que a máquina
estava com **load 7,6 subindo para 17** (build concorrente de outro worktree).
Sozinho, com a máquina livre, o mesmo teste passa em **2,7s**; e ele passou nas
outras três rodadas, inclusive nas duas com GA. Não encosta em nada deste PR —
fica registrado porque contar 666 e chamar de 667 seria o tipo de arredondamento
que este PR existe para não fazer.

`npm run lint`: **6 problemas, 0 erros** — o baseline da `main`, sem alteração.
Guarda de commit: `✓` nos quatro commits.

### ⚠️ O CI verde deste PR não prova o Grupo 1 — a medição local prova

Vale dizer alto, porque é fácil olhar os checks verdes aqui e concluir demais. O
job que estava reprovando é o `Playwright (no artefato que vai ao ar)`, e ele tem
`if: github.event_name != 'pull_request'` — em PR ele sai **`skipping`**, como sai
neste. Quem roda em PR é o `tests.yml`, que constrói por conta própria e **sem**
`NEXT_PUBLIC_GA_ID`, então o beacon do GA nem existe lá.

Ou seja: nenhum CI de PR consegue exercitar o Grupo 1. Por isso reproduzi as 14
falhas localmente com `NEXT_PUBLIC_GA_ID` injetado — mesmo build, mesmo cenário do
job de deploy — e rodei a suíte inteira nesse build, quatro vezes.

O que fecha o ciclo é o push na `main`: é lá que `Playwright (no artefato que vai
ao ar)` roda de verdade, e é lá que dá para ver o `Deploy to Cloudflare Pages`
deixar de sair `skipped`.

## Fronteira

Só `tests/`. Nada de `src/`, `content/`, `scripts/` (#65), `package.json`,
`playwright.config.ts` ou `.github/`. Nenhum arquivo em conflito com os PRs #65,
#66 e #67.
