### PR TITLE
refactor(viz): um formatador e um plural só, com os nomes dizendo o que devolvem

### DIFF
--- a/content/visualizers/ArraysCrescimento.tsx
+++ b/content/visualizers/ArraysCrescimento.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -88,10 +89,6 @@ type Step = {
 };
 
 type Summary = { copies: number; reallocs: number; ops: number; finalCap: number; avg: number };
-
-function thousands(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 // Média com uma casa decimal, sem Intl (o HTML do build tem que bater com o do
 // cliente na hidratação).

--- a/content/visualizers/ArraysOperacoes.tsx
+++ b/content/visualizers/ArraysOperacoes.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -82,10 +83,6 @@ const OPS: OpKey[] = ["read", "push-end", "insert", "remove", "pop-end"];
 const DEFAULT_NUMS = [12, 7, 45, 3, 20, 8];
 const SLACK = 3; // vagas livres à direita, para caber a inserção
 const BIG_N = 1000000;
-
-function thousands(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 function buildSteps(op: OpKey, nums: number[], rawK: number, value: number): Step[] {
   const out: Step[] = [];

--- a/content/visualizers/ArraysVisualizer.tsx
+++ b/content/visualizers/ArraysVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -43,10 +44,6 @@ const DEFAULT_NUMS = [12, 7, 45, 3, 20, 8, 31, 16];
 // o leitor que não clica em nada vê o caso em que a fórmula some. Antes da casca
 // isso era o `useState(3)` do componente.
 const INITIAL_INDEX = 3;
-
-function thousands(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 function hex(v: number): string {
   const t = Math.max(0, Math.round(v)).toString(16).toUpperCase();

--- a/content/visualizers/BacktrackingPoda.tsx
+++ b/content/visualizers/BacktrackingPoda.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -107,11 +108,6 @@ function comPoda(n: number): Resultado {
 // fórmula da árvore cheia, e não medido aqui.
 const TAMANHOS = [4, 5, 6, 7];
 
-// Formatador determinístico: Intl.NumberFormat diverge entre build e cliente.
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 export function BacktrackingPoda() {
   const [n, setN] = useState(6);
   const sem = useMemo(() => semPoda(n), [n]);
@@ -170,10 +166,10 @@ export function BacktrackingPoda() {
                 <span className="ord-medida-rot">nós visitados</span>
                 <div className="bb-barra">
                   <div className="bb-barra-fill" style={{ width: "100%" }} />
-                  <span className="bb-barra-txt">{num(sem.nos)}</span>
+                  <span className="bb-barra-txt">{thousands(sem.nos)}</span>
                 </div>
                 <span className="ord-lei">
-                  {num(Math.pow(n, n))} disposições possíveis, todas percorridas até o fim
+                  {thousands(Math.pow(n, n))} disposições possíveis, todas percorridas até o fim
                 </span>
               </div>
               <div className="ord-medida">
@@ -195,10 +191,10 @@ export function BacktrackingPoda() {
                 <span className="ord-medida-rot">nós visitados</span>
                 <div className="bb-barra">
                   <div className="bb-barra-fill" style={{ width: `${(com.nos / sem.nos) * 100}%` }} />
-                  <span className="bb-barra-txt">{num(com.nos)}</span>
+                  <span className="bb-barra-txt">{thousands(com.nos)}</span>
                 </div>
                 <span className="ord-lei">
-                  {num(com.podas)} escolhas cortadas antes de virarem ramo
+                  {thousands(com.podas)} escolhas cortadas antes de virarem ramo
                 </span>
               </div>
               <div className={`ord-medida${mesmasSolucoes ? " melhor" : ""}`}>
@@ -256,8 +252,8 @@ export function BacktrackingPoda() {
           As duas versões devolvem <strong>{com.solucoes.length} soluções</strong>
           {mesmasSolucoes ? ", e são as mesmas soluções, uma a uma" : ""}. A poda não troca a resposta por uma
           aproximação, ela só evita descer por caminhos que já são impossíveis: com {n} rainhas, ela corta{" "}
-          {num(com.podas)} escolhas antes de virarem ramo e visita <strong>{num(com.nos)}</strong> nós contra{" "}
-          <strong>{num(sem.nos)}</strong>, {razao.toFixed(1)} vezes menos. É a diferença entre perguntar
+          {thousands(com.podas)} escolhas antes de virarem ramo e visita <strong>{thousands(com.nos)}</strong> nós contra{" "}
+          <strong>{thousands(sem.nos)}</strong>, {razao.toFixed(1)} vezes menos. É a diferença entre perguntar
           &quot;isto ainda pode dar certo?&quot; a cada passo e perguntar só no fim.
         </p>
 

--- a/content/visualizers/BigOChartVisualizer.tsx
+++ b/content/visualizers/BigOChartVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { thousandsDecimal } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -73,21 +74,13 @@ const INPUT_SIZES = [10, 25, 50, 100, 250, 500, 1000, 5000, 10000, 100000, 10000
 
 const DEFAULT_KEYS = new Set(["c", "log", "n", "nlog", "n2"]);
 
-// Formatação determinística (nada de Intl, para o HTML do servidor e do
-// cliente baterem exatamente na hidratação).
-function num(v: number): string {
-  const r = Math.round(v * 10) / 10;
-  const txt = Number.isInteger(r) ? String(r) : r.toFixed(1).replace(".", ",");
-  return txt.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 function fmt(v: number): string {
   if (!isFinite(v)) return "grande demais";
   if (v >= 1e15) return `10^${Math.round(Math.log10(v))}`;
-  if (v >= 1e12) return `${num(v / 1e12)} tri`;
-  if (v >= 1e9) return `${num(v / 1e9)} bi`;
-  if (v >= 1e6) return `${num(v / 1e6)} mi`;
-  return num(Math.round(v));
+  if (v >= 1e12) return `${thousandsDecimal(v / 1e12)} tri`;
+  if (v >= 1e9) return `${thousandsDecimal(v / 1e9)} bi`;
+  if (v >= 1e6) return `${thousandsDecimal(v / 1e6)} mi`;
+  return thousandsDecimal(Math.round(v));
 }
 
 function fmtLog(log10v: number): string {
@@ -98,7 +91,7 @@ function fmtLog(log10v: number): string {
 // Rótulo do eixo Y em escala log: sempre uma potência de 10 redonda.
 function decade(exp: number): string {
   if (exp === 0) return "1";
-  if (exp <= 6) return num(Math.pow(10, exp));
+  if (exp <= 6) return thousandsDecimal(Math.pow(10, exp));
   return `10^${exp}`;
 }
 
@@ -334,7 +327,7 @@ export function BigOChartVisualizer() {
       {/* Sem linha do tempo, o número que resume o estado entra onde ficaria o
           "passo N de M" — com o rótulo junto, que é o que lhe dá contexto. */}
       <VizHeader viz={viz}>
-        <span className="viz-step">n = {num(nMarker)}</span>
+        <span className="viz-step">n = {thousandsDecimal(nMarker)}</span>
       </VizHeader>
 
       <div {...viz.bodyProps}>
@@ -367,7 +360,7 @@ export function BigOChartVisualizer() {
             aria-valuemin={1}
             aria-valuemax={nMax}
             aria-valuenow={nMarker}
-            aria-valuetext={`n igual a ${num(nMarker)}, ${readings.map((l) => `${l.value} operações em ${l.label}`).join(", ")}`}
+            aria-valuetext={`n igual a ${thousandsDecimal(nMarker)}, ${readings.map((l) => `${l.value} operações em ${l.label}`).join(", ")}`}
             onKeyDown={onCanvasKey}
             onPointerDown={(e) => { moveMarker(e); capture(e); }}
             onPointerMove={(e) => { if (e.buttons === 1) moveMarker(e); }}
@@ -377,7 +370,7 @@ export function BigOChartVisualizer() {
         </div>
 
         <p className="viz-note">
-          Com <strong>n = {num(nMarker)}</strong>, {readings.length === 1 ? "a família marcada faz" : "as famílias marcadas fazem"}{" "}
+          Com <strong>n = {thousandsDecimal(nMarker)}</strong>, {readings.length === 1 ? "a família marcada faz" : "as famílias marcadas fazem"}{" "}
           {readings.map((l, i) => (
             <span key={l.key}>
               {i > 0 ? (i === readings.length - 1 ? " e " : ", ") : ""}
@@ -405,7 +398,7 @@ export function BigOChartVisualizer() {
           desenha reprodução nenhuma, só estes controles. */}
       <VizFooter viz={viz}>
         <div className="viz-field grow">
-          <span>Entrada máxima: n até {num(nMax)}</span>
+          <span>Entrada máxima: n até {thousandsDecimal(nMax)}</span>
           <input
             type="range"
             min={0}

--- a/content/visualizers/BinarioBases.tsx
+++ b/content/visualizers/BinarioBases.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -33,18 +34,13 @@ const BASES: { base: number; name: string; note: string }[] = [
   { base: 16, name: "hexadecimal", note: "16 símbolos, de 0 a F. Cada dígito vale exatamente 4 bits, e é por isso que ele é a forma curta de escrever binário." },
 ];
 
-// Formatador determinístico: Intl.NumberFormat diverge entre build e cliente.
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 function compact(v: number): string {
-  if (v >= 1e18) return `${num(v / 1e18)} qui`;
-  if (v >= 1e15) return `${num(v / 1e15)} quatri`;
-  if (v >= 1e12) return `${num(v / 1e12)} tri`;
-  if (v >= 1e9) return `${num(v / 1e9)} bi`;
-  if (v >= 1e6) return `${num(v / 1e6)} mi`;
-  return num(v);
+  if (v >= 1e18) return `${thousands(v / 1e18)} qui`;
+  if (v >= 1e15) return `${thousands(v / 1e15)} quatri`;
+  if (v >= 1e12) return `${thousands(v / 1e12)} tri`;
+  if (v >= 1e9) return `${thousands(v / 1e9)} bi`;
+  if (v >= 1e6) return `${thousands(v / 1e6)} mi`;
+  return thousands(v);
 }
 
 const TYPES = [
@@ -86,7 +82,7 @@ export function BinarioBases() {
           entra no lugar dele, com os três formatos juntos. */}
       <VizHeader viz={viz}>
         <span className="viz-step">
-          {num(value)} = 0x{hex} = 0b{bin}
+          {thousands(value)} = 0x{hex} = 0b{bin}
         </span>
       </VizHeader>
 
@@ -94,7 +90,7 @@ export function BinarioBases() {
         <div className="bigo-chips">
           {VALUES.map((v) => (
             <button key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
-              {num(v)}
+              {thousands(v)}
             </button>
           ))}
         </div>
@@ -107,7 +103,7 @@ export function BinarioBases() {
 
         <div className="hp-bloco">
           <div className="tt-painel-tit">
-            O mesmo {num(value)} em quatro bases <em>quanto menor a base, mais dígitos</em>
+            O mesmo {thousands(value)} em quatro bases <em>quanto menor a base, mais dígitos</em>
           </div>
           <div className="bigo-fam-scroll">
             <table className="bigo-fam-table">
@@ -196,7 +192,7 @@ export function BinarioBases() {
                       <td>
                         <div className="hp-veredito">
                           {t.example}
-                          {fits ? "" : ` · o ${num(value)} escolhido acima NÃO cabe aqui`}
+                          {fits ? "" : ` · o ${thousands(value)} escolhido acima NÃO cabe aqui`}
                         </div>
                       </td>
                     </tr>
@@ -208,7 +204,7 @@ export function BinarioBases() {
         </div>
 
         <p className="viz-note ok">
-          Os {num(value)} escolhidos precisam de <strong>{bin.length} bits</strong> para serem escritos, ou{" "}
+          Os {thousands(value)} escolhidos precisam de <strong>{bin.length} bits</strong> para serem escritos, ou{" "}
           {hex.length} dígitos hexadecimais. Repare que dobrar a quantidade de bits não dobra o alcance, ele
           eleva ao quadrado: 8 bits vão até 255, 16 até 65.535, e 32 até mais de 4 bilhões. É a mesma curva
           exponencial de sempre, vista do lado de dentro.

--- a/content/visualizers/BuscaBinariaOverflow.tsx
+++ b/content/visualizers/BuscaBinariaOverflow.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousandsSigned } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -78,12 +79,6 @@ const div2 = (v: number) => Math.trunc(v / 2);
 function bits32(v: number): string[] {
   const u = v >>> 0;
   return Array.from({ length: 32 }, (_, i) => ((u >>> (31 - i)) & 1 ? "1" : "0"));
-}
-
-function num(v: number): string {
-  const neg = v < 0;
-  const s = String(Math.abs(Math.trunc(v))).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-  return neg ? `-${s}` : s;
 }
 
 export function BuscaBinariaOverflow() {
@@ -191,17 +186,17 @@ export function BuscaBinariaOverflow() {
             <ol className="bb-passos">
               <li>
                 <span>esq + dir</span>
-                <b>{num(conta.somaReal)}</b>
+                <b>{thousandsSigned(conta.somaReal)}</b>
               </li>
               {conta.estourou && (
                 <li className="ruim">
                   <span>não cabe em 32 bits, dá a volta</span>
-                  <b>{num(conta.soma)}</b>
+                  <b>{thousandsSigned(conta.soma)}</b>
                 </li>
               )}
               <li className={conta.estourou ? "ruim" : ""}>
                 <span>dividido por 2</span>
-                <b>{num(conta.meioIngenuo)}</b>
+                <b>{thousandsSigned(conta.meioIngenuo)}</b>
               </li>
             </ol>
             <p className="bb-formula-fim">
@@ -225,15 +220,15 @@ export function BuscaBinariaOverflow() {
             <ol className="bb-passos">
               <li>
                 <span>dir - esq (a distância)</span>
-                <b>{num(conta.dist)}</b>
+                <b>{thousandsSigned(conta.dist)}</b>
               </li>
               <li>
                 <span>dividido por 2 (metade da distância)</span>
-                <b>{num(div2(conta.dist))}</b>
+                <b>{thousandsSigned(div2(conta.dist))}</b>
               </li>
               <li>
                 <span>somado a esq</span>
-                <b>{num(conta.meioSeguro)}</b>
+                <b>{thousandsSigned(conta.meioSeguro)}</b>
               </li>
             </ol>
             <p className="bb-formula-fim">
@@ -281,7 +276,7 @@ export function BuscaBinariaOverflow() {
         <p className={`viz-note${conta.iguais ? " ok" : " invalid"}`}>
           {conta.iguais ? (
             <>
-              As duas fórmulas devolveram <strong>{num(conta.meioSeguro)}</strong>. Com estes valores não há
+              As duas fórmulas devolveram <strong>{thousandsSigned(conta.meioSeguro)}</strong>. Com estes valores não há
               diferença nenhuma, e é por isso que o bug sobreviveu por quase uma década dentro do{" "}
               <code className="prose-code">java.util.Arrays</code>: nenhum teste com array de tamanho
               razoável consegue expô-lo.
@@ -289,8 +284,8 @@ export function BuscaBinariaOverflow() {
           ) : (
             <>
               Mesma entrada, respostas diferentes: a fórmula ingênua devolveu{" "}
-              <strong>{num(conta.meioIngenuo)}</strong> e a segura devolveu{" "}
-              <strong>{num(conta.meioSeguro)}</strong>. As duas são matematicamente equivalentes; o que separa
+              <strong>{thousandsSigned(conta.meioIngenuo)}</strong> e a segura devolveu{" "}
+              <strong>{thousandsSigned(conta.meioSeguro)}</strong>. As duas são matematicamente equivalentes; o que separa
               elas é que só uma sobrevive ao tipo de dado.
             </>
           )}
@@ -299,15 +294,15 @@ export function BuscaBinariaOverflow() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>teto do int de 32 bits</span>
-            <strong>{num(INT_MAX)}</strong>
+            <strong>{thousandsSigned(INT_MAX)}</strong>
           </div>
           <div className="bigo-stat">
             <span>piso do int de 32 bits</span>
-            <strong>{num(INT_MIN)}</strong>
+            <strong>{thousandsSigned(INT_MIN)}</strong>
           </div>
           <div className="bigo-stat">
             <span>folga até o teto</span>
-            <strong>{!limitado ? "não se aplica" : conta.estourou ? "estourada" : num(INT_MAX - conta.somaReal)}</strong>
+            <strong>{!limitado ? "não se aplica" : conta.estourou ? "estourada" : thousandsSigned(INT_MAX - conta.somaReal)}</strong>
           </div>
           <div className="bigo-stat">
             <span>array mínimo para quebrar</span>

--- a/content/visualizers/HashTableBuscaVisualizer.tsx
+++ b/content/visualizers/HashTableBuscaVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { Fragment, useMemo, useState } from "react";
 
+import { comNumero } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -64,10 +65,6 @@ function thousands(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
-function plural(v: number, one: string, many: string): string {
-  return `${v} ${v === 1 ? one : many}`;
-}
-
 function build(names: string[], bad: boolean): Entry[][] {
   const buckets: Entry[][] = Array.from({ length: CAP }, () => [] as Entry[]);
   for (const name of names) {
@@ -84,7 +81,7 @@ function generateListSteps(names: string[], target: string): ListStep[] {
     comparisons: 0,
     found: false,
     done: false,
-    note: `${plural(names.length, "nome guardado", "nomes guardados")} e nenhuma ordem que me ajude: não dá para cortar nada. Vou comparar "${target}" com a posição 0, depois a 1, e assim por diante.`,
+    note: `${comNumero(names.length, "nome guardado", "nomes guardados")} e nenhuma ordem que me ajude: não dá para cortar nada. Vou comparar "${target}" com a posição 0, depois a 1, e assim por diante.`,
   });
   for (let j = 0; j < names.length; j++) {
     const same = names[j] === target;
@@ -94,7 +91,7 @@ function generateListSteps(names: string[], target: string): ListStep[] {
       found: same,
       done: same,
       note: same
-        ? `Posição ${j}: "${names[j]}" é o alvo. Achei, depois de ${plural(j + 1, "comparação", "comparações")}.`
+        ? `Posição ${j}: "${names[j]}" é o alvo. Achei, depois de ${comNumero(j + 1, "comparação", "comparações")}.`
         : `Posição ${j}: "${names[j]}" não é "${target}". Passo para a próxima.`,
     });
     if (same) return out;
@@ -104,7 +101,7 @@ function generateListSteps(names: string[], target: string): ListStep[] {
     comparisons: names.length,
     found: false,
     done: true,
-    note: `Cheguei ao fim da lista: "${target}" não está aqui. Só que precisei de ${plural(names.length, "comparação", "comparações")} para ter certeza disso.`,
+    note: `Cheguei ao fim da lista: "${target}" não está aqui. Só que precisei de ${comNumero(names.length, "comparação", "comparações")} para ter certeza disso.`,
   });
   return out;
 }
@@ -130,7 +127,7 @@ function generateHashSteps(buckets: Entry[][], target: string, bad: boolean): Ha
     found: false,
     done: false,
     note: bad
-      ? `Endereço 0, igual a todas as outras chaves: ${plural(buckets[0].length, "chave está amontoada", "chaves estão amontoadas")} no bucket 0 e os outros ${CAP - 1} estão vazios.`
+      ? `Endereço 0, igual a todas as outras chaves: ${comNumero(buckets[0].length, "chave está amontoada", "chaves estão amontoadas")} no bucket 0 e os outros ${CAP - 1} estão vazios.`
       : `${sum} % ${CAP} = ${i}. Salto direto para o bucket ${i} e nem olho os outros ${CAP - 1}.`,
   });
   const chain = buckets[i];
@@ -154,7 +151,7 @@ function generateHashSteps(buckets: Entry[][], target: string, bad: boolean): Ha
       found: same,
       done: same,
       note: same
-        ? `"${chain[k].key}" bate com o alvo. ${plural(k + 1, "comparação", "comparações")} e acabou.`
+        ? `"${chain[k].key}" bate com o alvo. ${comNumero(k + 1, "comparação", "comparações")} e acabou.`
         : `"${chain[k].key}" caiu no mesmo bucket, mas não é "${target}". Ando um nó na corrente.`,
     });
     if (same) return out;
@@ -241,8 +238,8 @@ export function HashTableBuscaVisualizer() {
   const chain = ph.index == null ? [] : buckets[ph.index];
 
   const summary = bad
-    ? `Com todas as chaves no mesmo bucket, a tabela hash faz ${plural(ph.comparisons, "comparação", "comparações")}, o mesmo trabalho da lista. Esse é o O(n) do pior caso, e ele não vem de azar: vem de uma função de hash que não distribui.`
-    : `A lista gastou ${plural(pl.comparisons, "comparação", "comparações")} e a tabela hash gastou ${plural(ph.comparisons, "comparação", "comparações")}. O que importa não é a diferença aqui, é o que acontece quando a entrada cresce: a lista acompanha n, a tabela hash não se mexe.`;
+    ? `Com todas as chaves no mesmo bucket, a tabela hash faz ${comNumero(ph.comparisons, "comparação", "comparações")}, o mesmo trabalho da lista. Esse é o O(n) do pior caso, e ele não vem de azar: vem de uma função de hash que não distribui.`
+    : `A lista gastou ${comNumero(pl.comparisons, "comparação", "comparações")} e a tabela hash gastou ${comNumero(ph.comparisons, "comparação", "comparações")}. O que importa não é a diferença aqui, é o que acontece quando a entrada cresce: a lista acompanha n, a tabela hash não se mexe.`;
 
   const frame = (
     <figure {...viz.figureProps} style={{ margin: 0 }}>
@@ -314,7 +311,7 @@ export function HashTableBuscaVisualizer() {
         <div className="ht-painel">
           <div className="ht-painel-tit">
             <span>1. Busca linear na lista</span>
-            <em>{plural(pl.comparisons, "comparação", "comparações")}</em>
+            <em>{comNumero(pl.comparisons, "comparação", "comparações")}</em>
           </div>
           <div className="ht-lista">
             {names.map((name, j) => {
@@ -335,7 +332,7 @@ export function HashTableBuscaVisualizer() {
         <div className="ht-painel">
           <div className="ht-painel-tit">
             <span>2. Busca na tabela hash ({CAP} buckets)</span>
-            <em>{plural(ph.comparisons, "comparação", "comparações")}</em>
+            <em>{comNumero(ph.comparisons, "comparação", "comparações")}</em>
           </div>
           <div className="ht-strip">
             {buckets.map((b, i) => (

--- a/content/visualizers/HashTableBuscaVisualizer.tsx
+++ b/content/visualizers/HashTableBuscaVisualizer.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, useMemo, useState } from "react";
 
-import { comNumero } from "@/lib/format";
+import { comNumero, thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -58,11 +58,6 @@ function asciiDetail(s: string): string {
   const parts: string[] = [];
   for (const c of s) parts.push(String(c.codePointAt(0) ?? 0));
   return parts.join(" + ");
-}
-
-// Formatação determinística de milhar (nada de Intl no render).
-function thousands(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
 }
 
 function build(names: string[], bad: boolean): Entry[][] {

--- a/content/visualizers/HashTableBuscaVisualizer.tsx
+++ b/content/visualizers/HashTableBuscaVisualizer.tsx
@@ -46,7 +46,6 @@ type HashStep = {
 };
 
 const CAP = 11;
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
 function asciiSum(s: string): number {
   let t = 0;
@@ -199,7 +198,6 @@ export function HashTableBuscaVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · busca linear x busca por hash",
     total: Math.max(listSteps.length, hashSteps.length),
-    speeds: SPEEDS,
     // Sem `measureOn`: com `collapsible: false` não há bloco para recolher, o
     // hook não toma decisão nenhuma e a lista seria ruído sugerindo uma medição
     // que não acontece (contrato §6).

--- a/content/visualizers/MergeSortNiveis.tsx
+++ b/content/visualizers/MergeSortNiveis.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 import { segments } from "./MergeSortVisualizer";
 
@@ -30,18 +31,12 @@ import { segments } from "./MergeSortVisualizer";
 
 const SIZES = [8, 16, 32, 64];
 
-// Formatador determinístico: Intl.NumberFormat diverge entre build e cliente e
-// quebra a hidratação.
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 function compact(v: number): string {
-  if (v >= 1e15) return `${num(v / 1e15)} quatri`;
-  if (v >= 1e12) return `${num(v / 1e12)} tri`;
-  if (v >= 1e9) return `${num(v / 1e9)} bi`;
-  if (v >= 1e6) return `${num(v / 1e6)} mi`;
-  return num(v);
+  if (v >= 1e15) return `${thousands(v / 1e15)} quatri`;
+  if (v >= 1e12) return `${thousands(v / 1e12)} tri`;
+  if (v >= 1e9) return `${thousands(v / 1e9)} bi`;
+  if (v >= 1e6) return `${thousands(v / 1e6)} mi`;
+  return thousands(v);
 }
 
 const SCALES = [1_000, 1_000_000, 1_000_000_000];
@@ -127,11 +122,11 @@ export function MergeSortNiveis() {
           </div>
           <div className="bigo-stat">
             <span>movimentos totais</span>
-            <strong>{num(moves)}</strong>
+            <strong>{thousands(moves)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso de um O(n²)</span>
-            <strong>{num(quadratic)}</strong>
+            <strong>{thousands(quadratic)}</strong>
           </div>
         </div>
 
@@ -139,7 +134,7 @@ export function MergeSortNiveis() {
           Com {n} elementos dá para partir ao meio <strong>{rounds} vezes</strong> antes de sobrar um elemento
           por trecho, porque {n} = 2<sup>{rounds}</sup>. Cada rodada de intercalação toca cada elemento uma vez
           e só uma, então o trabalho de uma rodada é sempre {n}. O total é o produto: {n} x {rounds} ={" "}
-          {num(moves)} movimentos. É literalmente isso que a notação n log n descreve, e é por isso que ela
+          {thousands(moves)} movimentos. É literalmente isso que a notação n log n descreve, e é por isso que ela
           vale no melhor, no médio e no pior caso: a estrutura da recursão não olha para os dados.
         </p>
 

--- a/content/visualizers/NAryTreeVisualizer.tsx
+++ b/content/visualizers/NAryTreeVisualizer.tsx
@@ -147,8 +147,6 @@ const ORDER_LABEL: Record<Order, string> = {
   level: "Por nível (BFS)",
 };
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 const STEP_X = 96;
 const STEP_Y = 68;
 const NODE_W = 84;
@@ -287,7 +285,6 @@ export function NAryTreeVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · o mesmo template quando os filhos viram uma lista",
     total: steps.length,
-    speeds: SPEEDS,
     // A marcha inicial desta peça é a 4 ("1.5x"), não a 3 do hook: o percurso
     // mais curto tem 19 passos e o mais longo 28, e no 1x a reprodução inteira
     // fica longa demais para quem só quer ver a forma do percurso. Era o valor

--- a/content/visualizers/NAryTreeVisualizer.tsx
+++ b/content/visualizers/NAryTreeVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -271,10 +272,6 @@ function heightFor(n: number, k: number): number {
   if (k < 2) return n;
   return Math.ceil(Math.log(n * (k - 1) + 1) / Math.log(k));
 }
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 const DEGREES = [2, 4, 8, 16, 64, 256];
 const N_EXAMPLE = 1_000_000;
 
@@ -483,7 +480,7 @@ export function NAryTreeVisualizer() {
             duas aulas. Renomear a classe aqui quebraria a peça de lá. */}
         <div className="rec-comp-wrap">
           <table className="rec-comp">
-            <caption>Altura mínima para guardar {num(N_EXAMPLE)} nós, por grau</caption>
+            <caption>Altura mínima para guardar {thousands(N_EXAMPLE)} nós, por grau</caption>
             <thead>
               <tr>
                 <th>Grau (filhos por nó)</th>
@@ -496,7 +493,7 @@ export function NAryTreeVisualizer() {
                 <tr key={k} className={k === maxDegree ? "on" : undefined}>
                   <td>{k}{k === maxDegree ? " (o desta árvore)" : ""}</td>
                   <td>{heightFor(N_EXAMPLE, k)}</td>
-                  <td>~{num(heightFor(N_EXAMPLE, k) * Math.ceil(Math.log2(k)))}</td>
+                  <td>~{thousands(heightFor(N_EXAMPLE, k) * Math.ceil(Math.log2(k)))}</td>
                 </tr>
               ))}
             </tbody>

--- a/content/visualizers/PrefixSumGrade2D.tsx
+++ b/content/visualizers/PrefixSumGrade2D.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -199,12 +200,6 @@ function generateSteps(m: number[][], p: number[][], sel: Region): Step[] {
   return out;
 }
 
-// Formatação determinística (nada de Intl, para o HTML do servidor e do
-// cliente baterem exatamente na hidratação).
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 function inside(reg: Region | null, r: number, c: number) {
   return !!reg && r >= reg.r1 && r <= reg.r2 && c >= reg.c1 && c <= reg.c2;
 }
@@ -391,19 +386,19 @@ export function PrefixSumGrade2D() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>células no retângulo</span>
-            <strong style={{ color: "#fbbf24" }}>{num(cells)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{thousands(cells)}</strong>
           </div>
           <div className="bigo-stat">
             <span>leituras na tabela</span>
-            <strong style={{ color: "var(--ccc-green)" }}>{num(s.ops)}</strong>
+            <strong style={{ color: "var(--ccc-green)" }}>{thousands(s.ops)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pré-processamento ({rows} × {cols})</span>
-            <strong>{num(rows * cols)}</strong>
+            <strong>{thousands(rows * cols)}</strong>
           </div>
           <div className="bigo-stat">
             <span>soma do retângulo</span>
-            <strong>{s.accumulated == null ? "-" : num(s.accumulated)}</strong>
+            <strong>{s.accumulated == null ? "-" : thousands(s.accumulated)}</strong>
           </div>
         </div>
 

--- a/content/visualizers/PrefixSumTradeoff.tsx
+++ b/content/visualizers/PrefixSumTradeoff.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -38,17 +39,10 @@ const SLICE_LABELS = ["1% de n", "5% de n", "10% de n", "25% de n", "50% de n", 
 const BRUTE_COLOR = "#fbbf24";
 const PREFIX_COLOR = "#34d399";
 
-// Formatação determinística (nada de Intl, para o HTML do servidor e do
-// cliente baterem exatamente na hidratação). Um separador de milhar só, o
-// mesmo em todo o eixo: misturar "10 mil" com "8.000" pareceria bug.
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
 // A razão entre as duas curvas é o único número que costuma cair no meio do
 // caminho (4,5 não é 5), então ela ganha uma casa decimal enquanto for pequena.
 function ratioText(v: number): string {
-  if (v >= 10) return num(v);
+  if (v >= 10) return thousands(v);
   const d = Math.round(v * 10);
   return `${Math.floor(d / 10)},${d % 10}`;
 }
@@ -144,7 +138,7 @@ export function PrefixSumTradeoff() {
       ctx.lineTo(padL + gw, Math.round(y) + 0.5);
       ctx.stroke();
       ctx.fillStyle = "#61748c";
-      ctx.fillText(num((k / 5) * yMax), padL - 8, y);
+      ctx.fillText(thousands((k / 5) * yMax), padL - 8, y);
     }
 
     // Eixo X
@@ -159,7 +153,7 @@ export function PrefixSumTradeoff() {
       ctx.lineTo(Math.round(x) + 0.5, padT + gh);
       ctx.stroke();
       ctx.fillStyle = "#61748c";
-      ctx.fillText(num(v), x, padT + gh + 8);
+      ctx.fillText(thousands(v), x, padT + gh + 8);
     }
 
     ctx.textAlign = "left";
@@ -274,16 +268,16 @@ export function PrefixSumTradeoff() {
   const ratio = prefixCost > 0 ? bruteCost / prefixCost : 0;
 
   const reading = useMemo(() => {
-    if (winner === "empate") return `Com ${num(q)} consultas as duas abordagens custam o mesmo: ${num(bruteCost)} operações. Este é o ponto de virada.`;
-    if (winner === "bruta") return `Com só ${num(q)} ${q === 1 ? "consulta" : "consultas"}, a força bruta ainda ganha: ${num(bruteCost)} operações contra ${num(prefixCost)} do prefixo. Montar a tabela custou mais do que ela economizou.`;
-    if (ratio < 2) return `Com ${num(q)} consultas, o prefixo faz ${num(prefixCost)} operações contra ${num(bruteCost)} da força bruta. O pré-processamento acabou de se pagar, e a distância só cresce daqui para frente.`;
-    return `Com ${num(q)} consultas, o prefixo faz ${num(prefixCost)} operações contra ${num(bruteCost)} da força bruta, ${ratioText(ratio)} vezes menos. O pré-processamento já se pagou com folga.`;
+    if (winner === "empate") return `Com ${thousands(q)} consultas as duas abordagens custam o mesmo: ${thousands(bruteCost)} operações. Este é o ponto de virada.`;
+    if (winner === "bruta") return `Com só ${thousands(q)} ${q === 1 ? "consulta" : "consultas"}, a força bruta ainda ganha: ${thousands(bruteCost)} operações contra ${thousands(prefixCost)} do prefixo. Montar a tabela custou mais do que ela economizou.`;
+    if (ratio < 2) return `Com ${thousands(q)} consultas, o prefixo faz ${thousands(prefixCost)} operações contra ${thousands(bruteCost)} da força bruta. O pré-processamento acabou de se pagar, e a distância só cresce daqui para frente.`;
+    return `Com ${thousands(q)} consultas, o prefixo faz ${thousands(prefixCost)} operações contra ${thousands(bruteCost)} da força bruta, ${ratioText(ratio)} vezes menos. O pré-processamento já se pagou com folga.`;
   }, [winner, q, bruteCost, prefixCost, ratio]);
 
   const frame = (
     <figure {...viz.figureProps} style={{ margin: 0 }}>
       <VizHeader viz={viz} color={PREFIX_COLOR}>
-        <span className="viz-step">q = {num(q)}</span>
+        <span className="viz-step">q = {thousands(q)}</span>
       </VizHeader>
 
       <div {...viz.bodyProps}>
@@ -313,7 +307,7 @@ export function PrefixSumTradeoff() {
             aria-valuemin={0}
             aria-valuemax={qMax}
             aria-valuenow={q}
-            aria-valuetext={`${num(q)} consultas: força bruta ${num(bruteCost)} operações, com prefixo ${num(prefixCost)} operações. Ponto de virada em ${num(turningPoint)} consultas.`}
+            aria-valuetext={`${thousands(q)} consultas: força bruta ${thousands(bruteCost)} operações, com prefixo ${thousands(prefixCost)} operações. Ponto de virada em ${thousands(turningPoint)} consultas.`}
             onKeyDown={onKeyDown}
             onPointerDown={(e) => { onMove(e); capture(e); }}
             onPointerMove={(e) => { if (e.buttons === 1) onMove(e); }}
@@ -330,35 +324,35 @@ export function PrefixSumTradeoff() {
           <div className="bigo-card" style={{ borderLeftColor: BRUTE_COLOR }}>
             <div className="bigo-card-top">
               <span className="bigo-card-nome" style={{ color: BRUTE_COLOR }}>força bruta</span>
-              <span className="bigo-card-val">{num(bruteCost)}</span>
+              <span className="bigo-card-val">{thousands(bruteCost)}</span>
             </div>
-            <div className="bigo-card-ex">q × m = {num(q)} × {num(m)}</div>
+            <div className="bigo-card-ex">q × m = {thousands(q)} × {thousands(m)}</div>
           </div>
           <div className="bigo-card" style={{ borderLeftColor: PREFIX_COLOR }}>
             <div className="bigo-card-top">
               <span className="bigo-card-nome" style={{ color: PREFIX_COLOR }}>com prefixo</span>
-              <span className="bigo-card-val">{num(prefixCost)}</span>
+              <span className="bigo-card-val">{thousands(prefixCost)}</span>
             </div>
-            <div className="bigo-card-ex">n + q = {num(n)} + {num(q)}</div>
+            <div className="bigo-card-ex">n + q = {thousands(n)} + {thousands(q)}</div>
           </div>
         </div>
 
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>n (tamanho do array)</span>
-            <strong>{num(n)}</strong>
+            <strong>{thousands(n)}</strong>
           </div>
           <div className="bigo-stat">
             <span>m (tamanho do intervalo)</span>
-            <strong>{num(m)}</strong>
+            <strong>{thousands(m)}</strong>
           </div>
           <div className="bigo-stat">
             <span>ponto de virada</span>
-            <strong>{num(turningPoint)}</strong>
+            <strong>{thousands(turningPoint)}</strong>
           </div>
           <div className="bigo-stat">
             <span>memória extra</span>
-            <strong>{num(n + 1)}</strong>
+            <strong>{thousands(n + 1)}</strong>
           </div>
         </div>
       </div>
@@ -367,7 +361,7 @@ export function PrefixSumTradeoff() {
           painel expandido — ver o cabeçalho deste arquivo. */}
       <VizFooter viz={viz}>
         <div className="viz-field grow">
-          <span>n: array de {num(n)} posições</span>
+          <span>n: array de {thousands(n)} posições</span>
           <input
             type="range"
             min={0}

--- a/content/visualizers/QueueDequeMonotonico.tsx
+++ b/content/visualizers/QueueDequeMonotonico.tsx
@@ -57,8 +57,6 @@ const CODE = [
   "    return saida",
 ];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 function generateSteps(nums: number[], k: number): Step[] {
   const out: Step[] = [];
   const dq: number[] = [];
@@ -207,7 +205,6 @@ export function QueueDequeMonotonico() {
   const viz = useVisualizer({
     title: "Visualizador · deque monotônico: o máximo de cada janela",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o tamanho do array (as células e as fichas
     // da saída quebram linha) e o k, que decide quantas janelas fecham. O
     // número de passos entra porque ele liga e desliga o rodapé inteiro.

--- a/content/visualizers/QueueDuasPilhas.tsx
+++ b/content/visualizers/QueueDuasPilhas.tsx
@@ -58,8 +58,6 @@ const CODE = [
   "        return self.saida.pop()",
 ];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 function scriptOf(s: string): Op[] {
@@ -210,7 +208,6 @@ export function QueueDuasPilhas() {
   const viz = useVisualizer({
     title: "Visualizador · fila com duas pilhas: a virada que inverte a ordem",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o tamanho do roteiro (as fichas quebram
     // linha e as torres crescem) e o número de passos, porque um roteiro vazio
     // gera UM passo só e aí o rodapé inteiro some.

--- a/content/visualizers/QueueVisualizer.tsx
+++ b/content/visualizers/QueueVisualizer.tsx
@@ -102,8 +102,6 @@ const L: Record<Mode, Record<string, number>> = {
   circular: { init: 3, guardFull: 6, full: 7, write: 8, inc: 10, guardEmpty: 13, empty: 14, read: 15, moveStart: 16, dec: 17 },
 };
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 const LETTERS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
 // Roteiro compacto: cada letra é um enfileirar, cada "-" é um desenfileirar.
@@ -320,7 +318,6 @@ export function QueueVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · a fila no array: ingênua x buffer circular",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o modo (o circular ganha uma quinta ficha de
     // estatística), a capacidade (as células da fita), o tamanho do roteiro (as
     // fichas quebram linha) e o número de passos, porque um roteiro vazio gera

--- a/content/visualizers/RecursionArvoreVisualizer.tsx
+++ b/content/visualizers/RecursionArvoreVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -84,12 +85,6 @@ const STEP_X = 52;
 const STEP_Y = 52;
 const MARGIN = 16;
 const TOP = 14;
-
-// Formatação determinística (nada de Intl, para o HTML do servidor bater com o
-// do cliente na hidratação).
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 function fibNum(n: number): number {
   let a = 0;
@@ -188,12 +183,12 @@ function generateSteps(nodes: TreeNode[], n0: number, withMemo: boolean): Step[]
       // porque fib(k-1) e fib(k-2) já estariam guardados.)
       const avoided = naiveCalls(node.k) - 1;
       pruned++;
-      note = `fib(${node.k}) já está no cache valendo ${num(node.value)}. Devolvo na hora e podo a subárvore inteira: sem cache, este mesmo ramo custaria ${num(avoided)} ${avoided === 1 ? "chamada" : "chamadas"} abaixo dele.`;
+      note = `fib(${node.k}) já está no cache valendo ${thousands(node.value)}. Devolvo na hora e podo a subárvore inteira: sem cache, este mesmo ramo custaria ${thousands(avoided)} ${avoided === 1 ? "chamada" : "chamadas"} abaixo dele.`;
     } else {
       line = withMemo ? 7 : 3;
       const size = node.end - node.id + 1;
       note = node.repeated
-        ? `fib(${node.k}) outra vez, e sem cache eu não tenho como saber disso. Vou refazer a subárvore inteira, mais ${num(size - 1)} ${size - 1 === 1 ? "chamada" : "chamadas"}, para chegar de novo no mesmo ${num(node.value)}.`
+        ? `fib(${node.k}) outra vez, e sem cache eu não tenho como saber disso. Vou refazer a subárvore inteira, mais ${thousands(size - 1)} ${size - 1 === 1 ? "chamada" : "chamadas"}, para chegar de novo no mesmo ${thousands(node.value)}.`
         : `Entro em fib(${node.k}). Não sei responder direto, então quebro em fib(${node.k - 1}) e fib(${node.k - 2}) e desço mais um nível.`;
     }
 
@@ -203,8 +198,8 @@ function generateSteps(nodes: TreeNode[], n0: number, withMemo: boolean): Step[]
   const total = nodes.length;
   const answer = nodes[0].value;
   const closing = withMemo
-    ? `fib(${n0}) = ${num(answer)} com ${num(total)} ${total === 1 ? "chamada" : "chamadas"}. Cada valor foi calculado uma vez só: o cache transformou a árvore numa espinha, e a complexidade caiu de exponencial para O(n).`
-    : `fib(${n0}) = ${num(answer)} depois de ${num(total)} ${total === 1 ? "chamada" : "chamadas"}, das quais ${num(repeats)} ${repeats === 1 ? "foi" : "foram"} para valores que a árvore já tinha calculado. Com cache seriam ${num(memoCalls(n0))}.`;
+    ? `fib(${n0}) = ${thousands(answer)} com ${thousands(total)} ${total === 1 ? "chamada" : "chamadas"}. Cada valor foi calculado uma vez só: o cache transformou a árvore numa espinha, e a complexidade caiu de exponencial para O(n).`
+    : `fib(${n0}) = ${thousands(answer)} depois de ${thousands(total)} ${total === 1 ? "chamada" : "chamadas"}, das quais ${thousands(repeats)} ${repeats === 1 ? "foi" : "foram"} para valores que a árvore já tinha calculado. Com cache seriam ${thousands(memoCalls(n0))}.`;
 
   out.push({ node: -1, line: withMemo ? 8 : 3, repeats, pruned, note: closing, ok: true });
   return out;
@@ -295,8 +290,8 @@ export function RecursionArvoreVisualizer() {
   const vars = [
     { name: "n (chamada atual)", value: current ? `${current.k}` : "-" },
     { name: "profundidade", value: current ? `${current.depth}` : "0" },
-    { name: "devolve", value: current && viz.step >= current.end ? num(current.value) : "pendente" },
-    { name: "chamadas", value: num(callsSoFar), best: true },
+    { name: "devolve", value: current && viz.step >= current.end ? thousands(current.value) : "pendente" },
+    { name: "chamadas", value: thousands(callsSoFar), best: true },
   ];
 
   const tableRows = [n, 10, 20, 30];
@@ -379,7 +374,7 @@ export function RecursionArvoreVisualizer() {
                   />
                   <text x={cx(node)} y={cyTop(node) + 13} textAnchor="middle">fib({node.k})</text>
                   <text x={cx(node)} y={cyTop(node) + 26} textAnchor="middle" className="rec-no-val">
-                    {resolved ? `= ${num(node.value)}` : "= ?"}
+                    {resolved ? `= ${thousands(node.value)}` : "= ?"}
                   </text>
                 </g>
               );
@@ -428,25 +423,25 @@ export function RecursionArvoreVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>chamadas até aqui</span>
-            <strong>{num(callsSoFar)}</strong>
+            <strong>{thousands(callsSoFar)}</strong>
           </div>
           <div className="bigo-stat">
             <span>chamadas no total</span>
-            <strong>{num(nodes.length)}</strong>
+            <strong>{thousands(nodes.length)}</strong>
           </div>
           <div className="bigo-stat">
             <span>{withMemo ? "acertos no cache" : "chamadas repetidas"}</span>
-            <strong>{num(withMemo ? p.pruned : p.repeats)}</strong>
+            <strong>{thousands(withMemo ? p.pruned : p.repeats)}</strong>
           </div>
           {/* O contraste que fecha a seção: a árvore tem dezenas de nós, mas a
               pilha nunca passa da profundidade. Tempo exponencial, espaço linear. */}
           <div className="bigo-stat">
             <span>pico da pilha</span>
-            <strong>{num(maxDepth + 1)}</strong>
+            <strong>{thousands(maxDepth + 1)}</strong>
           </div>
           <div className="bigo-stat">
             <span>fib({n})</span>
-            <strong>{num(nodes[0].value)}</strong>
+            <strong>{thousands(nodes[0].value)}</strong>
           </div>
         </div>
 
@@ -465,9 +460,9 @@ export function RecursionArvoreVisualizer() {
               {tableRows.map((v, i) => (
                 <tr key={`${v}-${i}`} className={i === 0 ? "on" : undefined}>
                   <td>{v}{i === 0 ? " (o seu)" : ""}</td>
-                  <td>{num(naiveCalls(v))}</td>
-                  <td>{num(memoCalls(v))}</td>
-                  <td>{num(Math.round(naiveCalls(v) / memoCalls(v)))}×</td>
+                  <td>{thousands(naiveCalls(v))}</td>
+                  <td>{thousands(memoCalls(v))}</td>
+                  <td>{thousands(Math.round(naiveCalls(v) / memoCalls(v)))}×</td>
                 </tr>
               ))}
             </tbody>
@@ -475,7 +470,7 @@ export function RecursionArvoreVisualizer() {
         </div>
 
         <p className="viz-caption" style={{ margin: "12px 0 0" }}>
-          Sem cache, fib({n}) custa {num(naiveTotal)} chamadas; com cache, {num(memoTotal)}. Em fib(20) a diferença
+          Sem cache, fib({n}) custa {thousands(naiveTotal)} chamadas; com cache, {thousands(memoTotal)}. Em fib(20) a diferença
           é 21.891 contra 39.
         </p>
       </div>

--- a/content/visualizers/RecursionArvoreVisualizer.tsx
+++ b/content/visualizers/RecursionArvoreVisualizer.tsx
@@ -75,8 +75,6 @@ const MEMO_CODE = [
   "    return memo[n]",
 ];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 // Geometria da árvore. O SVG rola dentro do próprio container quando fica mais
 // largo que a tela, então dá para abrir n = 8 sem a página rolar na horizontal.
 const NODE_W = 46;
@@ -225,7 +223,6 @@ export function RecursionArvoreVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · a árvore de chamadas do Fibonacci e o retrabalho",
     total: steps.length,
-    speeds: SPEEDS,
     // A marcha inicial desta peça é a 4 ("1.5x"), não a 3 do hook: a árvore tem
     // dezenas de nós e no 1x a reprodução inteira fica longa demais para quem
     // só quer ver a forma do retrabalho. Era o valor que o componente já tinha.

--- a/content/visualizers/RecursionVisualizer.tsx
+++ b/content/visualizers/RecursionVisualizer.tsx
@@ -85,8 +85,6 @@ const UNREACHABLE = [
   "    return contagem(n + 1)",
 ];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 function factorialOf(n: number): number {
   let f = 1;
   for (let i = 2; i <= n; i++) f *= i;
@@ -452,7 +450,6 @@ export function RecursionVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · a pilha de chamadas: empilha na descida, resolve na subida",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o modo (o código vai de 4 a 5 linhas e o
     // painel de variáveis troca de conteúdo) e, sobretudo, quantos frames cabem
     // na pilha — que é o produto de `n` com `limit`. O eixo que vira ALTURA

--- a/content/visualizers/RecursionVisualizer.tsx
+++ b/content/visualizers/RecursionVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -85,12 +86,6 @@ const UNREACHABLE = [
 ];
 
 const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
-// Formatação determinística (nada de Intl, para o HTML do servidor bater com o
-// do cliente na hidratação).
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 function factorialOf(n: number): number {
   let f = 1;
@@ -192,12 +187,12 @@ function generateClassic(n0: number, limit: number): Step[] {
     const next = top.n * value;
     top.state = "volta";
     top.pending = undefined;
-    top.ret = num(next);
+    top.ret = thousands(next);
     emit(
       4,
-      `fatorial(${top.n}) recebe ${num(value)} de baixo, resolve a conta que estava pendurada, ${top.n} × ${num(value)} = ${num(next)}, e devolve. O frame sai da pilha e a memória dele é liberada.`,
+      `fatorial(${top.n}) recebe ${thousands(value)} de baixo, resolve a conta que estava pendurada, ${top.n} × ${thousands(value)} = ${thousands(next)}, e devolve. O frame sai da pilha e a memória dele é liberada.`,
       `${top.n}`,
-      num(next)
+      thousands(next)
     );
     value = next;
     frames.pop();
@@ -208,10 +203,10 @@ function generateClassic(n0: number, limit: number): Step[] {
     frames: [],
     calls,
     maxDepth,
-    note: `A pilha voltou a ficar vazia: fatorial(${n0}) = ${num(value)}. Deu ${calls} ${calls === 1 ? "chamada" : "chamadas"} no total e, no pico, ${maxDepth} ${maxDepth === 1 ? "frame vivo" : "frames vivos"} ao mesmo tempo. Esse pico é a complexidade de espaço da recursão: O(n).`,
+    note: `A pilha voltou a ficar vazia: fatorial(${n0}) = ${thousands(value)}. Deu ${calls} ${calls === 1 ? "chamada" : "chamadas"} no total e, no pico, ${maxDepth} ${maxDepth === 1 ? "frame vivo" : "frames vivos"} ao mesmo tempo. Esse pico é a complexidade de espaço da recursão: O(n).`,
     vars: [
       { name: "n (frame do topo)", value: "-" },
-      { name: "valor devolvido", value: num(value) },
+      { name: "valor devolvido", value: thousands(value) },
       { name: "frames na pilha", value: "0" },
       { name: "chamadas", value: `${calls}`, best: true },
     ],
@@ -259,7 +254,7 @@ function generateTail(n0: number, limit: number): Step[] {
 
   while (guard++ < 40) {
     const mine = id++;
-    frames.push({ id: mine, level: frames.length + 1, n: k, label: `fatorial(n=${k}, acc=${num(acc)})`, state: "ativo" });
+    frames.push({ id: mine, level: frames.length + 1, n: k, label: `fatorial(n=${k}, acc=${thousands(acc)})`, state: "ativo" });
     calls++;
 
     if (frames.length > limit) {
@@ -268,7 +263,7 @@ function generateTail(n0: number, limit: number): Step[] {
         0,
         `Tentei abrir o frame ${frames.length} e o limite da pilha é ${limit}: RecursionError. Sem otimização de chamada final, a recursão de cauda empilha exatamente igual à clássica.`,
         `${k}`,
-        num(acc),
+        thousands(acc),
         "-",
         { done: true, error: true },
         mine
@@ -280,37 +275,37 @@ function generateTail(n0: number, limit: number): Step[] {
 
     emit(
       0,
-      `Entro em fatorial(${k}, acc=${num(acc)}). Repare que o trabalho já vem feito de cima: o acumulador carrega tudo o que foi multiplicado até aqui.`,
+      `Entro em fatorial(${k}, acc=${thousands(acc)}). Repare que o trabalho já vem feito de cima: o acumulador carrega tudo o que foi multiplicado até aqui.`,
       `${k}`,
-      num(acc),
+      thousands(acc),
       "-",
       undefined,
       mine
     );
 
     if (k <= 1) {
-      emit(1, `n = ${k} bate no caso base.`, `${k}`, num(acc), "-");
+      emit(1, `n = ${k} bate no caso base.`, `${k}`, thousands(acc), "-");
       frames[frames.length - 1].state = "base";
-      frames[frames.length - 1].ret = num(acc);
+      frames[frames.length - 1].ret = thousands(acc);
       emit(
         2,
-        `Devolvo o acumulador: ${num(acc)}. A resposta final já estava pronta ANTES da volta começar, ninguém precisa calcular mais nada na subida.`,
+        `Devolvo o acumulador: ${thousands(acc)}. A resposta final já estava pronta ANTES da volta começar, ninguém precisa calcular mais nada na subida.`,
         `${k}`,
-        num(acc),
-        num(acc)
+        thousands(acc),
+        thousands(acc)
       );
       break;
     }
 
-    emit(1, `n = ${k} ainda não é caso base.`, `${k}`, num(acc), "-");
+    emit(1, `n = ${k} ainda não é caso base.`, `${k}`, thousands(acc), "-");
     const next = acc * k;
     frames[frames.length - 1].state = "espera";
     frames[frames.length - 1].pending = "nada pendente";
     emit(
       3,
-      `Chamo fatorial(${k - 1}, ${num(acc)} × ${k} = ${num(next)}). A chamada é a ÚLTIMA operação da função: depois dela não sobra nenhuma conta neste frame.`,
+      `Chamo fatorial(${k - 1}, ${thousands(acc)} × ${k} = ${thousands(next)}). A chamada é a ÚLTIMA operação da função: depois dela não sobra nenhuma conta neste frame.`,
       `${k}`,
-      num(acc),
+      thousands(acc),
       "-"
     );
     acc = next;
@@ -325,13 +320,13 @@ function generateTail(n0: number, limit: number): Step[] {
     const top = frames[frames.length - 1];
     top.state = "volta";
     top.pending = undefined;
-    top.ret = num(result);
+    top.ret = thousands(result);
     emit(
       3,
-      `O frame de fatorial(${top.n}, ...) recebe ${num(result)} e só repassa, porque não tinha nada pendente. Este frame ficou vivo à toa: é justamente ele que a otimização de chamada final sabe reaproveitar.`,
+      `O frame de fatorial(${top.n}, ...) recebe ${thousands(result)} e só repassa, porque não tinha nada pendente. Este frame ficou vivo à toa: é justamente ele que a otimização de chamada final sabe reaproveitar.`,
       `${top.n}`,
-      num(acc),
-      num(result)
+      thousands(acc),
+      thousands(result)
     );
     frames.pop();
   }
@@ -341,11 +336,11 @@ function generateTail(n0: number, limit: number): Step[] {
     frames: [],
     calls,
     maxDepth,
-    note: `fatorial(${n0}) = ${num(result)} com ${calls} ${calls === 1 ? "chamada" : "chamadas"} e pico de ${maxDepth} ${maxDepth === 1 ? "frame" : "frames"}: os mesmos números do modo clássico. Em Python o custo é idêntico, o ganho da cauda só aparece em linguagem que faz a otimização.`,
+    note: `fatorial(${n0}) = ${thousands(result)} com ${calls} ${calls === 1 ? "chamada" : "chamadas"} e pico de ${maxDepth} ${maxDepth === 1 ? "frame" : "frames"}: os mesmos números do modo clássico. Em Python o custo é idêntico, o ganho da cauda só aparece em linguagem que faz a otimização.`,
     vars: [
       { name: "n (frame do topo)", value: "-" },
-      { name: "acc", value: num(result) },
-      { name: "valor devolvido", value: num(result) },
+      { name: "acc", value: thousands(result) },
+      { name: "valor devolvido", value: thousands(result) },
       { name: "chamadas", value: `${calls}`, best: true },
     ],
     ok: true,
@@ -604,11 +599,11 @@ export function RecursionVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>chamadas feitas</span>
-            <strong>{num(p.calls)}</strong>
+            <strong>{thousands(p.calls)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pico de frames</span>
-            <strong>{num(p.maxDepth)}</strong>
+            <strong>{thousands(p.maxDepth)}</strong>
           </div>
           <div className="bigo-stat">
             <span>memória da pilha</span>
@@ -616,7 +611,7 @@ export function RecursionVisualizer() {
           </div>
           <div className="bigo-stat">
             <span>{expected === null ? "resposta" : `fatorial(${n})`}</span>
-            <strong>{expected === null ? (overflowed ? "estourou" : "nunca chega") : num(expected)}</strong>
+            <strong>{expected === null ? (overflowed ? "estourou" : "nunca chega") : thousands(expected)}</strong>
           </div>
         </div>
       </div>

--- a/content/visualizers/SkipListNiveis.tsx
+++ b/content/visualizers/SkipListNiveis.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -35,12 +36,6 @@ const PS = [
   { value: 0.5, label: "p = 0,5", note: "a moeda, o padrão" },
   { value: 0.75, label: "p = 0,75", note: "sobe 3 a cada 4" },
 ];
-
-// Formatação determinística: nada de Intl, para o HTML do build bater com o do
-// cliente na hidratação.
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 // Zeros à direita saem fora: "p = 0,5" e "2 ponteiros", nunca "0,50" e "2,00".
 // É o mesmo número que o artigo escreve, e o aluno compara os dois.
@@ -124,9 +119,9 @@ export function SkipListNiveis() {
 
   const stats = [
     { k: "niv", label: "níveis esperados", value: `${levels}` },
-    { k: "cmp", label: "comparações na busca", value: `${num(comparisons)}` },
+    { k: "cmp", label: "comparações na busca", value: `${thousands(comparisons)}` },
     { k: "pt", label: "ponteiros por nó", value: dec(pointersPerNode, 2) },
-    { k: "mem", label: "ponteiros no total", value: num(totalPointers) },
+    { k: "mem", label: "ponteiros no total", value: thousands(totalPointers) },
   ];
 
   const frame = (
@@ -136,7 +131,7 @@ export function SkipListNiveis() {
           contexto que o explicava. */}
       <VizHeader viz={viz}>
         <span className="viz-step">
-          n = {num(n)} · p = {dec(p, 2)}
+          n = {thousands(n)} · p = {dec(p, 2)}
         </span>
       </VizHeader>
 
@@ -168,9 +163,9 @@ export function SkipListNiveis() {
                   {obs !== null ? <b style={{ width: `${Math.max(0.35, (obs / n) * 100)}%` }} /> : null}
                 </span>
                 <span className="sl-pval">
-                  {num(l.expected)}
+                  {thousands(l.expected)}
                   <em>{pct(l.fraction)}</em>
-                  {obs !== null ? <span className="obs">{num(obs)} sorteados</span> : null}
+                  {obs !== null ? <span className="obs">{thousands(obs)} sorteados</span> : null}
                 </span>
               </div>
             );
@@ -178,13 +173,13 @@ export function SkipListNiveis() {
         </div>
 
         <p className="viz-note">
-          Com <strong>n = {num(n)}</strong> e <strong>p = {dec(p, 2)}</strong>, cada nível guarda{" "}
+          Com <strong>n = {thousands(n)}</strong> e <strong>p = {dec(p, 2)}</strong>, cada nível guarda{" "}
           <strong>{pct(p)}</strong> do nível de baixo. A conta para o nível {top} ainda ter pelo menos 1 nó é{" "}
           <strong>
-            {num(n)} × {dec(p, 2)}
+            {thousands(n)} × {dec(p, 2)}
             <sup>{top}</sup> ≥ 1
           </strong>
-          , e é daí que sai a altura de <strong>{levels} níveis</strong>: é o logaritmo de {num(n)} na base{" "}
+          , e é daí que sai a altura de <strong>{levels} níveis</strong>: é o logaritmo de {thousands(n)} na base{" "}
           {dec(1 / p, 2)}, arredondado para cima.
           {simValid ? (
             <>
@@ -210,9 +205,9 @@ export function SkipListNiveis() {
             <em>o pior caso existe, só não acontece</em>
           </div>
           <p className="sl-azar">
-            Para a skip list virar uma lista encadeada comum, os {num(n)} nós teriam que tirar coroa de primeira, todos.
+            Para a skip list virar uma lista encadeada comum, os {thousands(n)} nós teriam que tirar coroa de primeira, todos.
             A chance disso é <strong>(1 − {dec(p, 2)})</strong>
-            <sup>{num(n)}</sup> = <strong>{chance(log10BadLuck)}</strong>. O pior caso é O(n) de verdade, mas ele não é
+            <sup>{thousands(n)}</sup> = <strong>{chance(log10BadLuck)}</strong>. O pior caso é O(n) de verdade, mas ele não é
             uma entrada ruim que alguém pode escolher: é azar puro, e o tamanho dessa fração é o motivo de dar para
             confiar no sorteio.
           </p>
@@ -224,7 +219,7 @@ export function SkipListNiveis() {
           deixa parados no pé do painel enquanto a pirâmide rola. */}
       <VizFooter viz={viz}>
         <div className="viz-field grow">
-          <span>Elementos: n = {num(n)}</span>
+          <span>Elementos: n = {thousands(n)}</span>
           <input
             type="range"
             min={0}
@@ -239,7 +234,7 @@ export function SkipListNiveis() {
           />
         </div>
         <button className="viz-btn" onClick={rollCoins}>
-          Sortear {num(n)} moedas
+          Sortear {thousands(n)} moedas
         </button>
         <button
           className="viz-btn"

--- a/content/visualizers/StringsBytesVisualizer.tsx
+++ b/content/visualizers/StringsBytesVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { thousands } from "@/lib/format";
 import { useVisualizer, VizHeader } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -91,10 +92,6 @@ const DEFAULT_TEXT = "CCC";
 const MAX_CP = 20;
 
 const COLORS = ["#60a5fa", "#34d399", "#fbbf24", "#f472b6", "#a78bfa", "#22d3ee"];
-
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 function hex2(b: number): string {
   const s = b.toString(16).toUpperCase();
@@ -192,7 +189,7 @@ export function StringsBytesVisualizer() {
           aqui: é o número que resume o estado desta peça. */}
       <VizHeader viz={viz}>
         <span className="viz-step">
-          {num(totals[enc])} bytes em {currentEnc.name}
+          {thousands(totals[enc])} bytes em {currentEnc.name}
         </span>
       </VizHeader>
 
@@ -236,7 +233,7 @@ export function StringsBytesVisualizer() {
                 aria-pressed={on}
               >
                 <span className="str-enc-nome">{e.name}</span>
-                <span className="str-enc-val">{num(totals[e.key])} bytes</span>
+                <span className="str-enc-val">{thousands(totals[e.key])} bytes</span>
                 <span className="str-enc-sub">
                   {loses
                     ? `perde ${lost} ${lost === 1 ? "caractere" : "caracteres"}, viram "?"`
@@ -250,19 +247,19 @@ export function StringsBytesVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>o que você vê (grafemas)</span>
-            <strong style={{ color: "#34d399" }}>{num(graphemes)}</strong>
+            <strong style={{ color: "#34d399" }}>{thousands(graphemes)}</strong>
           </div>
           <div className="bigo-stat">
             <span>code points (len no Python)</span>
-            <strong>{num(cps.length)}</strong>
+            <strong>{thousands(cps.length)}</strong>
           </div>
           <div className="bigo-stat">
             <span>unidades UTF-16 (Length no C#)</span>
-            <strong>{num(utf16Units)}</strong>
+            <strong>{thousands(utf16Units)}</strong>
           </div>
           <div className="bigo-stat">
             <span>bytes em {currentEnc.name}</span>
-            <strong style={{ color: "#93bbfd" }}>{num(totals[enc])}</strong>
+            <strong style={{ color: "#93bbfd" }}>{thousands(totals[enc])}</strong>
           </div>
         </div>
 
@@ -334,8 +331,8 @@ export function StringsBytesVisualizer() {
 
         <p className="viz-note">
           {graphemes === cps.length && cps.length === utf16Units
-            ? `Aqui os três números batem: ${num(graphemes)} ${graphemes === 1 ? "caractere" : "caracteres"} na tela, ${num(cps.length)} code ${cps.length === 1 ? "point" : "points"} e ${num(utf16Units)} ${utf16Units === 1 ? "unidade" : "unidades"} UTF-16. É o caso fácil, e é o único que a intuição acerta.`
-            : `Repare no desencontro: são ${num(graphemes)} ${graphemes === 1 ? "caractere" : "caracteres"} na tela, ${num(cps.length)} code points e ${num(utf16Units)} unidades UTF-16. Um contador de caracteres feito com o length errado corta o texto no lugar errado.`}
+            ? `Aqui os três números batem: ${thousands(graphemes)} ${graphemes === 1 ? "caractere" : "caracteres"} na tela, ${thousands(cps.length)} code ${cps.length === 1 ? "point" : "points"} e ${thousands(utf16Units)} ${utf16Units === 1 ? "unidade" : "unidades"} UTF-16. É o caso fácil, e é o único que a intuição acerta.`
+            : `Repare no desencontro: são ${thousands(graphemes)} ${graphemes === 1 ? "caractere" : "caracteres"} na tela, ${thousands(cps.length)} code points e ${thousands(utf16Units)} unidades UTF-16. Um contador de caracteres feito com o length errado corta o texto no lugar errado.`}
         </p>
       </div>
     </figure>

--- a/content/visualizers/StringsRotateVisualizer.tsx
+++ b/content/visualizers/StringsRotateVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { plural } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -76,10 +77,6 @@ const SPEEDS = [0, 1400, 950, 650, 420, 250];
 
 function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
-function plural(n: number, one: string, many: string): string {
-  return n === 1 ? one : many;
 }
 
 // Quantos caracteres batem antes de divergir. Serve para o contador de

--- a/content/visualizers/StringsRotateVisualizer.tsx
+++ b/content/visualizers/StringsRotateVisualizer.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 
-import { plural } from "@/lib/format";
+import { plural, thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -74,10 +74,6 @@ const WORDS = ["abcde", "craft", "codigo", "rotate", "banana"];
 
 const MAX = 10;
 const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 // Quantos caracteres batem antes de divergir. Serve para o contador de
 // comparações não mentir: comparar duas strings NÃO é uma operação só.
@@ -329,9 +325,9 @@ export function StringsRotateVisualizer() {
 
   const vars = [
     { name: "n", value: `${n}` },
-    { name: "strings novas", value: num(p.strings) },
-    { name: "cópias", value: num(p.copies) },
-    { name: "comparações", value: num(p.comparisons), best: true },
+    { name: "strings novas", value: thousands(p.strings) },
+    { name: "cópias", value: thousands(p.copies) },
+    { name: "comparações", value: thousands(p.comparisons), best: true },
   ];
 
   const frame = (
@@ -416,19 +412,19 @@ export function StringsRotateVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>caracteres copiados</span>
-            <strong style={{ color: cfg.color }}>{num(p.copies)}</strong>
+            <strong style={{ color: cfg.color }}>{thousands(p.copies)}</strong>
           </div>
           <div className="bigo-stat">
             <span>comparações de caractere</span>
-            <strong>{num(p.comparisons)}</strong>
+            <strong>{thousands(p.comparisons)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso com o laço</span>
-            <strong style={{ color: "#fbbf24" }}>{num(worstLoop)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{thousands(worstLoop)}</strong>
           </div>
           <div className="bigo-stat">
             <span>pior caso com o truque</span>
-            <strong style={{ color: "#34d399" }}>{num(2 * n)}</strong>
+            <strong style={{ color: "#34d399" }}>{thousands(2 * n)}</strong>
           </div>
         </div>
 

--- a/content/visualizers/StringsRotateVisualizer.tsx
+++ b/content/visualizers/StringsRotateVisualizer.tsx
@@ -73,8 +73,6 @@ const PRESETS: { label: string; s: string; goal: string }[] = [
 const WORDS = ["abcde", "craft", "codigo", "rotate", "banana"];
 
 const MAX = 10;
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 // Quantos caracteres batem antes de divergir. Serve para o contador de
 // comparações não mentir: comparar duas strings NÃO é uma operação só.
 function commonPrefix(a: string[], b: string[]): number {
@@ -289,7 +287,6 @@ export function StringsRotateVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · Rotate String, força bruta contra o truque",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o modo (no truque a fita passa de n para 2n
     // células e quebra linha antes), o tamanho de s e o de goal — quando os dois
     // diferem o gerador para em dois passos e a peça encolhe.

--- a/content/visualizers/StringsVisualizer.tsx
+++ b/content/visualizers/StringsVisualizer.tsx
@@ -2,7 +2,7 @@
 
 import { useMemo, useState } from "react";
 
-import { plural } from "@/lib/format";
+import { plural, thousands } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -75,12 +75,6 @@ const DEFAULT_WORD = "CRAFTCODE";
 const MAX = 16;
 
 const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
-// Formatação determinística (nada de Intl, para o HTML do servidor bater com o
-// do cliente na hidratação).
-function num(v: number): string {
-  return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
 
 function generateSteps(word: string, mode: Mode): Step[] {
   const chars = Array.from(word).slice(0, MAX);
@@ -246,13 +240,13 @@ export function StringsVisualizer() {
           { name: "s", value: `"${chars.slice(0, p.used).join("")}"` },
           { name: "len(s)", value: `${p.used}` },
           { name: "c", value: p.i >= 0 ? `"${chars[p.i]}"` : "-" },
-          { name: "cópias", value: num(p.copies), best: true },
+          { name: "cópias", value: thousands(p.copies), best: true },
         ]
       : [
           { name: "len(partes)", value: `${p.parts.length}` },
           { name: "c", value: p.i >= 0 ? `"${chars[p.i]}"` : "-" },
           { name: "strings novas", value: `${p.strings}` },
-          { name: "cópias", value: num(p.copies), best: true },
+          { name: "cópias", value: thousands(p.copies), best: true },
         ];
 
   const noteClass = "viz-note" + (p.ok ? " ok" : "");
@@ -352,19 +346,19 @@ export function StringsVisualizer() {
         <div className="bigo-stats">
           <div className="bigo-stat">
             <span>caracteres copiados</span>
-            <strong style={{ color: cfg.color }}>{num(p.copies)}</strong>
+            <strong style={{ color: cfg.color }}>{thousands(p.copies)}</strong>
           </div>
           <div className="bigo-stat">
             <span>strings alocadas</span>
-            <strong>{num(p.strings)}</strong>
+            <strong>{thousands(p.strings)}</strong>
           </div>
           <div className="bigo-stat">
             <span>total com s = s + c</span>
-            <strong style={{ color: "#fbbf24" }}>{num(concatTotal)}</strong>
+            <strong style={{ color: "#fbbf24" }}>{thousands(concatTotal)}</strong>
           </div>
           <div className="bigo-stat">
             <span>total com join</span>
-            <strong style={{ color: "#34d399" }}>{num(n)}</strong>
+            <strong style={{ color: "#34d399" }}>{thousands(n)}</strong>
           </div>
         </div>
 

--- a/content/visualizers/StringsVisualizer.tsx
+++ b/content/visualizers/StringsVisualizer.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from "react";
 
+import { plural } from "@/lib/format";
 import { useVisualizer, VizHeader, VizFooter } from "@/lib/visualizer";
 
 // ---------------------------------------------------------------------------
@@ -79,10 +80,6 @@ const SPEEDS = [0, 1400, 950, 650, 420, 250];
 // do cliente na hidratação).
 function num(v: number): string {
   return String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".");
-}
-
-function plural(n: number, one: string, many: string): string {
-  return n === 1 ? one : many;
 }
 
 function generateSteps(word: string, mode: Mode): Step[] {

--- a/content/visualizers/StringsVisualizer.tsx
+++ b/content/visualizers/StringsVisualizer.tsx
@@ -74,8 +74,6 @@ const PRESETS: { label: string; text: string }[] = [
 const DEFAULT_WORD = "CRAFTCODE";
 const MAX = 16;
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 function generateSteps(word: string, mode: Mode): Step[] {
   const chars = Array.from(word).slice(0, MAX);
   const n = chars.length;
@@ -196,7 +194,6 @@ export function StringsVisualizer() {
   const viz = useVisualizer({
     title: "Visualizador · o custo de montar uma string",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o modo (o join ganha a lista de pedaços, um
     // bloco inteiro a mais) e o tamanho da palavra (as células quebram linha).
     measureOn: [mode, n],

--- a/content/visualizers/TwoPointersCiclo.tsx
+++ b/content/visualizers/TwoPointersCiclo.tsx
@@ -41,8 +41,6 @@ const CODE = [
   "    return False",
 ];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 const R_NODE = 17; // raio do nó
 const GAP = 68; // distância entre nós da cauda
 
@@ -149,7 +147,6 @@ export function TwoPointersCiclo() {
   const viz = useVisualizer({
     title: "Visualizador · rápido e lento: existe ciclo na lista ligada?",
     total: steps.length,
-    speeds: SPEEDS,
     // O que muda a altura da peça: o desenho. O SVG tem largura 100% e altura
     // automática, então a altura na tela sai da razão do viewBox — e os dois
     // lados dessa razão dependem da cauda e do ciclo.

--- a/content/visualizers/TwoPointersPalindromo.tsx
+++ b/content/visualizers/TwoPointersPalindromo.tsx
@@ -50,8 +50,6 @@ const CODE = [
   "    return True",
 ];
 
-const SPEEDS = [0, 1400, 950, 650, 420, 250];
-
 function alnum(c: string): boolean {
   return /[a-zA-Z0-9]/.test(c);
 }
@@ -132,7 +130,6 @@ export function TwoPointersPalindromo() {
   const viz = useVisualizer({
     title: "Visualizador · palíndromo com ponteiros em ritmos diferentes",
     total: steps.length,
-    speeds: SPEEDS,
     initialSpeed: 4,
     // O que muda a altura da peça: a fita de caracteres some quando a string é
     // vazia e dá lugar ao aviso, que tem outra altura. O comprimento não muda a

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -5,8 +5,8 @@
  * `content/visualizers/`, e as cópias tinham divergido em silêncio:
  *
  * - o formatador de milhar aparecia sob DOIS nomes (`num` e `thousands`) com
- *   TRÊS comportamentos: o que arredonda, o que mostra uma casa decimal e o que
- *   preserva o sinal. Nome igual, texto de tela diferente;
+ *   TRÊS corpos: o que arredonda, o que mostra uma casa decimal e o que trunca.
+ *   Nome igual, texto de tela diferente;
  * - `plural(v, one, many)` tinha a MESMA assinatura e retorno incompatível. Em
  *   alguns arquivos devolvia `"3 comparações"` e em outros devolvia
  *   `"comparações"`. Mover uma linha de nota entre dois desses arquivos produzia
@@ -30,8 +30,9 @@ const agrupaMilhar = (s: string): string => s.replace(/\B(?=(\d{3})+(?!\d))/g, "
  * Arredonda para inteiro e agrupa o milhar: `1234567` vira `"1.234.567"`.
  *
  * É o formatador da grande maioria dos visualizadores: contadores de operações,
- * de comparações, de bytes. Para número negativo use {@link thousandsSigned},
- * porque aqui o `-` entra no agrupamento e desloca os pontos.
+ * de comparações, de bytes. Ele lida bem com negativo INTEIRO: `-2147483648`
+ * sai `"-2.147.483.648"`. O que ele NÃO faz é truncar — para isso existe
+ * {@link thousandsSigned}, e a nota de lá explica a diferença medida.
  */
 export function thousands(v: number): string {
   return agrupaMilhar(String(Math.round(v)));
@@ -51,12 +52,25 @@ export function thousandsDecimal(v: number): string {
 }
 
 /**
- * Trunca preservando o sinal e agrupa o milhar: `-2147483648` vira
- * `"-2.147.483.648"`.
+ * TRUNCA preservando o sinal e agrupa o milhar: `-2147483648` vira
+ * `"-2.147.483.648"` e `-999.6` vira `"-999"`.
  *
- * O sinal fica FORA do agrupamento de propósito: aplicar a regex na string com
- * o `-` na frente conta o traço como caractere e desloca os pontos. É o
- * formatador do visualizador de overflow, onde `INT_MIN` é o valor central.
+ * É o formatador do visualizador de overflow, onde `INT_MIN` é o valor central.
+ *
+ * ⚠️ O que separa esta função de {@link thousands} é o TRUNCAR, não o sinal, e a
+ * cópia que ela substituiu dizia o contrário: o comentário lá alegava que
+ * aplicar a regex com o `-` na frente deslocaria os pontos. Não desloca. Em
+ * JavaScript `\B` nunca casa logo depois do `-`, porque ali existe uma fronteira
+ * de palavra de verdade — `-2147483648` sai `"-2.147.483.648"` com ou sem o
+ * tratamento de sinal, e o mesmo vale para todo negativo INTEIRO. Medido em
+ * `tests/format.spec.ts`.
+ *
+ * A diferença que sobra é real e é só para valor fracionário: `-999.6` sai
+ * `"-999"` aqui e `"-1.000"` em {@link thousands}. Nenhum valor que o
+ * visualizador de overflow formata hoje é fracionário (as entradas são inteiras
+ * e `div2` trunca), então esta função existe pela intenção declarada dele —
+ * mostrar a conta que estoura sem arredondar por cima — e não por um texto de
+ * tela que mudaria se ela sumisse.
  */
 export function thousandsSigned(v: number): string {
   const negativo = v < 0;

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,90 @@
+/**
+ * Formatação de número e concordância de plural para os visualizadores.
+ *
+ * Existe porque as mesmas funções estavam copiadas dezenas de vezes em
+ * `content/visualizers/`, e as cópias tinham divergido em silêncio:
+ *
+ * - o formatador de milhar aparecia sob DOIS nomes (`num` e `thousands`) com
+ *   TRÊS comportamentos: o que arredonda, o que mostra uma casa decimal e o que
+ *   preserva o sinal. Nome igual, texto de tela diferente;
+ * - `plural(v, one, many)` tinha a MESMA assinatura e retorno incompatível. Em
+ *   alguns arquivos devolvia `"3 comparações"` e em outros devolvia
+ *   `"comparações"`. Mover uma linha de nota entre dois desses arquivos produzia
+ *   "depois de comparações" ou "3 3 comparações", e o `tsc` aprovava as duas.
+ *
+ * Por isso aqui os nomes dizem o que a função DEVOLVE, em vez de descrever o
+ * assunto dela: `plural` devolve só a palavra, `comNumero` devolve número e
+ * palavra. Trocar um pelo outro vira erro visível na frase, não um detalhe que
+ * só aparece na tela do aluno.
+ *
+ * ⚠️ Nada de `Intl.NumberFormat` aqui, e essa era a nota repetida em quinze das
+ * cópias: o resultado dele depende do locale do ambiente, então o HTML do build
+ * sai diferente do que o cliente renderiza e a hidratação quebra. O agrupamento
+ * é feito à mão, por regex, justamente para o número ser o mesmo dos dois lados.
+ */
+
+/** Agrupa milhar com ponto, do jeito brasileiro. Não mexe em casa decimal. */
+const agrupaMilhar = (s: string): string => s.replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+
+/**
+ * Arredonda para inteiro e agrupa o milhar: `1234567` vira `"1.234.567"`.
+ *
+ * É o formatador da grande maioria dos visualizadores: contadores de operações,
+ * de comparações, de bytes. Para número negativo use {@link thousandsSigned},
+ * porque aqui o `-` entra no agrupamento e desloca os pontos.
+ */
+export function thousands(v: number): string {
+  return agrupaMilhar(String(Math.round(v)));
+}
+
+/**
+ * Uma casa decimal com vírgula, milhar com ponto: `1234.56` vira `"1.234,6"`.
+ * Valor inteiro sai sem casa nenhuma (`2` vira `"2"`, não `"2,0"`).
+ *
+ * É o que o gráfico do Big O usa ao dividir por mil, milhão e bilhão: sem a
+ * casa decimal, `1,4 bi` sairia como `1 bi`.
+ */
+export function thousandsDecimal(v: number): string {
+  const r = Math.round(v * 10) / 10;
+  const txt = Number.isInteger(r) ? String(r) : r.toFixed(1).replace(".", ",");
+  return agrupaMilhar(txt);
+}
+
+/**
+ * Trunca preservando o sinal e agrupa o milhar: `-2147483648` vira
+ * `"-2.147.483.648"`.
+ *
+ * O sinal fica FORA do agrupamento de propósito: aplicar a regex na string com
+ * o `-` na frente conta o traço como caractere e desloca os pontos. É o
+ * formatador do visualizador de overflow, onde `INT_MIN` é o valor central.
+ */
+export function thousandsSigned(v: number): string {
+  const negativo = v < 0;
+  const s = agrupaMilhar(String(Math.abs(Math.trunc(v))));
+  return negativo ? `-${s}` : s;
+}
+
+/**
+ * SÓ a palavra concordada: `plural(1, "caractere", "caracteres")` devolve
+ * `"caractere"`.
+ *
+ * Use quando o número JÁ está escrito na frase, o caso de
+ * `` `${n} ${plural(n, "cópia", "cópias")}` ``. Se o número não estiver lá, o
+ * que você quer é {@link comNumero}.
+ */
+export function plural(v: number, one: string, many: string): string {
+  return v === 1 ? one : many;
+}
+
+/**
+ * Número E palavra concordada: `comNumero(1, "comparação", "comparações")`
+ * devolve `"1 comparação"`.
+ *
+ * Use quando a frase NÃO escreve o número em separado, o caso de
+ * `` `Achei depois de ${comNumero(n, "comparação", "comparações")}.` ``. O
+ * número entra cru, sem agrupamento de milhar: essas contagens são pequenas e o
+ * texto em volta já as apresenta.
+ */
+export function comNumero(v: number, one: string, many: string): string {
+  return `${v} ${plural(v, one, many)}`;
+}

--- a/tests/format.spec.ts
+++ b/tests/format.spec.ts
@@ -170,7 +170,7 @@ test("rotate string: o prefixo que bate concorda sem duplicar o número", async 
 // não "unificar" as três em uma.
 // ---------------------------------------------------------------------------
 
-test("thousands arredonda e agrupa; thousandsDecimal guarda a casa; thousandsSigned guarda o sinal", () => {
+test("thousands arredonda e agrupa; thousandsDecimal guarda a casa; thousandsSigned trunca em vez de arredondar", () => {
   // O caso comum: contador de operações, de cópias, de bytes.
   expect(thousands(0)).toBe("0");
   expect(thousands(999)).toBe("999");
@@ -185,18 +185,30 @@ test("thousands arredonda e agrupa; thousandsDecimal guarda a casa; thousandsSig
   // O ponto do milhar não pode invadir a casa decimal.
   expect(thousandsDecimal(12345.6)).toBe("12.345,6");
 
-  // A variante do overflow: o "-" fica FORA do agrupamento, senão desloca os
-  // pontos e INT_MIN sai como "-2.14.748.3648".
+  // A variante do overflow, onde INT_MIN é o valor central.
   expect(thousandsSigned(-2147483648)).toBe("-2.147.483.648");
   expect(thousandsSigned(2147483647)).toBe("2.147.483.647");
   expect(thousandsSigned(0)).toBe("0");
   expect(thousandsSigned(-1)).toBe("-1");
-  // Trunca, não arredonda: é o que a soma que estoura precisa.
+
+  // O que separa essa variante da primeira é o TRUNCAR, e não o sinal. A cópia
+  // que ela substituiu afirmava o contrário, no comentário logo acima dela: que
+  // o "-" na frente desloca os pontos do agrupamento. Não desloca — em
+  // JavaScript `\B` nunca casa depois do "-", porque ali há fronteira de
+  // palavra. Estas duas linhas são a medição dessa afirmação, e elas reprovam
+  // se alguém "consertar" o agrupamento acreditando no comentário antigo.
+  expect(thousands(-2147483648)).toBe("-2.147.483.648");
+  expect(thousands(-1234567)).toBe(thousandsSigned(-1234567));
+
+  // A diferença que sobra, e é ela que impede fundir as duas: valor fracionário.
   expect(thousandsSigned(-1999.9)).toBe("-1.999");
+  expect(thousands(-1999.9)).toBe("-2.000");
+  expect(thousandsSigned(-999.6)).toBe("-999");
+  expect(thousands(-999.6)).toBe("-1.000");
 
   // A prova de que as três NÃO são a mesma função com nomes diferentes.
   expect(thousandsDecimal(1234.56)).not.toBe(thousands(1234.56));
-  expect(thousandsSigned(-1234)).not.toBe(thousands(-1234));
+  expect(thousandsSigned(-1999.9)).not.toBe(thousands(-1999.9));
 });
 
 test("plural devolve só a palavra e comNumero devolve número mais palavra", () => {

--- a/tests/format.spec.ts
+++ b/tests/format.spec.ts
@@ -241,7 +241,7 @@ test("plural devolve só a palavra e comNumero devolve número mais palavra", ()
 // ficaram como estavam.
 //
 // A prova de que isso não mudou nada tem duas partes: o padrão do hook continua
-// sendo AQUELE array (se alguém retunar `DEFAULT_SPEEDS`, este teste avisa, e
+// sendo AQUELE array (se alguém reafinar `DEFAULT_SPEEDS`, este teste avisa, e
 // aí a decisão volta a ser consciente), e a marcha continua NOMEADA na tela de
 // quem deixou de passar a prop.
 // ---------------------------------------------------------------------------

--- a/tests/format.spec.ts
+++ b/tests/format.spec.ts
@@ -1,0 +1,220 @@
+import { test, expect, type Page } from "@playwright/test";
+
+import { thousands, thousandsDecimal, thousandsSigned, plural, comNumero } from "../src/lib/format";
+
+// Os utilitários que estavam copiados em `content/visualizers/`, agora em
+// `src/lib/format.ts` — e a prova de que unificar não mexeu numa palavra da tela.
+//
+// A parte que importa NÃO é o teste de unidade lá embaixo. É a primeira metade:
+// as frases são montadas em EXECUÇÃO, dentro de template literal, e o HTML do
+// build só carrega o passo 0. Só percorrendo a animação e lendo a frase inteira
+// dá para ver a diferença entre "Achei, depois de 1 comparação." e "Achei,
+// depois de comparação." — as duas compilam, e as duas passam por qualquer
+// contagem de elemento.
+//
+// Por isso cada asserção aqui lê a FRASE, com o número junto da palavra, nos
+// presets que exercitam singular E plural. Trocar `comNumero` por `plural` (ou
+// o contrário) reprova com o texto quebrado no `Received`.
+
+const CONGELA =
+  "*, *::before, *::after { transition: none !important; animation: none !important; }";
+
+async function preparar(page: Page) {
+  await page.evaluate(() => document.fonts.ready);
+  await page.addStyleTag({ content: CONGELA });
+}
+
+/** Abre o painel expandido da peça `i` da página e devolve o `<figure>` dele. */
+async function expandir(page: Page, url: string, i: number) {
+  await page.goto(url);
+  await preparar(page);
+  await page.locator("article figure.viz").nth(i).getByRole("button", { name: /Expandir/ }).click();
+  const painel = page.locator(".viz-overlay figure.viz");
+  await expect(painel).toBeVisible();
+  await preparar(page);
+  return painel;
+}
+
+// ---------------------------------------------------------------------------
+// 1 · O plural que TRAZ o número: HashTableBuscaVisualizer
+//
+// Aqui a frase não escreve o número em separado — quem escreve é a função. Se
+// ela passar a devolver só a palavra, sai "Achei, depois de comparações." e o
+// `tsc` não reclama, porque a assinatura é a mesma.
+// ---------------------------------------------------------------------------
+
+const HASH = "/topico/hash-table/";
+
+/**
+ * A ordem das peças na página, que é o que o `nth()` endereça.
+ *
+ * Em `/topico/hash-table/` o `HashTableOperacoes` é tabela estática, sem casca
+ * e sem overlay: ele não conta. Em `/topico/strings/` as três peças contam.
+ */
+const HASH_BUSCA = 1;
+const STRINGS_CONCAT = 1; // 0 é o StringsBytesVisualizer
+const STRINGS_ROTATE = 2;
+
+/** Clica "Próximo ›" enquanto ele estiver habilitado, no máximo `max` vezes. */
+async function avancar(painel: import("@playwright/test").Locator, max: number) {
+  const proximo = painel.getByRole("button", { name: /Próximo/ });
+  for (let k = 0; k < max; k++) {
+    if (await proximo.isDisabled()) return;
+    await proximo.click();
+  }
+}
+
+test("busca linear: a frase de acerto traz o número junto da palavra, no singular e no plural", async ({
+  page,
+}) => {
+  const painel = await expandir(page, HASH, HASH_BUSCA);
+  const nota = painel.locator(".ht-painel").first().locator("p.viz-note");
+  const proximo = painel.getByRole("button", { name: /Próximo/ });
+
+  // Cenário com o alvo na PRIMEIRA posição: uma comparação só, singular.
+  await painel.getByRole("button", { name: "Alvo na primeira posição" }).click();
+  for (let k = 0; k < 12; k++) {
+    if ((await nota.innerText()).includes("é o alvo")) break;
+    await proximo.click();
+  }
+  expect(await nota.innerText()).toContain('Posição 0: "Ana" é o alvo. Achei, depois de 1 comparação.');
+
+  // Mesmo visualizador, alvo no FIM: oito comparações, plural.
+  await painel.getByRole("button", { name: "Alvo no fim da lista" }).click();
+  for (let k = 0; k < 12; k++) {
+    if ((await nota.innerText()).includes("é o alvo")) break;
+    await proximo.click();
+  }
+  expect(await nota.innerText()).toContain('Posição 7: "Mia" é o alvo. Achei, depois de 8 comparações.');
+});
+
+test("busca linear: a abertura e o cartão de comparações escrevem o número que a palavra concorda", async ({
+  page,
+}) => {
+  const painel = await expandir(page, HASH, HASH_BUSCA);
+  await painel.getByRole("button", { name: "Alvo no fim da lista" }).click();
+
+  // Passo 0, antes de qualquer clique: a nota abre contando os nomes.
+  const nota = painel.locator(".ht-painel").first().locator("p.viz-note");
+  expect(await nota.innerText()).toContain("8 nomes guardados e nenhuma ordem que me ajude");
+
+  // O cartão ao lado do título do painel: número E palavra no mesmo elemento.
+  // Ler só o número aprovaria "8" debaixo de "comparação".
+  const cartao = painel.locator(".ht-painel").first().locator(".ht-painel-tit em");
+  expect(await cartao.innerText()).toBe("0 comparações");
+
+  const proximo = painel.getByRole("button", { name: /Próximo/ });
+  await proximo.click();
+  expect(await cartao.innerText()).toBe("1 comparação");
+  await proximo.click();
+  expect(await cartao.innerText()).toBe("2 comparações");
+});
+
+test("o resumo do pior caso compara os dois números sem perder a palavra", async ({ page }) => {
+  const painel = await expandir(page, HASH, HASH_BUSCA);
+  await painel.getByRole("button", { name: "Com hash ruim" }).click();
+
+  const resumo = painel.locator("p.viz-note").last();
+  await avancar(painel, 30);
+
+  expect(await resumo.innerText()).toContain(
+    "Com todas as chaves no mesmo bucket, a tabela hash faz 8 comparações, o mesmo trabalho da lista."
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 2 · O plural que devolve SÓ a palavra: StringsVisualizer e Strings Rotate
+//
+// Aqui o número já está escrito na frase, ao lado da chamada. Se a função
+// passar a trazer o número, sai "aloco uma string nova de 1 1 caractere".
+// ---------------------------------------------------------------------------
+
+test("montar string caractere a caractere: a volta 1 fala no singular e a volta 2 no plural", async ({
+  page,
+}) => {
+  const painel = await expandir(page, "/topico/strings/", STRINGS_CONCAT);
+  const nota = painel.locator("p.viz-note");
+  const proximo = painel.getByRole("button", { name: /Próximo/ });
+
+  await proximo.click();
+  await expect(nota).toContainText("Volta 1: aloco uma string nova de 1 caractere,");
+  expect(await nota.innerText()).toContain("1 cópia nesta volta, 1 no total.");
+
+  await proximo.click();
+  await expect(nota).toContainText("Volta 2: aloco uma string nova de 2 caracteres,");
+  expect(await nota.innerText()).toContain("2 cópias nesta volta, 3 no total.");
+});
+
+test("rotate string: o prefixo que bate concorda sem duplicar o número", async ({ page }) => {
+  const painel = await expandir(page, "/topico/strings/", STRINGS_ROTATE);
+  const nota = painel.locator("p.viz-note");
+  const proximo = painel.getByRole("button", { name: /Próximo/ });
+
+  // A primeira nota de rotação escreve o tamanho da fatia copiada.
+  for (let k = 0; k < 10; k++) {
+    if ((await nota.innerText()).includes("Rotação 1:")) break;
+    await proximo.click();
+  }
+  const texto = await nota.innerText();
+  expect(texto).toContain("Rotação 1: s[1:] já é uma string nova com 4 caracteres copiados");
+  // O número aparece UMA vez antes da palavra, nunca duas.
+  expect(texto).not.toMatch(/\b(\d+) \1 /);
+});
+
+// ---------------------------------------------------------------------------
+// 3 · As três variantes do formatador de milhar
+//
+// Elas tinham o MESMO nome (`num`) em arquivos diferentes e produziam texto de
+// tela diferente. Estes casos fixam o que cada uma faz, para a próxima pessoa
+// não "unificar" as três em uma.
+// ---------------------------------------------------------------------------
+
+test("thousands arredonda e agrupa; thousandsDecimal guarda a casa; thousandsSigned guarda o sinal", () => {
+  // O caso comum: contador de operações, de cópias, de bytes.
+  expect(thousands(0)).toBe("0");
+  expect(thousands(999)).toBe("999");
+  expect(thousands(1000)).toBe("1.000");
+  expect(thousands(1234567)).toBe("1.234.567");
+  expect(thousands(1234.6)).toBe("1.235"); // arredonda, não trunca
+
+  // A variante do gráfico do Big O: sem ela, "1,4 bi" sairia como "1 bi".
+  expect(thousandsDecimal(1.4)).toBe("1,4");
+  expect(thousandsDecimal(2)).toBe("2"); // inteiro não ganha ",0"
+  expect(thousandsDecimal(1234.56)).toBe("1.234,6");
+  // O ponto do milhar não pode invadir a casa decimal.
+  expect(thousandsDecimal(12345.6)).toBe("12.345,6");
+
+  // A variante do overflow: o "-" fica FORA do agrupamento, senão desloca os
+  // pontos e INT_MIN sai como "-2.14.748.3648".
+  expect(thousandsSigned(-2147483648)).toBe("-2.147.483.648");
+  expect(thousandsSigned(2147483647)).toBe("2.147.483.647");
+  expect(thousandsSigned(0)).toBe("0");
+  expect(thousandsSigned(-1)).toBe("-1");
+  // Trunca, não arredonda: é o que a soma que estoura precisa.
+  expect(thousandsSigned(-1999.9)).toBe("-1.999");
+
+  // A prova de que as três NÃO são a mesma função com nomes diferentes.
+  expect(thousandsDecimal(1234.56)).not.toBe(thousands(1234.56));
+  expect(thousandsSigned(-1234)).not.toBe(thousands(-1234));
+});
+
+test("plural devolve só a palavra e comNumero devolve número mais palavra", () => {
+  expect(plural(1, "caractere", "caracteres")).toBe("caractere");
+  expect(plural(0, "caractere", "caracteres")).toBe("caracteres");
+  expect(plural(2, "caractere", "caracteres")).toBe("caracteres");
+
+  expect(comNumero(1, "comparação", "comparações")).toBe("1 comparação");
+  expect(comNumero(0, "comparação", "comparações")).toBe("0 comparações");
+  expect(comNumero(8, "comparação", "comparações")).toBe("8 comparações");
+
+  // O erro que o `tsc` aprovava: mesma assinatura, retorno incompatível.
+  expect(`Achei depois de ${comNumero(3, "comparação", "comparações")}.`).toBe(
+    "Achei depois de 3 comparações."
+  );
+  expect(`${3} ${plural(3, "cópia", "cópias")}`).toBe("3 cópias");
+  // Trocados, sairia isto — e é o que as asserções acima impedem.
+  expect(`Achei depois de ${plural(3, "comparação", "comparações")}.`).toBe(
+    "Achei depois de comparações."
+  );
+  expect(`${3} ${comNumero(3, "cópia", "cópias")}`).toBe("3 3 cópias");
+});

--- a/tests/format.spec.ts
+++ b/tests/format.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect, type Page } from "@playwright/test";
 
 import { thousands, thousandsDecimal, thousandsSigned, plural, comNumero } from "../src/lib/format";
+import { DEFAULT_SPEEDS, SPEED_LABELS } from "../src/lib/visualizer";
 
 // Os utilitários que estavam copiados em `content/visualizers/`, agora em
 // `src/lib/format.ts` — e a prova de que unificar não mexeu numa palavra da tela.
@@ -217,4 +218,43 @@ test("plural devolve só a palavra e comNumero devolve número mais palavra", ()
     "Achei depois de comparações."
   );
   expect(`${3} ${comNumero(3, "cópia", "cópias")}`).toBe("3 3 cópias");
+});
+
+// ---------------------------------------------------------------------------
+// 4 · Os `SPEEDS` que já eram o padrão do hook
+//
+// Onze visualizadores declaravam `[0, 1400, 950, 650, 420, 250]` e passavam a
+// prop `speeds` com exatamente o valor que o hook já usa quando ninguém passa
+// nada. Eles pararam de passar. Os outros vinte e quatro têm marcha própria e
+// ficaram como estavam.
+//
+// A prova de que isso não mudou nada tem duas partes: o padrão do hook continua
+// sendo AQUELE array (se alguém retunar `DEFAULT_SPEEDS`, este teste avisa, e
+// aí a decisão volta a ser consciente), e a marcha continua NOMEADA na tela de
+// quem deixou de passar a prop.
+// ---------------------------------------------------------------------------
+
+test("o padrão do hook é o array que os onze visualizadores deixaram de repetir", () => {
+  expect([...DEFAULT_SPEEDS]).toEqual([0, 1400, 950, 650, 420, 250]);
+  expect(DEFAULT_SPEEDS.length).toBe(SPEED_LABELS.length);
+});
+
+test("sem a prop `speeds`, o controle de velocidade continua nomeando as marchas", async ({
+  page,
+}) => {
+  // A fila é uma das onze que deixaram de passar a prop.
+  const painel = await expandir(page, "/topico/filas/", 0);
+  const slider = painel.getByRole("slider", { name: "Velocidade" });
+
+  // Marcha inicial: a terceira do array, que a tela chama de "1x".
+  await expect(slider).toHaveAttribute("aria-valuetext", "1x");
+  expect(await painel.locator(".viz-speed .val").innerText()).toBe("1x");
+
+  await slider.fill("5");
+  await expect(slider).toHaveAttribute("aria-valuetext", "2x");
+  expect(await painel.locator(".viz-speed .val").innerText()).toBe("2x");
+
+  await slider.fill("1");
+  await expect(slider).toHaveAttribute("aria-valuetext", "0.5x");
+  expect(await painel.locator(".viz-speed .val").innerText()).toBe("0.5x");
 });


### PR DESCRIPTION
Os mesmos utilitários estavam copiados dezenas de vezes em `content/visualizers/`,
e as cópias tinham divergido em silêncio. Agora eles moram em `src/lib/format.ts`,
com nomes que dizem o que a função devolve.

**A garantia desta PR é que nenhuma palavra de tela mudou**, e ela está medida
mais abaixo.

## O que foi medido, antes

| duplicata | arquivos na `main` | corpos distintos |
|---|---|---|
| `num()` / `thousands()` | 21 | 3 |
| `plural(v, one, many)` | 5 | 2 (retorno incompatível) |
| `SPEEDS` | 35 | 24 distintos, 17 iguais ao padrão do hook |

## O que a PR faz

### 1 · `plural()`, que é o que quebra frase

Cinco arquivos declaravam `plural(v, one, many)` com a **mesma assinatura** e
retorno incompatível: em três a função devolvia `"3 comparações"` e em dois
devolvia `"comparações"`. Mover uma linha de nota entre dois desses arquivos
produzia "depois de comparações" ou "3 3 comparações", e o `tsc` aprovava as
duas.

Viraram dois nomes:

- `plural(v, one, many)` devolve **só a palavra**, para quando o número já está
  escrito na frase;
- `comNumero(v, one, many)` devolve **número mais palavra**.

Cada chamador foi conferido frase a frase. Três dos cinco arquivos entram aqui.

### 2 · O formatador de milhar

O corpo `String(Math.round(v)).replace(/\B(?=(\d{3})+(?!\d))/g, ".")` estava
copiado em **16 visualizadores**, sob dois nomes. Todos importam `thousands`
agora.

As outras duas **não eram cópia**, e por isso ganharam nome próprio em vez de
sumir na unificação:

- `thousandsDecimal` — o gráfico do Big O mostra **uma casa decimal**. Sem ela,
  "1,4 bi" viraria "1 bi".
- `thousandsSigned` — o visualizador de overflow **trunca** em vez de arredondar.

### 3 · Os `SPEEDS` inertes

Onze dos 35 declaravam exatamente `[0, 1400, 950, 650, 420, 250]`, que é byte a
byte o `DEFAULT_SPEEDS` do `useVisualizer`, e passavam a prop `speeds` com o
valor que o hook já usa por padrão. Esses onze pararam de passar.

Os outros 24 têm marcha própria e ficaram: o Sudoku roda em 8ms no passo mais
rápido, o A* em 40ms, a forma de cauda em 900ms. Cada número foi escolhido para
a peça. **O hook não foi tocado.**

## As provas

**1. Diff do texto renderizado, contra a `origin/main`: vazio.**
As 54 páginas de `out/` foram construídas nos dois lados, o texto visível de cada
uma foi extraído (nós de texto mais `aria-label`, `title`, `alt`, `placeholder`,
sem script nem estilo) e comparado. `diff -r` sai **0**, sem uma linha.

Não é o diff do código: é o que o aluno lê.

**2. Guarda de idioma sobre os 23 visualizadores alterados: `TELA intacta`,
exit 0.** Nenhum texto entrou, nenhum saiu. O único literal de código que mudou
é `'@/lib/format'`, e ele não é nome de classe. (O guarda compara **conjunto**,
não posição — por isso quem manda é a prova 1.)

**3. Onde a frase é montada em execução, o teste percorre a animação e lê a
frase inteira**, nos presets que exercitam singular **e** plural. O HTML do build
só carrega o passo 0; sem interagir, nada disso aparece.

**4. Diff normalizado do código.** Trocando os três nomes do formatador por um
token só, **18 de 18** arquivos ficam byte a byte iguais aos de antes, fora a
declaração removida e o import acrescentado.

### Provas de quebra

Cada uma reprova **na linha da asserção**, com o texto errado no `Received`:

| o que quebrei | o que apareceu na tela |
|---|---|
| `comNumero` → `plural` no `HashTableBuscaVisualizer` | `Achei, depois de comparação.` |
| `plural` → `comNumero` no `StringsVisualizer` | `aloco uma string nova de 1 1 caractere` |
| `thousandsDecimal` passa a arredondar | `thousandsDecimal(1.4)` devolve `"1"` |

## Uma correção de documentação, de carona

A cópia do formatador com sinal trazia um comentário afirmando que aplicar a
regex com o `-` na frente **desloca os pontos** do agrupamento. **Não desloca.**
Em JavaScript `\B` nunca casa logo depois do `-`, porque ali há uma fronteira de
palavra de verdade: `-2147483648` sai `"-2.147.483.648"` com ou sem o tratamento
de sinal, e o mesmo vale para todo negativo inteiro.

O que separa `thousandsSigned` de `thousands` é o **truncar**, e a diferença só
aparece em valor fracionário (`-999.6` → `"-999"` contra `"-1.000"`). Nenhum
valor que o visualizador de overflow formata hoje é fracionário. A função ficou
pela intenção declarada dele, com a nota agora dizendo o que é verdade, e as
duas linhas que medem isso estão no teste — para ninguém "consertar" o
agrupamento acreditando no comentário antigo.

## CI

A branch trouxe a `main` com a suíte recalibrada do #68, e com isso a medição
mudou: as 7 reprovações de `regressao-css-celular.spec.ts` que apareciam nos
dois lados **não existem mais**.

Medição de agora, nesta branch, `npm run test:build` na porta 4502:
**676 passed, 0 failed**.

`npm run lint`: **6 problemas, 0 erros** — a baseline da `main`, sem mudança.

⚠️ **Um flake pré-existente, que não é desta PR.** Na primeira rodada,
`tests/navegacao.spec.ts:1892` reprovou com
`pilhas[0]: travou em "passo 1 de 8"`. Repetido isolado, `--repeat-each=3`
passou 3 de 3, e a rodada seguinte da suíte inteira passou 676 de 676.
O `pilhas[0]` é o `<StackImplementacoes />`, e os três arquivos envolvidos
(`content/visualizers/StackImplementacoes.tsx`, `src/lib/visualizer.tsx`,
`tests/navegacao.spec.ts`) estão **byte a byte iguais à `origin/main`** nesta
branch — `git diff origin/main..HEAD` sobre os três sai vazio, e o
`StackImplementacoes` nem importa `src/lib/format.ts`. É instabilidade que já
mora na `main`, e está anotada abaixo.

## O que ficou de fora, e por quê

Arquivos do **PR #66**, que ainda está aberto e é dono deles:

| arquivo:linha | duplicata que ficou |
|---|---|
| `content/visualizers/HashTableVisualizer.tsx:112` | `plural()` do tipo "traz o número" |
| `content/visualizers/SlidingWindowVisualizer.tsx:72` | `plural()` do tipo "traz o número" |
| `content/visualizers/PrefixSumVisualizer.tsx:186` | `num()` |
| `content/visualizers/TailRecursionVisualizer.tsx:75` | `thousands()` |
| `content/visualizers/TailRecursionTrampolim.tsx:62` | `thousands()` |
| `content/visualizers/TwoPointersVisualizer.tsx:53` | `SPEEDS` igual ao padrão |
| `content/visualizers/SlidingWindowVisualizer.tsx:60` | `SPEEDS` igual ao padrão |
| `content/visualizers/PrefixSumVisualizer.tsx:73` | `SPEEDS` igual ao padrão |
| `content/visualizers/HashTableVisualizer.tsx:60` | `SPEEDS` igual ao padrão |
| `content/visualizers/TailRecursionVisualizer.tsx:71` | `SPEEDS` igual ao padrão |
| `content/visualizers/TailRecursionTrampolim.tsx:58` | `SPEEDS` igual ao padrão |

São 6 arquivos, e o trabalho é mecânico depois que o #66 mergear. Os dois
`plural()` são os que merecem cuidado: os dois são do tipo "traz o número", então
vão para `comNumero`.

Fora isso, os 24 `SPEEDS` com marcha própria ficam onde estão, de propósito.

## Revisão

**Erro de digitação em `tests/format.spec.ts:244`** — apontado pelo revisor,
corrigido em 28c3c57.

`retunar` estava errado mesmo, mas a correção sugerida (`retornar`) deixaria o
comentário mentindo: `DEFAULT_SPEEDS` é uma `const` em
`src/lib/visualizer.tsx:57`, não uma função, e a asserção que o comentário
descreve compara o **conteúdo** do array. Não há retorno para o teste guardar —
o que ele avisa é quando alguém **muda os valores**, que é exatamente o risco
criado pela seção 3 desta PR. Ficou **`reafinar`**, que é a leitura que fecha
com o teste e com a metáfora de marcha que o parágrafo usa inteira.

**Varredura de classe.** Se escapou um, provavelmente escapou outro, então em
vez de consertar só aquela linha rodei um corretor sobre as **549 linhas `+`**
desta PR. Não há aspell/hunspell na máquina, então foram dois métodos
independentes sobre a prosa (comentários `//`, blocos `/* */` e conteúdo de
string), com corpus nos 233 arquivos `.mdx/.md/.ts/.tsx/.py` da `origin/main`
(17.072 palavras distintas):

| método | o que compara | suspeitas |
|---|---|---|
| palavra inédita | as 664 palavras da prosa contra o corpus | 47 com 0 ou 1 ocorrência |
| vizinhança por distância de edição | as 66 palavras raras contra as 4.722 frequentes, distância ≤ 2 | 152 pares |

Os dois apontaram `retunar` **sozinhos**, sem eu dizer onde estava — é o
controle que mostra que a varredura funciona. Revisadas as 47 e os 152 à mão,
todo o resto é palavra legítima, flexão que o corpus ainda não tinha, ou
identificador (`comNumero`, `thousandsDecimal`, `thousandsSigned`).
**`retunar` era o único erro de digitação da PR.**

Dois levantados e descartados com verificação: `qui` e `quatri`
(`BinarioBases.tsx:38-39`, `MergeSortNiveis.tsx:35`) são abreviação de
quintilhão e quatrilhão e **já estavam assim na `main`** — esta PR só renomeou
`num` para `thousands` na mesma linha; e `podo` no `RecursionArvoreVisualizer`
é a primeira pessoa de podar.

A correção é uma linha de comentário em arquivo de teste: **nenhuma string
renderizada mudou**, então não houve o que reconferir em 390x844.

## Achado que não foi consertado aqui

`tests/navegacao.spec.ts:1892` — o teste "todo visualizador com passos tem
controles que funcionam" é **flaky** sob a suíte inteira, no
`<StackImplementacoes />` de `/topico/pilhas/`. Ele clica em "Próximo ›" uma vez
e espera 3s o rótulo mudar; sob carga, às vezes não muda a tempo. O arquivo do
teste e o do visualizador são idênticos à `origin/main`, então **é dívida da
`main`, não desta PR**, e consertar aqui sairia da fronteira desta branch.

