### PR TITLE
feat(seo): a aula gravada declara a data e sai marcada como VideoObject

### DIFF
--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -63,12 +63,18 @@ type TopicBase = {
 // publicado, ou não tem nem um nem outro. Não existe meio-termo, e é o
 // compilador que garante isso — `youtube` sem `videoUploadDate` não compila.
 //
-// Por que uma UNIÃO e não mais um campo opcional: `VideoObject` (o JSON-LD que
-// põe a aula na aba Vídeos do Google) exige `uploadDate`. Campo opcional deixa
-// o próximo tópico entrar sem data, e a marcação dele sai silenciosamente
-// incompleta — ninguém quebra, o vídeo só não aparece na busca. A união move
-// esse esquecimento para o `tsc`, que é onde ele custa trinta segundos em vez
-// de uma auditoria de SEO.
+// Por que uma UNIÃO e não mais um campo opcional: `VideoObject` exige
+// `uploadDate`. Campo opcional deixa o próximo tópico entrar sem data, e a
+// marcação dele sai silenciosamente incompleta — ninguém quebra, o dado só sai
+// errado. A união move esse esquecimento para o `tsc`, que é onde ele custa
+// trinta segundos.
+//
+// E o que a união NÃO compra: a aba Vídeos do Google. Desde 04/12/2023 ela só
+// mostra páginas onde o vídeo é o CONTEÚDO PRINCIPAL, e uma página de tópico
+// daqui é artigo + visualizadores + uma seção de vídeo no fim. A união existe
+// para a marcação nunca sair pela metade, não para ganhar posição em busca —
+// quem ler isto daqui a um ano não deve inferir um benefício que esta forma de
+// página não pode receber.
 //
 // O custo medido de escolher a união: ZERO. Os 8 pontos do código que leem
 // `t.youtube` continuam compilando sem uma linha de mudança (o tipo lido segue

--- a/content/roadmap.ts
+++ b/content/roadmap.ts
@@ -31,15 +31,15 @@ export type VideoLink = { title: string; youtube?: string; url?: string; duratio
 // Referências / "leia mais": links para artigos (do blog ou de qualquer site).
 export type Reference = { title: string; url: string; source?: string };
 
-export type Topic = {
+// Tudo que um tópico tem com ou sem aula gravada. Os campos do vídeo NÃO moram
+// aqui: eles andam em bloco, e quem decide isso é o `Topic` logo abaixo.
+type TopicBase = {
   slug: string;
   name: string;
   group: string;
   level: Level;
   description: string;
   status: "ready" | "soon";
-  youtube?: string; // id do vídeo
-  videoMinutes?: string;
   article?: string; // url do artigo/aula no blog
   repo?: string; // implementação de referência
   viz?: Visualizer;
@@ -58,6 +58,35 @@ export type Topic = {
   extraVideos?: VideoLink[];
   references?: Reference[];
 };
+
+// A aula gravada é um pacote: ou o tópico tem vídeo E a data em que ele foi
+// publicado, ou não tem nem um nem outro. Não existe meio-termo, e é o
+// compilador que garante isso — `youtube` sem `videoUploadDate` não compila.
+//
+// Por que uma UNIÃO e não mais um campo opcional: `VideoObject` (o JSON-LD que
+// põe a aula na aba Vídeos do Google) exige `uploadDate`. Campo opcional deixa
+// o próximo tópico entrar sem data, e a marcação dele sai silenciosamente
+// incompleta — ninguém quebra, o vídeo só não aparece na busca. A união move
+// esse esquecimento para o `tsc`, que é onde ele custa trinta segundos em vez
+// de uma auditoria de SEO.
+//
+// O custo medido de escolher a união: ZERO. Os 8 pontos do código que leem
+// `t.youtube` continuam compilando sem uma linha de mudança (o tipo lido segue
+// `string | undefined`), e `npx tsc --noEmit` fica limpo. O que ela reprova é
+// só o caso que interessa: um tópico com `youtube` e sem `videoUploadDate`
+// para no `tsc` com "Property 'videoUploadDate' is missing".
+//
+// `?: never` (e não a ausência do campo) no ramo sem aula é o que faz o
+// estreitamento funcionar: depois de `if (t.youtube)`, o TypeScript sabe que o
+// ramo é o `ComAula` e que `t.videoUploadDate` é `string`, sem `!` nem cast.
+type ComAula = {
+  youtube: string; // id do vídeo
+  videoUploadDate: string; // ISO 8601 com fuso, como o YouTube publica
+  videoMinutes?: string; // "H:MM:SS", o que a página mostra ao lado do embed
+};
+type SemAula = { youtube?: never; videoUploadDate?: never; videoMinutes?: never };
+
+export type Topic = TopicBase & (ComAula | SemAula);
 
 export type Group = {
   id: string;
@@ -84,6 +113,7 @@ export const GROUPS: Group[] = [
         viz: "big-o",
         youtube: yt("MtLv9Rwb55Q"),
         videoMinutes: "1:38:08",
+        videoUploadDate: "2024-02-22T13:42:16-08:00",
         readingTime: "10 min",
         language: "Python",
         description: "Como medir tempo e espaço de um algoritmo sem cronômetro.",
@@ -117,6 +147,7 @@ export const GROUPS: Group[] = [
         viz: "arrays",
         youtube: yt("c95xvXCU34A"),
         videoMinutes: "2:15:08",
+        videoUploadDate: "2024-03-02T06:00:26-08:00",
         readingTime: "16 min",
         language: "Python",
         description: "A estrutura sequencial base: acesso por índice em O(1).",
@@ -144,6 +175,7 @@ export const GROUPS: Group[] = [
         viz: "strings",
         youtube: yt("B9CCEwjoXBk"),
         videoMinutes: "1:45:57",
+        videoUploadDate: "2024-03-04T06:00:13-08:00",
         readingTime: "16 min",
         language: "Python",
         description: "String é um array de caracteres com duas regras a mais: o elemento não é um byte e você não pode escrever numa posição. É dessa imutabilidade que nasce o O(n²) escondido em qualquer concatenação dentro de um laço.",
@@ -202,6 +234,7 @@ export const GROUPS: Group[] = [
         viz: "two-pointers",
         youtube: yt("a1QMdXgcQwY"),
         videoMinutes: "1:11:13",
+        videoUploadDate: "2024-03-28T07:00:01-07:00",
         readingTime: "18 min",
         language: "Python",
         description: "Dois índices caminhando na mesma passada. Em array ordenado, um começa na ponta esquerda e o outro na direita, e eles convergem.",
@@ -231,6 +264,7 @@ export const GROUPS: Group[] = [
         viz: "sliding-window",
         youtube: yt("OvIJw1AMNzI"),
         videoMinutes: "18:24",
+        videoUploadDate: "2024-04-01T04:00:17-07:00",
         readingTime: "12 min",
         language: "Python",
         description: "Uma janela contígua que anda pelo array. Fixa, com tamanho travado em k, ou variável, crescendo pela direita e encolhendo pela esquerda enquanto está inválida.",
@@ -258,6 +292,7 @@ export const GROUPS: Group[] = [
         viz: "prefix-sum",
         youtube: yt("yMnLofkS7DM"),
         videoMinutes: "1:42:35",
+        videoUploadDate: "2024-04-15T04:00:49-07:00",
         readingTime: "18 min",
         language: "Python",
         description: "Somas de intervalo em tempo constante depois de um pré-processamento.",
@@ -317,6 +352,7 @@ export const GROUPS: Group[] = [
         viz: "hash-table",
         youtube: yt("JFhdCBrKTX0"),
         videoMinutes: "2:31:40",
+        videoUploadDate: "2024-04-24T07:00:20-07:00",
         readingTime: "19 min",
         language: "Python",
         description: "Busca, inserção e remoção em O(1) amortizado, quase sempre. A chave calcula o próprio endereço, e o preço disso é colisão, fator de carga e rehash.",
@@ -351,6 +387,7 @@ export const GROUPS: Group[] = [
         viz: "listas-ligadas",
         youtube: yt("j0E5hJZ__EA"),
         videoMinutes: "2:00:47",
+        videoUploadDate: "2024-03-13T07:00:28-07:00",
         readingTime: "23 min",
         language: "Python",
         description: "Nós apontando para nós. Ponteiro rápido e lento, sentinelas e detecção de ciclos.",
@@ -378,6 +415,7 @@ export const GROUPS: Group[] = [
         viz: "skip-list",
         youtube: yt("R9sVLuJ7FSg"),
         videoMinutes: "1:58:55",
+        videoUploadDate: "2025-08-12T06:19:46-07:00",
         article: "https://craftcodeclub.io/posts/dsa-skip-list",
         readingTime: "19 min",
         language: "Python",
@@ -412,6 +450,7 @@ export const GROUPS: Group[] = [
         viz: "pilhas",
         youtube: yt("JRbrNgsYuT0"),
         videoMinutes: "2:26:51",
+        videoUploadDate: "2024-04-29T07:00:14-07:00",
         readingTime: "17 min",
         language: "Python",
         description: "LIFO: parênteses balanceados e próximo maior elemento (pilha monotônica).",
@@ -439,6 +478,7 @@ export const GROUPS: Group[] = [
         viz: "filas",
         youtube: yt("KJaVKLZsMcg"),
         videoMinutes: "2:03:02",
+        videoUploadDate: "2024-06-19T04:00:15-07:00",
         readingTime: "19 min",
         language: "Python",
         description: "FIFO e a fila de duas pontas para a janela com máximo.",
@@ -473,6 +513,7 @@ export const GROUPS: Group[] = [
         viz: "recursao",
         youtube: yt("KkSAaQHCkSE"),
         videoMinutes: "1:59:28",
+        videoUploadDate: "2024-05-06T15:00:16-07:00",
         readingTime: "17 min",
         language: "Python",
         description: "Funções que chamam a si mesmas, sem medo do stack.",
@@ -500,6 +541,7 @@ export const GROUPS: Group[] = [
         viz: "recursao-funcional",
         youtube: yt("rbEYjJdaIZI"),
         videoMinutes: "2:21:37",
+        videoUploadDate: "2024-06-12T04:00:51-07:00",
         readingTime: "16 min",
         language: "Python",
         description: "Recursão de cauda e o estilo funcional.",
@@ -533,6 +575,7 @@ export const GROUPS: Group[] = [
         viz: "tree-traversals",
         youtube: yt("_-2F65OVWjo"),
         videoMinutes: "1:49:46",
+        videoUploadDate: "2024-06-21T04:00:37-07:00",
         readingTime: "12 min",
         language: "Python",
         description: "Pré, in, pós-ordem e por nível.",
@@ -560,6 +603,7 @@ export const GROUPS: Group[] = [
         viz: "arvores-binarias",
         youtube: yt("OAcm2rXqz9M"),
         videoMinutes: "1:50:49",
+        videoUploadDate: "2024-06-26T04:00:18-07:00",
         readingTime: "10 min",
         language: "Python",
         description: "Recursão estrutural sobre dois filhos.",
@@ -588,6 +632,7 @@ export const GROUPS: Group[] = [
         viz: "n-ary-trees",
         youtube: yt("FLZxMQFTqvY"),
         videoMinutes: "1:26:48",
+        videoUploadDate: "2024-07-01T04:00:22-07:00",
         readingTime: "10 min",
         language: "Python",
         description: "Nós com qualquer número de filhos.",
@@ -615,6 +660,7 @@ export const GROUPS: Group[] = [
         viz: "bst",
         youtube: yt("CITquySB4ls"),
         videoMinutes: "2:13:44",
+        videoUploadDate: "2024-07-03T04:00:19-07:00",
         readingTime: "12 min",
         language: "Python",
         description: "Ordem invariante para busca em O(log n).",
@@ -649,6 +695,7 @@ export const GROUPS: Group[] = [
         viz: "grafos-intro",
         youtube: yt("cILrU-dtuEc"),
         videoMinutes: "1:46:55",
+        videoUploadDate: "2024-08-03T08:05:09-07:00",
         readingTime: "11 min",
         language: "Python",
         description: "Vértices, arestas e representação (matriz / lista de adjacência).",
@@ -676,6 +723,7 @@ export const GROUPS: Group[] = [
         viz: "dfs-bfs",
         youtube: yt("sCT-_EjbVqQ"),
         videoMinutes: "2:06:45",
+        videoUploadDate: "2024-08-23T19:16:04-07:00",
         readingTime: "11 min",
         language: "Python",
         description: "Os dois jeitos de percorrer um grafo.",
@@ -703,6 +751,7 @@ export const GROUPS: Group[] = [
         viz: "dijkstra",
         youtube: yt("b4kWEWtCVzA"),
         videoMinutes: "2:09:19",
+        videoUploadDate: "2025-01-21T05:51:45-08:00",
         readingTime: "12 min",
         language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-dijkstra",
@@ -731,6 +780,7 @@ export const GROUPS: Group[] = [
         viz: "bellman-ford",
         youtube: yt("0GcXgQTpYcE"),
         videoMinutes: "2:22:53",
+        videoUploadDate: "2025-02-04T02:33:11-08:00",
         readingTime: "11 min",
         language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-bellman-ford",
@@ -758,6 +808,7 @@ export const GROUPS: Group[] = [
         viz: "a-star",
         youtube: yt("0PYx7erkdXo"),
         videoMinutes: "2:34:10",
+        videoUploadDate: "2025-03-04T03:30:06-08:00",
         readingTime: "11 min",
         language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-a-star",
@@ -786,6 +837,7 @@ export const GROUPS: Group[] = [
         viz: "topological-sort",
         youtube: yt("4fTjXqcMFtk"),
         videoMinutes: "1:41:07",
+        videoUploadDate: "2025-04-01T03:30:02-07:00",
         readingTime: "10 min",
         language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-topological-sorting",
@@ -814,6 +866,7 @@ export const GROUPS: Group[] = [
         viz: "mst",
         youtube: yt("a9iI9N4FLsg"),
         videoMinutes: "2:12:12",
+        videoUploadDate: "2025-05-05T05:20:41-07:00",
         readingTime: "11 min",
         language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-mst",
@@ -849,6 +902,7 @@ export const GROUPS: Group[] = [
         viz: "binary-heap",
         youtube: yt("HVWw20nOLHk"),
         videoMinutes: "2:21:46",
+        videoUploadDate: "2024-07-29T07:00:15-07:00",
         readingTime: "12 min",
         language: "Python",
         description: "A fila de prioridade por trás do heap sort e do Dijkstra.",
@@ -878,6 +932,7 @@ export const GROUPS: Group[] = [
         viz: "heap-sort",
         youtube: yt("wUfOyKMjamM"),
         videoMinutes: "2:10:31",
+        videoUploadDate: "2024-07-30T04:01:00-07:00",
         readingTime: "11 min",
         language: "Python",
         description: "Ordenar com um heap em O(n log n).",
@@ -912,6 +967,7 @@ export const GROUPS: Group[] = [
         viz: "busca-binaria",
         youtube: yt("62ZGcXDpbys"),
         videoMinutes: "1:30:11",
+        videoUploadDate: "2024-03-20T06:30:06-07:00",
         readingTime: "11 min",
         language: "Python",
         description: "Corte o espaço de busca pela metade a cada passo: O(log n).",
@@ -948,6 +1004,7 @@ export const GROUPS: Group[] = [
         viz: "ordenacao-basica",
         youtube: yt("GxhxsbbzaTI"),
         videoMinutes: "1:52:10",
+        videoUploadDate: "2024-03-05T19:00:08-08:00",
         readingTime: "12 min",
         language: "Python",
         description: "Bubble, Selection e Insertion Sort, os O(n²) que ensinam a base.",
@@ -976,6 +1033,7 @@ export const GROUPS: Group[] = [
         viz: "merge-sort",
         youtube: yt("lbktBOwmmhg"),
         videoMinutes: "3:14:02",
+        videoUploadDate: "2024-07-31T04:00:49-07:00",
         readingTime: "13 min",
         language: "Python",
         description: "Divisão e conquista, estável, O(n log n).",
@@ -1004,6 +1062,7 @@ export const GROUPS: Group[] = [
         viz: "quick-sort",
         youtube: yt("2T0Itw-oaEA"),
         videoMinutes: "1:58:04",
+        videoUploadDate: "2024-08-02T04:00:04-07:00",
         readingTime: "13 min",
         language: "Python",
         description: "Particiona em torno de um pivô. O(n log n) na média.",
@@ -1032,6 +1091,7 @@ export const GROUPS: Group[] = [
         viz: "shell-sort",
         youtube: yt("symbT7Cgrr8"),
         videoMinutes: "1:58:45",
+        videoUploadDate: "2024-08-01T04:00:56-07:00",
         readingTime: "12 min",
         language: "Python",
         description: "Insertion Sort turbinado com gap sequences.",
@@ -1070,6 +1130,7 @@ export const GROUPS: Group[] = [
         isNew: true,
         youtube: yt("Vcm6mhLKU5A"),
         videoMinutes: "2:08:38",
+        videoUploadDate: "2025-06-02T01:00:28-07:00",
         readingTime: "13 min",
         language: "Python",
         article: "https://craftcodeclub.io/posts/dsa-backtracking",
@@ -1139,6 +1200,7 @@ export const GROUPS: Group[] = [
         isNew: true,
         youtube: yt("8VHi44rAVFo"),
         videoMinutes: "27:33",
+        videoUploadDate: "2026-07-13T13:30:13-07:00",
         readingTime: "10 min",
         language: "Python",
         description: "O sistema binário e a conversão entre decimal e binário.",
@@ -1168,6 +1230,7 @@ export const GROUPS: Group[] = [
         isNew: true,
         youtube: yt("93CpmUXLbzc"),
         videoMinutes: "26:13",
+        videoUploadDate: "2026-07-16T14:36:02-07:00",
         readingTime: "11 min",
         language: "Python",
         description: "Sign-magnitude, complemento de um e de dois.",

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTopic, getNeighbors, isEmptyTopic, ALL_TOPICS } from "@content/roadmap";
 import { getArticle } from "@content/topics";
-import { breadcrumbJsonLd, JsonLd, topicJsonLd } from "@/lib/jsonld";
+import { breadcrumbJsonLd, JsonLd, topicJsonLd, videoObjectJsonLd } from "@/lib/jsonld";
 import { LINKS, ytEmbed, ytWatch } from "@/lib/links";
 import { pageMetadata } from "@/lib/seo";
 import { levelClass } from "@/lib/ui";
@@ -72,6 +72,14 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
       ? `${ondeEstudar.slice(0, -1).join(", ")} e ${ondeEstudar[ondeEstudar.length - 1]}`
       : ondeEstudar[0];
 
+  // Os nós JSON-LD desta página. O `VideoObject` entra só onde a seção "Vídeo
+  // da aula" existe de fato — `videoObjectJsonLd` devolve `undefined` sem
+  // `t.youtube`, que é a MESMA condição do `<iframe>` lá embaixo. Marcar vídeo
+  // numa página sem embed seria a contradição que o `isEmptyTopic` já fecha
+  // para o recurso de aprendizado.
+  const video = videoObjectJsonLd(t);
+  const marcacao = [topicJsonLd(t), breadcrumbJsonLd(t), ...(video ? [video] : [])];
+
   // Índice "Nesta página": títulos do artigo + seções que a página acrescenta.
   const toc: string[] = [
     ...(article?.summary ?? []),
@@ -89,7 +97,7 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
           indexada. O `noindex` vence no Google, então não é defeito de ranking —
           é a mesma contradição que este PR foi escrito para fechar, e o
           consumidor que lê JSON-LD sem olhar `robots` acredita na declaração. */}
-      {!isEmptyTopic(t) && <JsonLd data={[topicJsonLd(t), breadcrumbJsonLd(t)]} />}
+      {!isEmptyTopic(t) && <JsonLd data={marcacao} />}
       <article>
         {/* Trilha navegável, e não três `<span>`: "Início" leva à home, o grupo
             leva ao roadmap e o tópico corrente se identifica com `aria-current`.

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -1,6 +1,6 @@
 import { createElement } from "react";
 import { ALL_TOPICS, type Topic } from "@content/roadmap";
-import { LINKS, SITE_URL } from "@/lib/links";
+import { LINKS, SITE_URL, ytEmbed } from "@/lib/links";
 import { SITE_NAME } from "@/lib/seo";
 
 // Dados estruturados (JSON-LD), em funções puras `dado → objeto`.
@@ -16,13 +16,18 @@ import { SITE_NAME } from "@/lib/seo";
 //   inLanguage        → `pt-BR`, o `lang` do `<html>` (não confundir com o de cima)
 //   about             → o grupo, que a trilha mostra logo acima do título
 //   itemListElement   → os cards que o /roadmap renderiza, na mesma ordem
+//   embedUrl          → o `src` do `<iframe>` da seção "Vídeo da aula"
+//   duration          → o "· 2:08:22" que a página escreve ao lado daquele embed
 //
 // Campo sem correspondente fica de fora, e é por isso que não há
 // `learningResourceType` (seria uma classificação chutada) nem `SearchAction` no
 // `WebSite` (a busca do site é filtro no cliente, não tem URL de resultado).
 //
-// `VideoObject` também fica de fora, e a falta é concreta: ele exige
-// `uploadDate`, que não existe no type `Topic`. Acrescentar o campo é PR próprio.
+// `VideoObject` ficou de fora por muito tempo porque exige `uploadDate`, que não
+// existia no type `Topic`. Existe agora: `videoUploadDate`, obrigatório por
+// união de tipos sempre que houver `youtube` (ver `content/roadmap.ts`). Com a
+// data no lugar, a razão da ausência caiu e o nó entra — só nas páginas que de
+// fato embutem a aula.
 //
 // Tudo isto roda no build e sai no HTML do export: `<script type="application/
 // ld+json">` não é executado pelo navegador, então o custo no cliente é zero.
@@ -36,6 +41,30 @@ const ID_SITE = `${SITE_URL}/#website`;
 function duracaoIso(readingTime: string | undefined): string | undefined {
   const m = readingTime?.match(/^(\d+)\s*min$/);
   return m ? `PT${m[1]}M` : undefined;
+}
+
+/**
+ * "2:08:22" → "PT2H8M22S"; "27:33" → "PT27M33S". Mesma regra do `duracaoIso`
+ * acima: formato inesperado devolve `undefined`, e o campo some da marcação.
+ *
+ * Os componentes zerados não são escritos ("2:00:47" → "PT2H47S"), que é a
+ * mesma forma que o YouTube publica no schema.org da própria página de watch —
+ * conferida contra os 34 vídeos. `PT` sozinho (tudo zero) não é duração válida,
+ * então também vira `undefined`.
+ */
+function duracaoDoVideo(videoMinutes: string | undefined): string | undefined {
+  const m = videoMinutes?.match(/^(?:(\d+):)?(\d{1,2}):(\d{2})$/);
+  if (!m) return undefined;
+  const horas = m[1] ? Number(m[1]) : 0;
+  const minutos = Number(m[2]);
+  const segundos = Number(m[3]);
+  if (minutos > 59 || segundos > 59) return undefined;
+  const iso = [
+    horas ? `${horas}H` : "",
+    minutos ? `${minutos}M` : "",
+    segundos ? `${segundos}S` : "",
+  ].join("");
+  return iso ? `PT${iso}` : undefined;
 }
 
 /**
@@ -90,6 +119,62 @@ export function topicJsonLd(t: Topic) {
     ...(timeRequired ? { timeRequired } : {}),
     ...(t.language ? { programmingLanguage: t.language } : {}),
     isPartOf: { "@id": ID_SITE },
+    publisher: { "@id": ID_ORG },
+  };
+}
+
+/**
+ * A aula gravada que a página embute, para o Google poder tratá-la como vídeo
+ * (aba Vídeos, miniatura no resultado) e não como mais um `<iframe>` opaco.
+ *
+ * Devolve `undefined` quando o tópico não tem aula — e o tipo garante que, se
+ * tiver, a data existe: `youtube` e `videoUploadDate` andam em bloco na união
+ * do `Topic`. Por isso não há `!` nem cast aqui embaixo.
+ *
+ * Os quatro obrigatórios do Google (`name`, `description`, `thumbnailUrl`,
+ * `uploadDate`) saem todos de dado que já está na página; o resto segue o
+ * contrato do topo do arquivo e só entra se tiver correspondente na tela.
+ *
+ * `embedUrl` e não `contentUrl`: o vídeo não é hospedado aqui, é embutido. O
+ * valor é literalmente o `src` do `<iframe>` que a página renderiza, montado
+ * pelo MESMO `ytEmbed` — marcação e tela não têm como divergir.
+ *
+ * `thumbnailUrl` traz duas resoluções, e as duas medidas contra o `i.ytimg.com`
+ * antes de entrar aqui:
+ *
+ *   - `maxresdefault.jpg` (1280x720) responde 200 nos 34 vídeos das aulas, e as
+ *     amostras baixadas são imagem de verdade, não o cinza de placeholder;
+ *   - `hqdefault.jpg` (480x360) é o piso que o YouTube gera para TODO vídeo.
+ *
+ * A segunda entrada não é redundância: `maxresdefault` só existe quando o
+ * upload tinha 720p, e nada neste repositório impede que a próxima aula seja
+ * uma gravação menor. Nesse dia o campo continua com uma URL que resolve, em
+ * vez de virar um 404 solitário.
+ */
+export function videoObjectJsonLd(t: Topic) {
+  if (!t.youtube) return undefined;
+  const url = abs(`/topico/${t.slug}/`);
+  const duration = duracaoDoVideo(t.videoMinutes);
+  return {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    "@id": `${url}#video`,
+    // O nome do `<iframe title>` da seção "Vídeo da aula", caractere por
+    // caractere: é o nome acessível do embed na tela.
+    name: `Aula: ${t.name}`,
+    description: t.description,
+    uploadDate: t.videoUploadDate,
+    thumbnailUrl: [
+      `https://i.ytimg.com/vi/${t.youtube}/maxresdefault.jpg`,
+      `https://i.ytimg.com/vi/${t.youtube}/hqdefault.jpg`,
+    ],
+    embedUrl: ytEmbed(t.youtube),
+    ...(duration ? { duration } : {}),
+    inLanguage: "pt-BR",
+    // O encontro da comunidade é aberto e gratuito no YouTube, e o conteúdo é
+    // aula de programação: as duas declarações descrevem o que o aluno recebe.
+    isAccessibleForFree: true,
+    isFamilyFriendly: true,
     publisher: { "@id": ID_ORG },
   };
 }

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -124,8 +124,14 @@ export function topicJsonLd(t: Topic) {
 }
 
 /**
- * A aula gravada que a página embute, para o Google poder tratá-la como vídeo
- * (aba Vídeos, miniatura no resultado) e não como mais um `<iframe>` opaco.
+ * A aula gravada que a página embute, descrita como vídeo em vez de ficar
+ * escondida dentro de um `<iframe>` opaco.
+ *
+ * O que isto NÃO promete: aba Vídeos nem miniatura no resultado. Desde
+ * 04/12/2023 esses recursos só valem para páginas cujo CONTEÚDO PRINCIPAL é o
+ * vídeo, e aqui ele é uma seção depois do artigo e dos visualizadores. O nó
+ * existe para quem consome JSON-LD receber o dado certo — não como garantia de
+ * resultado rico, que o Google decide e esta forma de página não alcança.
  *
  * Devolve `undefined` quando o tópico não tem aula — e o tipo garante que, se
  * tiver, a data existe: `youtube` e `videoUploadDate` andam em bloco na união

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -483,12 +483,187 @@ test("o /roadmap lista os tópicos que ele renderiza, na ordem em que renderiza"
   expect(itens.map((i) => i.position)).toEqual(ALL_TOPICS.map((_, i) => i + 1));
 });
 
-test("o JSON-LD do tópico não promete vídeo, que é o que falta para o VideoObject", () => {
-  // `VideoObject` exige `uploadDate`, que não existe no type `Topic`. Marcar o
-  // vídeo sem ele é marcação inválida; marcar com data inventada é pior.
-  const comVideo = ALL_TOPICS.find((t) => t.youtube)!;
-  const nos = jsonLd(`/topico/${comVideo.slug}/`);
-  expect(doTipo(nos, "VideoObject"), "VideoObject só entra quando houver uploadDate").toBeUndefined();
+// --- VideoObject: a aula gravada -------------------------------------------
+//
+// Este bloco substituiu um teste que exigia a AUSÊNCIA do `VideoObject`: ele
+// existia porque o nó precisa de `uploadDate` e o type `Topic` não tinha data.
+// Hoje tem (`videoUploadDate`, obrigatório por união quando há `youtube`), e o
+// que se cobra passou a ser o contrário — que o nó esteja lá, completo, em toda
+// página que embute a aula, e em nenhuma que não embute.
+
+/** Segundos de uma duração ISO 8601 do tipo `PT1H38M8S`. `null` se não parsear. */
+function segundosDoIso(iso: string): number | null {
+  const m = iso.match(/^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?$/);
+  if (!m || (!m[1] && !m[2] && !m[3])) return null;
+  return Number(m[1] ?? 0) * 3600 + Number(m[2] ?? 0) * 60 + Number(m[3] ?? 0);
+}
+
+/** Segundos de um "H:MM:SS" ou "MM:SS" da tela. `null` se não parsear. */
+function segundosDoRelogio(txt: string): number | null {
+  const m = txt.match(/^(?:(\d+):)?(\d{1,2}):(\d{2})$/);
+  if (!m) return null;
+  return Number(m[1] ?? 0) * 3600 + Number(m[2]) * 60 + Number(m[3]);
+}
+
+test("toda página com aula entrega um VideoObject com os quatro campos obrigatórios", () => {
+  // Os obrigatórios do Google para VideoObject: name, description, thumbnailUrl
+  // e uploadDate. "Presente" não basta — string vazia e array vazio passariam
+  // por um teste que só perguntasse `toBeDefined`, e é assim que marcação
+  // aparentemente completa chega ao Search Console como campo faltando.
+  const OBRIGATORIOS = ["name", "description", "thumbnailUrl", "uploadDate"] as const;
+  const comAula = ALL_TOPICS.filter((t) => t.youtube);
+  expect(comAula.length, "nenhum tópico com vídeo: o teste não teria o que provar").toBeGreaterThan(0);
+
+  const problemas: string[] = [];
+  for (const t of comAula) {
+    const rota = `/topico/${t.slug}/`;
+    const video = doTipo(jsonLd(rota), "VideoObject");
+    if (!video) {
+      problemas.push(`${rota}: tem <iframe> da aula e nenhum VideoObject`);
+      continue;
+    }
+    for (const campo of OBRIGATORIOS) {
+      const v = video[campo];
+      const vazio =
+        v === undefined ||
+        v === null ||
+        (typeof v === "string" && v.trim() === "") ||
+        (Array.isArray(v) && (v.length === 0 || v.some((x) => typeof x !== "string" || !x.trim())));
+      if (vazio) problemas.push(`${rota}: ${campo} = ${JSON.stringify(v)}`);
+    }
+  }
+  expect(
+    problemas,
+    `${problemas.length} campo(s) obrigatório(s) faltando nos ${comAula.length} VideoObject entregues`
+  ).toEqual([]);
+});
+
+test("todo tópico com vídeo declara uma data de publicação real, e não do futuro", () => {
+  // O guarda que sustenta a união de tipos do `Topic` do lado do ARTEFATO: a
+  // união reprova no `tsc` quem entrar sem data, e este teste reprova quem
+  // entrar com data que não é data. Os dois cobrem o mesmo esquecimento em
+  // pontos diferentes, e o que não pode é o próximo tópico passar pelos dois.
+  const agora = Date.now();
+  const problemas: string[] = [];
+  let conferidos = 0;
+  for (const t of ALL_TOPICS.filter((t) => t.youtube)) {
+    const rota = `/topico/${t.slug}/`;
+    const video = doTipo(jsonLd(rota), "VideoObject");
+    if (!video) continue; // já reprovado no teste acima
+    const data = video.uploadDate;
+    if (typeof data !== "string") {
+      problemas.push(`${rota}: uploadDate não é string (${JSON.stringify(data)})`);
+      continue;
+    }
+    conferidos += 1;
+    const ms = Date.parse(data);
+    if (Number.isNaN(ms)) {
+      problemas.push(`${rota}: "${data}" não é ISO 8601 parseável`);
+      continue;
+    }
+    // ISO 8601 de verdade, não um "01/04/2024" que o `Date.parse` aceitaria por
+    // tolerância: ano-mês-dia, e fuso declarado (Z ou ±HH:MM) quando há hora.
+    if (!/^\d{4}-\d{2}-\d{2}(T\d{2}:\d{2}:\d{2}(Z|[+-]\d{2}:\d{2}))?$/.test(data)) {
+      problemas.push(`${rota}: "${data}" não está na forma ISO 8601 com fuso`);
+    }
+    if (ms > agora) problemas.push(`${rota}: uploadDate no futuro (${data})`);
+    // A data também não pode ser anterior ao canal: aula gravada em 1970 é o
+    // sintoma clássico de timestamp zerado passando por "data válida".
+    if (ms < Date.parse("2020-01-01T00:00:00Z")) {
+      problemas.push(`${rota}: uploadDate anterior ao canal da comunidade (${data})`);
+    }
+    if (t.videoUploadDate !== undefined) {
+      expect(data, `${rota}: a data entregue não é a do roadmap`).toBe(t.videoUploadDate);
+    }
+  }
+  expect(problemas, "datas de publicação inválidas").toEqual([]);
+  expect(
+    conferidos,
+    "quantidade de tópicos com vídeo cuja data foi conferida no HTML entregue"
+  ).toBe(ALL_TOPICS.filter((t) => t.youtube).length);
+});
+
+test("o VideoObject aponta para o embed e a miniatura daquele vídeo", () => {
+  // A marcação reflete o que está na tela: o `embedUrl` tem que ser o MESMO
+  // `src` do `<iframe>` que a página renderiza. Comparar contra o HTML, e não
+  // contra `ytEmbed(t.youtube)` de novo, é o que impede o teste de repetir o
+  // erro do código — se os dois saíssem da mesma função, marcar o vídeo errado
+  // passaria verde.
+  const problemas: string[] = [];
+  for (const t of ALL_TOPICS.filter((t) => t.youtube)) {
+    const rota = `/topico/${t.slug}/`;
+    const doc = html(rota);
+    const video = doTipo(jsonLd(rota), "VideoObject");
+    if (!video) continue;
+    const iframes = [...doc.matchAll(/<iframe[^>]*src="([^"]+)"/g)].map((m) => m[1]);
+    const embed = video.embedUrl as string | undefined;
+    if (!embed || !iframes.includes(embed)) {
+      problemas.push(`${rota}: embedUrl=${embed} não está entre os iframes da página (${iframes.join(", ") || "nenhum"})`);
+    }
+    // `contentUrl` seria mentira: o arquivo do vídeo não é servido daqui.
+    if (video.contentUrl !== undefined) problemas.push(`${rota}: contentUrl num vídeo que é só embutido`);
+    // A miniatura tem que ser a DESTE vídeo, e a URL precisa ser absoluta.
+    for (const thumb of (video.thumbnailUrl as string[] | undefined) ?? []) {
+      if (!thumb.startsWith("https://i.ytimg.com/vi/")) problemas.push(`${rota}: miniatura fora do i.ytimg.com (${thumb})`);
+      if (!thumb.includes(`/vi/${t.youtube}/`)) problemas.push(`${rota}: miniatura de outro vídeo (${thumb})`);
+    }
+    if (video.publisher === undefined) problemas.push(`${rota}: VideoObject sem publisher`);
+    if (video.inLanguage !== "pt-BR") problemas.push(`${rota}: inLanguage=${video.inLanguage}`);
+  }
+  expect(problemas, "VideoObject que não descreve o vídeo da própria página").toEqual([]);
+});
+
+test("a duração marcada é a duração escrita ao lado do vídeo", () => {
+  // O par que o Google lê (`duration`, em ISO 8601) e o par que o aluno lê
+  // ("· 2:08:22", na linha acima do embed) têm que valer a MESMA quantidade de
+  // segundos. Os dois lados são parseados por regras independentes e comparados
+  // em segundos — um conversor que trocasse minutos por horas reprova aqui.
+  const problemas: string[] = [];
+  let conferidos = 0;
+  for (const t of ALL_TOPICS.filter((t) => t.youtube)) {
+    const rota = `/topico/${t.slug}/`;
+    const video = doTipo(jsonLd(rota), "VideoObject");
+    if (!video) continue;
+    const duration = video.duration as string | undefined;
+    if (t.videoMinutes === undefined) {
+      expect(duration, `${rota}: sem duração na tela, sem duration na marcação`).toBeUndefined();
+      continue;
+    }
+    if (duration === undefined) {
+      problemas.push(`${rota}: a página mostra "${t.videoMinutes}" e a marcação não tem duration`);
+      continue;
+    }
+    const emSegundos = segundosDoIso(duration);
+    const naTela = segundosDoRelogio(t.videoMinutes);
+    if (emSegundos === null) {
+      problemas.push(`${rota}: duration="${duration}" não é duração ISO 8601 válida`);
+      continue;
+    }
+    if (naTela !== null && emSegundos !== naTela) {
+      problemas.push(`${rota}: duration=${duration} (${emSegundos}s) ≠ "${t.videoMinutes}" (${naTela}s)`);
+    }
+    // O texto do embed é o que o aluno lê; ele tem que estar mesmo no HTML.
+    if (!html(rota).includes(t.videoMinutes)) {
+      problemas.push(`${rota}: "${t.videoMinutes}" não aparece no HTML entregue`);
+    }
+    conferidos += 1;
+  }
+  expect(problemas, "duração marcada divergindo da duração na tela").toEqual([]);
+  expect(conferidos, "durações conferidas contra a tela").toBeGreaterThan(0);
+});
+
+test("página sem aula não inventa VideoObject", () => {
+  // A outra metade, e a que envelhece sozinha: a lista sai de `ALL_TOPICS`, não
+  // de um slug escrito à mão, então um tópico novo sem vídeo entra na cobertura
+  // no mesmo commit que o cria.
+  const semAula = ALL_TOPICS.filter((t) => !t.youtube);
+  expect(semAula.length, "todos os tópicos têm vídeo: esta metade ficou sem o que provar").toBeGreaterThan(0);
+  const intrusos: string[] = [];
+  for (const t of semAula) {
+    const rota = `/topico/${t.slug}/`;
+    if (doTipo(jsonLd(rota), "VideoObject")) intrusos.push(rota);
+  }
+  expect(intrusos, `${intrusos.length} páginas sem embed declarando VideoObject`).toEqual([]);
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
> ⚠️ **Leia a seção "O que a pesquisa derrubou" antes de mergear.** O trabalho
> está pronto e verde, mas a medição feita *depois* dele mostra que o ganho de
> busca provavelmente é **zero** para páginas com esta forma. Este PR existe
> para a decisão ser tomada com o código na frente, não no escuro.

As 34 páginas com aula passam a emitir um nó `VideoObject` no JSON-LD, ao lado
do `LearningResource` e do `BreadcrumbList` que já saíam. Páginas sem vídeo não
emitem nada de novo.

## Por que `uploadDate` era o bloqueio

O comentário do `src/lib/jsonld.ts` dizia isso desde sempre: *"`VideoObject`
também fica de fora, e a falta é concreta: ele exige `uploadDate`, que não
existe no type `Topic`. Acrescentar o campo é PR próprio."* Este é esse PR.

As datas vieram do `uploadDate` que o **próprio YouTube publica** no schema.org
da página de watch, vídeo a vídeo — nada foi digitado à mão nem estimado.

O campo é obrigatório **por união de tipos**: `youtube` e `videoUploadDate`
andam em bloco, e um tópico com vídeo e sem data **não compila**. O custo dessa
escolha foi medido, não estimado: `npx tsc --noEmit` dá **0 erros**, porque os
8 pontos que leem `t.youtube` continuam vendo `string | undefined`.

## O que a pesquisa derrubou

Depois que o código ficou pronto, uma rodada de pesquisa adversarial contra a
documentação do Google chegou a isto:

**Desde 04/12/2023, o modo Vídeo só mostra páginas onde o vídeo é o conteúdo
principal.** O contra-exemplo que a própria documentação lista é literalmente
esta página: artigo com vídeo de apoio. Aqui o `<iframe>` vem **depois** do MDX
inteiro e dos visualizadores, sob um `<h2>Vídeo da aula</h2>`. O Search Console
responderia *"Video is not the main content of the page"*.

| superfície | veredito |
|---|---|
| aba Vídeos | fechada — vídeo não é o conteúdo principal |
| miniatura ao lado do resultado de texto | fechada pela mesma regra, desde abr/2023 |
| *key moments* | impossível — `SeekToAction` exige que o Google baixe os bytes, que não hospedamos |

O mito de que "o YouTube rouba a atribuição" é **falso** — a doc diz que o
Google pode indexar os dois. O item não cai por isso; cai pela regra de conteúdo
principal.

**E há um risco líquido pequeno, mas real:** a documentação de datas pede
*"Minimize the presence of other dates on the page"*. Uma data de gravação de
2024 convivendo com o `dateModified` que o PR de autoria vai introduzir aumenta
a chance de o Google exibir a data velha no snippet.

## O que continua verdadeiro a favor

- **Custo de execução zero.** JSON-LD é gerado no build e sai no HTML do export;
  não vira um byte de JavaScript no cliente.
- **O dado está certo e é conferível**, o que já vale para qualquer consumidor de
  JSON-LD que não seja a Busca do Google.
- **A união de tipos é higiene de modelo de conteúdo** e vale por si: nenhuma
  aula futura entra sem data.
- Se um dia existir uma rota cujo **único** propósito seja o vídeo, a marcação
  passa a ser elegível sem trabalho novo.

## Recomendação

Mergear **só se** você quiser o dado correto pelo dado. Se o objetivo era ganho
de busca, o retorno medido é zero e o `followups.md` precisa registrar o motivo
— o comentário do `jsonld.ts` acertou a conclusão pelo motivo menor ("falta o
campo") e quem lê hoje conclui que basta acrescentá-lo.

## Ordem

Este PR **precisa rebasear na `main` depois do #72**. Ele carrega a duração
antiga de `sliding-window` (`18:24` para um vídeo de `2:08:22`), e `duration`
lê justamente esse campo. O conserto saiu deste PR e virou o #72, para valer
independente da decisão acima.

## Como provar que os testes prestam

Todas as quebras em `src/lib/jsonld.ts`, uma por vez, com `npm run build` antes
de rodar. **Executadas, não sugeridas:**

| quebra | efeito medido |
|---|---|
| `uploadDate: t.videoUploadDate` → `uploadDate: ""` | 2 testes falham: *"os quatro campos obrigatórios"* e *"data real, e não do futuro"* |
| `` horas ? `${horas}H` `` → `` `${horas}M` `` | 1 teste falha: *"a duração marcada é a duração escrita ao lado do vídeo"* — a comparação é em **segundos**, não em string |
| `if (!t.youtube) return undefined` → guarda que não guarda | **não compila**: `TS2345: Argument of type 'string \| undefined' is not assignable to parameter of type 'string'`. A união pega antes do teste |

Suíte inteira na branch: **675 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUbtzKsXafUrmiFM3gPMYz