### PR TITLE
docs: o código vira open source de verdade, o conteúdo fica da comunidade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,12 @@ português, feito **pela comunidade Craft & Code Club**. Cada tópico tem: algor
 a passo (visualizador), artigo, vídeo, problemas (LeetCode/GeeksforGeeks) e referências.
 
 - Domínio: `https://dsa.craftcodeclub.io`. Repo: `craft-code-club/roadmap-dsa`.
-- Licença: **PolyForm Noncommercial 1.0.0** (uso não comercial). Contribuições sob a mesma.
+- Licença: **dupla**. Código sob **MIT** (open source, uso comercial permitido); conteúdo
+  didático sob **CC BY-NC-SA 4.0**. A fronteira **não é por diretório** — ela atravessa
+  arquivos: num visualizador, o componente é código e as strings didáticas (notas de passo,
+  Python da tela, rótulos que explicam) são conteúdo. Regra completa e exemplos em
+  [`LICENSE`](./LICENSE) e [`LICENSE-CONTENT`](./LICENSE-CONTENT). Contribuições entram sob a
+  licença correspondente ao que a mudança toca.
 
 ## Stack e comandos
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,10 +223,28 @@ liberar a execução.
 
 ## <a name="licenca"></a> Licença
 
-Ao contribuir, você concorda que a sua contribuição será licenciada sob a
-**[PolyForm Noncommercial License 1.0.0](./LICENSE)** — livre para qualquer uso
-**não comercial** (estudo, ensino, comunidade, outros projetos livres). Uso
-comercial não é permitido.
+O repositório tem **duas licenças**, e a sua contribuição entra sob a que
+corresponde ao que você escreveu:
 
-Na prática, é o que garante que o guia siga aberto e gratuito para quem quer
-aprender, sem virar produto de ninguém.
+- **Código** → **[MIT](./LICENSE)**. Componentes, hooks, testes, scripts,
+  configuração, e toda a maquinaria dos visualizadores.
+- **Conteúdo** → **[CC BY-NC-SA 4.0](./LICENSE-CONTENT)**. Artigos MDX,
+  descrições de tópico, e o material didático que mora dentro dos
+  visualizadores: as notas de passo, o código exibido na tela, os rótulos que
+  explicam.
+
+Ao abrir um PR, você concorda com isso para as duas partes — a maioria dos PRs
+daqui mexe nas duas ao mesmo tempo, porque um visualizador é as duas coisas no
+mesmo arquivo.
+
+**A fronteira não é por diretório.** Ela atravessa arquivos individuais, e está
+definida com exemplos na seção "Onde passa a fronteira" do
+[LICENSE](./LICENSE). A pergunta que decide: se esta linha sumisse, quebraria o
+**programa** (código) ou a **aula** (conteúdo)?
+
+Na prática, é o que garante as duas coisas de uma vez: o código é open source
+de verdade, e o conteúdo intelectual segue gratuito para quem quer aprender,
+sem virar produto de ninguém.
+
+Você continua sendo autor do que escreveu. A licença é permissão para o projeto
+e para quem o usa, não transferência de copyright.

--- a/LICENSE
+++ b/LICENSE
@@ -15,8 +15,8 @@ Este repositório guarda duas coisas diferentes, e cada uma tem a sua licença:
                    (Atribuição · NãoComercial · CompartilhaIgual)
                    O material didático. Ver o arquivo LICENSE-CONTENT.
 
-A intenção, em uma frase: **o código é open source de verdade, e o conteúdo
-intelectual é da comunidade.** Quem quiser pegar o motor dos visualizadores e
+A intenção, em uma frase: o código é open source de verdade, e o conteúdo
+intelectual é da comunidade. Quem quiser pegar o motor dos visualizadores e
 construir outra coisa — inclusive um produto pago — pode. Quem quiser pegar os
 artigos e as explicações e vendê-los, não: eles foram escritos para ficar
 gratuitos para quem estuda.
@@ -108,8 +108,14 @@ Os casos fáceis, para referência
     · as strings didáticas dentro de content/visualizers/*.tsx.
 
   CÓDIGO (MIT)
-    · src/** — aplicação, componentes, bibliotecas, CSS.
-    · tests/**, scripts/**, .github/**, e os arquivos de configuração da raiz.
+    · src/** — aplicação, componentes, bibliotecas, CSS, ícone.
+    · tests/**, scripts/**, .github/**, public/**.
+    · os arquivos da raiz, sem exceção. Os de configuração (next.config.ts,
+      playwright.config.ts, eslint.config.mjs, commitlint.config.mjs,
+      tsconfig.json, package.json); o mdx-components.tsx, onde moram os
+      componentes que os artigos usam, como <Callout>; e a documentação do
+      projeto (README.md, CONTRIBUTING.md, CLAUDE.md, CODE_OF_CONDUCT.md,
+      SECURITY.md), que ensina a MEXER no projeto, não a matéria do guia.
     · content/topics/index.ts, e o esqueleto de content/roadmap.ts.
     · a maquinaria dos visualizadores, como descrito acima.
     · a COPY DA INTERFACE em src/** (títulos de seção, botões, o texto da home).

--- a/LICENSE
+++ b/LICENSE
@@ -1,85 +1,147 @@
 Roadmap DSA — o guia visual e gratuito de Algoritmos e Estruturas de Dados.
 Copyright © 2026 Craft & Code Club (https://craftcodeclub.io)
 
-This project (code and content) is licensed under the PolyForm Noncommercial
-License 1.0.0. You are free to use, copy, modify, and share it for ANY
-NONCOMMERCIAL purpose (personal study, education, community, research, other
-open/free projects). COMMERCIAL USE IS NOT PERMITTED.
+================================================================================
+DUAS LICENÇAS, PORQUE SÃO DUAS COISAS
+================================================================================
 
-Required Notice: Copyright © 2026 Craft & Code Club (https://craftcodeclub.io)
+Este repositório guarda duas coisas diferentes, e cada uma tem a sua licença:
+
+  O CÓDIGO      →  MIT
+                   Open source pela definição da OSI. Uso comercial permitido.
+                   Texto integral no fim deste arquivo.
+
+  O CONTEÚDO    →  CC BY-NC-SA 4.0
+                   (Atribuição · NãoComercial · CompartilhaIgual)
+                   O material didático. Ver o arquivo LICENSE-CONTENT.
+
+A intenção, em uma frase: **o código é open source de verdade, e o conteúdo
+intelectual é da comunidade.** Quem quiser pegar o motor dos visualizadores e
+construir outra coisa — inclusive um produto pago — pode. Quem quiser pegar os
+artigos e as explicações e vendê-los, não: eles foram escritos para ficar
+gratuitos para quem estuda.
+
+In short, for readers who do not speak Portuguese: the SOURCE CODE of this
+project is licensed under the MIT License (full text at the end of this file);
+the EDUCATIONAL CONTENT is licensed under Creative Commons
+Attribution-NonCommercial-ShareAlike 4.0 International, see LICENSE-CONTENT.
+The section below defines exactly where the line between the two falls.
+
+
+================================================================================
+ONDE PASSA A FRONTEIRA
+================================================================================
+
+A fronteira NÃO é por diretório. Ela atravessa arquivos individuais, e é por
+isso que esta seção existe: sem ela, um leitor de boa-fé erra.
 
 --------------------------------------------------------------------------------
+A pergunta que decide
 
-# PolyForm Noncommercial License 1.0.0
+    Se esta linha sumisse, o que quebraria: o PROGRAMA ou a AULA?
 
-<https://polyformproject.org/licenses/noncommercial/1.0.0>
+  · Quebra o programa (não compila, o passo não avança, o painel some do
+    layout, o teste falha) ......................... é CÓDIGO      → MIT
 
-## Acceptance
+  · O programa continua rodando e o que se perde é o ENSINO (a explicação, o
+    exemplo, a frase que diz por que aquele passo importa) ..............
+    ............................................... é CONTEÚDO    → CC BY-NC-SA
 
-In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+--------------------------------------------------------------------------------
+O caso que mais confunde: content/visualizers/*.tsx
 
-## Copyright License
+Cada visualizador é um componente React que ensina um algoritmo. Ele é as duas
+coisas ao mesmo tempo, no mesmo arquivo.
 
-The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+É CÓDIGO (MIT) a máquina:
 
-## Distribution License
+  · o componente e os seus tipos — `type Step = { slots, n, writes, line, ... }`
+  · a casca compartilhada — `useVisualizer`, `VizHeader`, `VizFooter`, e todo o
+    `src/lib/visualizer.tsx` que está por trás deles
+  · o gerador de passos: o laço que produz a sequência, o estado, os handlers
+  · a interface genérica: classes de CSS, `role="group"`, `aria-label="Operação"`
 
-The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+É CONTEÚDO (CC BY-NC-SA) o que aquela máquina ENSINA:
 
-## Notices
+  · as notas do passo a passo. Em `ArraysOperacoes.tsx`:
+        note: `Endereço = base + ${k} × tamanho. Leio ${nums[k]} e acabou:
+               1 operação, com 6 posições ou com 6 milhões. Isso é O(1).`
+    O campo `note` é código; a frase guardada dentro dele é conteúdo.
 
-You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+  · o código Python que aparece na tela do aluno. Ainda em
+    `ArraysOperacoes.tsx`, a declaração `const CODE: Record<OpKey, string[]>` é
+    código, e cada linha dentro dela é conteúdo:
+        "    for i in range(n - 1, k - 1, -1):   # do fim até a posição k"
+    Ele não roda: ele é lido. É material didático que por acaso tem a forma de
+    um programa.
 
-> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+  · os títulos e rótulos que ensinam, e não apenas nomeiam:
+        title: "Visualizador · o que cada operação custa de verdade"
 
-## Changes and New Works License
+  · as legendas dos presets, os textos de conclusão, as explicações de cada
+    estado.
 
-The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+E se eu quiser levar o arquivo inteiro? Ele carrega as duas licenças ao mesmo
+tempo, e isso tem consequência prática — ver LICENSE-CONTENT, seção "LEVAR UM
+VISUALIZADOR INTEIRO".
 
-## Patent License
+--------------------------------------------------------------------------------
+A fronteira também corta content/roadmap.ts
 
-The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+Mesma lógica, na direção contrária. `export type Problem = { ... }` e a
+estrutura do arquivo são código (MIT). Já as descrições dos tópicos são texto
+didático (CC BY-NC-SA) — esta, por exemplo:
 
-## Noncommercial Purposes
+    "String é um array de caracteres com duas regras a mais: o elemento não é
+     um byte e você não pode escrever numa posição. É dessa imutabilidade que
+     nasce o O(n²) escondido em qualquer concatenação dentro de um laço."
 
-Any noncommercial purpose is a permitted purpose.
+Isso é uma aula em uma frase. Não vira código por morar num arquivo `.ts`.
 
-## Personal Uses
+--------------------------------------------------------------------------------
+Os casos fáceis, para referência
 
-Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+  CONTEÚDO (CC BY-NC-SA 4.0)
+    · content/topics/*.mdx — os artigos, na íntegra. O componente `<Callout>` é
+      código; o texto escrito dentro dele é conteúdo.
+    · as descrições didáticas de content/roadmap.ts.
+    · as strings didáticas dentro de content/visualizers/*.tsx.
 
-## Noncommercial Organizations
+  CÓDIGO (MIT)
+    · src/** — aplicação, componentes, bibliotecas, CSS.
+    · tests/**, scripts/**, .github/**, e os arquivos de configuração da raiz.
+    · content/topics/index.ts, e o esqueleto de content/roadmap.ts.
+    · a maquinaria dos visualizadores, como descrito acima.
+    · a COPY DA INTERFACE em src/** (títulos de seção, botões, o texto da home).
+      Ela é a moldura do site, não a aula: viaja com o código, sob MIT.
 
-Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+--------------------------------------------------------------------------------
+Ainda em dúvida?
 
-## Fair Use
+Abra uma issue em https://github.com/craft-code-club/roadmap-dsa/issues e
+pergunte. Uma dúvida sua é uma falha desta seção, e a gente conserta o texto.
 
-You may have "fair use" rights for the software under the law. These terms do not limit them.
 
-## No Other Rights
+================================================================================
+MIT License — aplica-se ao CÓDIGO deste repositório
+================================================================================
 
-These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+Copyright © 2026 Craft & Code Club (https://craftcodeclub.io)
 
-## Patent Defense
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-## Violations
-
-The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
-
-## No Liability
-
-***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
-
-## Definitions
-
-The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
-
-**You** refers to the individual or entity agreeing to these terms.
-
-**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
-
-**Your licenses** are all the licenses granted to you for the software under these terms.
-
-**Use** means anything you do with the software requiring one of your licenses.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE-CONTENT
+++ b/LICENSE-CONTENT
@@ -1,0 +1,87 @@
+Roadmap DSA — licença do CONTEÚDO
+Copyright © 2026 Craft & Code Club (https://craftcodeclub.io)
+
+O CONTEÚDO deste repositório — o material didático — está sob a licença
+
+    Creative Commons Atribuição-NãoComercial-CompartilhaIgual 4.0 Internacional
+    (CC BY-NC-SA 4.0)
+
+O CÓDIGO está sob MIT, e a fronteira entre os dois é definida no arquivo
+LICENSE, na seção "ONDE PASSA A FRONTEIRA". Leia-a antes de usar este texto:
+sem ela, este arquivo não diz a que se aplica.
+
+--------------------------------------------------------------------------------
+TEXTO CANÔNICO
+
+Este arquivo é um resumo de orientação, e não substitui a licença. Quem governa
+é o texto oficial da Creative Commons:
+
+    Português:  https://creativecommons.org/licenses/by-nc-sa/4.0/deed.pt-br
+    Inglês:     https://creativecommons.org/licenses/by-nc-sa/4.0/
+    Legal code: https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+
+Em qualquer divergência entre este resumo e o texto canônico, o canônico vence.
+
+--------------------------------------------------------------------------------
+O QUE VOCÊ PODE FAZER
+
+  · COMPARTILHAR — copiar e redistribuir o material em qualquer suporte ou
+    formato.
+  · ADAPTAR — remixar, transformar e criar a partir do material, inclusive
+    traduzir para outro idioma.
+
+De graça, sem pedir permissão, para sempre, desde que respeitadas as três
+condições abaixo.
+
+--------------------------------------------------------------------------------
+AS TRÊS CONDIÇÕES
+
+  ATRIBUIÇÃO (BY)
+    Dê o crédito apropriado, com link para a licença e para a fonte, e indique
+    se mudanças foram feitas. Um crédito que cumpre isso:
+
+        "Roadmap DSA, da comunidade Craft & Code Club
+         (https://dsa.craftcodeclub.io) — CC BY-NC-SA 4.0.
+         Adaptado de <link para a página original>."
+
+    Se você adaptou, diga o que mudou. O crédito não pode sugerir que a
+    comunidade endossa você ou o seu uso.
+
+  NÃO COMERCIAL (NC)
+    Você não pode usar o material para fins primariamente comerciais nem
+    voltados a vantagem comercial ou compensação monetária. Vender um curso
+    montado com estes artigos, colocá-los atrás de um paywall ou usá-los como
+    material de um treinamento pago não é permitido. Usar numa aula gratuita,
+    num grupo de estudo, numa universidade ou num projeto pessoal é.
+
+  COMPARTILHA IGUAL (SA)
+    Se você remixar, transformar ou criar a partir do material, precisa
+    distribuir o resultado sob esta MESMA licença.
+
+E mais uma regra da própria CC: você não pode aplicar termos jurídicos ou
+medidas tecnológicas que restrinjam outras pessoas de fazer o que a licença
+permite.
+
+--------------------------------------------------------------------------------
+LEVAR UM VISUALIZADOR INTEIRO
+
+O caso prático que mais aparece. Um arquivo `content/visualizers/*.tsx` carrega
+as duas licenças ao mesmo tempo: o componente é MIT, as strings didáticas são
+CC BY-NC-SA. Então:
+
+  · Copiar o arquivo INTEIRO, com as notas e o Python da tela, carrega junto a
+    restrição NãoComercial — porque o conteúdo veio junto.
+
+  · Quer usar comercialmente? Fique com a máquina e troque o material didático
+    pelo seu: as notas de passo, o código exibido, os rótulos que explicam. O
+    que sobra é MIT, e é seu para o que quiser.
+
+Não é uma pegadinha, é a linha que a decisão desenhou: a engenharia é de todo
+mundo, a aula é da comunidade.
+
+--------------------------------------------------------------------------------
+SEM GARANTIA
+
+O material é oferecido "no estado em que se encontra", sem garantias de
+qualquer natureza, na maior extensão permitida por lei. A licença canônica
+detalha isenções de garantia e limitações de responsabilidade.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Duas licenças, porque são duas coisas:
   Pegue o motor dos visualizadores e construa o que quiser.
 - **O conteúdo** — [CC BY-NC-SA 4.0](./LICENSE-CONTENT). Os artigos e o material didático
   (inclusive as explicações que moram dentro dos visualizadores): livres para estudar, ensinar
-  e adaptar, com crédito e sem uso comercial.
+  e adaptar, desde que com crédito (BY), sem uso comercial (NC) e com a adaptação distribuída
+  sob esta mesma licença (SA).
 
 A fronteira entre os dois **não é por diretório** — ela atravessa arquivos. A seção
 [Onde passa a fronteira](./LICENSE) explica com exemplos, e a pergunta que decide é: se esta

--- a/README.md
+++ b/README.md
@@ -129,5 +129,14 @@ Toda ajuda é bem-vinda! Veja o [guia de contribuição](./CONTRIBUTING.md) e o
 
 ## Licença
 
-[PolyForm Noncommercial License 1.0.0](./LICENSE): livre para qualquer uso **não comercial**
-(estudo, ensino, comunidade, outros projetos livres). Uso comercial não é permitido.
+Duas licenças, porque são duas coisas:
+
+- **O código** — [MIT](./LICENSE). Open source pela definição da OSI, uso comercial permitido.
+  Pegue o motor dos visualizadores e construa o que quiser.
+- **O conteúdo** — [CC BY-NC-SA 4.0](./LICENSE-CONTENT). Os artigos e o material didático
+  (inclusive as explicações que moram dentro dos visualizadores): livres para estudar, ensinar
+  e adaptar, com crédito e sem uso comercial.
+
+A fronteira entre os dois **não é por diretório** — ela atravessa arquivos. A seção
+[Onde passa a fronteira](./LICENSE) explica com exemplos, e a pergunta que decide é: se esta
+linha sumisse, quebraria o **programa** (código) ou a **aula** (conteúdo)?

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "description": "DSA Visual — o guia visual e gratuito de Algoritmos e Estruturas de Dados, feito pela comunidade Craft & Code Club.",
   "license": "MIT",
-  "licenseNote": "O CÓDIGO deste pacote é MIT. O CONTEÚDO didático do repositório (artigos MDX e as strings didáticas dentro dos visualizadores) é CC BY-NC-SA 4.0. A fronteira está definida em ./LICENSE.",
+  "licenseNote": "O CÓDIGO deste pacote é MIT. O CONTEÚDO didático do repositório (artigos MDX e as strings didáticas dentro dos visualizadores) é CC BY-NC-SA 4.0: crédito (BY), sem uso comercial (NC) e adaptação distribuída sob esta mesma licença (SA). A fronteira está definida em ./LICENSE.",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "description": "DSA Visual — o guia visual e gratuito de Algoritmos e Estruturas de Dados, feito pela comunidade Craft & Code Club.",
+  "license": "MIT",
+  "licenseNote": "O CÓDIGO deste pacote é MIT. O CONTEÚDO didático do repositório (artigos MDX e as strings didáticas dentro dos visualizadores) é CC BY-NC-SA 4.0. A fronteira está definida em ./LICENSE.",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/public/_headers
+++ b/public/_headers
@@ -27,9 +27,10 @@
 # O risco aqui NÃO é sequestro de clique: o site é estático, não tem login, não
 # tem formulário e não tem ação destrutiva atrás de um clique. O risco é
 # republicação: envelopar o guia inteiro num iframe de um site com anúncios e
-# servir o nosso conteúdo como se fosse dele. A licença do repositório é
-# PolyForm Noncommercial 1.0.0, e esse uso a contraria. `DENY` é o único
-# cabeçalho que o navegador aplica sem depender de o outro site colaborar.
+# servir o nosso conteúdo como se fosse dele. O conteúdo didático está sob
+# CC BY-NC-SA 4.0, e esse uso contraria as duas cláusulas de uma vez: é
+# comercial (NC) e sem crédito (BY). `DENY` é o único cabeçalho que o navegador
+# aplica sem depender de o outro site colaborar.
 #
 # Não quebra nada, e a direção é o que importa: o único iframe do projeto é de
 # SAÍDA (o embed do YouTube em `src/app/topico/[slug]/page.tsx`, que é a nossa

--- a/public/_headers
+++ b/public/_headers
@@ -28,7 +28,7 @@
 # tem formulário e não tem ação destrutiva atrás de um clique. O risco é
 # republicação: envelopar o guia inteiro num iframe de um site com anúncios e
 # servir o nosso conteúdo como se fosse dele. O conteúdo didático está sob
-# CC BY-NC-SA 4.0, e esse uso contraria as duas cláusulas de uma vez: é
+# CC BY-NC-SA 4.0, e esse uso contraria duas das três cláusulas de uma vez: é
 # comercial (NC) e sem crédito (BY). `DENY` é o único cabeçalho que o navegador
 # aplica sem depender de o outro site colaborar.
 #


### PR DESCRIPTION
A `LICENSE` cobria **"code and content"** num bloco só, sob **PolyForm Noncommercial 1.0.0** — que **não é open source pela definição da OSI**, porque proíbe uso comercial. A home dizia "open source", a licença dizia outra coisa, e o PR #67 estava prestes a resolver a contradição apagando a palavra da home.

Este PR resolve pelo outro lado: **a palavra fica, e a licença passa a sustentá-la.**

| dimensão | antes | agora |
|---|---|---|
| **código** | PolyForm Noncommercial 1.0.0 | **MIT** |
| **conteúdo** (artigos MDX, textos) | PolyForm Noncommercial 1.0.0 | **CC BY-NC-SA 4.0** |
| **visualizadores** (`content/visualizers/*.tsx`) | PolyForm Noncommercial 1.0.0 | **componente é código (MIT); strings didáticas são conteúdo (CC BY-NC-SA)** |

A intenção em uma frase: **o código é open source de verdade, e o conteúdo intelectual é da comunidade.** Quem quiser pegar o motor dos visualizadores e construir outra coisa — inclusive um produto pago — pode. Quem quiser pegar os artigos e vendê-los, não.

## A relicenciação é limpa: um único titular

Relicenciar para algo **mais permissivo** exige o aval de todo detentor de copyright. Conferido antes de escrever qualquer linha:

```
$ git log --format='%aN <%aE>' | sort -u
Wilson Gomes <20674439+wilsongomes-swe@users.noreply.github.com>
Wilson Neto  <20674439+wilsonneto-swe@users.noreply.github.com>
```

Dois nomes, **um titular**: os dois endereços carregam o mesmo ID de usuário do GitHub, `20674439`. `wilsongomes-swe` e `wilsonneto-swe` são a mesma conta, renomeada. **Zero contribuidores externos**, logo nada a consentir.

O conjunto de *committers* confirma (só o mesmo autor mais o `GitHub <noreply@github.com>` dos merges pela interface).

## A estrutura escolhida, e por quê

Dois arquivos:

- **`LICENSE`** — o documento de entrada. Diz que são duas licenças, define **onde passa a fronteira** com exemplos, e traz o **texto integral da MIT** com `Copyright © 2026 Craft & Code Club`.
- **`LICENSE-CONTENT`** — CC BY-NC-SA 4.0: o que a licença permite, as três condições, e o **ponteiro para o texto canônico** (PT-BR, EN e o *legal code*), com a nota explícita de que o canônico vence em qualquer divergência.

**Por que a explicação vive na `LICENSE`, e não num terceiro arquivo.** A alternativa óbvia era deixar a `LICENSE` com a MIT pura e pôr o roteiro num `LICENSING.md`. Ela foi descartada porque cria exatamente o erro que este PR existe para evitar: alguém abre `LICENSE`, lê "MIT", e conclui que os artigos são MIT. **O arquivo que as pessoas abrem primeiro não pode deixar ninguém sair com a conclusão errada.**

**O custo assumido.** Com um preâmbulo antes do texto da MIT, o detector de licenças do GitHub pode marcar o repositório como "Other" em vez de exibir o selo "MIT" na barra lateral. Achei o preço justo: o selo é conveniência, e um leitor concluindo a licença errada é dano. A resposta legível por máquina existe do mesmo jeito, no `package.json`.

**Por que a MIT em inglês e o resto em português.** O texto da MIT é **verbatim** — tradução não é a licença. As partes explicativas ficam em português, como o resto dos guias, com um parágrafo curto em inglês no topo para quem cair aqui de fora.

## A fronteira: a parte que exigia cuidado

**A fronteira não é por diretório.** Ela atravessa arquivos individuais. Um `content/visualizers/*.tsx` é as duas coisas ao mesmo tempo, no mesmo arquivo.

Em vez de uma lista de pastas, que envelhece e não decide caso novo, a `LICENSE` traz **a pergunta que decide**:

> Se esta linha sumisse, o que quebraria: o **PROGRAMA** ou a **AULA**?
>
> - Quebra o programa (não compila, o passo não avança, o painel some) → **código, MIT**
> - O programa continua rodando e o que se perde é o **ensino** → **conteúdo, CC BY-NC-SA**

Os exemplos são citados do código de hoje, com o texto real. De `ArraysOperacoes.tsx`:

| trecho | lado |
|---|---|
| `type Step = { slots, n, writes, line, ... }` | código |
| `useVisualizer`, `VizHeader`, `VizFooter` | código |
| o gerador de passos, o estado, os handlers | código |
| `role="group"`, `aria-label="Operação"` | código (moldura de UI) |
| a declaração `const CODE: Record<OpKey, string[]>` | código |
| `"    for i in range(n - 1, k - 1, -1):   # do fim até a posição k"` | **conteúdo** |
| ``note: `Endereço = base + ${k} × tamanho. (...) Isso é O(1).` `` | **conteúdo** |
| `title: "Visualizador · o que cada operação custa de verdade"` | **conteúdo** |

O campo `note` é código; a frase guardada dentro dele é conteúdo. O Python do `CODE` **não roda: ele é lido** — é material didático que por acaso tem a forma de um programa.

**E a fronteira corta na direção contrária também**, o que é a melhor prova de que "por diretório" não funcionaria. Em `content/roadmap.ts`, `export type Problem = { ... }` é código, e isto é aula:

> "String é um array de caracteres com duas regras a mais: o elemento não é um byte e você não pode escrever numa posição. É dessa imutabilidade que nasce o O(n²) escondido em qualquer concatenação dentro de um laço."

Não vira código por morar num arquivo `.ts`.

**O caso prático que vai aparecer** está respondido em `LICENSE-CONTENT`: copiar um visualizador **inteiro** carrega junto a restrição NãoComercial, porque o conteúdo veio junto. Quem quer usar comercialmente fica com a máquina e troca o material didático pelo seu. A engenharia é de todo mundo, a aula é da comunidade.

## `package.json`: `"MIT"`, e não um SPDX composto

O campo `license` **não existia**. Agora existe, com `"MIT"` mais um `licenseNote`.

O pacote npm é o código: os artigos MDX não são distribuídos como pacote, eles são o site. `"MIT"` é a resposta honesta para "sob que licença está o código deste pacote", e é um identificador SPDX limpo.

`"MIT AND CC-BY-NC-SA-4.0"` seria pior, mesmo sendo SPDX válido: faria toda ferramenta de *compliance* marcar o **código** como restrito a uso não comercial — exatamente o contrário da decisão. O `licenseNote` conta a história inteira e aponta para a `LICENSE`.

## A varredura: 3 citações previstas, 4 encontradas

**Antes** (`grep -rn "PolyForm\|Noncommercial\|não comercial"`, `*.md` `*.ts` `*.tsx`):

```
README.md:132        [PolyForm Noncommercial License 1.0.0](./LICENSE): livre para qualquer uso **não comercial**
CONTRIBUTING.md:227  **[PolyForm Noncommercial License 1.0.0](./LICENSE)** — livre para qualquer uso
CONTRIBUTING.md:228  **não comercial** (estudo, ensino, comunidade, outros projetos livres). Uso
CLAUDE.md:13         - Licença: **PolyForm Noncommercial 1.0.0** (uso não comercial). Contribuições sob a mesma.
```

**A quarta, que esse grep não acha.** Achado é amostra de uma classe, então repeti a varredura sobre `git ls-files` inteiro, **sem filtro de extensão**:

```
public/_headers:30   # servir o nosso conteúdo como se fosse dele. A licença do repositório é
public/_headers:31   # PolyForm Noncommercial 1.0.0, e esse uso a contraria.
```

`_headers` não tem extensão, então `--include='*.md' --include='*.ts'` passa por cima dele.

**Depois** — varredura final sobre todos os arquivos rastreados, sem filtro:

```
$ git ls-files | grep -v package-lock | xargs grep -n "PolyForm\|Noncommercial\|noncommercial\|NONCOMMERCIAL"
$ echo $?
1
```

**Zero.** Nenhuma menção órfã, e nenhuma nota histórica deixada de propósito.

<details>
<summary>Sobre <code>public/_headers</code>: uma extensão de fronteira que declaro</summary>

`public/` não estava na fronteira que recebi (`LICENSE`, arquivos novos de licença, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`, `package.json`). Toquei nele mesmo assim, e o commit é separado (`6a23b4a`) justamente para ser fácil de descartar se você discordar.

O raciocínio: é uma **citação de licença**, que é exatamente a classe de coisa que este PR conserta, e deixá-la contradiria a prova de "zero menções órfãs". É uma linha de **comentário** — o Cloudflare ignora tudo que começa com `#` —, então nenhum cabeçalho servido muda.

O argumento do comentário (por que `X-Frame-Options: DENY`) **sobrevive e fica mais forte**: republicar o guia num iframe com anúncios, sob CC BY-NC-SA, quebra duas cláusulas de uma vez — a comercial (NC) e a de crédito (BY).
</details>

## O que muda para quem contribui

O `CONTRIBUTING.md` é o arquivo mais importante dos três, porque é o que o contribuidor lê **antes** de abrir PR, e o que ele aceitava mudou. Agora ele diz:

- a contribuição entra sob a licença **correspondente ao que foi escrito** — código sob MIT, material didático sob CC BY-NC-SA;
- **a maioria dos PRs daqui mexe nas duas ao mesmo tempo**, porque um visualizador é as duas coisas no mesmo arquivo;
- o autor **continua sendo autor**: a licença é permissão para o projeto e para quem o usa, não transferência de copyright.

Os três guias apontam para a seção da fronteira em vez de repetirem a regra, para não existir uma segunda cópia que envelheça sozinha.

## Relação com o PR #67

O #67 tinha dois consertos. O dos **números (47 → 36) continua certo e fica**. O que trocava **"open source" → "código no GitHub"** deixou de fazer sentido: com MIT, "open source" passa a ser **verdade**. Esse commit está sendo **revertido no próprio #67**, com o teste que o acompanhava.

Consequência direta: **`src/lib/og.tsx:93`** — o array `["100% grátis", "open source", "feito pela comunidade"]` dos selos do card de compartilhamento — estava inventariado como pendência a corrigir e **agora está correto**. Não deve ser mexido.

## Rodada de revisão: a cláusula que faltava nos resumos

Duas threads apontaram a mesma omissão, e as duas procediam. O resumo da licença de conteúdo enumerava **BY e NC** e parava aí. Quem lê "com crédito e sem uso comercial" conclui que pode adaptar sob licença fechada — e a **CompartilhaIgual (SA)** proíbe exatamente isso. É texto que orienta quem for reusar o material, então a imprecisão custa caro.

Consertado em `4c727d9`, e a varredura da classe conferiu **os 9 resumos da licença de conteúdo** que existem no repositório:

| onde | veredito |
|---|---|
| `README.md:136` | enumerava BY e NC em prosa — **omitia SA, corrigido** |
| `package.json:7` (`licenseNote`) | citava só o identificador — **expandido para as três siglas** |
| `public/_headers:31` | dizia "contraria **as duas** cláusulas de uma vez" — **virou "duas das três"**; o artigo definido fazia a licença parecer ter duas |
| `CONTRIBUTING.md:231` | ok — identificador e escopo, sem enumerar condição |
| `CLAUDE.md:13` | ok — identificador e fronteira, sem enumerar condição |
| `LICENSE:14` | ok — "(Atribuição · NãoComercial · CompartilhaIgual)" |
| `LICENSE:18` | ok — declarado como intenção, logo abaixo da expansão completa |
| `LICENSE:26` (inglês) | ok — "Attribution-NonCommercial-ShareAlike" |
| `LICENSE-CONTENT:37` | ok — é o texto de referência, com um parágrafo por cláusula |

Dois resumos incompletos e um terceiro com a mesma imprecisão de **forma**: enumeração parcial escrita como se fosse completa. Os seis restantes ou citam as três cláusulas, ou não citam nenhuma — e nenhum resumo é melhor que resumo que omite cláusula.

Uma correção de premissa que vale registrar: o `licenseNote` **não** dizia "com crédito e sem uso comercial", como a thread supôs. Ele trazia o identificador canônico, que já contém o SA. O que sustentou o conserto foi a outra metade do argumento — o campo pode ser lido isoladamente por ferramenta, longe do `LICENSE` que ele referencia.

**Nada renderizado mudou.** Depois do build, `grep -rl "uso comercial\|BY-NC-SA\|CompartilhaIgual" out/` devolve **um único arquivo**: o próprio `out/_headers`, que o Pages lê e não serve. Nenhuma página HTML carrega esses textos, então não houve o que reconferir em 390x844. E nenhum teste ou código lê as strings: `grep -rn "licenseNote\|LICENSE-CONTENT\|BY-NC-SA" tests/ scripts/ src/ .github/` não devolve nada.

## Verificação

- Suíte inteira ✅ — **667 passed (1,9 min)**, via `npm run test:build` na porta 4503.
- `npm run lint` ✅ — **6 problemas, 0 erros**, idêntico à baseline da `main`.
- `package.json` continua JSON válido, com `license` lendo `MIT`.
- Cada afirmação da `LICENSE` foi conferida contra o repositório de hoje: os trechos citados de `ArraysOperacoes.tsx` e de `content/roadmap.ts` são texto real.
- **A lista de "casos fáceis" foi conferida por máquina, não por releitura**: toda entrada de `git ls-files` tem que cair em algum item da lista. A conferência achou dois buracos que a releitura não tinha achado — `mdx-components.tsx` (onde mora o `<Callout>` que os 36 artigos usam, justamente o arquivo que alguém consultaria depois de ler a seção da fronteira) e `eslint.config.mjs`/`public/**` debaixo de um vago "arquivos de configuração da raiz". Fechados no commit `6b045ff`.
- Guarda de commit, pelo `stdin`, com uma linha por commit:

```
$ git log --format="%s" origin/main..HEAD | python3 scripts/guarda-commit.py
✓ docs: citar a cláusula compartilha igual nos resumos da licença
✓ docs: fechar as lacunas da lista de casos fáceis da licença
✓ docs: corrigir a citação de licença no comentário do _headers
✓ chore: declarar mit no campo license do package.json
✓ docs: atualizar as citações de licença nos guias
✓ docs: relicenciar código como mit e conteúdo como cc by-nc-sa
✓ 6 header(s) checado(s).
```

Nenhum arquivo de `src/**`, `content/**`, `tests/**`, `.github/**` foi tocado, e o `package.json` mudou **só** no campo de licença — nenhuma dependência, nenhum script (`scripts/` é do #65).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3BfAzcaMzDmPLn9xFnHVv

