### PR TITLE
fix(roadmap): a aula de sliding window tem 2:08:22, não 18:24

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -230,7 +230,7 @@ export const GROUPS: Group[] = [
         status: "ready",
         viz: "sliding-window",
         youtube: yt("OvIJw1AMNzI"),
-        videoMinutes: "18:24",
+        videoMinutes: "2:08:22",
         readingTime: "12 min",
         language: "Python",
         description: "Uma janela contígua que anda pelo array. Fixa, com tamanho travado em k, ou variável, crescendo pela direita e encolhendo pela esquerda enquanto está inválida.",


### PR DESCRIPTION
A página de `sliding-window` anuncia **· 18:24** ao lado do vídeo desde que o
tópico foi publicado. O vídeo é o mesmo — o id `OvIJw1AMNzI` não mudou —, mas
ele dura **7702 segundos**: duas horas e oito minutos.

## Como isso foi conferido

Na fonte, no `lengthSeconds` que o próprio YouTube publica na página de watch:

```
$ curl -s "https://www.youtube.com/watch?v=OvIJw1AMNzI" | grep -o '"lengthSeconds":"[0-9]*"'
"lengthSeconds":"7702"
```

E o título confirma que é a aula certa: *#008: Sliding Window Pattern — Subarray
Problems*.

## Por que não é cosmético

Um rótulo de duração que erra por **6,9x** muda a decisão de quem lê. Quem tem
vinte minutos abre a aula achando que dá tempo, e descobre no meio que não dá.
É o único número da página que o aluno usa para se planejar.

## Os outros 33 estão certos

A duração das **34** aulas foi conferida contra o YouTube, uma a uma, comparando
o `videoMinutes` do `content/roadmap.ts` com o `lengthSeconds` da página de
watch. `sliding-window` é a **única** divergência — as outras 33 batem ao
segundo.

## Como provar

```
npm run build
grep -o "2:08:22" out/topico/sliding-window/index.html
```

Nenhum teste ou conteúdo do repositório cita `18:24` (`grep -rn "18:24" tests/
content/ src/` devolve zero), então não há assertiva presa ao valor antigo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUbtzKsXafUrmiFM3gPMYz