### PR TITLE
fix: o ✓ no meio do quadradinho de progresso, medido pela tinta

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -195,11 +195,42 @@ html { scroll-behavior: smooth; }
 .side-item:hover { background: rgba(255, 255, 255, 0.05); color: #fff; }
 .side-item.on { background: var(--ccc-accent-soft); color: #dbeafe; font-weight: 600; box-shadow: inset 2px 0 0 var(--ccc-accent); }
 .side-item.soon { color: #6f83a0; }
+/* O quadradinho de progresso, e as duas coisas que a marca dentro dele exige.
+ *
+ * `padding: 0` NÃO é higiene. O agente do usuário entrega todo `<button>` com
+ * `padding: 1px 6px`; num quadrado de 16px com 1px de borda sobravam 2px de
+ * caixa de conteúdo, e a marca media 7,66px. Item de grade que não cabe na área
+ * de alinhamento cai para `start` — é o que a especificação manda, para não
+ * cortar conteúdo —, então o `place-items: center` virava enfeite e a marca
+ * encostava na borda direita. Medido: 7,75px de folga à esquerda contra 0,5px à
+ * direita, num quadrado de 16px.
+ *
+ * A marca é `<svg>` e não o caractere `✓` (ver Shell.tsx) porque com o padding
+ * já zerado ela CONTINUAVA torta: 4,75px à esquerda contra 3,25px à direita, e
+ * 4,75px em cima contra 3,75px embaixo. O glifo tem bearings assimétricos, e
+ * `<button>` sequer herda a fonte do site — o computado aqui é `Arial`, ou seja
+ * o desenho vem da cadeia de fallback do sistema. Medido trocando só a família
+ * declarada, com o padding já zerado: o desnível horizontal foi de 0 a 1,75px,
+ * o vertical de 0,12 a 1,5px, e a área de tinta variou 3,9x. O CI roda em
+ * ubuntu, que não tem nenhuma dessas fontes. Com o traço do SVG simétrico em
+ * torno do centro da `viewBox`, a conta fecha igual em todo sistema: medido,
+ * 0,00px de desnível na horizontal e 0,03px na vertical, os mesmos em 1280x720,
+ * 1440x700 e 1512x900. Com o glifo, o MESMO elemento dava 0,20px em 1280x720 e
+ * 1,80px em 1440x700, porque a linha de base gruda noutro pixel quando a linha
+ * cai em outro offset.
+ *
+ * O TAMANHO DO QUADRADO não mudou (16px aqui, 20px no `.problem-check`): o que
+ * o aluno vê alinhado é o ✓ com o nome do tópico ao lado, e mexer na caixa
+ * mexeria nas 47 linhas da trilha.
+ *
+ * O tamanho do desenho deixa sobra PAR na caixa de conteúdo (14px de caixa para
+ * 10px de marca, 2px de cada lado) para o centro não cair em meio pixel. */
 .side-check {
   display: grid; place-items: center; width: 16px; height: 16px; flex: none; border-radius: 5px;
-  font-size: 10px; font-weight: 700; border: 1px solid rgba(255, 255, 255, 0.16);
+  padding: 0; border: 1px solid rgba(255, 255, 255, 0.16);
   background: transparent; color: transparent; cursor: pointer;
 }
+.side-check svg { display: block; width: 10px; height: 10px; }
 .side-check.done { border-color: rgba(52, 211, 153, 0.6); background: rgba(52, 211, 153, 0.18); color: var(--ccc-green); }
 .side-item-name { flex: 1; }
 /* A linha do tópico: o ✓ é irmão do link (ver Shell.tsx), então quem pinta
@@ -414,7 +445,12 @@ html { scroll-behavior: smooth; }
 .problems { border: 1px solid var(--ccc-line); border-radius: 12px; overflow: hidden; }
 .problem-row { display: flex; align-items: center; gap: 14px; padding: 13px 16px; background: var(--ccc-surface); border-bottom: 1px solid var(--ccc-line); }
 .problem-row:last-child { border-bottom: none; }
-.problem-check { display: grid; place-items: center; width: 20px; height: 20px; flex: none; border-radius: 6px; border: 1px solid rgba(255, 255, 255, 0.18); background: transparent; color: transparent; cursor: pointer; font-size: 11px; font-weight: 700; }
+/* Mesmo contrato do `.side-check`, e o porquê medido está lá em cima:
+   `padding: 0` contra o do `<button>` (aqui a caixa de conteúdo tinha 6px para
+   uma marca de 8,41px), marca em SVG, e sobra PAR — 18px de caixa de conteúdo
+   para 12px de marca, 3px de cada lado. */
+.problem-check { display: grid; place-items: center; width: 20px; height: 20px; flex: none; border-radius: 6px; padding: 0; border: 1px solid rgba(255, 255, 255, 0.18); background: transparent; color: transparent; cursor: pointer; }
+.problem-check svg { display: block; width: 12px; height: 12px; }
 .problem-check.done { border-color: rgba(52, 211, 153, 0.6); background: rgba(52, 211, 153, 0.16); color: var(--ccc-green); }
 .problem-level { min-width: 62px; padding: 3px 8px; border-radius: 99px; text-align: center; font-size: 11px; font-weight: 600; border: 1px solid; }
 .problem-name { flex: 1; font-size: 14.5px; color: var(--ccc-text); font-weight: 500; text-decoration: none; }

--- a/src/components/ProblemList.tsx
+++ b/src/components/ProblemList.tsx
@@ -20,6 +20,10 @@ export function ProblemList({ problems }: { problems: Problem[] }) {
         return (
           <div className="problem-row" key={pr.id}>
             <button
+              // `type="button"` como no `Shell` e no `RoadmapGroups`: o padrão
+              // do HTML é `submit`, e um dia que este componente cair dentro de
+              // um `<form>` marcar um problema viraria envio de formulário.
+              type="button"
               className={`problem-check${feito ? " done" : ""}`}
               role="checkbox"
               aria-checked={feito}

--- a/src/components/ProblemList.tsx
+++ b/src/components/ProblemList.tsx
@@ -26,7 +26,22 @@ export function ProblemList({ problems }: { problems: Problem[] }) {
               aria-label={`Marcar ${pr.name} como resolvido`}
               onClick={() => toggleProblema(pr.id)}
             >
-              {feito ? "✓" : ""}
+              {/* O mesmo traço do `Shell` e do `RoadmapGroups`; o porquê medido
+                  de ser desenho, e não o caractere `✓`, está no `globals.css`.
+                  `aria-hidden` porque é decoração: o estado é `aria-checked`, o
+                  nome é o `aria-label`. */}
+              {feito ? (
+                <svg viewBox="0 0 12 12" aria-hidden="true" focusable="false">
+                  <path
+                    d="M2.4 6.4 5.1 8.6 9.6 3.4"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              ) : null}
             </button>
             <span className={`problem-level ${LEVEL_CLASS[pr.level] ?? "level-guia"}`} style={{ borderStyle: "solid" }}>
               {pr.level}

--- a/src/components/RoadmapGroups.tsx
+++ b/src/components/RoadmapGroups.tsx
@@ -53,7 +53,22 @@ export function RoadmapGroups() {
                       aria-label={`Marcar ${t.name} como concluído`}
                       onClick={() => toggleTopico(t.slug)}
                     >
-                      {feito ? "✓" : ""}
+                      {/* O mesmo traço do `Shell` e do `ProblemList`; o porquê
+                          medido de ser desenho, e não o caractere `✓`, está no
+                          `globals.css`. `aria-hidden` porque é decoração: o
+                          estado é `aria-checked`, o nome é o `aria-label`. */}
+                      {feito ? (
+                        <svg viewBox="0 0 12 12" aria-hidden="true" focusable="false">
+                          <path
+                            d="M2.4 6.4 5.1 8.6 9.6 3.4"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                          />
+                        </svg>
+                      ) : null}
                     </button>
                     <Link href={`/topico/${t.slug}`} className={`topic-card${feito ? " done" : ""}`}>
                       <div className="topic-card-top">

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -188,6 +188,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
       <header className="header">
         <div className="header-left">
           <button
+            type="button"
             className="header-menu-toggle nav-icon"
             aria-label="Menu de tópicos"
             aria-expanded={mobileNav}
@@ -224,7 +225,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
             <span className="dot" />Apoiar
           </Link>
           <span className="nav-more">
-            <button className="nav-icon" aria-label="Mais opções" aria-expanded={menu} onClick={() => setMenu((v) => !v)}>
+            <button type="button" className="nav-icon" aria-label="Mais opções" aria-expanded={menu} onClick={() => setMenu((v) => !v)}>
               <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
                 <circle cx="5" cy="12" r="1.8" /><circle cx="12" cy="12" r="1.8" /><circle cx="19" cy="12" r="1.8" />
               </svg>
@@ -304,6 +305,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
                     e ele é decoração: sem o atributo, quem usa leitor de tela ouve só
                     "Grafos, botão" e não sabe se está abrindo ou fechando o grupo. */}
                 <button
+                  type="button"
                   className="side-group-btn"
                   aria-expanded={g.aberto}
                   onClick={() => setAbertos((a) => ({ ...a, [g.id]: !a[g.id] }))}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -351,7 +351,27 @@ export function Shell({ children }: { children: React.ReactNode }) {
                           aria-label={`Marcar ${t.name} como concluído`}
                           onClick={() => toggleTopico(t.slug)}
                         >
-                          {feito ? "✓" : ""}
+                          {/* Desenho, e não o caractere `✓`: o glifo continuava
+                              torto mesmo com o padding do `<button>` zerado, e
+                              o botão nem herda a fonte do site — o porquê
+                              medido está no `globals.css`. O mesmo traço
+                              aparece no `RoadmapGroups` e no `ProblemList`, e o
+                              teste `check-alinhado` mede os três; ele é o que
+                              segura as três cópias iguais.
+                              É DECORAÇÃO: o estado é `aria-checked` e o nome é
+                              o `aria-label`, por isso `aria-hidden`. */}
+                          {feito ? (
+                            <svg viewBox="0 0 12 12" aria-hidden="true" focusable="false">
+                              <path
+                                d="M2.4 6.4 5.1 8.6 9.6 3.4"
+                                fill="none"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                              />
+                            </svg>
+                          ) : null}
                         </button>
                         <Link
                           href={`/topico/${t.slug}`}

--- a/src/components/TopicComplete.tsx
+++ b/src/components/TopicComplete.tsx
@@ -7,7 +7,7 @@ export function TopicComplete({ slug, grande = false }: { slug: string; grande?:
   const feito = isTopico(slug);
   const cls = grande ? `btn-concluir-lg${feito ? " done" : ""}` : `btn-concluir${feito ? " done" : ""}`;
   return (
-    <button className={cls} onClick={() => toggleTopico(slug)}>
+    <button type="button" className={cls} onClick={() => toggleTopico(slug)}>
       {feito ? "✓ Concluído" : "Marcar como concluído"}
     </button>
   );

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -164,7 +164,12 @@ export type Visualizer = {
   blockProps: { id: string; inert: boolean; "aria-hidden": true | undefined };
   /** No panel de variáveis: vira fileira quando o blockName recolhe. */
   varsProps: { className: string };
+  // `type` faz parte do contrato, e não é higiene: o padrão do HTML para
+  // `<button>` é `submit`. Como estes dois objetos são espalhados em TODO
+  // visualizador, declarar aqui é o que faz o conserto valer para os 62 de uma
+  // vez, em vez de depender de cada arquivo lembrar.
   blockButtonProps: {
+    type: "button";
     className: string;
     "aria-expanded": boolean;
     "aria-controls": string;
@@ -172,6 +177,7 @@ export type Visualizer = {
     children: string;
   };
   expandButtonProps: {
+    type: "button";
     className: string;
     ref: React.RefObject<HTMLButtonElement | null>;
     onClick: () => void;
@@ -710,6 +716,7 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     blockProps: { id: blockId, inert: !open, "aria-hidden": !open || undefined },
     varsProps: { className: `viz-vars${open ? "" : " linha"}` },
     blockButtonProps: {
+      type: "button",
       className: "viz-expand viz-toggle-codigo",
       "aria-expanded": open,
       "aria-controls": blockId,
@@ -717,6 +724,7 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
       children: `${open ? "Ocultar" : "Mostrar"} ${blockName}`,
     },
     expandButtonProps: {
+      type: "button",
       className: "viz-expand",
       ref: expandButtonRef,
       onClick: toggleExpanded,
@@ -812,8 +820,9 @@ export function VizFooter({
             do nome acessível, então o leitor de tela anunciava o nome Unicode do
             glifo (ou nada). Os quatro vizinhos desta linha têm texto; este era o
             único mudo. */}
-        <button className="viz-btn" title="Reiniciar" aria-label="Reiniciar" onClick={viz.reset}>↺</button>
+        <button type="button" className="viz-btn" title="Reiniciar" aria-label="Reiniciar" onClick={viz.reset}>↺</button>
         <button
+          type="button"
           className="viz-btn"
           disabled={viz.step === 0}
           aria-keyshortcuts="ArrowLeft"
@@ -821,10 +830,11 @@ export function VizFooter({
         >
           ‹ Anterior
         </button>
-        <button className="viz-play" aria-keyshortcuts="Space" onClick={viz.togglePlay}>
+        <button type="button" className="viz-play" aria-keyshortcuts="Space" onClick={viz.togglePlay}>
           {viz.playing ? "❚❚ Pausar" : "▶ Rodar"}
         </button>
         <button
+          type="button"
           className="viz-btn"
           disabled={viz.step === viz.total - 1}
           aria-keyshortcuts="ArrowRight"

--- a/tests/check-alinhado.spec.ts
+++ b/tests/check-alinhado.spec.ts
@@ -1,0 +1,388 @@
+import { test, expect, type Locator, type Page } from "@playwright/test";
+
+// O ✓ do quadradinho de progresso, medido pela TINTA e não pela caixa de linha.
+//
+// `place-items: center` centraliza a caixa da LINHA. Ela não é a mancha que o
+// aluno enxerga, e a diferença não era sutil: medida, a tinta encostava na borda
+// DIREITA do quadrado de 16px — 7,75px de folga à esquerda contra 0,5px à
+// direita. Contar elemento, ler `justify-items` ou olhar o
+// `getBoundingClientRect` do botão diriam "centralizado" nos três casos.
+//
+// COMO MEDIMOS, e por que é assim.
+//
+// 1. TRÊS FOTOS da mesma região, não duas. A primeira normal; a segunda com
+//    `color: transparent`, que apaga só a marca; a terceira apagando também
+//    fundo e borda. A diferença 1-2 é exatamente o desenho do ✓, e a diferença
+//    2-3 é exatamente o quadrado pintado.
+//
+//    A referência TEM que ser o quadrado PINTADO, e não o `boundingBox` do
+//    layout. O Chromium arredonda a origem de pintura para pixel inteiro de CSS,
+//    e dois dos três quadradinhos moram em coordenada fracionária (o do card,
+//    por causa do `top: 17.5px`; o da lista de problemas, por causa da altura da
+//    linha). Medido contra o layout, um CÍRCULO PERFEITO — desenho simétrico por
+//    construção — acusava 0,72px de desnível vertical na lista de problemas e
+//    0,62px no card, e 0,00px na lateral, que é a única em offset inteiro. O
+//    desnível batia com `2 x (distância até o pixel inteiro)` nas três casas
+//    decimais. Não era o desenho: era a régua. Quadrado e marca são pintados com
+//    o mesmo arredondamento, então medir um contra o outro pergunta o que o
+//    olho pergunta.
+//
+// 2. Extremos por MASSA, e não por limiar de pixel. A ponta de cima do ✓ é um
+//    cap redondo (fina, pouca cobertura) e a de baixo é uma junta (grossa). Com
+//    "primeiro pixel acima do limiar", o antialiasing da ponta grossa entra e o
+//    da fina não, e a medida vira o formato da ponta em vez da posição. Cortar a
+//    MESMA FRAÇÃO de tinta de cada lado é simétrico por construção.
+//
+// Nada disso pergunta nada à fonte nem ao SVG: a mesma régua serviu para
+// comparar as duas implementações uma com a outra.
+const ESCALA = 4; // 4 pixels de foto por pixel de CSS: 0,25px de resolução.
+
+test.use({ deviceScaleFactor: ESCALA });
+
+/** Fração da tinta descartada em cada ponta antes de ler o extremo. Ver (2). */
+const CORTE = 0.01;
+
+type Medida = {
+  folgaTopo: number;
+  folgaBaixo: number;
+  folgaEsq: number;
+  folgaDir: number;
+  desnivelV: number;
+  desnivelH: number;
+  quadrado: string;
+  marca: string;
+};
+
+const arred = (v: number) => Number(v.toFixed(2));
+
+/** Perfis de diferença (soma dos 4 canais) por linha e por coluna entre duas fotos. */
+async function perfis(page: Page, a: string, b: string) {
+  return page.evaluate(
+    async ([x, y]) => {
+      const carregar = (b64: string) =>
+        new Promise<HTMLImageElement>((ok, erro) => {
+          const img = new Image();
+          img.onload = () => ok(img);
+          img.onerror = () => erro(new Error("a foto não decodificou"));
+          img.src = `data:image/png;base64,${b64}`;
+        });
+      const [ia, ib] = await Promise.all([carregar(x), carregar(y)]);
+      const w = ia.width;
+      const h = ia.height;
+      const pixels = (img: HTMLImageElement) => {
+        const c = document.createElement("canvas");
+        c.width = w;
+        c.height = h;
+        const ctx = c.getContext("2d")!;
+        ctx.drawImage(img, 0, 0);
+        return ctx.getImageData(0, 0, w, h).data;
+      };
+      const pa = pixels(ia);
+      const pb = pixels(ib);
+      const linhas = new Array<number>(h).fill(0);
+      const colunas = new Array<number>(w).fill(0);
+      let total = 0;
+      for (let yy = 0; yy < h; yy++) {
+        for (let xx = 0; xx < w; xx++) {
+          const i = (yy * w + xx) * 4;
+          const d =
+            Math.abs(pa[i] - pb[i]) +
+            Math.abs(pa[i + 1] - pb[i + 1]) +
+            Math.abs(pa[i + 2] - pb[i + 2]) +
+            Math.abs(pa[i + 3] - pb[i + 3]);
+          linhas[yy] += d;
+          colunas[xx] += d;
+          total += d;
+        }
+      }
+      return { linhas, colunas, total };
+    },
+    [a, b]
+  );
+}
+
+/**
+ * Extremos de um perfil, em pixels de foto (com casas decimais), descartando
+ * `fracao` da massa em cada ponta. Interpola dentro do pixel onde o corte cai,
+ * para a medida não ficar refém da grade da foto.
+ */
+function extremos(perfil: number[], fracao: number): [number, number] {
+  const soma = perfil.reduce((a, b) => a + b, 0);
+  const cota = soma * fracao;
+
+  let acc = 0;
+  let inicio = 0;
+  for (let i = 0; i < perfil.length; i++) {
+    if (acc + perfil[i] > cota) {
+      // A borda cai DENTRO deste pixel: interpola, para a medida não ficar
+      // refém da grade da foto.
+      inicio = i + (cota - acc) / perfil[i];
+      break;
+    }
+    acc += perfil[i];
+  }
+
+  acc = 0;
+  let fim = perfil.length;
+  for (let i = perfil.length - 1; i >= 0; i--) {
+    if (acc + perfil[i] > cota) {
+      fim = i + 1 - (cota - acc) / perfil[i];
+      break;
+    }
+    acc += perfil[i];
+  }
+
+  return [inicio, fim];
+}
+
+/** Folgas, em px de CSS, entre o quadrado PINTADO e a tinta do ✓ dentro dele. */
+async function medir(page: Page, alvo: Locator): Promise<Medida> {
+  await expect(alvo).toBeVisible();
+  await alvo.scrollIntoViewIfNeeded();
+  const caixa = await alvo.boundingBox();
+  if (!caixa) throw new Error("elemento sem caixa");
+
+  // Recorte ancorado em pixel INTEIRO de CSS e folgado: `elemento.screenshot()`
+  // arredonda para fora quando o elemento cai em coordenada fracionária, e
+  // devolvia foto de 17px de altura para uma caixa de 16px.
+  const MARGEM = 3;
+  const recorte = {
+    x: Math.floor(caixa.x) - MARGEM,
+    y: Math.floor(caixa.y) - MARGEM,
+    width: Math.ceil(caixa.x + caixa.width) - Math.floor(caixa.x) + 2 * MARGEM,
+    height: Math.ceil(caixa.y + caixa.height) - Math.floor(caixa.y) + 2 * MARGEM,
+  };
+
+  const comTudo = (await page.screenshot({ clip: recorte })).toString("base64");
+  await alvo.evaluate((el) => ((el as HTMLElement).style.color = "transparent"));
+  const semMarca = (await page.screenshot({ clip: recorte })).toString("base64");
+  await alvo.evaluate((el) => {
+    const e = el as HTMLElement;
+    e.style.background = "transparent";
+    e.style.borderColor = "transparent";
+  });
+  const semNada = (await page.screenshot({ clip: recorte })).toString("base64");
+  await alvo.evaluate((el) => {
+    const e = el as HTMLElement;
+    e.style.color = "";
+    e.style.background = "";
+    e.style.borderColor = "";
+  });
+
+  const marca = await perfis(page, comTudo, semMarca);
+  const quadrado = await perfis(page, semMarca, semNada);
+
+  expect(marca.total, "o ✓ precisa estar desenhado para ser medido").toBeGreaterThan(2000);
+  expect(quadrado.total, "o quadrado precisa estar pintado para servir de régua").toBeGreaterThan(2000);
+
+  // O quadrado é simétrico por construção (retângulo de cantos arredondados),
+  // então o mesmo corte de massa devolve os extremos verdadeiros dele.
+  const [qx0, qx1] = extremos(quadrado.colunas, CORTE);
+  const [qy0, qy1] = extremos(quadrado.linhas, CORTE);
+  const [mx0, mx1] = extremos(marca.colunas, CORTE);
+  const [my0, my1] = extremos(marca.linhas, CORTE);
+
+  const p = (v: number) => v / ESCALA; // pixel de foto -> pixel de CSS
+  const folgaTopo = arred(p(my0 - qy0));
+  const folgaBaixo = arred(p(qy1 - my1));
+  const folgaEsq = arred(p(mx0 - qx0));
+  const folgaDir = arred(p(qx1 - mx1));
+
+  const m: Medida = {
+    folgaTopo,
+    folgaBaixo,
+    folgaEsq,
+    folgaDir,
+    desnivelV: arred(Math.abs(folgaTopo - folgaBaixo)),
+    desnivelH: arred(Math.abs(folgaEsq - folgaDir)),
+    quadrado: `${arred(p(qx1 - qx0))}x${arred(p(qy1 - qy0))}`,
+    marca: `${arred(p(mx1 - mx0))}x${arred(p(my1 - my0))}`,
+  };
+
+  // A tinta tem que estar DENTRO do quadrado: folga negativa quer dizer que ela
+  // vaza pela borda, e aí "centralizado" não é a pergunta certa.
+  for (const lado of ["folgaTopo", "folgaBaixo", "folgaEsq", "folgaDir"] as const) {
+    expect(m[lado], `${lado}: a tinta do ✓ vaza para fora do quadrado`).toBeGreaterThan(-0.3);
+  }
+  return m;
+}
+
+/**
+ * A tolerância, e de onde ela vem.
+ *
+ * O desenho é exato: o traço do SVG é simétrico em torno do centro da `viewBox`
+ * (cap e junta redondos de raio 1 sobre `M2.4 6.4 5.1 8.6 9.6 3.4` dão tinta de
+ * 1,4 a 10,6 em x e de 2,4 a 9,6 em y — centro 6,0 nos dois eixos, que é o
+ * centro da `viewBox` de 12), e a caixa dele sobra PAR dentro do quadrado.
+ *
+ * O que sobra é o rasterizador. Medido com esta mesma régua, o desnível do SVG
+ * ficou em 0,00px na horizontal e 0,03–0,04px na vertical, igual nas três telas
+ * e nos três lugares; um CÍRCULO de controle — simétrico, e portanto com
+ * desnível verdadeiro zero — deu os mesmos 0,00px. O teto de 0,35px é oito
+ * vezes esse ruído, e ainda assim é um terço de pixel: menos do que qualquer
+ * olho enxerga.
+ *
+ * Do outro lado, ele é apertado o bastante para pegar o defeito. No código de
+ * antes, medido com esta régua nas três telas:
+ *
+ *     horizontal ... 4,10px (lista de problemas) a 7,05px (lateral e card)
+ *     vertical ..... 0,20px a 1,80px
+ *
+ * A horizontal reprova nos três lugares e nas três telas, e é ela a prova de
+ * quebra deste teto. A vertical reprova em sete dos nove casos: na lista de
+ * problemas em 1280x720 ela dá 0,20px e passa. Isso é honesto e é o próprio
+ * motivo do conserto — o MESMO elemento, com o MESMO CSS, dá 0,20px em 1280x720
+ * e 1,80px em 1440x700, porque a linha cai em outro offset e a linha de base do
+ * glifo gruda noutro pixel. Um número que muda com a largura da janela não é um
+ * número que dá para calibrar; o desenho dá 0,04px nas três.
+ */
+const TOLERANCIA = 0.35;
+
+/** Os três lugares onde o quadradinho aparece, já no estado marcado. */
+async function marcados(page: Page) {
+  await page.goto("/topico/two-pointers/");
+
+  const lateral = page
+    .locator(".sidebar")
+    .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+  if ((await lateral.getAttribute("aria-checked")) === "false") await lateral.click();
+  await expect(lateral).toHaveAttribute("aria-checked", "true");
+
+  const problema = page.locator(".problem-check").first();
+  if ((await problema.getAttribute("aria-checked")) === "false") await problema.click();
+  await expect(problema).toHaveAttribute("aria-checked", "true");
+
+  return { lateral, problema };
+}
+
+const TELAS = [
+  { nome: "1280x720", width: 1280, height: 720 },
+  { nome: "1440x700", width: 1440, height: 700 },
+  { nome: "1512x900", width: 1512, height: 900 },
+];
+
+for (const tela of TELAS) {
+  test(`o ✓ fica centralizado nos três quadradinhos de progresso (${tela.nome})`, async ({ page }) => {
+    await page.setViewportSize({ width: tela.width, height: tela.height });
+    const { lateral, problema } = await marcados(page);
+
+    const medidas: [string, Medida][] = [
+      ["trilha lateral (.side-check)", await medir(page, lateral)],
+      ["lista de problemas (.problem-check)", await medir(page, problema)],
+    ];
+
+    // O terceiro mora no /roadmap, e o progresso marcado acima chega junto.
+    await page.goto("/roadmap/");
+    const card = page
+      .locator(".topic-card-wrap")
+      .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+    await expect(card).toHaveAttribute("aria-checked", "true");
+    medidas.push(["card do /roadmap (.tcard-check)", await medir(page, card)]);
+
+    for (const [onde, m] of medidas) console.log(`${tela.nome}  ${onde.padEnd(38)} ${JSON.stringify(m)}`);
+
+    for (const [onde, m] of medidas) {
+      expect(
+        m.desnivelV,
+        `${onde} em ${tela.nome}: o ✓ não está no meio na vertical — ${m.folgaTopo}px em cima contra ${m.folgaBaixo}px embaixo`
+      ).toBeLessThanOrEqual(TOLERANCIA);
+      expect(
+        m.desnivelH,
+        `${onde} em ${tela.nome}: o ✓ não está no meio na horizontal — ${m.folgaEsq}px à esquerda contra ${m.folgaDir}px à direita`
+      ).toBeLessThanOrEqual(TOLERANCIA);
+    }
+  });
+}
+
+// O erro de hoje nasceu de o `<button>` chegar com `padding: 1px 6px` do agente
+// do usuário e ninguém zerar. Num quadrado de 16px com 1px de borda isso deixa
+// 2px de caixa de conteúdo: a marca de 7,66px transborda, o alinhamento cai para
+// `start` — a especificação manda isso para não cortar conteúdo — e ela encosta
+// na direita. O teste acima pega o sintoma; este pega a causa, que é o que uma
+// quarta lista com ✓ vai repetir se ninguém disser.
+test("o quadradinho de progresso não herda o padding do <button>", async ({ page }) => {
+  const { lateral, problema } = await marcados(page);
+
+  const sobra = async (alvo: Locator) =>
+    alvo.evaluate((el) => {
+      const cs = getComputedStyle(el);
+      const r = el.getBoundingClientRect();
+      const px = (v: string) => parseFloat(v) || 0;
+      // `Range` sobre o conteúdo, e não `firstElementChild`: no código de antes
+      // a marca era um NÓ DE TEXTO, que não tem `getBoundingClientRect`. Medi-lo
+      // como elemento devolve 0, e `0 <= qualquer coisa` fazia este teste passar
+      // no código quebrado — que é exatamente o que ele existe para reprovar.
+      const faixa = document.createRange();
+      faixa.selectNodeContents(el);
+      const g = faixa.getBoundingClientRect();
+      const n = (v: number) => Number(v.toFixed(2));
+      return {
+        conteudoLargura: n(
+          r.width - px(cs.borderLeftWidth) - px(cs.borderRightWidth) - px(cs.paddingLeft) - px(cs.paddingRight)
+        ),
+        conteudoAltura: n(
+          r.height - px(cs.borderTopWidth) - px(cs.borderBottomWidth) - px(cs.paddingTop) - px(cs.paddingBottom)
+        ),
+        marcaLargura: n(g.width),
+        marcaAltura: n(g.height),
+      };
+    });
+
+  const conferir = async (onde: string, alvo: Locator) => {
+    const s = await sobra(alvo);
+    console.log(`${onde.padEnd(22)} ${JSON.stringify(s)}`);
+    expect(
+      s.conteudoLargura,
+      `${onde}: a caixa de conteúdo tem ${s.conteudoLargura}px e a marca ${s.marcaLargura}px — a marca transborda e o centro vira canto`
+    ).toBeGreaterThanOrEqual(s.marcaLargura);
+    expect(
+      s.conteudoAltura,
+      `${onde}: a caixa de conteúdo tem ${s.conteudoAltura}px de altura e a marca ${s.marcaAltura}px`
+    ).toBeGreaterThanOrEqual(s.marcaAltura);
+    // Sobra PAR: com sobra ímpar o centro cai em meio pixel e o rasterizador
+    // desempata para um dos lados.
+    expect(
+      (s.conteudoLargura - s.marcaLargura) % 2,
+      `${onde}: sobram ${arred(s.conteudoLargura - s.marcaLargura)}px na horizontal, que não dá para dividir em dois inteiros`
+    ).toBe(0);
+    expect(
+      (s.conteudoAltura - s.marcaAltura) % 2,
+      `${onde}: sobram ${arred(s.conteudoAltura - s.marcaAltura)}px na vertical, que não dá para dividir em dois inteiros`
+    ).toBe(0);
+  };
+
+  await conferir("trilha lateral", lateral);
+  await conferir("lista de problemas", problema);
+
+  await page.goto("/roadmap/");
+  const card = page
+    .locator(".topic-card-wrap")
+    .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+  await conferir("card do /roadmap", card);
+});
+
+// O ✓ é DECORAÇÃO: quem conta o estado é `role="checkbox"` + `aria-checked`, e
+// quem dá o nome é o `aria-label`. Trocar o caractere por desenho não pode mudar
+// nada disso, e é fácil esquecer o `aria-hidden` num `<svg>`.
+test("o desenho do ✓ não entra no nome acessível", async ({ page }) => {
+  const { lateral, problema } = await marcados(page);
+  await expect(lateral).toHaveAccessibleName("Marcar Two Pointers como concluído");
+  await expect(problema).toHaveAccessibleName(/^Marcar .+ como resolvido$/);
+
+  const conferirAriaHidden = async (onde: string) => {
+    const soltos = await page.evaluate(() =>
+      Array.from(document.querySelectorAll(".side-check svg, .problem-check svg"))
+        .filter((s) => s.getAttribute("aria-hidden") !== "true")
+        .map((s) => s.parentElement?.className ?? "?")
+    );
+    expect(soltos, `${onde}: todo <svg> do quadradinho tem que ser aria-hidden`).toEqual([]);
+  };
+  await conferirAriaHidden("/topico/two-pointers");
+
+  await page.goto("/roadmap/");
+  const card = page
+    .locator(".topic-card-wrap")
+    .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+  await expect(card).toHaveAccessibleName("Marcar Two Pointers como concluído");
+  await conferirAriaHidden("/roadmap");
+});

--- a/tests/check-alinhado.spec.ts
+++ b/tests/check-alinhado.spec.ts
@@ -371,6 +371,11 @@ test("o quadradinho de progresso não herda o padding do <button>", async ({ pag
         ),
         marcaLargura: n(g.width),
         marcaAltura: n(g.height),
+        // O OUTRO padrão de `<button>` que morde: sem `type`, ele é `submit`.
+        // Lido da PROPRIEDADE, e não do atributo, porque é ela que o navegador
+        // consulta na hora de decidir se o clique envia o formulário — um botão
+        // sem o atributo devolve `"submit"` aqui, que é o defeito.
+        tipo: (el as HTMLButtonElement).type,
       };
     });
 
@@ -395,6 +400,10 @@ test("o quadradinho de progresso não herda o padding do <button>", async ({ pag
       (s.conteudoAltura - s.marcaAltura) % 2,
       `${onde}: sobram ${arred(s.conteudoAltura - s.marcaAltura)}px na vertical, que não dá para dividir em dois inteiros`
     ).toBe(0);
+    expect(
+      s.tipo,
+      `${onde}: sem \`type="button"\` o padrão do HTML é \`submit\`, e um dia dentro de um <form> marcar vira enviar`
+    ).toBe("button");
   };
 
   await conferir("trilha lateral", lateral);

--- a/tests/check-alinhado.spec.ts
+++ b/tests/check-alinhado.spec.ts
@@ -255,6 +255,11 @@ async function marcados(page: Page) {
   return { lateral, problema };
 }
 
+// Três larguras de desktop, e não uma. O desnível do código de antes MUDAVA com
+// a largura da janela — 0,20px em 1280x720 e 1,80px em 1440x700 no mesmo
+// elemento —, então uma tela só teria contado meia verdade. O celular tem teste
+// próprio logo abaixo, porque lá a trilha lateral é gaveta e não dá para chegar
+// nela pelo mesmo caminho.
 const TELAS = [
   { nome: "1280x720", width: 1280, height: 720 },
   { nome: "1440x700", width: 1440, height: 700 },
@@ -293,6 +298,47 @@ for (const tela of TELAS) {
     }
   });
 }
+
+// No celular a trilha lateral é uma gaveta fechada, então o caminho de cima não
+// serve. Sobram os dois quadradinhos que aparecem sem abrir nada: o do card do
+// /roadmap e o da lista de problemas. Vale medir mesmo com a largura sem efeito
+// sobre o quadrado, porque quem muda no celular é a ALTURA das linhas e do card,
+// e é ela que empurra o quadradinho para outro offset — que foi exatamente o que
+// fazia o número do código de antes variar.
+test("o ✓ fica centralizado no celular (390x844)", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+
+  await page.goto("/roadmap/");
+  const card = page
+    .locator(".topic-card-wrap")
+    .getByRole("checkbox", { name: "Marcar Two Pointers como concluído" });
+  if ((await card.getAttribute("aria-checked")) === "false") await card.click();
+  await expect(card).toHaveAttribute("aria-checked", "true");
+  const noCard = await medir(page, card);
+
+  await page.goto("/topico/two-pointers/");
+  const problema = page.locator(".problem-check").first();
+  if ((await problema.getAttribute("aria-checked")) === "false") await problema.click();
+  await expect(problema).toHaveAttribute("aria-checked", "true");
+  const naLista = await medir(page, problema);
+
+  const medidas: [string, Medida][] = [
+    ["card do /roadmap (.tcard-check)", noCard],
+    ["lista de problemas (.problem-check)", naLista],
+  ];
+  for (const [onde, m] of medidas) console.log(`390x844  ${onde.padEnd(38)} ${JSON.stringify(m)}`);
+
+  for (const [onde, m] of medidas) {
+    expect(
+      m.desnivelV,
+      `${onde} em 390x844: o ✓ não está no meio na vertical — ${m.folgaTopo}px em cima contra ${m.folgaBaixo}px embaixo`
+    ).toBeLessThanOrEqual(TOLERANCIA);
+    expect(
+      m.desnivelH,
+      `${onde} em 390x844: o ✓ não está no meio na horizontal — ${m.folgaEsq}px à esquerda contra ${m.folgaDir}px à direita`
+    ).toBeLessThanOrEqual(TOLERANCIA);
+  }
+});
 
 // O erro de hoje nasceu de o `<button>` chegar com `padding: 1px 6px` do agente
 // do usuário e ninguém zerar. Num quadrado de 16px com 1px de borda isso deixa

--- a/tests/check-alinhado.spec.ts
+++ b/tests/check-alinhado.spec.ts
@@ -441,3 +441,89 @@ test("o desenho do ✓ não entra no nome acessível", async ({ page }) => {
   await expect(card).toHaveAccessibleName("Marcar Two Pointers como concluído");
   await conferirAriaHidden("/roadmap");
 });
+
+// A VARREDURA DE CLASSE do achado acima.
+//
+// O revisor apontou UM `<button>` sem `type` (o da lista de problemas) e disse
+// que `Shell` e `RoadmapGroups` "já usam". Medido no repositório inteiro, não
+// usavam: das 211 tags `<button>` de `src/` e `content/`, só 5 declaravam
+// `type`. Na fronteira desta casa — o chassi do site e a casca do visualizador —
+// eram 10 sem, e não 1. As outras 196 vivem em `content/visualizers/`, que este
+// PR não toca.
+//
+// O teste lê a PROPRIEDADE `type` e não o atributo, porque é ela que o navegador
+// consulta na hora de decidir se o clique envia: um botão sem o atributo devolve
+// `"submit"` aqui. E é ela que enxerga através do `{...spread}` — os dois botões
+// da casca do visualizador (`⤢ Expandir` e `Mostrar código`) recebem as props de
+// `blockButtonProps`/`expandButtonProps`, então nenhuma varredura de texto no
+// código-fonte prova que eles foram consertados. Só o DOM prova.
+//
+// O piso de contagem (`minimo`) não é o teste — o teste é o `type` lido. Ele
+// existe porque um seletor errado casa com zero elementos, e "nenhum botão
+// errado entre zero botões" é verde vazio.
+type Grupo = { sel: string; onde: string; minimo: number };
+
+const CHASSI_TOPICO: Grupo[] = [
+  { sel: ".header-menu-toggle", onde: "abrir o menu de tópicos (Shell)", minimo: 1 },
+  { sel: ".nav-more .nav-icon", onde: "mais opções, no topo (Shell)", minimo: 1 },
+  { sel: ".side-group-btn", onde: "abrir/fechar grupo da trilha (Shell)", minimo: 5 },
+  { sel: ".side-check", onde: "quadradinho da trilha (Shell)", minimo: 1 },
+  { sel: ".btn-concluir, .btn-concluir-lg", onde: "marcar tópico concluído (TopicComplete)", minimo: 1 },
+  { sel: ".problem-check", onde: "quadradinho da lista de problemas (ProblemList)", minimo: 1 },
+  // A casca do visualizador. `.viz-expand` cobre os DOIS botões espalhados;
+  // `.viz-play` e `[aria-keyshortcuts]` cobrem o rodapé. Nenhuma dessas três
+  // âncoras aparece em `content/visualizers/` (o `.viz-btn` sozinho aparece, em
+  // 55 lugares, e por isso NÃO serve de seletor aqui).
+  { sel: ".viz-expand", onde: "expandir / mostrar código (casca do visualizador)", minimo: 1 },
+  { sel: ".viz-play", onde: "rodar/pausar (casca do visualizador)", minimo: 1 },
+  { sel: ".viz-foot [aria-keyshortcuts]", onde: "anterior/próximo/rodar (casca)", minimo: 3 },
+  { sel: '.viz-btn[aria-label="Reiniciar"]', onde: "reiniciar (casca do visualizador)", minimo: 1 },
+];
+
+const CHASSI_ROADMAP: Grupo[] = [
+  { sel: ".header-menu-toggle", onde: "abrir o menu de tópicos (Shell)", minimo: 1 },
+  { sel: ".tcard-check", onde: "quadradinho do card do roadmap (RoadmapGroups)", minimo: 10 },
+];
+
+async function varrer(page: Page, grupos: Grupo[], pagina: string) {
+  const achado = await page.evaluate(
+    (gs) =>
+      gs.map((g) => {
+        const els = Array.from(document.querySelectorAll<HTMLButtonElement>(g.sel));
+        return {
+          ...g,
+          total: els.length,
+          // Só o que está ERRADO volta, com nome acessível para o relatório
+          // dizer QUAL botão, e não só quantos.
+          errados: els
+            .filter((el) => el.type !== "button")
+            .map((el) => `${el.getAttribute("aria-label") ?? el.textContent?.trim().slice(0, 28) ?? "?"} → type="${el.type}"`),
+        };
+      }),
+    grupos
+  );
+
+  for (const g of achado) {
+    expect(
+      g.total,
+      `${pagina}: o seletor \`${g.sel}\` (${g.onde}) casou com ${g.total} botões — menos que os ${g.minimo} esperados, então a varredura estaria verde por vazio`
+    ).toBeGreaterThanOrEqual(g.minimo);
+    expect(
+      g.errados,
+      `${pagina}: ${g.onde} — sem \`type="button"\` o padrão do HTML é \`submit\`, e dentro de um <form> o clique envia a página`
+    ).toEqual([]);
+  }
+  console.log(`${pagina.padEnd(24)} ${achado.reduce((s, g) => s + g.total, 0)} botões do chassi conferidos`);
+}
+
+test("nenhum <button> do chassi nem da casca do visualizador é submit por omissão", async ({ page }) => {
+  await page.goto("/topico/two-pointers/");
+  // A casca do visualizador só existe depois que o componente hidrata; sem
+  // esperar, a varredura passaria por não achar nada (e o piso acusaria).
+  await expect(page.locator(".viz-expand").first()).toBeVisible();
+  await varrer(page, CHASSI_TOPICO, "/topico/two-pointers");
+
+  await page.goto("/roadmap/");
+  await expect(page.locator(".tcard-check").first()).toBeVisible();
+  await varrer(page, CHASSI_ROADMAP, "/roadmap");
+});


### PR DESCRIPTION
O Wilson mandou um print da barra lateral: o ✓ dentro do quadradinho de progresso
estava visivelmente descentralizado. Ele estava, e a hipótese de partida (bearings
do glifo) era só metade da história.

## A medição, antes

Régua do diagnóstico: duas fotos da mesma região a 4x, uma normal e outra com
`color: transparent`, comparadas contra o `boundingBox` do elemento. A diferença
entre as fotos é exatamente a tinta do ✓. Contar elemento, ler `justify-items` ou
olhar o `getBoundingClientRect` do botão diriam "centralizado" nos três casos.

(Esta régua tem um viés que só apareceu depois, e está na seção "A régua teve que
mudar". Os números finais e os da prova de quebra são da régua corrigida, por isso
diferem destes na segunda casa.)

| lugar | caixa | tinta | esquerda / direita | em cima / embaixo |
|---|---|---|---|---|
| trilha lateral (`.side-check`) | 16x16 | 7,75x7,5 | **7,75 / 0,50** | 4,75 / 3,75 |
| lista de problemas (`.problem-check`) | 20x20 | 8,75x8,25 | **7,75 / 3,50** | 6,36 / 5,39 |
| card do /roadmap (`.tcard-check`) | 16x16 | 7,75x7,5 | **7,75 / 0,50** | 5,06 / 3,44 |

A tinta encostava na borda direita nos dois quadrados de 16px.

## A causa, que não era a que eu esperava

**Primeira, e dominante: o `padding` do agente do usuário.** Todo `<button>` chega
com `padding: 1px 6px`. Num quadrado de 16px com 1px de borda isso deixa **2px de
caixa de conteúdo**, e a marca mede 7,66px. Item de grade que não cabe na área de
alinhamento **cai para `start`** — é o que a especificação manda, para não cortar
conteúdo —, então o `place-items: center` virava enfeite.

A prova de que era isso, e não o glifo: o `Range` sobre o conteúdo começa
exatamente em `x + 7`, que é `1px de borda + 6px de padding`. Ou seja, a marca
está no começo da caixa de conteúdo, não no meio dela.

**Segunda: o glifo, que é a hipótese do enunciado, e ela também vale.** Com o
`padding` zerado a marca **continuava torta**:

| lugar | esquerda / direita | em cima / embaixo | desnível H | desnível V |
|---|---|---|---|---|
| trilha lateral | 4,75 / 3,25 | 4,75 / 3,75 | 1,50 | 1,00 |
| lista de problemas | 6,50 / 4,75 | 6,36 / 5,39 | 1,75 | 0,97 |
| card do /roadmap | 4,75 / 3,25 | 5,06 / 3,44 | 1,50 | 1,62 |

E é pior do que "torto": é **instável**. O `<button>` sequer herda a fonte do site
(o computado é `Arial`), então o desenho vem da cadeia de fallback do sistema
operacional. Trocando **só a família declarada**, com o `padding` já zerado:

| família | desnível H | desnível V | área de tinta |
|---|---|---|---|
| Arial / Helvetica / Verdana / sans-serif | 1,50 | 1,00 | 270 px |
| serif | 0,00 | 1,25 | 299 px |
| Menlo | 0,00 | 1,50 | 110 px |

O CI roda em ubuntu, que não tem nenhuma dessas fontes.

## A opção escolhida: SVG, e por quê

O enunciado deixava escolher entre SVG e compensação de `line-height`/`padding`.
Escolhi **SVG**, com estes números:

- **Compensação de fonte não resolve.** O desnível a compensar não é um número: ele
  vai de 0,00 a 1,75px na horizontal e de 0,12 a 1,50px na vertical **só trocando a
  família**, e a área de tinta varia 3,9x. Calibrar contra a Arial do meu Mac é
  calibrar contra uma fonte que a máquina do CI não tem.
- **Nem é só a fonte.** Medido com a régua final, o **mesmo elemento com o mesmo
  CSS** dá 0,20px de desnível vertical em 1280x720 e **1,80px** em 1440x700 — a
  linha cai em outro offset e a linha de base do glifo gruda noutro pixel. Um
  número que muda com a largura da janela não dá para compensar.
- **O SVG fecha a conta por construção.** Cap e junta redondos de raio 1 sobre
  `M2.4 6.4 5.1 8.6 9.6 3.4` dão tinta de 1,4 a 10,6 em x e de 2,4 a 9,6 em y:
  centro 6,0 nos dois eixos, que é o centro da `viewBox` de 12. E a caixa dele
  sobra **par** dentro do quadrado (14px para 10px, 18px para 12px), então o centro
  não cai em meio pixel.

O `padding: 0` entra junto: é a causa dominante, e vale para qualquer marca que
alguém ponha ali depois.

## A medição, depois

Nos três lugares e nas três telas (1280x720, 1440x700, 1512x900):

| lugar | esquerda / direita | em cima / embaixo | desnível H | desnível V |
|---|---|---|---|---|
| trilha lateral | 4,22 / 4,22 | 5,03 / 5,06 | **0,00** | **0,03** |
| lista de problemas | 5,48 / 5,48 | 6,46 / 6,50 | **0,00** | **0,04** |
| card do /roadmap | 4,22 / 4,22 | 5,03 / 5,06 | **0,00** | **0,03** |

**O tamanho do quadrado não mudou** (16px e 20px), então as 47 linhas da trilha
lateral e o alinhamento do ✓ com o nome do tópico continuam como estavam.

## A régua teve que mudar no meio do caminho, e isso é um achado

Medindo contra o `boundingBox` do layout, o SVG acusava 0,72px de desnível vertical
na lista de problemas e 0,62px no card — e 0,00px na lateral.

Troquei o ✓ por um **círculo perfeito**, simétrico por construção e portanto com
desnível verdadeiro zero. Ele acusou **os mesmos 0,72 e 0,62**. Não era o desenho:
era a régua. O Chromium arredonda a origem de pintura para pixel inteiro de CSS, e
dois dos três quadradinhos moram em coordenada fracionária (o do card por causa do
`top: 17.5px`, o da lista por causa da altura da linha). O desnível batia com
`2 x (distância até o pixel inteiro)` nas três casas decimais.

O teste final usa **três fotos**: normal, sem a marca, e sem marca nem fundo nem
borda. A primeira diferença é o ✓, a segunda é o **quadrado pintado**. Quadrado e
marca são pintados com o mesmo arredondamento, então medir um contra o outro
pergunta o que o olho pergunta.

E os extremos saem **por massa**, não por limiar de pixel: a ponta de cima do ✓ é um
cap redondo (fina) e a de baixo é uma junta (grossa), então "primeiro pixel acima do
limiar" mede o formato da ponta em vez da posição.

## Tolerância

**0,35px.** O ruído medido do SVG é 0,00–0,04px, e o círculo de controle deu 0,00px:
o teto é oito vezes o ruído, e ainda assim é um terço de pixel. Do outro lado, o
código de antes dá 4,10–7,05px de desnível horizontal — reprovado nos três lugares e
nas três telas.

Na vertical o código de antes dá 0,20 a 1,80px, e reprova em **sete dos nove** casos.
O caso que passa (lista de problemas em 1280x720, 0,20px) está dito no comentário do
teste: é justamente o sintoma da instabilidade que motivou o conserto, e ali quem
reprova é a horizontal.

## Prova de quebra

Duas vezes, por caminhos independentes.

**1. Voltando o CSS e o markup na mão** (sem `git checkout --`), reconstruindo e
rodando o teste novo. **2. Copiando o teste para um worktree limpo em `origin/main`**
e rodando lá. Os dois deram **exatamente os mesmos números**:

```
1) o ✓ fica centralizado nos três quadradinhos de progresso (1280x720)
   Error: trilha lateral (.side-check) em 1280x720: o ✓ não está no meio na
          vertical — 4.74px em cima contra 4.2px embaixo
   expect(received).toBeLessThanOrEqual(expected)
   Expected: <= 0.35
   Received:    0.54
     > 275 |       ).toBeLessThanOrEqual(TOLERANCIA);

4) o quadradinho de progresso não herda o padding do <button>
   Error: trilha lateral: a caixa de conteúdo tem 2px e a marca 7.66px — a marca
          transborda e o centro vira canto
   expect(received).toBeGreaterThanOrEqual(expected)
   Expected: >= 7.66
   Received:    2
     > 322 |       s.conteudoLargura,
```

Reprovou **na minha linha**, com o **número antigo no `Received`**, nas três telas.
O teste de nome acessível passa nos dois lados de propósito: ele é guarda de não
regressão, e o que ele afirma (`aria-checked` conta o estado, `aria-label` dá o nome,
`aria-hidden` no `<svg>`) não podia mudar.

## Fronteira

Mexi em `src/app/globals.css` e nos três componentes que desenham o quadradinho.
Os três componentes eram inevitáveis: o `✓` é um nó de texto dentro deles, e não dá
para trocá-lo por desenho só pelo CSS.

O SVG está **repetido nos três** em vez de virar um componente novo: um arquivo novo
está fora da fronteira desta lane, e o teste mede os três lugares, então uma cópia
que divergir reprova.

Não toquei em `content/**` (#66), `src/app/page.tsx` (#67), `scripts/**` (#65),
`src/lib/**`, `package.json`, `playwright.config.ts` nem em nenhum `.spec.ts` que já
existia.

**Observado e não consertado, para não misturar assunto:**

- `.tcard-check { top: 17.5px }` põe o quadradinho do card em meio pixel, o que
  borra o quadrado inteiro (não só a marca). É outro conserto, com outro efeito
  visual.
- `TopicComplete.tsx` usa `"✓ Concluído"` como texto ao lado de uma palavra. Não é o
  quadradinho, e ali o glifo alinha como texto, que é o certo.

## Revisão do Copilot

Um achado, e ele está certo: o `<button>` do `ProblemList` não declarava `type`, e
o padrão do HTML é `submit`. Hoje não há `<form>` em volta e nada acontece — no dia
em que houver, marcar um problema viraria enviar formulário. Consertado no commit
`fix: o quadradinho da lista de problemas não é botão de enviar`.

### O achado era amostra de uma classe, e a varredura mudou o diagnóstico

O comentário dizia que `Shell` e `RoadmapGroups` "já usam `type="button"`". Medido,
não usavam: o `RoadmapGroups` tem um `<button>` só, e ele tinha; o `Shell` tem
cinco, e só um (o `.side-check`) tinha.

Contei as tags de `src/` e `content/` com um parser que descarta ocorrência dentro
de comentário e de string — o `grep` cru dá 217 e inclui exemplos de código dos
artigos e o texto dos próprios comentários:

| | |
|---|---|
| tags `<button>` reais | **211** |
| declaravam `type` | **5** |
| não declaravam | **206** |
| **na fronteira deste PR** (`src/components/**`, `src/lib/visualizer.tsx`) | **10 sem `type`**, e não 1 |

Os 10, consertados no commit `fix: o chassi e a casca do visualizador não são
botões de enviar`:

| arquivo | botões |
|---|---|
| `src/components/Shell.tsx` | abrir o menu de tópicos, mais opções, abrir/fechar grupo da trilha |
| `src/components/TopicComplete.tsx` | marcar o tópico como concluído |
| `src/lib/visualizer.tsx` | reiniciar, anterior, rodar/pausar, próximo |
| `src/lib/visualizer.tsx` | `blockButtonProps` e `expandButtonProps` |

Os dois últimos são a parte que interessa: não são JSX, são **objetos de props
espalhados com `{...}` em todo visualizador**. O `type` entrou no objeto e no tipo,
então o conserto vale para os 62 visualizadores de uma vez em vez de depender de
cada arquivo lembrar.

### O que o teste mede

A asserção lê a **propriedade** `type` no DOM, e não o atributo no fonte, por dois
motivos: é a propriedade que o navegador consulta na hora de decidir se o clique
envia (um botão sem o atributo devolve `"submit"` ali), e é a única coisa que
**enxerga através do spread** — nenhum `grep` no código-fonte prova que
`⤢ Expandir` e `Mostrar código` foram consertados.

A varredura tem um piso de contagem por seletor. Ele não é o teste — o teste é o
`type` lido —, mas um seletor errado casa com zero elementos, e "nenhum botão
errado entre zero botões" é verde vazio.

### Prova de quebra

Com os cinco arquivos despidos do `type` e rebuild:

```
Error: /topico/two-pointers: abrir o menu de tópicos (Shell) — sem `type="button"`
       o padrão do HTML é `submit`, e dentro de um <form> o clique envia a página
expect(received).toEqual(expected)
Received: Array [ "Menu de tópicos → type=\"submit\"" ]
  > 514 |     ).toEqual([]);
```

E, restaurando tudo menos o `visualizer.tsx`, os seis botões espalhados da página
de two-pointers — que é o caso que nenhuma varredura de texto no fonte pegaria:

```
Received: Array [
  "Mostrar código → type=\"submit\"", "⤢ Expandir → type=\"submit\"",
  "Mostrar código → type=\"submit\"", "⤢ Expandir → type=\"submit\"",
  "Mostrar código → type=\"submit\"", "⤢ Expandir → type=\"submit\"",
]
```

Reprovou na minha linha, com o valor antigo no `Received`.

### A latência do defeito, conferida

`<form>` aparece **zero vezes** no HTML entregue em `out/`, e a única ocorrência no
fonte é o comentário que o commit anterior escreveu. É defeito latente de verdade,
e o conserto é um atributo — o que também quer dizer que ele **não pode** mudar
comportamento de clique hoje.

### Reportado e NÃO consertado

As **196 tags restantes, em 78 arquivos de `content/visualizers/`**. Estão fora da
fronteira deste PR, e três desses arquivos pertencem a PRs abertos agora (#66 e
#70). Vai como PR próprio.

Detalhe para quem pegar: o seletor da varredura evita `.viz-btn` sozinho porque
essa classe é reusada em **55** lugares do conteúdo; as âncoras usadas
(`.viz-expand`, `.viz-play`, `[aria-keyshortcuts]`, `aria-label="Reiniciar"`) são
exclusivas da casca.

### Suíte depois da varredura

**674 passaram, 0 reprovaram** (1,9 min, máquina livre), `npm run lint` em 6
problemas e 0 erros, guarda de commit com um `✓` por commit. Nenhuma string
renderizada mudou: `type` não aparece na tela.

Rodadas anteriores com a máquina em disputa (load average 20) reprovaram
`navegacao:1892` e `viz-mst`, e **os visualizadores que reprovavam mudavam a cada
rodada** — intervals, hash-table, prefix-sum, filas, skip-list, pilhas,
two-pointers, negative-binary. Defeito de código seria o mesmo conjunto toda vez; o
mecanismo é o timeout de 3s da asserção web-first sob contenção. Com a máquina
livre, zero.

## Conferência no preview, com o navegador e por interação

Contra a **URL remota** do preview (`https://0a6b0881.c3-dsa.pages.dev`, com
`?v=<timestamp>` para furar cache), nunca contra build local. Em cada tela: abre a
página, **clica** no quadradinho, confere que o `aria-checked` virou `true`, mede a
tinta contra o quadrado pintado, **lê o `aria-label`** e confere o `aria-hidden` do
`<svg>`. Console limpo nas quatro telas.

| tela | lugar | esq / dir | cima / baixo | svg | `aria-hidden` | nome acessível |
|---|---|---|---|---|---|---|
| 390x844 | card do /roadmap | 4,22 / 4,22 | 5,03 / 5,06 | 1 | true | Marcar Two Pointers como concluído |
| 390x844 | lista de problemas | 5,48 / 5,48 | 6,46 / 6,50 | 1 | true | Marcar Valid Palindrome como resolvido |
| 1280x720 | trilha lateral | 4,22 / 4,22 | 5,03 / 5,06 | 1 | true | Marcar Two Pointers como concluído |
| 1280x720 | card do /roadmap | 4,22 / 4,22 | 5,03 / 5,06 | 1 | true | Marcar Two Pointers como concluído |
| 1280x720 | lista de problemas | 5,48 / 5,48 | 6,46 / 6,50 | 1 | true | Marcar Valid Palindrome como resolvido |
| 1440x700 | os três | iguais aos de cima | iguais aos de cima | 1 | true | inalterado |
| 1512x900 | os três | iguais aos de cima | iguais aos de cima | 1 | true | inalterado |

A **produção** rodou no mesmo script e **reprovou na hora de achar o `<svg>`** — lá
o ✓ ainda é o caractere. É a confirmação pelos dois lados: o desenho é novo, e ele
chegou ao preview.

## Suíte

`npm run lint`: **6 problemas, 0 erros** — o baseline da `main`, sem mudança.
`npx tsc --noEmit`: limpo.

### No CI, que é onde a escolha do SVG se paga

**664 passaram, 7 reprovaram**, e as 7 são exatamente as de
`regressao-css-celular` que a `main` já traz vermelhas (as mesmas 3 de `faixas` e 4
de `gaveta`, mesmo arquivo, mesmo título, mesma linha). **Nenhuma flaky.**

Os **6 testes novos passaram em ubuntu** — a máquina que **não tem Arial,
Helvetica nem Menlo**, as fontes contra as quais eu medi no meu Mac. A tolerância
de 0,35px foi calibrada aqui e valeu lá sem tocar em nada. É a confirmação de que a
escolha certa era o desenho e não a compensação de fonte: qualquer número tirado do
glifo teria sido calibrado contra uma fonte que a máquina do CI não tem.

### Na minha máquina

Suíte inteira nesta branch, rodada final: **664 passaram, 8 reprovaram**. Não
aceitei "são as da `main`" de palavra — montei um worktree limpo em `origin/main`,
construí e rodei os mesmos arquivos:

| spec | nesta branch | em `origin/main` limpa |
|---|---|---|
| `regressao-css-celular` (`faixas` x3, `gaveta` x4) | 7 reprovam | **as mesmas 7 reprovam** |
| `navegacao-a11y:133` | reprovou numa rodada cheia | passa |
| `orcamento-bundle:378` | reprovou numa rodada cheia | passa |
| `navegacao:1892` | reprovou noutra rodada cheia | passa isolada |

As 7 de `regressao-css-celular` são idênticas em arquivo, título e linha nos dois
lados: são da `main` vermelha, e estão na lista que o enunciado já dá como de outra
lane.

As outras eu conferi uma a uma porque **não** estão nessa lista, e uma delas
(`navegacao-a11y`, "a marca de progresso não mora dentro do link") mexe justamente
com o que eu toquei. **Todas passam isoladas**, e o conjunto que reprova muda de
rodada para rodada: são as falhas por disputa de máquina que este repositório já
conhece — a suíte cheia rodou junto com outros builds.

