### PR TITLE
feat(seo): o tópico diz quem assina e quando foi atualizado, e o site ganha um /sobre

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -147,6 +147,7 @@ function Footer() {
         <span>Open source · gratuito para sempre</span>
       </div>
       <div className="foot-links">
+        <Link href="/sobre">Sobre</Link>
         <a href={LINKS.github} target="_blank" rel="noopener noreferrer">GitHub</a>
         <a href={LINKS.discord} target="_blank" rel="noopener noreferrer">Discord</a>
         <Link href="/apoie">Apoiar</Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -133,25 +133,7 @@ export default function Home() {
         </div>
       </section>
 
-      <Footer />
     </>
   );
 }
 
-function Footer() {
-  return (
-    <footer className="site-foot">
-      <div className="foot-text">
-        <span>Feito <span className="heart">♥</span> pela comunidade, para a comunidade.</span>
-        <span className="foot-sep">·</span>
-        <span>Open source · gratuito para sempre</span>
-      </div>
-      <div className="foot-links">
-        <Link href="/sobre">Sobre</Link>
-        <a href={LINKS.github} target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href={LINKS.discord} target="_blank" rel="noopener noreferrer">Discord</a>
-        <Link href="/apoie">Apoiar</Link>
-      </div>
-    </footer>
-  );
-}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -13,7 +13,7 @@ export const dynamic = "force-static";
 // Console. O filtro abaixo chama a MESMA função que a página chama — recriar a
 // condição aqui é o que fez o buraco existir, e recriá-la de novo o reabriria na
 // primeira vez que a regra de "tópico vazio" mudasse de um lado só.
-const rotasFixas = ["/", "/introducao/", "/roadmap/", "/apoie/"] as const;
+const rotasFixas = ["/", "/introducao/", "/roadmap/", "/apoie/", "/sobre/"] as const;
 
 // Arquivos que respondem pelo conteúdo de cada rota, para a data sair do Git.
 //
@@ -28,6 +28,10 @@ export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly stri
   "/introducao/": ["src/app/introducao/page.tsx"],
   "/roadmap/": ["src/app/roadmap/page.tsx", "content/roadmap.ts"],
   "/apoie/": ["src/app/apoie/page.tsx", "src/app/apoie/apoiadores.ts"],
+  // O /sobre também lê o `roadmap.ts`: os números de tópicos, visualizadores e
+  // problemas que o texto cita saem de lá, como na home. Tópico novo muda a
+  // página sem ninguém tocar no `page.tsx` dela.
+  "/sobre/": ["src/app/sobre/page.tsx", "content/roadmap.ts"],
 };
 
 // `lastmod` é o único dos três campos opcionais que o Google declarou usar;
@@ -42,7 +46,7 @@ export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly stri
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = rotasFixas.map((rota) => ({
     url: `${SITE_URL}${rota}`,
-    priority: rota === "/" ? 1 : rota === "/apoie/" ? 0.5 : 0.9,
+    priority: rota === "/" ? 1 : rota === "/apoie/" || rota === "/sobre/" ? 0.5 : 0.9,
     changeFrequency: rota === "/" || rota === "/roadmap/" ? ("weekly" as const) : ("monthly" as const),
     lastModified: ultimaAlteracao(...CONTEUDO_DA_ROTA[rota]),
   }));

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,18 @@
 import type { MetadataRoute } from "next";
 import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
-import { atualizacaoDoTopico, comDataUtil, ultimaAlteracao } from "@/lib/datas-do-git";
+import {
+  atualizacaoDoTopico,
+  comDataUtil,
+  CONTEUDO_DA_ROTA,
+  ROTAS_FIXAS,
+  ultimaAlteracao,
+} from "@/lib/datas-do-git";
 import { SITE_URL } from "@/lib/links";
+
+// `CONTEUDO_DA_ROTA` continua exportado daqui porque é daqui que ele sempre foi
+// importado; a casa dele agora é o módulo de datas, junto do guarda que mede
+// esses mesmos caminhos.
+export { CONTEUDO_DA_ROTA, ROTAS_FIXAS };
 
 export const dynamic = "force-static";
 
@@ -13,26 +24,10 @@ export const dynamic = "force-static";
 // Console. O filtro abaixo chama a MESMA função que a página chama — recriar a
 // condição aqui é o que fez o buraco existir, e recriá-la de novo o reabriria na
 // primeira vez que a regra de "tópico vazio" mudasse de um lado só.
-const rotasFixas = ["/", "/introducao/", "/roadmap/", "/apoie/", "/sobre/"] as const;
-
-// Arquivos que respondem pelo conteúdo de cada rota, para a data sair do Git.
 //
-// É uma LISTA, e não um arquivo só, porque `page.tsx` quase nunca é onde o texto
-// mora. A home e o `/roadmap/` importam de `content/roadmap.ts`: mexer num
-// tópico muda as duas telas sem tocar em nenhum dos dois `page.tsx`, e o
-// `lastmod` ficava parado no dia em que o layout da página mudou pela última
-// vez. O `/apoie/` tem a mesma forma com `apoiadores.ts`, que é onde a lista de
-// nomes é mantida à mão. A data da rota é a MAIS RECENTE entre esses arquivos.
-export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly string[]> = {
-  "/": ["src/app/page.tsx", "content/roadmap.ts"],
-  "/introducao/": ["src/app/introducao/page.tsx"],
-  "/roadmap/": ["src/app/roadmap/page.tsx", "content/roadmap.ts"],
-  "/apoie/": ["src/app/apoie/page.tsx", "src/app/apoie/apoiadores.ts"],
-  // O /sobre também lê o `roadmap.ts`: os números de tópicos, visualizadores e
-  // problemas que o texto cita saem de lá, como na home. Tópico novo muda a
-  // página sem ninguém tocar no `page.tsx` dela.
-  "/sobre/": ["src/app/sobre/page.tsx", "content/roadmap.ts"],
-};
+// A lista das rotas fixas e o mapa de que arquivos datam cada uma vêm do módulo
+// de datas: é o mesmo conjunto de caminhos que o guarda de lá mede, e ele só
+// pode ser um.
 
 // `lastmod` é o único dos três campos opcionais que o Google declarou usar;
 // `priority` e `changeFrequency`, que este arquivo já preenchia, ele ignora.
@@ -44,7 +39,7 @@ export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly stri
 // profundidade do clone, está lá em cima do arquivo.
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const base = rotasFixas.map((rota) => ({
+  const base = ROTAS_FIXAS.map((rota) => ({
     url: `${SITE_URL}${rota}`,
     priority: rota === "/" ? 1 : rota === "/apoie/" || rota === "/sobre/" ? 0.5 : 0.9,
     changeFrequency: rota === "/" || rota === "/roadmap/" ? ("weekly" as const) : ("monthly" as const),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,6 +1,6 @@
-import { execFileSync } from "node:child_process";
 import type { MetadataRoute } from "next";
 import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
+import { atualizacaoDoTopico, comDataUtil, ultimaAlteracao } from "@/lib/datas-do-git";
 import { SITE_URL } from "@/lib/links";
 
 export const dynamic = "force-static";
@@ -33,70 +33,11 @@ export const CONTEUDO_DA_ROTA: Record<(typeof rotasFixas)[number], readonly stri
 // `lastmod` é o único dos três campos opcionais que o Google declarou usar;
 // `priority` e `changeFrequency`, que este arquivo já preenchia, ele ignora.
 //
-// A data vem do Git, e não de um campo `updatedAt` no `content/roadmap.ts`:
-// data que depende de alguém lembrar de atualizá-la em cada PR envelhece errado
-// e passa a mentir, o que é pior do que não existir.
-//
-// O guarda contra a data falsa NÃO pergunta se o clone é raso, e a diferença
-// custou duas reprovações de CI. A primeira versão consultava
-// `git rev-parse --is-shallow-repository`; a segunda leu direto o arquivo
-// `.git/shallow`, que é o que aquele comando consulta. As duas reprovaram a
-// suíte num job com histórico de sobra, e o diagnóstico que eu embuti na
-// mensagem mostrou por quê:
-//
-//     marcador de clone raso em /home/runner/.../.git/shallow
-//     datas distintas que ele resolve: 2
-//
-// O `actions/checkout` com `fetch-depth: 0` DEIXA o marcador para trás, e o
-// histórico ali é fundo o bastante para o `git log` responder datas diferentes
-// por caminho. Marcador presente e histórico utilizável ao mesmo tempo: a
-// pergunta é que estava errada.
-//
-// O que este arquivo precisa saber não é a profundidade do clone, é uma
-// CAPACIDADE: o `git log` consegue distinguir um caminho do outro? A resposta
-// está nas próprias datas que ele acabou de coletar. Se todas as URLs saírem
-// com o MESMO carimbo, esse carimbo não é informação — é a data do último
-// commit repetida 40 vezes, exatamente o `lastmod` que o Google aprendeu a
-// ignorar —, e aí o campo inteiro não sai.
-//
-// A vantagem sobre qualquer sonda de ambiente: build e teste chegam à mesma
-// conclusão porque olham o mesmo dado, o resultado do `git log`, e não um
-// marcador que cada máquina mantém do seu jeito.
-
-// Um `git log` por caminho, e não por consulta. São 48 chamadas para montar o
-// sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,
-// 1,39s no total): `content/roadmap.ts` sozinho é consultado 6 vezes, uma por
-// rota fixa que o lista e uma por tópico sem artigo que cai no fallback. O
-// cache vale por build — o `git log` de um caminho não muda no meio dele.
-const cacheDeCommit = new Map<string, number | undefined>();
-
-function commitDoArquivo(arquivo: string): number | undefined {
-  const emCache = cacheDeCommit.get(arquivo);
-  if (emCache !== undefined || cacheDeCommit.has(arquivo)) return emCache;
-  const valor = consultarCommit(arquivo);
-  cacheDeCommit.set(arquivo, valor);
-  return valor;
-}
-
-function consultarCommit(arquivo: string): number | undefined {
-  try {
-    const iso = execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    if (!iso) return undefined; // caminho que nunca existiu no histórico
-    const ms = Date.parse(iso);
-    return Number.isNaN(ms) ? undefined : ms;
-  } catch {
-    return undefined;
-  }
-}
-
-/** A data da rota é a do arquivo de conteúdo dela que mudou por último. */
-function ultimaAlteracao(...arquivos: readonly string[]): Date | undefined {
-  const datas = arquivos.map(commitDoArquivo).filter((ms): ms is number => ms !== undefined);
-  return datas.length ? new Date(Math.max(...datas)) : undefined;
-}
+// A derivação da data — o `git log`, o cache por build e o guarda que decide se
+// o carimbo é informação — mora em `src/lib/datas-do-git.ts`, porque a página do
+// tópico precisa exatamente da mesma resposta para o `dateModified` do JSON-LD.
+// A memória de por que o guarda pergunta por CAPACIDADE, e não pela
+// profundidade do clone, está lá em cima do arquivo.
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const base = rotasFixas.map((rota) => ({
@@ -109,31 +50,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     url: `${SITE_URL}/topico/${t.slug}/`,
     priority: t.status === "ready" ? 0.8 : 0.4,
     changeFrequency: "monthly" as const,
-    // O artigo é o corpo da página; o tópico sem artigo cai no `roadmap.ts`, que
-    // é onde mora cada palavra que essa página mostra.
-    //
-    // Aqui é `??` e NÃO o `max(...)` das rotas fixas, e a diferença foi medida:
-    // os 36 `.mdx` do repositório são todos mais antigos que o último commit do
-    // `roadmap.ts`, então `max` daria a MESMA data às 36 páginas de tópico e
-    // qualquer edição no `roadmap.ts` (marcar um `isNew`, mexer num link)
-    // reescreveria o `lastmod` das 40 URLs de uma vez. Isso é exatamente o
-    // "lastmod = data do último deploy" que o Google aprendeu a ignorar. A home
-    // e o `/roadmap/` não têm essa escolha: lá o `roadmap.ts` É o conteúdo.
-    lastModified: ultimaAlteracao(`content/topics/${t.slug}.mdx`) ?? ultimaAlteracao("content/roadmap.ts"),
+    lastModified: atualizacaoDoTopico(t.slug),
   }));
   return comDataUtil([...base, ...topicos]);
-}
-
-/**
- * Devolve as entradas sem `lastModified` quando as datas não carregam
- * informação: uma só distinta (ou nenhuma) significa que o `git log` respondeu
- * o mesmo para todo caminho. Exportada para o teste conferir a MESMA regra em
- * vez de recriá-la — foi recriando que este guarda errou duas vezes.
- */
-export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T[] {
-  const distintas = new Set(
-    entradas.map((e) => e.lastModified?.getTime()).filter((v): v is number => v !== undefined)
-  );
-  if (distintas.size > 1) return entradas;
-  return entradas.map(({ lastModified: _, ...resto }) => resto as T);
 }

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -74,10 +74,27 @@ export default function SobrePage() {
           LeetCode e do GeeksforGeeks, na ordem em que recomendamos resolver.
         </li>
         <li className="prose-li">
-          Progresso salvo <strong className="prose-strong">no seu navegador</strong>. Não há conta,
-          não há login e nada é enviado para lugar nenhum.
+          Progresso salvo <strong className="prose-strong">no seu navegador</strong>: os tópicos e
+          problemas que você marca ficam no armazenamento local deste aparelho. Não há conta, não
+          há login, e o que você marcou não é enviado para servidor nenhum.
         </li>
       </ul>
+
+      {/* Esta frase já esteve errada, e vale dizer por quê: ela dizia que "nada é
+          enviado para lugar nenhum", sem qualificar, enquanto o site carrega
+          Google Analytics em produção (`src/components/Analytics.tsx`). Uma
+          página institucional afirmando o que o próprio site desmente é o pior
+          tipo de erro que ela pode ter. Cada afirmação abaixo é verificável no
+          código, e o teste `a /sobre não promete privacidade que o código
+          desmente` amarra a página ao `Analytics.tsx`. */}
+      <p className="prose-p">
+        O que sai do seu navegador: em produção o site carrega o{" "}
+        <strong className="prose-strong">Google Analytics</strong>, que registra as páginas
+        visitadas. É a única medição do site — não há outro rastreador, nem anúncio —, ela só é
+        carregada depois que a página termina de abrir, e não existe em preview de Pull Request
+        nem quando você roda o projeto na sua máquina. O seu progresso não vai junto: ele nunca
+        sai do armazenamento local.
+      </p>
       <p className="prose-p">
         <Link className="prose-a" href="/roadmap/">
           Ver o roadmap completo

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -131,11 +131,10 @@ export default function SobrePage() {
           cita o nome de uma pessoa; o `git log` deste repositório tem uma única
           conta humana. Ou seja: não há de onde tirar nome nem data.
 
-          É a MESMA razão pela qual o `author` do JSON-LD aponta para a
-          organização e não para uma pessoa (ver `src/lib/jsonld.ts`, constante
-          `AUTOR`). Se você escrever nomes aqui, o `author` de lá pode passar a
-          nomear a mesma pessoa, porque a regra do arquivo é que a marcação reflita o
-          que está na tela, e a partir daí o nome estaria na tela.
+          O `author` do JSON-LD aponta para a organização e não para uma
+          pessoa (ver `src/lib/jsonld.ts`, constante `AUTOR`), e isso é decisão
+          tomada: o guia assina como comunidade. Escrever nomes AQUI, contando a
+          história, é bem-vindo; o que não muda por causa disso é o `author`.
 
           Onde escrever: um `<p className="prose-p">` logo abaixo, dentro desta
           mesma seção "Quem faz".

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -11,14 +11,14 @@ import { pageMetadata } from "@/lib/seo";
 
 // A página que responde "quem está por trás disto?".
 //
-// Ela existe porque o site afirmava autoria em três lugares soltos — o "por
+// Ela existe porque o site afirmava autoria em três lugares soltos (o "por
 // Craft & Code Club" da marca, o "feito pela comunidade" do rodapé e o
-// `Organization` do JSON-LD — e não tinha uma única URL para onde apontar quem
+// `Organization` do JSON-LD) e não tinha uma única URL para onde apontar quem
 // quisesse conferir. Agora tem, e é ela que o `author` do tópico descreve.
 //
 // ⚠️ REGRA DESTA PÁGINA: só entra o que dá para conferir no próprio
 // repositório ou nos canais linkados. Nada de data de fundação, número de
-// membros, história de origem ou nome de pessoa — nenhum desses fatos existe
+// membros, história de origem ou nome de pessoa: nenhum desses fatos existe
 // escrito em lugar nenhum daqui, e uma página "sobre" com fato inventado é pior
 // do que uma página curta. O que falta está marcado em bloco, mais abaixo.
 //
@@ -90,7 +90,7 @@ export default function SobrePage() {
       <p className="prose-p">
         O que sai do seu navegador: em produção o site carrega o{" "}
         <strong className="prose-strong">Google Analytics</strong>, que registra as páginas
-        visitadas. É a única medição do site — não há outro rastreador, nem anúncio —, ela só é
+        visitadas. É a única medição do site: não há outro rastreador, nem anúncio. Ela só é
         carregada depois que a página termina de abrir, e não existe em preview de Pull Request
         nem quando você roda o projeto na sua máquina. O seu progresso não vai junto: ele nunca
         sai do armazenamento local.
@@ -115,7 +115,7 @@ export default function SobrePage() {
       </p>
 
       {/* ────────────────────────────────────────────────────────────────────
-          PARA O WILSON ESCREVER — bloco 1 de 2: a história da comunidade.
+          PARA O WILSON ESCREVER, bloco 1 de 2: a história da comunidade.
 
           O que falta, e o que eu NÃO escrevi por não ter como conferir:
 
@@ -125,7 +125,7 @@ export default function SobrePage() {
 
           Por que ficou vazio em vez de preenchido: nenhum desses fatos está
           escrito no repositório. O `LICENSE` traz "Copyright © 2026", que é ano
-          de copyright e NÃO data de fundação — usá-lo como tal seria inventar.
+          de copyright e NÃO data de fundação; usá-lo como tal seria inventar.
           Os 34 vídeos que alimentam os tópicos têm todos
           `ownerChannelName: "Craft & Code Club"` e nenhuma das 34 descrições
           cita o nome de uma pessoa; o `git log` deste repositório tem uma única
@@ -134,7 +134,7 @@ export default function SobrePage() {
           É a MESMA razão pela qual o `author` do JSON-LD aponta para a
           organização e não para uma pessoa (ver `src/lib/jsonld.ts`, constante
           `AUTOR`). Se você escrever nomes aqui, o `author` de lá pode passar a
-          nomear a mesma pessoa — a regra do arquivo é que a marcação reflita o
+          nomear a mesma pessoa, porque a regra do arquivo é que a marcação reflita o
           que está na tela, e a partir daí o nome estaria na tela.
 
           Onde escrever: um `<p className="prose-p">` logo abaixo, dentro desta
@@ -150,14 +150,14 @@ export default function SobrePage() {
           <a className="prose-a" href={LINKS.discord} target="_blank" rel="noopener noreferrer">
             Discord
           </a>{" "}
-          — dúvidas, revisão de código e as maratonas de problemas. É o canal mais rápido para
-          falar com a gente.
+          para dúvidas, revisão de código e as maratonas de problemas. É o canal mais rápido
+          para falar com a gente.
         </li>
         <li className="prose-li">
           <a className="prose-a" href={LINKS.youtube} target="_blank" rel="noopener noreferrer">
             YouTube
           </a>{" "}
-          — as gravações dos encontros, que são o vídeo de cada tópico.
+          com as gravações dos encontros, que são o vídeo de cada tópico.
         </li>
         <li className="prose-li">
           <a className="prose-a" href={LINKS.eventos} target="_blank" rel="noopener noreferrer">
@@ -172,13 +172,13 @@ export default function SobrePage() {
           >
             clube do livro
           </a>{" "}
-          — o que a comunidade faz além do roadmap.
+          mostram o que a comunidade faz além do roadmap.
         </li>
         <li className="prose-li">
           <a className="prose-a" href={LINKS.blog} target="_blank" rel="noopener noreferrer">
             Blog
           </a>{" "}
-          — artigos publicados fora do guia.
+          com artigos publicados fora do guia.
         </li>
       </ul>
 
@@ -186,7 +186,7 @@ export default function SobrePage() {
       <p className="prose-p">
         Tudo aqui é gratuito: sem paywall, sem login e sem anúncios. A ideia é que quem está
         estudando para uma entrevista, ou aprendendo do zero, não precise pagar por isso. O
-        projeto se mantém com o apoio de quem acha que ele deve continuar existindo — se for o seu
+        projeto se mantém com o apoio de quem acha que ele deve continuar existindo. Se for o seu
         caso,{" "}
         <Link className="prose-a" href="/apoie/">
           conheça a página de apoio
@@ -228,7 +228,7 @@ export default function SobrePage() {
 
       <h2 className="prose-h2">Licença</h2>
       <p className="prose-p">
-        São duas licenças, porque são duas coisas — e a fronteira não é por diretório: ela
+        São duas licenças, porque são duas coisas. E a fronteira não é por diretório: ela
         atravessa arquivos, porque num visualizador o componente é código e as explicações que
         aparecem na tela são conteúdo.
       </p>
@@ -274,9 +274,9 @@ export default function SobrePage() {
       </p>
 
       {/* ────────────────────────────────────────────────────────────────────
-          PARA O WILSON ESCREVER — bloco 2 de 2: o convite do fim.
+          PARA O WILSON ESCREVER, bloco 2 de 2: o convite do fim.
 
-          Falta a frase de fechamento — o que você quer que a pessoa faça
+          Falta a frase de fechamento: o que você quer que a pessoa faça
           depois de ler a página. Deixei sem porque as opções são decisão sua e
           nenhuma delas é um fato que dê para conferir: entrar no Discord,
           começar pelo Big O, apoiar, contribuir. As quatro já têm link em
@@ -284,7 +284,7 @@ export default function SobrePage() {
           informação nova.
 
           Se quiser um cartão com botão, o padrão pronto é o `.cta-card` do
-          `/apoie` (`src/app/apoie/page.tsx`) — mas atenção: lá o título do
+          `/apoie` (`src/app/apoie/page.tsx`). Mas atenção: lá o título do
           cartão é `<h2>` com estilo copiado da regra `.cta-card h3`, porque a
           hierarquia de títulos da página não pode pular nível. Um `<h3>` aqui
           logo depois de um `<h2>` é válido; um `<h3>` sem `<h2>` antes não é, e

--- a/src/app/sobre/page.tsx
+++ b/src/app/sobre/page.tsx
@@ -1,0 +1,278 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import {
+  TOTAL_PROBLEMS,
+  TOTAL_TOPICS,
+  TOTAL_TOPICS_PRONTOS,
+  TOTAL_VISUALIZERS,
+} from "@content/roadmap";
+import { LINKS } from "@/lib/links";
+import { pageMetadata } from "@/lib/seo";
+
+// A página que responde "quem está por trás disto?".
+//
+// Ela existe porque o site afirmava autoria em três lugares soltos — o "por
+// Craft & Code Club" da marca, o "feito pela comunidade" do rodapé e o
+// `Organization` do JSON-LD — e não tinha uma única URL para onde apontar quem
+// quisesse conferir. Agora tem, e é ela que o `author` do tópico descreve.
+//
+// ⚠️ REGRA DESTA PÁGINA: só entra o que dá para conferir no próprio
+// repositório ou nos canais linkados. Nada de data de fundação, número de
+// membros, história de origem ou nome de pessoa — nenhum desses fatos existe
+// escrito em lugar nenhum daqui, e uma página "sobre" com fato inventado é pior
+// do que uma página curta. O que falta está marcado em bloco, mais abaixo.
+//
+// Os números vêm do `content/roadmap.ts`, como na home: tópico novo entra aqui
+// sozinho, no mesmo PR que o cria.
+
+export function generateMetadata(): Metadata {
+  return pageMetadata({
+    title: "Sobre o Roadmap DSA",
+    description: `Quem faz o Roadmap DSA, por que ele é gratuito e como contribuir. Um guia visual de algoritmos e estruturas de dados em português, com ${TOTAL_TOPICS} tópicos, feito pela comunidade Craft & Code Club.`,
+    path: "/sobre/",
+    titleStyle: "template",
+    // Mesmo caso do /apoie, e pelo mesmo motivo: esta página fala do projeto
+    // inteiro, não de um conteúdo próprio, e não tem (nem vai ter) card de
+    // compartilhamento no segmento dela.
+    ogImage: "raiz",
+  });
+}
+
+export const dynamic = "force-static";
+
+export default function SobrePage() {
+  return (
+    <div className="intro-wrap">
+      <span className="hero-badge">Sobre</span>
+      <h1>Sobre o Roadmap DSA</h1>
+      <p className="lead">
+        O <strong style={{ color: "#fff" }}>Roadmap DSA</strong> é um guia visual e gratuito de
+        Algoritmos e Estruturas de Dados em português, feito pela comunidade{" "}
+        <a className="prose-a" href={LINKS.site} target="_blank" rel="noopener noreferrer">
+          Craft &amp; Code Club
+        </a>
+        . Ele é aberto: o código e o conteúdo ficam no GitHub, e qualquer pessoa pode ler,
+        estudar, adaptar e propor mudança.
+      </p>
+
+      <h2 className="prose-h2">O que você encontra aqui</h2>
+      <p className="prose-p">
+        A trilha tem <strong className="prose-strong">{TOTAL_TOPICS} tópicos</strong>, dos quais{" "}
+        <strong className="prose-strong">{TOTAL_TOPICS_PRONTOS} já têm material publicado</strong>.
+        Cada tópico vive numa página só, e reúne o que estiver disponível para ele: o algoritmo
+        rodando passo a passo, o artigo, o vídeo do canal da comunidade, os problemas para
+        praticar e as referências para se aprofundar.
+      </p>
+      <ul className="prose-ul">
+        <li className="prose-li">
+          <strong className="prose-strong">{TOTAL_VISUALIZERS} tópicos com visualização</strong>{" "}
+          interativa: você roda o algoritmo no seu ritmo, com a sua entrada, e acompanha o código
+          linha a linha.
+        </li>
+        <li className="prose-li">
+          <strong className="prose-strong">{TOTAL_PROBLEMS} problemas selecionados</strong> do
+          LeetCode e do GeeksforGeeks, na ordem em que recomendamos resolver.
+        </li>
+        <li className="prose-li">
+          Progresso salvo <strong className="prose-strong">no seu navegador</strong>. Não há conta,
+          não há login e nada é enviado para lugar nenhum.
+        </li>
+      </ul>
+      <p className="prose-p">
+        <Link className="prose-a" href="/roadmap/">
+          Ver o roadmap completo
+        </Link>{" "}
+        ou{" "}
+        <Link className="prose-a" href="/introducao/">
+          começar pela introdução
+        </Link>
+        .
+      </p>
+
+      <h2 className="prose-h2">Quem faz</h2>
+      <p className="prose-p">
+        O guia é publicado pela comunidade Craft &amp; Code Club, e é dela a autoria do conteúdo:
+        as aulas que dão origem aos tópicos são gravadas e publicadas no canal da comunidade, e o
+        material escrito nasce dos encontros. As contribuições chegam por Pull Request no
+        repositório aberto, de quem quiser participar.
+      </p>
+
+      {/* ────────────────────────────────────────────────────────────────────
+          PARA O WILSON ESCREVER — bloco 1 de 2: a história da comunidade.
+
+          O que falta, e o que eu NÃO escrevi por não ter como conferir:
+
+            · quando o Craft & Code Club começou, e por quê;
+            · quem tocou o projeto no começo e quem toca hoje (nomes);
+            · o tamanho da comunidade hoje (pessoas no Discord, inscritos).
+
+          Por que ficou vazio em vez de preenchido: nenhum desses fatos está
+          escrito no repositório. O `LICENSE` traz "Copyright © 2026", que é ano
+          de copyright e NÃO data de fundação — usá-lo como tal seria inventar.
+          Os 34 vídeos que alimentam os tópicos têm todos
+          `ownerChannelName: "Craft & Code Club"` e nenhuma das 34 descrições
+          cita o nome de uma pessoa; o `git log` deste repositório tem uma única
+          conta humana. Ou seja: não há de onde tirar nome nem data.
+
+          É a MESMA razão pela qual o `author` do JSON-LD aponta para a
+          organização e não para uma pessoa (ver `src/lib/jsonld.ts`, constante
+          `AUTOR`). Se você escrever nomes aqui, o `author` de lá pode passar a
+          nomear a mesma pessoa — a regra do arquivo é que a marcação reflita o
+          que está na tela, e a partir daí o nome estaria na tela.
+
+          Onde escrever: um `<p className="prose-p">` logo abaixo, dentro desta
+          mesma seção "Quem faz".
+          ──────────────────────────────────────────────────────────────────── */}
+
+      <h2 className="prose-h2">Onde a comunidade acontece</h2>
+      <p className="prose-p">
+        O guia é uma das frentes do Craft &amp; Code Club. As outras:
+      </p>
+      <ul className="prose-ul">
+        <li className="prose-li">
+          <a className="prose-a" href={LINKS.discord} target="_blank" rel="noopener noreferrer">
+            Discord
+          </a>{" "}
+          — dúvidas, revisão de código e as maratonas de problemas. É o canal mais rápido para
+          falar com a gente.
+        </li>
+        <li className="prose-li">
+          <a className="prose-a" href={LINKS.youtube} target="_blank" rel="noopener noreferrer">
+            YouTube
+          </a>{" "}
+          — as gravações dos encontros, que são o vídeo de cada tópico.
+        </li>
+        <li className="prose-li">
+          <a className="prose-a" href={LINKS.eventos} target="_blank" rel="noopener noreferrer">
+            Eventos
+          </a>{" "}
+          e{" "}
+          <a
+            className="prose-a"
+            href={LINKS.clubeDoLivro}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            clube do livro
+          </a>{" "}
+          — o que a comunidade faz além do roadmap.
+        </li>
+        <li className="prose-li">
+          <a className="prose-a" href={LINKS.blog} target="_blank" rel="noopener noreferrer">
+            Blog
+          </a>{" "}
+          — artigos publicados fora do guia.
+        </li>
+      </ul>
+
+      <h2 className="prose-h2">Gratuito, e por quê</h2>
+      <p className="prose-p">
+        Tudo aqui é gratuito: sem paywall, sem login e sem anúncios. A ideia é que quem está
+        estudando para uma entrevista, ou aprendendo do zero, não precise pagar por isso. O
+        projeto se mantém com o apoio de quem acha que ele deve continuar existindo — se for o seu
+        caso,{" "}
+        <Link className="prose-a" href="/apoie/">
+          conheça a página de apoio
+        </Link>
+        , que também lista quem já apoia.
+      </p>
+
+      <h2 className="prose-h2">Como contribuir</h2>
+      <p className="prose-p">
+        Corrigir um erro, escrever um tópico, criar um visualizador ou só apontar o que está
+        confuso: tudo entra pelo repositório, e quem contribui entra nos créditos.
+      </p>
+      <ul className="prose-ul">
+        <li className="prose-li">
+          O código e o conteúdo estão em{" "}
+          <a className="prose-a" href={LINKS.github} target="_blank" rel="noopener noreferrer">
+            craft-code-club/roadmap-dsa
+          </a>
+          , no GitHub. O guia de contribuição (
+          <a
+            className="prose-a"
+            href={`${LINKS.github}/blob/main/CONTRIBUTING.md`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            CONTRIBUTING
+          </a>
+          ) explica como rodar o projeto e como abrir um Pull Request.
+        </li>
+        <li className="prose-li">
+          Achou um erro no conteúdo e não quer mexer em código? Abra uma issue no repositório ou
+          avise no{" "}
+          <a className="prose-a" href={LINKS.discord} target="_blank" rel="noopener noreferrer">
+            Discord
+          </a>
+          .
+        </li>
+      </ul>
+
+      <h2 className="prose-h2">Licença</h2>
+      <p className="prose-p">
+        São duas licenças, porque são duas coisas — e a fronteira não é por diretório: ela
+        atravessa arquivos, porque num visualizador o componente é código e as explicações que
+        aparecem na tela são conteúdo.
+      </p>
+      <ul className="prose-ul">
+        <li className="prose-li">
+          <strong className="prose-strong">O código</strong> está sob{" "}
+          <a
+            className="prose-a"
+            href={`${LINKS.github}/blob/main/LICENSE`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            MIT
+          </a>
+          : open source pela definição da OSI, com uso comercial permitido. Pegue o motor dos
+          visualizadores e construa outra coisa, se quiser.
+        </li>
+        <li className="prose-li">
+          <strong className="prose-strong">O conteúdo didático</strong> está sob{" "}
+          <a
+            className="prose-a"
+            href={`${LINKS.github}/blob/main/LICENSE-CONTENT`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            CC BY-NC-SA 4.0
+          </a>
+          : você pode compartilhar e adaptar, dando crédito (BY), sem uso comercial (NC) e
+          distribuindo a adaptação sob esta mesma licença (SA).
+        </li>
+      </ul>
+      <p className="prose-p">
+        A regra completa, com os casos que mais confundem, está no arquivo{" "}
+        <a
+          className="prose-a"
+          href={`${LINKS.github}/blob/main/LICENSE`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          LICENSE
+        </a>
+        , na seção &ldquo;onde passa a fronteira&rdquo;.
+      </p>
+
+      {/* ────────────────────────────────────────────────────────────────────
+          PARA O WILSON ESCREVER — bloco 2 de 2: o convite do fim.
+
+          Falta a frase de fechamento — o que você quer que a pessoa faça
+          depois de ler a página. Deixei sem porque as opções são decisão sua e
+          nenhuma delas é um fato que dê para conferir: entrar no Discord,
+          começar pelo Big O, apoiar, contribuir. As quatro já têm link em
+          algum lugar acima, então o fecho é sobre a ÊNFASE, não sobre
+          informação nova.
+
+          Se quiser um cartão com botão, o padrão pronto é o `.cta-card` do
+          `/apoie` (`src/app/apoie/page.tsx`) — mas atenção: lá o título do
+          cartão é `<h2>` com estilo copiado da regra `.cta-card h3`, porque a
+          hierarquia de títulos da página não pode pular nível. Um `<h3>` aqui
+          logo depois de um `<h2>` é válido; um `<h3>` sem `<h2>` antes não é, e
+          o teste `nenhuma rota pula um nível de título` reprova.
+          ──────────────────────────────────────────────────────────────────── */}
+    </div>
+  );
+}

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -3,6 +3,8 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { getTopic, getNeighbors, isEmptyTopic, ALL_TOPICS } from "@content/roadmap";
 import { getArticle } from "@content/topics";
+import { datasDoTopico } from "@/lib/datas-do-git";
+import { dataLonga, diaIso } from "@/lib/format";
 import { breadcrumbJsonLd, JsonLd, topicJsonLd } from "@/lib/jsonld";
 import { LINKS, ytEmbed, ytWatch } from "@/lib/links";
 import { pageMetadata } from "@/lib/seo";
@@ -59,6 +61,10 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
   const article = getArticle(slug);
   const Body = article?.Body;
   const { previous, next } = getNeighbors(slug);
+  // Datas do Git, ou nada. Ver `src/lib/datas-do-git.ts`: em clone raso o
+  // `git log` responde o mesmo para todo caminho, e aí o selo não é desenhado e
+  // os campos de data do JSON-LD não saem — exatamente como o `lastmod`.
+  const datas = datasDoTopico(t.slug);
 
   // Onde o tópico já pode ser estudado hoje (usado no aviso de quem não tem artigo).
   // Cobre tudo que a página mostra, inclusive os vídeos extras.
@@ -89,7 +95,7 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
           indexada. O `noindex` vence no Google, então não é defeito de ranking —
           é a mesma contradição que este PR foi escrito para fechar, e o
           consumidor que lê JSON-LD sem olhar `robots` acredita na declaração. */}
-      {!isEmptyTopic(t) && <JsonLd data={[topicJsonLd(t), breadcrumbJsonLd(t)]} />}
+      {!isEmptyTopic(t) && <JsonLd data={[topicJsonLd(t, datas), breadcrumbJsonLd(t)]} />}
       <article>
         {/* Trilha navegável, e não três `<span>`: "Início" leva à home, o grupo
             leva ao roadmap e o tópico corrente se identifica com `aria-current`.
@@ -114,6 +120,21 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
           {t.readingTime && <span className="chip">⏱ {t.readingTime} de leitura</span>}
           <span className={`level ${levelClass(t.level)}`} style={{ borderStyle: "solid" }}>{t.level}</span>
           {t.language && <span className="chip">{t.language}</span>}
+          {/* O selo "Publicado em" só aparece quando o dia é OUTRO: em 31 dos 36
+              artigos o primeiro e o último commit caem no mesmo dia, e dois
+              selos com a mesma data não informam nada. */}
+          {datas?.publicado && diaIso(datas.publicado) !== diaIso(datas.atualizado) && (
+            <span className="chip">
+              Publicado em{" "}
+              <time dateTime={diaIso(datas.publicado)}>{dataLonga(datas.publicado)}</time>
+            </span>
+          )}
+          {datas && (
+            <span className="chip">
+              Atualizado em{" "}
+              <time dateTime={diaIso(datas.atualizado)}>{dataLonga(datas.atualizado)}</time>
+            </span>
+          )}
           <TopicComplete slug={t.slug} />
         </div>
 

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -120,15 +120,6 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
           {t.readingTime && <span className="chip">⏱ {t.readingTime} de leitura</span>}
           <span className={`level ${levelClass(t.level)}`} style={{ borderStyle: "solid" }}>{t.level}</span>
           {t.language && <span className="chip">{t.language}</span>}
-          {/* O selo "Publicado em" só aparece quando o dia é OUTRO: em 28 dos 36
-              tópicos a publicação e a última atualização caem no mesmo dia, e
-              dois selos com a mesma data não informam nada. */}
-          {datas?.publicado && diaIso(datas.publicado) !== diaIso(datas.atualizado) && (
-            <span className="chip">
-              Publicado em{" "}
-              <time dateTime={diaIso(datas.publicado)}>{dataLonga(datas.publicado)}</time>
-            </span>
-          )}
           {datas && (
             <span className="chip">
               Atualizado em{" "}

--- a/src/app/topico/[slug]/page.tsx
+++ b/src/app/topico/[slug]/page.tsx
@@ -120,9 +120,9 @@ export default async function TopicoPage({ params }: { params: Promise<{ slug: s
           {t.readingTime && <span className="chip">⏱ {t.readingTime} de leitura</span>}
           <span className={`level ${levelClass(t.level)}`} style={{ borderStyle: "solid" }}>{t.level}</span>
           {t.language && <span className="chip">{t.language}</span>}
-          {/* O selo "Publicado em" só aparece quando o dia é OUTRO: em 31 dos 36
-              artigos o primeiro e o último commit caem no mesmo dia, e dois
-              selos com a mesma data não informam nada. */}
+          {/* O selo "Publicado em" só aparece quando o dia é OUTRO: em 28 dos 36
+              tópicos a publicação e a última atualização caem no mesmo dia, e
+              dois selos com a mesma data não informam nada. */}
           {datas?.publicado && diaIso(datas.publicado) !== diaIso(datas.atualizado) && (
             <span className="chip">
               Publicado em{" "}

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -244,7 +244,12 @@ export function Shell({ children }: { children: React.ReactNode }) {
                   <a className="menu-item only-mobile ext" href={LINKS.youtube} target="_blank" rel="noopener noreferrer" onClick={() => setMenu(false)}>
                     <span className="mi-ico" style={{ color: "#ff0000" }}>▶</span> YouTube<span className="ext-arrow" aria-hidden="true">↗</span>
                   </a>
-                  {/* sempre no menu: comunidade, código e apoio */}
+                  {/* sempre no menu, e a `/sobre` primeiro: é a resposta à
+                      pergunta "quem escreveu isto?", que vem antes de qualquer
+                      link para fora. */}
+                  <Link className="menu-item" href="/sobre" onClick={() => setMenu(false)}>
+                    <span className="mi-ico">ⓘ</span> Sobre o projeto
+                  </Link>
                   <a className="menu-item ext" href={LINKS.site} target="_blank" rel="noopener noreferrer">
                     <span className="mi-ico">✦</span> Craft &amp; Code Club<span className="ext-arrow" aria-hidden="true">↗</span>
                   </a>
@@ -254,9 +259,6 @@ export function Shell({ children }: { children: React.ReactNode }) {
                     </span>
                     GitHub do projeto<span className="ext-arrow" aria-hidden="true">↗</span>
                   </a>
-                  <Link className="menu-item" href="/sobre" onClick={() => setMenu(false)}>
-                    <span className="mi-ico">ⓘ</span> Sobre o projeto
-                  </Link>
                   <Link className="menu-item" href="/apoie" onClick={() => setMenu(false)}>
                     <span className="mi-ico">♥</span> Apoiadores e Parceiros
                   </Link>
@@ -421,6 +423,25 @@ export function Shell({ children }: { children: React.ReactNode }) {
           Tab seguinte volta para o menu. */}
       <main className="main" id="conteudo" tabIndex={-1}>
         {children}
+
+        {/*
+          O rodapé vive AQUI, e não na home, porque ele é a única coisa da
+          página que diz quem publica. Ele existia só em `src/app/page.tsx`, e o
+          resultado medido era este: a home tinha rodapé e as 34 páginas de aula
+          tinham ZERO. Quem chega numa delas pela busca não tinha caminho nenhum
+          para descobrir de quem é o material.
+
+          Sem links: a barra de navegação é fixa e já leva a tudo que estava
+          aqui (Sobre, GitHub, Discord, Apoiar). Rodapé que repete o menu é
+          segundo lugar para a mesma verdade envelhecer.
+        */}
+        <footer className="site-foot">
+          <div className="foot-text">
+            <span>Feito <span className="heart">♥</span> pela comunidade, para a comunidade.</span>
+            <span className="foot-sep">·</span>
+            <span>Open source · gratuito para sempre</span>
+          </div>
+        </footer>
       </main>
     </div>
   );

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -254,6 +254,9 @@ export function Shell({ children }: { children: React.ReactNode }) {
                     </span>
                     GitHub do projeto<span className="ext-arrow" aria-hidden="true">↗</span>
                   </a>
+                  <Link className="menu-item" href="/sobre" onClick={() => setMenu(false)}>
+                    <span className="mi-ico">ⓘ</span> Sobre o projeto
+                  </Link>
                   <Link className="menu-item" href="/apoie" onClick={() => setMenu(false)}>
                     <span className="mi-ico">♥</span> Apoiadores e Parceiros
                   </Link>

--- a/src/lib/datas-do-git.ts
+++ b/src/lib/datas-do-git.ts
@@ -142,6 +142,9 @@ export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T
   return entradas.map(({ lastModified: _, ...resto }) => resto as T);
 }
 
+/** A resposta do guarda, uma vez por build. `undefined` = ainda não perguntei. */
+let gitDistingueCaminhos: boolean | undefined;
+
 /**
  * O MESMO guarda do sitemap, respondido uma vez por build.
  *
@@ -155,8 +158,6 @@ export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T
  * omitindo a data por não confiar nela enquanto a página a estampa em 40
  * lugares seria o site se contradizendo sobre o mesmo fato.
  */
-let gitDistingueCaminhos: boolean | undefined;
-
 function oGitDistingueCaminhos(): boolean {
   if (gitDistingueCaminhos === undefined) {
     const entradas = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => ({

--- a/src/lib/datas-do-git.ts
+++ b/src/lib/datas-do-git.ts
@@ -1,0 +1,107 @@
+import { execFileSync } from "node:child_process";
+
+// A data de uma página, derivada do `git log`. Um lugar só, porque são dois
+// consumidores que precisam responder a MESMA coisa: o `lastmod` do
+// `sitemap.ts` e o `dateModified` do JSON-LD do tópico. Dois predicados para a
+// mesma decisão é como o buraco do sitemap nasceu (ver o comentário do filtro
+// de `isEmptyTopic` lá), e aqui a consequência seria pior: o sitemap
+// escondendo a data por não confiar nela enquanto a página a estampa.
+//
+// A data vem do Git, e não de um campo `updatedAt` no `content/roadmap.ts`:
+// data que depende de alguém lembrar de atualizá-la em cada PR envelhece errado
+// e passa a mentir, o que é pior do que não existir.
+//
+// O guarda contra a data falsa NÃO pergunta se o clone é raso, e a diferença
+// custou duas reprovações de CI. A primeira versão consultava
+// `git rev-parse --is-shallow-repository`; a segunda leu direto o arquivo
+// `.git/shallow`, que é o que aquele comando consulta. As duas reprovaram a
+// suíte num job com histórico de sobra, e o diagnóstico que eu embuti na
+// mensagem mostrou por quê:
+//
+//     marcador de clone raso em /home/runner/.../.git/shallow
+//     datas distintas que ele resolve: 2
+//
+// O `actions/checkout` com `fetch-depth: 0` DEIXA o marcador para trás, e o
+// histórico ali é fundo o bastante para o `git log` responder datas diferentes
+// por caminho. Marcador presente e histórico utilizável ao mesmo tempo: a
+// pergunta é que estava errada.
+//
+// O que este arquivo precisa saber não é a profundidade do clone, é uma
+// CAPACIDADE: o `git log` consegue distinguir um caminho do outro? A resposta
+// está nas próprias datas que ele acabou de coletar. Se todas as páginas
+// saírem com o MESMO carimbo, esse carimbo não é informação — é a data do
+// último commit repetida 40 vezes, exatamente o `lastmod` que o Google
+// aprendeu a ignorar —, e aí o campo inteiro não sai.
+//
+// A vantagem sobre qualquer sonda de ambiente: build e teste chegam à mesma
+// conclusão porque olham o mesmo dado, o resultado do `git log`, e não um
+// marcador que cada máquina mantém do seu jeito.
+
+// Um `git log` por caminho, e não por consulta. São 48 chamadas só para montar
+// o sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,
+// 1,39s no total): `content/roadmap.ts` sozinho é consultado 6 vezes, uma por
+// rota fixa que o lista e uma por tópico sem artigo que cai no fallback. Com a
+// página de tópico consultando os mesmos caminhos, o cache deixou de ser uma
+// economia e virou o que segura o custo. Ele vale por build — o `git log` de um
+// caminho não muda no meio dele.
+const cacheDeCommit = new Map<string, number | undefined>();
+
+function commitDoArquivo(arquivo: string): number | undefined {
+  const emCache = cacheDeCommit.get(arquivo);
+  if (emCache !== undefined || cacheDeCommit.has(arquivo)) return emCache;
+  const valor = consultarCommit(arquivo);
+  cacheDeCommit.set(arquivo, valor);
+  return valor;
+}
+
+function consultarCommit(arquivo: string): number | undefined {
+  try {
+    const iso = execFileSync("git", ["log", "-1", "--format=%cI", "--", arquivo], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (!iso) return undefined; // caminho que nunca existiu no histórico
+    const ms = Date.parse(iso);
+    return Number.isNaN(ms) ? undefined : ms;
+  } catch {
+    return undefined;
+  }
+}
+
+/** A data da rota é a do arquivo de conteúdo dela que mudou por último. */
+export function ultimaAlteracao(...arquivos: readonly string[]): Date | undefined {
+  const datas = arquivos.map(commitDoArquivo).filter((ms): ms is number => ms !== undefined);
+  return datas.length ? new Date(Math.max(...datas)) : undefined;
+}
+
+/**
+ * A data de um tópico: a do artigo, com o `roadmap.ts` de reserva.
+ *
+ * O artigo é o corpo da página; o tópico sem artigo cai no `roadmap.ts`, que é
+ * onde mora cada palavra que essa página mostra.
+ *
+ * Aqui é `??` e NÃO o `max(...)` das rotas fixas, e a diferença foi medida: os
+ * 36 `.mdx` do repositório são todos mais antigos que o último commit do
+ * `roadmap.ts`, então `max` daria a MESMA data às 36 páginas de tópico e
+ * qualquer edição no `roadmap.ts` (marcar um `isNew`, mexer num link)
+ * reescreveria a data das 40 URLs de uma vez. Isso é exatamente o
+ * "lastmod = data do último deploy" que o Google aprendeu a ignorar. A home e o
+ * `/roadmap/` não têm essa escolha: lá o `roadmap.ts` É o conteúdo.
+ */
+export function atualizacaoDoTopico(slug: string): Date | undefined {
+  return ultimaAlteracao(`content/topics/${slug}.mdx`) ?? ultimaAlteracao("content/roadmap.ts");
+}
+
+/**
+ * Devolve as entradas sem `lastModified` quando as datas não carregam
+ * informação: uma só distinta (ou nenhuma) significa que o `git log` respondeu
+ * o mesmo para todo caminho. Exportada para o teste conferir a MESMA regra em
+ * vez de recriá-la — foi recriando que este guarda errou duas vezes.
+ */
+export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T[] {
+  const distintas = new Set(
+    entradas.map((e) => e.lastModified?.getTime()).filter((v): v is number => v !== undefined)
+  );
+  if (distintas.size > 1) return entradas;
+  return entradas.map(({ lastModified: _, ...resto }) => resto as T);
+}

--- a/src/lib/datas-do-git.ts
+++ b/src/lib/datas-do-git.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 
 // A data de uma página, derivada do `git log`. Um lugar só, porque são dois
 // consumidores que precisam responder a MESMA coisa: o `lastmod` do
@@ -68,6 +69,41 @@ function consultarCommit(arquivo: string): number | undefined {
   }
 }
 
+const cacheDoPrimeiroCommit = new Map<string, number | undefined>();
+
+/**
+ * O PRIMEIRO commit que tocou o caminho — a data em que aquele conteúdo entrou
+ * no repositório.
+ *
+ * Sem `-1`, e isso não é descuido: o `git log` aplica o limite ANTES de
+ * inverter, então `--reverse -1` devolve o commit mais NOVO. A saída inteira é
+ * percorrida e o que vale é a primeira linha.
+ *
+ * Sem `--follow` também, e a consequência é declarada: um artigo renomeado
+ * (slug trocado) passa a contar a partir do rename. `--follow` é heurística de
+ * similaridade e muda de resposta conforme o resto do commit — para um campo
+ * que vai virar `datePublished`, uma data estável e explicável vale mais do que
+ * uma data adivinhada.
+ */
+function primeiroCommitDoArquivo(arquivo: string): number | undefined {
+  const emCache = cacheDoPrimeiroCommit.get(arquivo);
+  if (emCache !== undefined || cacheDoPrimeiroCommit.has(arquivo)) return emCache;
+  let valor: number | undefined;
+  try {
+    const saida = execFileSync("git", ["log", "--reverse", "--format=%cI", "--", arquivo], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    const iso = saida.split("\n", 1)[0].trim();
+    const ms = iso ? Date.parse(iso) : NaN;
+    valor = Number.isNaN(ms) ? undefined : ms;
+  } catch {
+    valor = undefined;
+  }
+  cacheDoPrimeiroCommit.set(arquivo, valor);
+  return valor;
+}
+
 /** A data da rota é a do arquivo de conteúdo dela que mudou por último. */
 export function ultimaAlteracao(...arquivos: readonly string[]): Date | undefined {
   const datas = arquivos.map(commitDoArquivo).filter((ms): ms is number => ms !== undefined);
@@ -104,4 +140,56 @@ export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T
   );
   if (distintas.size > 1) return entradas;
   return entradas.map(({ lastModified: _, ...resto }) => resto as T);
+}
+
+/**
+ * O MESMO guarda do sitemap, respondido uma vez por build.
+ *
+ * Uma página sozinha não tem como saber se o carimbo dela é informação: a
+ * resposta só existe olhando o CONJUNTO. Então a pergunta é feita pelo site
+ * inteiro — as datas dos tópicos que o sitemap convida — e o conjunto passa
+ * pelo próprio `comDataUtil`. Se ele apagar as datas, o `git log` deste build
+ * respondeu o mesmo para todo caminho, e nenhuma página estampa data nenhuma.
+ *
+ * É a mesma pergunta do `lastmod` de propósito, e não por economia: o sitemap
+ * omitindo a data por não confiar nela enquanto a página a estampa em 40
+ * lugares seria o site se contradizendo sobre o mesmo fato.
+ */
+let gitDistingueCaminhos: boolean | undefined;
+
+function oGitDistingueCaminhos(): boolean {
+  if (gitDistingueCaminhos === undefined) {
+    const entradas = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => ({
+      lastModified: atualizacaoDoTopico(t.slug),
+    }));
+    gitDistingueCaminhos = comDataUtil(entradas).some((e) => e.lastModified !== undefined);
+  }
+  return gitDistingueCaminhos;
+}
+
+export type DatasDoTopico = {
+  /**
+   * O primeiro commit do artigo. Ausente quando o tópico não tem `.mdx`: aí a
+   * data de reserva é a do `content/roadmap.ts`, e o primeiro commit DELE é o
+   * começo do repositório — que não é a data em que aquele tópico nasceu.
+   */
+  publicado?: Date;
+  atualizado: Date;
+};
+
+/**
+ * As datas de um tópico, ou `undefined` quando elas não seriam informação.
+ *
+ * Devolver `undefined` é o caminho normal em clone raso, e é o comportamento
+ * certo: uma data errada é pior do que data nenhuma. Quem chama não precisa
+ * saber disso — sem datas, o selo não é desenhado e os campos não saem.
+ */
+export function datasDoTopico(slug: string): DatasDoTopico | undefined {
+  if (!oGitDistingueCaminhos()) return undefined;
+  const atualizado = atualizacaoDoTopico(slug);
+  if (!atualizado) return undefined;
+  const publicado = primeiroCommitDoArquivo(`content/topics/${slug}.mdx`);
+  return publicado === undefined
+    ? { atualizado }
+    : { publicado: new Date(publicado), atualizado };
 }

--- a/src/lib/datas-do-git.ts
+++ b/src/lib/datas-do-git.ts
@@ -164,6 +164,9 @@ export function ultimaAlteracao(...arquivos: readonly string[]): Date | undefine
 
 const ARQUIVO_DO_ROADMAP = "content/roadmap.ts";
 
+/** Os intervalos, lidos e validados uma vez por build. */
+let intervalos: Map<string, readonly [number, number]> | undefined;
+
 /**
  * O intervalo de linhas que descreve cada tópico dentro do `roadmap.ts`.
  *
@@ -240,8 +243,6 @@ function intervalosDosTopicos(): Map<string, readonly [number, number]> {
   }
   return intervalos;
 }
-
-let intervalos: Map<string, readonly [number, number]> | undefined;
 
 const cacheDoIntervalo = new Map<string, number | undefined>();
 

--- a/src/lib/datas-do-git.ts
+++ b/src/lib/datas-do-git.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 
 // As rotas fixas e os arquivos que respondem pelo conteúdo de cada uma.
@@ -161,22 +162,161 @@ export function ultimaAlteracao(...arquivos: readonly string[]): Date | undefine
   return datas.length ? new Date(Math.max(...datas)) : undefined;
 }
 
+const ARQUIVO_DO_ROADMAP = "content/roadmap.ts";
+
 /**
- * A data de um tópico: a do artigo, com o `roadmap.ts` de reserva.
+ * O intervalo de linhas que descreve cada tópico dentro do `roadmap.ts`.
  *
- * O artigo é o corpo da página; o tópico sem artigo cai no `roadmap.ts`, que é
- * onde mora cada palavra que essa página mostra.
+ * Existe porque a página de um tópico é feita de DOIS conteúdos: o artigo
+ * (`.mdx`) e a entrada dele aqui, de onde saem título, nível, tempo de leitura,
+ * vídeo, problemas e referências — tudo isso está na tela. Datar a página só
+ * pelo artigo é ignorar metade dela; datar pelo arquivo inteiro é dizer que
+ * todos os tópicos mudaram quando um mudou.
  *
- * Aqui é `??` e NÃO o `max(...)` das rotas fixas, e a diferença foi medida: os
- * 36 `.mdx` do repositório são todos mais antigos que o último commit do
- * `roadmap.ts`, então `max` daria a MESMA data às 36 páginas de tópico e
- * qualquer edição no `roadmap.ts` (marcar um `isNew`, mexer num link)
- * reescreveria a data das 40 URLs de uma vez. Isso é exatamente o
- * "lastmod = data do último deploy" que o Google aprendeu a ignorar. A home e o
- * `/roadmap/` não têm essa escolha: lá o `roadmap.ts` É o conteúdo.
+ * O intervalo é achado por balanço de chaves a partir do `slug:`, e serve para
+ * as DUAS formas de escrita que o arquivo usa hoje — o objeto multilinha dos
+ * tópicos com material e o objeto de uma linha só dos `soon`.
+ *
+ * ⚠️ O resultado é VALIDADO antes de valer: o intervalo tem que conter este
+ * `slug` e nenhum outro. Sem essa conferência, uma reformatação do arquivo faria
+ * o intervalo de um tópico engolir o vizinho e a página passaria a mostrar,
+ * com toda a confiança, a data de outro tópico. Intervalo que não valida não é
+ * usado — o tópico cai no plano B, que é a regra antiga.
+ *
+ * Medido na `main` de hoje: 47 de 47 tópicos validam.
+ */
+function intervalosDosTopicos(): Map<string, readonly [number, number]> {
+  if (intervalos) return intervalos;
+  intervalos = new Map();
+  let linhas: string[];
+  try {
+    linhas = readFileSync(ARQUIVO_DO_ROADMAP, "utf8").split("\n");
+  } catch {
+    return intervalos; // sem o arquivo, todo tópico cai no plano B
+  }
+
+  // Onde cada `slug:` começa, em linha e coluna. A coluna importa: no objeto de
+  // uma linha só, a chave que abre está ANTES do slug, na mesma linha.
+  const posicaoDoSlug = new Map<string, readonly [number, number]>();
+  linhas.forEach((linha, i) => {
+    const m = linha.match(/\bslug: "([^"]+)"/);
+    if (m && !posicaoDoSlug.has(m[1])) posicaoDoSlug.set(m[1], [i, m.index!]);
+  });
+
+  for (const [slug, [linhaDoSlug, coluna]] of posicaoDoSlug) {
+    // Para trás, até a chave que abre o objeto deste tópico.
+    let saldo = 0;
+    let inicio = -1;
+    for (let j = linhaDoSlug; j >= 0 && inicio < 0; j--) {
+      const linha = linhas[j];
+      for (let k = j === linhaDoSlug ? coluna : linha.length - 1; k >= 0; k--) {
+        if (linha[k] === "}") saldo--;
+        else if (linha[k] === "{" && ++saldo === 1) {
+          inicio = j;
+          break;
+        }
+      }
+    }
+    if (inicio < 0) continue;
+
+    // Para frente, até ela fechar.
+    let nivel = 0;
+    let fim = -1;
+    for (let j = inicio; j < linhas.length && fim < 0; j++) {
+      for (const ch of linhas[j]) {
+        if (ch === "{") nivel++;
+        else if (ch === "}" && --nivel === 0) {
+          fim = j;
+          break;
+        }
+      }
+    }
+    if (fim < 0) continue;
+
+    // A validação: um slug dentro, e um só.
+    let quantosSlugs = 0;
+    for (const [, [j]] of posicaoDoSlug) if (j >= inicio && j <= fim) quantosSlugs++;
+    if (quantosSlugs === 1) intervalos.set(slug, [inicio + 1, fim + 1]);
+  }
+  return intervalos;
+}
+
+let intervalos: Map<string, readonly [number, number]> | undefined;
+
+const cacheDoIntervalo = new Map<string, number | undefined>();
+
+/**
+ * O último commit que mexeu NAQUELE trecho do `roadmap.ts`.
+ *
+ * `git log -L <ini>,<fim>:<arquivo>` segue o intervalo de linhas ao longo do
+ * histórico — inclusive quando ele desliza porque alguém inseriu tópicos acima.
+ *
+ * Por que `-L` e não `git blame`, que responderia quase o mesmo por 1/26 do
+ * preço (medido: 207ms de um `blame` do arquivo inteiro contra 5,5s de 36
+ * `-L`): o `blame` só enxerga as linhas que SOBREVIVERAM até hoje, então um
+ * commit que só REMOVEU coisa do tópico (tirar um problema da lista, cortar uma
+ * referência) não move a data — e remover é mudar a página. Medido: as duas
+ * respostas divergem em 18 dos 36 tópicos, e em 3 deles a divergência muda o
+ * DIA que o aluno lê. Num selo visível, 3 páginas com data velha é o defeito
+ * que este mecanismo existe para não ter.
+ *
+ * O preço, dito na cara: 6,5s para os 47 tópicos (137ms cada), contra os ~1,4s
+ * de `git log` que o build já pagava. É custo de build, uma vez, num site
+ * estático — e vem com cache, então as 47 páginas dividem as 47 consultas.
+ */
+function commitDoIntervalo(ini: number, fim: number): number | undefined {
+  const chave = `${ini},${fim}`;
+  const emCache = cacheDoIntervalo.get(chave);
+  if (emCache !== undefined || cacheDoIntervalo.has(chave)) return emCache;
+  let valor: number | undefined;
+  try {
+    const saida = execFileSync(
+      "git",
+      ["log", "-L", `${ini},${fim}:${ARQUIVO_DO_ROADMAP}`, "--no-patch", "--format=%cI"],
+      { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+    );
+    const iso = saida.split("\n", 1)[0].trim();
+    const ms = iso ? Date.parse(iso) : NaN;
+    valor = Number.isNaN(ms) ? undefined : ms;
+  } catch {
+    valor = undefined;
+  }
+  cacheDoIntervalo.set(chave, valor);
+  return valor;
+}
+
+/**
+ * Quando a página deste tópico mudou pela última vez.
+ *
+ * É o MAIS RECENTE entre o artigo e a entrada do tópico no `roadmap.ts` —
+ * porque a página é as duas coisas, e o selo "Atualizado em" é uma afirmação
+ * sobre a página inteira.
+ *
+ * A regra anterior era `mdx ?? roadmap.ts`, e tinha dois furos que num campo
+ * invisível (`lastmod`) dava para tolerar e num selo visível não dá:
+ *
+ *   · tópico COM artigo ignorava o `roadmap.ts`, então mexer no título, no
+ *     nível, no tempo de leitura, no vídeo, nos problemas ou nas referências
+ *     não movia a data. Medido: 7 dos 36 tópicos mostravam data velha por isso;
+ *   · tópico SEM artigo herdava o último commit do arquivo INTEIRO, então
+ *     editar um tópico avançava a data de todos os outros.
+ *
+ * O intervalo de linhas fecha os dois: ele é daquele tópico e de mais ninguém.
+ * E ele NÃO recria o problema que o `??` evitava — o comentário antigo temia
+ * que o `max(...)` com o `roadmap.ts` desse a mesma data a todos, e daria
+ * mesmo, se fosse o arquivo inteiro. Com o intervalo, editar um tópico move só
+ * a data dele.
+ *
+ * O `??` sobrevive como plano B, para o tópico cujo intervalo não validou.
  */
 export function atualizacaoDoTopico(slug: string): Date | undefined {
-  return ultimaAlteracao(`content/topics/${slug}.mdx`) ?? ultimaAlteracao("content/roadmap.ts");
+  const doArtigo = ultimaAlteracao(`content/topics/${slug}.mdx`);
+  const intervalo = intervalosDosTopicos().get(slug);
+  const doIntervalo = intervalo ? commitDoIntervalo(intervalo[0], intervalo[1]) : undefined;
+  if (doIntervalo === undefined) {
+    return doArtigo ?? ultimaAlteracao(ARQUIVO_DO_ROADMAP);
+  }
+  return new Date(Math.max(doIntervalo, doArtigo?.getTime() ?? 0));
 }
 
 /**

--- a/src/lib/datas-do-git.ts
+++ b/src/lib/datas-do-git.ts
@@ -1,6 +1,37 @@
 import { execFileSync } from "node:child_process";
 import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 
+// As rotas fixas e os arquivos que respondem pelo conteúdo de cada uma.
+//
+// Mora AQUI, e não no `sitemap.ts` que é o principal consumidor, por uma razão
+// só: é deste inventário que sai o conjunto de caminhos que o guarda mede, e o
+// guarda precisa ser o mesmo para os dois consumidores. Com o mapa lá e o
+// guarda cá, a única saída seria o módulo importar o `sitemap.ts` — que já
+// importa o módulo.
+//
+// É uma LISTA por rota, e não um arquivo só, porque `page.tsx` quase nunca é
+// onde o texto mora. A home e o `/roadmap/` importam de `content/roadmap.ts`:
+// mexer num tópico muda as duas telas sem tocar em nenhum dos dois `page.tsx`,
+// e a data ficava parada no dia em que o layout mudou pela última vez. O
+// `/apoie/` tem a mesma forma com `apoiadores.ts`, que é onde a lista de nomes
+// é mantida à mão. A data da rota é a MAIS RECENTE entre esses arquivos.
+//
+// O tipo do `Record` é o que cobra a segunda metade: acrescentar uma rota em
+// `ROTAS_FIXAS` sem declarar de que arquivos ela tira data é erro de
+// compilação, não uma URL sem `lastmod` descoberta meses depois.
+export const ROTAS_FIXAS = ["/", "/introducao/", "/roadmap/", "/apoie/", "/sobre/"] as const;
+
+export const CONTEUDO_DA_ROTA: Record<(typeof ROTAS_FIXAS)[number], readonly string[]> = {
+  "/": ["src/app/page.tsx", "content/roadmap.ts"],
+  "/introducao/": ["src/app/introducao/page.tsx"],
+  "/roadmap/": ["src/app/roadmap/page.tsx", "content/roadmap.ts"],
+  "/apoie/": ["src/app/apoie/page.tsx", "src/app/apoie/apoiadores.ts"],
+  // O /sobre também lê o `roadmap.ts`: os números de tópicos, visualizadores e
+  // problemas que o texto cita saem de lá, como na home. Tópico novo muda a
+  // página sem ninguém tocar no `page.tsx` dela.
+  "/sobre/": ["src/app/sobre/page.tsx", "content/roadmap.ts"],
+};
+
 // A data de uma página, derivada do `git log`. Um lugar só, porque são dois
 // consumidores que precisam responder a MESMA coisa: o `lastmod` do
 // `sitemap.ts` e o `dateModified` do JSON-LD do tópico. Dois predicados para a
@@ -29,14 +60,34 @@ import { ALL_TOPICS, isEmptyTopic } from "@content/roadmap";
 //
 // O que este arquivo precisa saber não é a profundidade do clone, é uma
 // CAPACIDADE: o `git log` consegue distinguir um caminho do outro? A resposta
-// está nas próprias datas que ele acabou de coletar. Se todas as páginas
-// saírem com o MESMO carimbo, esse carimbo não é informação — é a data do
-// último commit repetida 40 vezes, exatamente o `lastmod` que o Google
-// aprendeu a ignorar —, e aí o campo inteiro não sai.
+// está nas próprias datas que ele acabou de coletar.
 //
 // A vantagem sobre qualquer sonda de ambiente: build e teste chegam à mesma
 // conclusão porque olham o mesmo dado, o resultado do `git log`, e não um
 // marcador que cada máquina mantém do seu jeito.
+//
+// E a medida dessa capacidade é CONCENTRAÇÃO, não contagem de distintas. A
+// diferença não é teórica: num clone raso com alguns commits em cima, os
+// caminhos que esses commits tocaram resolvem para eles e todo o RESTO resolve
+// para o commit-fronteira. Dá duas datas distintas — `Set.size > 1` aprova — e
+// a esmagadora maioria das URLs fica com uma data fabricada. Foi assim que uma
+// CI vermelha inteira se explicou: o git daquele processo achatou 39 dos 42
+// caminhos na data do merge da base e resolveu de verdade os TRÊS que o PR
+// tinha tocado; a contagem valia 2, o guarda concluía "o git enxerga", e 37
+// URLs corretas foram reprovadas.
+//
+// Então a medida é a fatia da MODA sobre todos os caminhos de que o site tira
+// data. Margens medidas neste repositório: com histórico de verdade, 45
+// caminhos, 24 datas distintas, moda de 6 (13,3%); no job achatado a moda era
+// 39 de 42 (92,9%). O corte em 50% fica longe dos dois, e cobre o caso antigo —
+// git que resolve UMA data para tudo tem moda de 100%.
+//
+// Este critério não nasceu aqui: ele já era o do `tests/seo-estrutura.spec.ts`,
+// que o descobriu na investigação daquela CI. O que mudou é que agora ele mora
+// no código de produção e o teste IMPORTA a mesma função, em vez de o
+// repositório manter duas versões da mesma regra — que é exatamente o erro que
+// o comentário do `sitemap.ts` registra sobre recriar a condição em dois
+// lugares.
 
 // Um `git log` por caminho, e não por consulta. São 48 chamadas só para montar
 // o sitemap e cada uma custa ~29ms de processo novo (medido neste repositório,
@@ -129,43 +180,78 @@ export function atualizacaoDoTopico(slug: string): Date | undefined {
 }
 
 /**
- * Devolve as entradas sem `lastModified` quando as datas não carregam
- * informação: uma só distinta (ou nenhuma) significa que o `git log` respondeu
- * o mesmo para todo caminho. Exportada para o teste conferir a MESMA regra em
- * vez de recriá-la — foi recriando que este guarda errou duas vezes.
+ * Acima desta fatia, o carimbo mais repetido denuncia histórico achatado.
+ *
+ * Margens medidas: 13,3% neste repositório com histórico de verdade, 92,9% no
+ * job achatado, 100% no git que resolve uma data só para tudo. O corte fica
+ * longe dos três.
  */
-export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T[] {
-  const distintas = new Set(
-    entradas.map((e) => e.lastModified?.getTime()).filter((v): v is number => v !== undefined)
-  );
-  if (distintas.size > 1) return entradas;
-  return entradas.map(({ lastModified: _, ...resto }) => resto as T);
-}
-
-/** A resposta do guarda, uma vez por build. `undefined` = ainda não perguntei. */
-let gitDistingueCaminhos: boolean | undefined;
+export const LIMITE_DE_CONCENTRACAO = 0.5;
 
 /**
- * O MESMO guarda do sitemap, respondido uma vez por build.
+ * A regra, pura e sem tocar no git: estes carimbos distinguem os caminhos de
+ * onde saíram, ou são o mesmo commit repetido?
  *
- * Uma página sozinha não tem como saber se o carimbo dela é informação: a
- * resposta só existe olhando o CONJUNTO. Então a pergunta é feita pelo site
- * inteiro — as datas dos tópicos que o sitemap convida — e o conjunto passa
- * pelo próprio `comDataUtil`. Se ele apagar as datas, o `git log` deste build
- * respondeu o mesmo para todo caminho, e nenhuma página estampa data nenhuma.
+ * Exportada para o teste conferir a MESMA regra em vez de recriá-la — foi
+ * recriando que este guarda errou duas vezes, e foi mantendo duas versões dela
+ * que o teste reprovou 37 URLs corretas.
  *
- * É a mesma pergunta do `lastmod` de propósito, e não por economia: o sitemap
- * omitindo a data por não confiar nela enquanto a página a estampa em 40
- * lugares seria o site se contradizendo sobre o mesmo fato.
+ * `undefined` (caminho que nunca existiu no histórico) não conta nem a favor
+ * nem contra: ele não é evidência de achatamento, é ausência de dado.
  */
-function oGitDistingueCaminhos(): boolean {
-  if (gitDistingueCaminhos === undefined) {
-    const entradas = ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => ({
-      lastModified: atualizacaoDoTopico(t.slug),
-    }));
-    gitDistingueCaminhos = comDataUtil(entradas).some((e) => e.lastModified !== undefined);
-  }
-  return gitDistingueCaminhos;
+export function datasDistinguemCaminhos(carimbos: readonly (number | undefined)[]): boolean {
+  const porCarimbo = new Map<number, number>();
+  for (const c of carimbos) if (c !== undefined) porCarimbo.set(c, (porCarimbo.get(c) ?? 0) + 1);
+  const resolvidos = [...porCarimbo.values()].reduce((a, b) => a + b, 0);
+  if (resolvidos === 0) return false;
+  return Math.max(...porCarimbo.values()) / resolvidos <= LIMITE_DE_CONCENTRACAO;
+}
+
+/**
+ * TODOS os caminhos de que o site tira data — as rotas fixas e os artigos.
+ *
+ * É este conjunto, e nenhum recorte dele, que o guarda mede. O recorte era um
+ * defeito de verdade: a página de tópico media só os artigos e o sitemap media
+ * rotas fixas mais tópicos, então num build onde as rotas fixas resolvessem
+ * para o HEAD e os artigos para a fronteira do raso, as duas respostas
+ * divergiriam — as páginas escondendo a data e o sitemap publicando o
+ * `lastmod`. O invariante que este PR anuncia (página e sitemap contam a mesma
+ * história) dependia de as duas perguntas serem uma só.
+ */
+export function caminhosDatados(): string[] {
+  return [
+    ...Object.values(CONTEUDO_DA_ROTA).flat(),
+    ...ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => `content/topics/${t.slug}.mdx`),
+  ];
+}
+
+/** A decisão, uma vez por build. `undefined` = ainda não perguntei. */
+let enxerga: boolean | undefined;
+
+/**
+ * UMA decisão de validade, com cache, para os dois consumidores.
+ *
+ * Enquanto ela for falsa, nem o `lastmod` nem o `dateModified` saem — o site
+ * inteiro fica sem data, que é o comportamento certo: data errada é pior do
+ * que data nenhuma, e meia data é o site se contradizendo sobre o mesmo fato.
+ */
+export function oGitEnxergaOHistorico(): boolean {
+  if (enxerga === undefined) enxerga = datasDistinguemCaminhos(caminhosDatados().map(commitDoArquivo));
+  return enxerga;
+}
+
+/**
+ * Devolve as entradas sem `lastModified` quando o `git log` deste build não
+ * distingue um caminho do outro.
+ *
+ * Repare que ele NÃO julga as entradas que recebe: quem decide é
+ * {@link oGitEnxergaOHistorico}, sobre o conjunto canônico de caminhos. Julgar
+ * o próprio argumento era o defeito — cada consumidor passava um conjunto
+ * diferente e podia chegar a uma resposta diferente.
+ */
+export function comDataUtil<T extends { lastModified?: Date }>(entradas: T[]): T[] {
+  if (oGitEnxergaOHistorico()) return entradas;
+  return entradas.map(({ lastModified: _, ...resto }) => resto as T);
 }
 
 export type DatasDoTopico = {
@@ -186,7 +272,7 @@ export type DatasDoTopico = {
  * saber disso — sem datas, o selo não é desenhado e os campos não saem.
  */
 export function datasDoTopico(slug: string): DatasDoTopico | undefined {
-  if (!oGitDistingueCaminhos()) return undefined;
+  if (!oGitEnxergaOHistorico()) return undefined;
   const atualizado = atualizacaoDoTopico(slug);
   if (!atualizado) return undefined;
   const publicado = primeiroCommitDoArquivo(`content/topics/${slug}.mdx`);

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,5 +1,9 @@
 /**
- * Formatação de número e concordância de plural para os visualizadores.
+ * Formatação de número, concordância de plural e data por extenso.
+ *
+ * Número e plural nasceram aqui pelos visualizadores; a data entrou pelo selo
+ * "Atualizado em" da página de tópico, e entrou AQUI porque este é o formatador
+ * único do projeto — a alternativa era uma terceira cópia de nome de mês.
  *
  * Existe porque as mesmas funções estavam copiadas dezenas de vezes em
  * `content/visualizers/`, e as cópias tinham divergido em silêncio:
@@ -101,4 +105,44 @@ export function plural(v: number, one: string, many: string): string {
  */
 export function comNumero(v: number, one: string, many: string): string {
   return `${v} ${plural(v, one, many)}`;
+}
+
+const MESES = [
+  "janeiro",
+  "fevereiro",
+  "março",
+  "abril",
+  "maio",
+  "junho",
+  "julho",
+  "agosto",
+  "setembro",
+  "outubro",
+  "novembro",
+  "dezembro",
+];
+
+/**
+ * O DIA de uma data, em UTC: `"2026-06-12"`. É o valor do atributo `datetime`
+ * do `<time>`, que a especificação do HTML lê como data completa.
+ *
+ * UTC, e não o fuso da máquina, pelo mesmo motivo do `Intl` proibido no topo
+ * deste arquivo: o HTML é gerado uma vez, no build, e o dia impresso não pode
+ * depender de onde o build rodou. O `%cI` do `git log` traz o fuso de quem
+ * commitou — normalizar para UTC dá o MESMO dia em qualquer runner, e é o que
+ * mantém o atributo e o texto ao lado dele sempre concordando.
+ */
+export function diaIso(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * A data por extenso, em português: `"12 de junho de 2026"`.
+ *
+ * Sempre o MESMO dia que {@link diaIso} devolve para a mesma data, porque os
+ * dois leem os componentes em UTC. Texto e `datetime` que discordam por um dia
+ * é o defeito que essa dupla existe para não ter.
+ */
+export function dataLonga(d: Date): string {
+  return `${d.getUTCDate()} de ${MESES[d.getUTCMonth()]} de ${d.getUTCFullYear()}`;
 }

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -17,7 +17,6 @@ import { SITE_NAME } from "@/lib/seo";
 //   about             → o grupo, que a trilha mostra logo acima do título
 //   author            → "por Craft & Code Club", ao lado da marca no topo
 //   dateModified      → o selo "Atualizado em", no mesmo `.topic-chips`
-//   datePublished     → o selo "Publicado em", quando o dia é outro
 //   itemListElement   → os cards que o /roadmap renderiza, na mesma ordem
 //
 // Campo sem correspondente fica de fora, e é por isso que não há
@@ -120,7 +119,6 @@ export function topicJsonLd(t: Topic, datas?: { publicado?: Date; atualizado?: D
     // quando é o mesmo dia — 28 dos 36 tópicos hoje —, o valor que ele carrega
     // é exatamente a data que está impressa ali. Nos dois casos o número na
     // marcação é um número que o leitor vê.
-    ...(datas?.publicado ? { datePublished: datas.publicado.toISOString() } : {}),
     ...(datas?.atualizado ? { dateModified: datas.atualizado.toISOString() } : {}),
     isPartOf: { "@id": ID_SITE },
     author: AUTOR,

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -15,6 +15,7 @@ import { SITE_NAME } from "@/lib/seo";
 //   programmingLanguage → o selo "Python", que é a linguagem do CÓDIGO
 //   inLanguage        → `pt-BR`, o `lang` do `<html>` (não confundir com o de cima)
 //   about             → o grupo, que a trilha mostra logo acima do título
+//   author            → "por Craft & Code Club", ao lado da marca no topo
 //   itemListElement   → os cards que o /roadmap renderiza, na mesma ordem
 //
 // Campo sem correspondente fica de fora, e é por isso que não há
@@ -31,6 +32,24 @@ const abs = (rota: string) => `${SITE_URL}${rota}`;
 
 const ID_ORG = `${SITE_URL}/#organization`;
 const ID_SITE = `${SITE_URL}/#website`;
+
+/**
+ * Quem assina o conteúdo do guia.
+ *
+ * É a ORGANIZAÇÃO, por `@id` para o nó `Organization` que o layout já emite em
+ * toda rota — e a escolha é factual, não uma preferência de estilo. Os 34
+ * vídeos que alimentam os tópicos têm `ownerChannelName: "Craft & Code Club"`,
+ * as 34 descrições não citam o nome de nenhuma pessoa, e o `git log` deste
+ * repositório tem uma única conta humana (mesmo ID do GitHub sob dois nomes de
+ * usuário). Não há base para atribuir autoria nominal a ninguém.
+ *
+ * ⚠️ A decisão de nomear uma PESSOA é do Wilson, e custa esta constante e mais
+ * nada: trocar por `{ "@type": "Person", name: "…", url: "…" }` — ou virar um
+ * array com os dois, que `author` aceita — já muda as 40 páginas de tópico.
+ * O que a troca exige junto: o nome tem que aparecer na tela, porque a regra
+ * que decide o desenho deste arquivo é "a marcação reflete o que está na tela".
+ */
+const AUTOR = { "@id": ID_ORG };
 
 /** "12 min" → "PT12M". Formato inesperado devolve `undefined`, e o campo some. */
 function duracaoIso(readingTime: string | undefined): string | undefined {
@@ -90,6 +109,7 @@ export function topicJsonLd(t: Topic) {
     ...(timeRequired ? { timeRequired } : {}),
     ...(t.language ? { programmingLanguage: t.language } : {}),
     isPartOf: { "@id": ID_SITE },
+    author: AUTOR,
     publisher: { "@id": ID_ORG },
   };
 }

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -16,6 +16,8 @@ import { SITE_NAME } from "@/lib/seo";
 //   inLanguage        → `pt-BR`, o `lang` do `<html>` (não confundir com o de cima)
 //   about             → o grupo, que a trilha mostra logo acima do título
 //   author            → "por Craft & Code Club", ao lado da marca no topo
+//   dateModified      → o selo "Atualizado em", no mesmo `.topic-chips`
+//   datePublished     → o selo "Publicado em", quando o dia é outro
 //   itemListElement   → os cards que o /roadmap renderiza, na mesma ordem
 //
 // Campo sem correspondente fica de fora, e é por isso que não há
@@ -92,7 +94,7 @@ export function webSiteJsonLd() {
  * programa com turma, instrutor e matrícula — e `Course` só rende resultado rico
  * com `hasCourseInstance`/`offers`, que este produto não tem para declarar.
  */
-export function topicJsonLd(t: Topic) {
+export function topicJsonLd(t: Topic, datas?: { publicado?: Date; atualizado?: Date }) {
   const url = abs(`/topico/${t.slug}/`);
   const timeRequired = duracaoIso(t.readingTime);
   return {
@@ -108,6 +110,18 @@ export function topicJsonLd(t: Topic) {
     about: { "@type": "Thing", name: t.group },
     ...(timeRequired ? { timeRequired } : {}),
     ...(t.language ? { programmingLanguage: t.language } : {}),
+    // As datas vêm do Git (`src/lib/datas-do-git.ts`) e chegam prontas, ou não
+    // chegam: quem decide se elas são informação é o mesmo guarda do `lastmod`
+    // do sitemap, e em clone raso os dois campos somem juntos. Data errada é
+    // pior do que data nenhuma.
+    //
+    // `dateModified` tem o selo "Atualizado em" na tela, em `.topic-chips`.
+    // `datePublished` ganha o selo "Publicado em" ao lado quando o dia é OUTRO;
+    // quando é o mesmo dia — 31 dos 36 artigos hoje —, o valor que ele carrega
+    // é exatamente a data que está impressa ali. Nos dois casos o número na
+    // marcação é um número que o leitor vê.
+    ...(datas?.publicado ? { datePublished: datas.publicado.toISOString() } : {}),
+    ...(datas?.atualizado ? { dateModified: datas.atualizado.toISOString() } : {}),
     isPartOf: { "@id": ID_SITE },
     author: AUTOR,
     publisher: { "@id": ID_ORG },

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -117,7 +117,7 @@ export function topicJsonLd(t: Topic, datas?: { publicado?: Date; atualizado?: D
     //
     // `dateModified` tem o selo "Atualizado em" na tela, em `.topic-chips`.
     // `datePublished` ganha o selo "Publicado em" ao lado quando o dia é OUTRO;
-    // quando é o mesmo dia — 31 dos 36 artigos hoje —, o valor que ele carrega
+    // quando é o mesmo dia — 28 dos 36 tópicos hoje —, o valor que ele carrega
     // é exatamente a data que está impressa ali. Nos dois casos o número na
     // marcação é um número que o leitor vê.
     ...(datas?.publicado ? { datePublished: datas.publicado.toISOString() } : {}),

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -38,17 +38,23 @@ const ID_SITE = `${SITE_URL}/#website`;
  * Quem assina o conteúdo do guia.
  *
  * É a ORGANIZAÇÃO, por `@id` para o nó `Organization` que o layout já emite em
- * toda rota — e a escolha é factual, não uma preferência de estilo. Os 34
- * vídeos que alimentam os tópicos têm `ownerChannelName: "Craft & Code Club"`,
- * as 34 descrições não citam o nome de nenhuma pessoa, e o `git log` deste
- * repositório tem uma única conta humana (mesmo ID do GitHub sob dois nomes de
- * usuário). Não há base para atribuir autoria nominal a ninguém.
+ * toda rota. E isso é DECISÃO TOMADA, não um valor provisório esperando alguém
+ * decidir: o guia é obra da comunidade, e assina como comunidade.
  *
- * ⚠️ A decisão de nomear uma PESSOA é do Wilson, e custa esta constante e mais
- * nada: trocar por `{ "@type": "Person", name: "…", url: "…" }` — ou virar um
- * array com os dois, que `author` aceita — já muda as 40 páginas de tópico.
- * O que a troca exige junto: o nome tem que aparecer na tela, porque a regra
- * que decide o desenho deste arquivo é "a marcação reflete o que está na tela".
+ * A decisão também é a que os fatos sustentam. Os 34 vídeos que alimentam os
+ * tópicos têm `ownerChannelName: "Craft & Code Club"`, as 34 descrições não
+ * citam o nome de nenhuma pessoa, e o `git log` deste repositório tem uma única
+ * conta humana (mesmo ID do GitHub sob dois nomes de usuário).
+ *
+ * ⚠️ NÃO troque por `Person`, nem acrescente uma ao lado num array. Autoria
+ * nominal aqui significaria escolher um nome entre muitos que contribuíram, num
+ * projeto que recebe PR da comunidade, e o `Organization` já é o sujeito certo:
+ * ele é quem publica os vídeos, quem mantém o repositório e quem responde no
+ * Discord.
+ *
+ * (Se um dia isso mudar, mude junto o que aparece na TELA: a regra que decide o
+ * desenho deste arquivo é "a marcação reflete o que está na tela", e nome que
+ * só existe no JSON-LD é marcação sem lastro.)
  */
 const AUTOR = { "@id": ID_ORG };
 

--- a/tests/format.spec.ts
+++ b/tests/format.spec.ts
@@ -1,6 +1,14 @@
 import { test, expect, type Page } from "@playwright/test";
 
-import { thousands, thousandsDecimal, thousandsSigned, plural, comNumero } from "../src/lib/format";
+import {
+  comNumero,
+  dataLonga,
+  diaIso,
+  plural,
+  thousands,
+  thousandsDecimal,
+  thousandsSigned,
+} from "../src/lib/format";
 import { DEFAULT_SPEEDS, SPEED_LABELS } from "../src/lib/visualizer";
 
 // Os utilitários que estavam copiados em `content/visualizers/`, agora em
@@ -269,4 +277,124 @@ test("sem a prop `speeds`, o controle de velocidade continua nomeando as marchas
   await slider.fill("1");
   await expect(slider).toHaveAttribute("aria-valuetext", "0.5x");
   expect(await painel.locator(".viz-speed .val").innerText()).toBe("0.5x");
+});
+
+// ---------------------------------------------------------------------------
+// 5 · As datas do selo "Atualizado em"
+//
+// Por que esta seção existe, e o que ela conserta: os testes de navegador
+// conferem o selo comparando o texto renderizado com `dataLonga(new
+// Date(datetime))` — ou seja, com A PRÓPRIA função que gerou o texto. Isso
+// prova que o atributo e o texto CONCORDAM, que é metade do que importa, e não
+// prova nada sobre o valor estar certo: trocar a tabela de meses inteira, ou
+// passar de UTC para o fuso da máquina, muda os dois lados junto e deixa a
+// suíte verde com o site mostrando outra data.
+//
+// Daí o oráculo escrito à mão aqui embaixo. Nenhuma asserção desta seção chama
+// `dataLonga` dos dois lados da comparação.
+// ---------------------------------------------------------------------------
+
+/** Os doze meses, escritos à mão. Se a tabela do `format.ts` mudar, morre aqui. */
+const MESES_ESPERADOS: ReadonlyArray<readonly [string, string]> = [
+  ["2026-01-09T12:00:00.000Z", "9 de janeiro de 2026"],
+  ["2026-02-28T12:00:00.000Z", "28 de fevereiro de 2026"],
+  ["2026-03-01T12:00:00.000Z", "1 de março de 2026"],
+  ["2026-04-30T12:00:00.000Z", "30 de abril de 2026"],
+  ["2026-05-15T12:00:00.000Z", "15 de maio de 2026"],
+  ["2026-06-12T12:00:00.000Z", "12 de junho de 2026"],
+  ["2026-07-04T12:00:00.000Z", "4 de julho de 2026"],
+  ["2026-08-03T12:00:00.000Z", "3 de agosto de 2026"],
+  ["2026-09-21T12:00:00.000Z", "21 de setembro de 2026"],
+  ["2026-10-10T12:00:00.000Z", "10 de outubro de 2026"],
+  ["2026-11-02T12:00:00.000Z", "2 de novembro de 2026"],
+  ["2026-12-31T12:00:00.000Z", "31 de dezembro de 2026"],
+];
+
+test("dataLonga escreve a data por extenso em português, mês a mês", () => {
+  for (const [iso, esperado] of MESES_ESPERADOS) {
+    expect(dataLonga(new Date(iso)), iso).toBe(esperado);
+  }
+  // O dia NÃO leva zero à esquerda: "1 de março", não "01 de março". É o que
+  // se escreve em português, e um `padStart` copiado do `diaIso` quebraria.
+  expect(dataLonga(new Date("2026-03-01T12:00:00.000Z"))).not.toContain("01 de");
+  // E `março` é a prova de que o arquivo não perdeu o acento numa reescrita.
+  expect(dataLonga(new Date("2026-03-01T12:00:00.000Z"))).toContain("março");
+});
+
+test("diaIso devolve o dia em UTC, no formato que o atributo datetime aceita", () => {
+  // Os dois lados da meia-noite UTC, com o resultado escrito à mão. É o caso
+  // que decide entre UTC e fuso local, e o único jeito de o texto e o
+  // `datetime` discordarem por um dia no ar.
+  //
+  //   23:30 em São Paulo (-03:00) já é o dia SEGUINTE em UTC;
+  //   01:00 em Tóquio (+09:00) ainda é o dia ANTERIOR em UTC.
+  expect(diaIso(new Date("2026-08-03T23:30:00.000-03:00"))).toBe("2026-08-04");
+  expect(dataLonga(new Date("2026-08-03T23:30:00.000-03:00"))).toBe("4 de agosto de 2026");
+  expect(diaIso(new Date("2026-08-04T01:00:00.000+09:00"))).toBe("2026-08-03");
+  expect(dataLonga(new Date("2026-08-04T01:00:00.000+09:00"))).toBe("3 de agosto de 2026");
+
+  // Vira o ano junto com a meia-noite.
+  expect(diaIso(new Date("2025-12-31T21:00:00.000-05:00"))).toBe("2026-01-01");
+  expect(dataLonga(new Date("2025-12-31T21:00:00.000-05:00"))).toBe("1 de janeiro de 2026");
+
+  // Formato exato, com zero à esquerda — aqui ELE é obrigatório.
+  expect(diaIso(new Date("2026-03-01T12:00:00.000Z"))).toBe("2026-03-01");
+  expect(diaIso(new Date("2026-03-01T12:00:00.000Z"))).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+});
+
+test("a data impressa não depende do fuso da máquina que rodou o build", () => {
+  // O defeito que este teste existe para pegar: trocar `getUTCDate()` por
+  // `getDate()`. Num runner em UTC — que é o caso da CI — a troca não muda
+  // NADA, e todo teste que compare os dois lados no mesmo processo passa. O
+  // estrago aparece quando o build roda noutro fuso: o mesmo commit vira duas
+  // datas diferentes no HTML.
+  //
+  // Então o teste varre fusos de verdade e exige a MESMA resposta, com o valor
+  // escrito à mão. `2026-08-04T02:30:00Z` é 23:30 do dia 3 em São Paulo: sob
+  // `getDate()` este teste devolveria duas respostas e reprovaria.
+  const instante = new Date("2026-08-04T02:30:00.000Z");
+  const tzOriginal = process.env.TZ;
+  const respostas = new Set<string>();
+  let oFusoMudou = false;
+  try {
+    for (const tz of ["UTC", "America/Sao_Paulo", "Asia/Tokyo", "Pacific/Kiritimati"]) {
+      process.env.TZ = tz;
+      // Canário: se esta plataforma ignorar a troca de `TZ` (o Node avisa que
+      // pode acontecer), o teste não pode PASSAR por não ter conseguido olhar.
+      if (instante.getDate() !== instante.getUTCDate()) oFusoMudou = true;
+      respostas.add(`${diaIso(instante)}|${dataLonga(instante)}`);
+    }
+  } finally {
+    if (tzOriginal === undefined) delete process.env.TZ;
+    else process.env.TZ = tzOriginal;
+  }
+  test.skip(
+    !oFusoMudou,
+    "esta plataforma não aplicou a troca de `process.env.TZ` em tempo de execução, " +
+      "então a varredura de fusos não mediu nada. Os casos de meia-noite do teste acima, " +
+      "com offset explícito no ISO, continuam valendo."
+  );
+  expect([...respostas], "a data mudou conforme o fuso do processo").toEqual([
+    "2026-08-04|4 de agosto de 2026",
+  ]);
+});
+
+test("o texto do selo e o atributo datetime são sempre o mesmo dia", () => {
+  // A invariante de que o selo depende, e a única asserção desta seção que usa
+  // as duas funções juntas: `dataLonga` do dia recortado por `diaIso` tem que
+  // dar o mesmo texto que `dataLonga` do instante inteiro. É exatamente a
+  // conta que o teste de navegador faz, aqui varrida sobre os horários que
+  // costumam quebrá-la.
+  const instantes = [
+    "2026-08-03T00:00:00.000Z",
+    "2026-08-03T23:59:59.999Z",
+    "2026-01-01T00:00:00.000Z",
+    "2026-12-31T23:59:59.999Z",
+    "2026-08-03T23:30:00.000-03:00",
+    "2026-08-04T01:00:00.000+09:00",
+  ];
+  for (const iso of instantes) {
+    const d = new Date(iso);
+    expect(dataLonga(new Date(diaIso(d))), iso).toBe(dataLonga(d));
+  }
 });

--- a/tests/seo-datas-e-autoria.spec.ts
+++ b/tests/seo-datas-e-autoria.spec.ts
@@ -135,19 +135,15 @@ test("as datas do tópico e o lastmod do sitemap contam a MESMA história", () =
   // ARTEFATO: o `dateModified` das páginas e o `lastmod` do sitemap saíram do
   // MESMO processo, do MESMO `git log` e do MESMO guarda.
   //
-  // Quatro afirmações, e cada uma cai por um defeito diferente:
+  // Três afirmações, e cada uma cai por um defeito diferente:
   //
   //   (a) ou todas as páginas têm data, ou nenhuma tem — nunca pela metade;
   //   (b) a presença bate, página a página, com a do `lastmod` da mesma URL;
-  //   (c) as datas presentes passam no critério de CONCENTRAÇÃO do módulo — é
-  //       aqui que morre a versão sem guarda, que em clone raso carimba as 36
-  //       páginas com a data do commit-fronteira;
-  //   (d) o valor é o mesmo instante nos dois artefatos.
+  //   (c) o valor é o mesmo instante nos dois artefatos.
   const lastmods = lastmodPorRota();
   const comData: string[] = [];
   const semData: string[] = [];
   const divergentes: string[] = [];
-  const entradas: { rota: string; lastModified?: Date }[] = [];
 
   for (const t of INDEXAVEIS) {
     const rota = rotaDo(t.slug);
@@ -165,11 +161,10 @@ test("as datas do tópico e o lastmod do sitemap contam a MESMA história", () =
     }
     if (!modificado) continue;
     expect(Number.isNaN(Date.parse(modificado)), `${rota}: ${modificado} não é data`).toBe(false);
-    // (d) mesmo instante
+    // (c) mesmo instante
     if (Date.parse(modificado) !== Date.parse(doSitemap!)) {
       divergentes.push(`${rota} → dateModified=${modificado}, lastmod=${doSitemap}`);
     }
-    entradas.push({ rota, lastModified: new Date(modificado) });
   }
 
   // (a)
@@ -180,27 +175,71 @@ test("as datas do tópico e o lastmod do sitemap contam a MESMA história", () =
 
   expect(divergentes, "a página e o sitemap discordam sobre a data").toEqual([]);
 
-  // (c) A regra vem do módulo, não daqui — e é a regra de CONCENTRAÇÃO, a mesma
-  // que o build usa para decidir se imprime data. Aplicada aqui às datas que o
-  // build de fato imprimiu: se elas não passam no critério, o build não devia
-  // tê-las impresso.
+  // Sobre o que este teste NÃO afirma, que é a parte que quase virou defeito:
   //
-  // `Set.size > 1` não serviria, e essa é a diferença que importa: num clone
-  // raso com alguns commits em cima, os caminhos tocados por esses commits
-  // resolvem para eles e todo o resto resolve para a fronteira. Duas datas
-  // distintas, contagem aprovada, e a maioria das URLs com data fabricada.
-  if (entradas.length) {
-    const carimbos = entradas.map((e) => e.lastModified!.getTime());
-    const porCarimbo = new Map<number, number>();
-    for (const c of carimbos) porCarimbo.set(c, (porCarimbo.get(c) ?? 0) + 1);
-    const moda = Math.max(...porCarimbo.values());
-    expect(
-      datasDistinguemCaminhos(carimbos),
-      `as datas impressas se concentram em poucos carimbos: ${moda} das ${carimbos.length} ` +
-        `páginas dividem a MESMA data (${((100 * moda) / carimbos.length).toFixed(1)}%, teto ` +
-        `de ${100 * LIMITE_DE_CONCENTRACAO}%), ou seja, é a data do commit-fronteira repetida`
-    ).toBe(true);
-  }
+  // Uma versão anterior exigia que as datas IMPRESSAS passassem no critério de
+  // concentração do módulo. Parecia o guarda mais forte possível e era um falso
+  // positivo esperando a vez: a data de um tópico é o mais recente entre o
+  // artigo e o intervalo dele no `roadmap.ts`, então um commit em lote naquele
+  // arquivo — renomear um campo em todos os tópicos, por exemplo — coloca as 36
+  // páginas na MESMA data. Medido: moda de 36/36, 100%, contra o teto de 50%.
+  // O build estaria certo (todas as páginas mudaram mesmo, naquele commit) e o
+  // teste reprovaria.
+  //
+  // Concentração é um bom sinal de "git cego" sobre CAMINHOS BRUTOS, que é onde
+  // o módulo a aplica, e um mau sinal sobre datas agregadas por página, que
+  // podem convergir por um motivo legítimo. A regra em si é provada com entrada
+  // sintética, no teste `o guarda de datas reprova histórico achatado`.
+});
+
+test("o guarda de datas reprova histórico achatado, e não só o caso extremo", () => {
+  // A regra do módulo, provada com entrada sintética — onde o veredito certo é
+  // conhecido sem perguntar nada ao git.
+  //
+  // O caso do meio é o que motivou a troca de critério. A regra anterior era
+  // `Set.size > 1`: bastavam DUAS datas distintas para ela aprovar. Num clone
+  // raso com alguns commits em cima, os caminhos que esses commits tocaram
+  // resolvem para eles e todo o resto resolve para o commit-fronteira — duas
+  // datas distintas, aprovação, e a maioria das páginas com data fabricada.
+  const FRONTEIRA = Date.parse("2026-08-08T10:00:00Z");
+  const repetido = (n: number) => Array.from({ length: n }, () => FRONTEIRA);
+  const distintos = (n: number) => Array.from({ length: n }, (_, i) => FRONTEIRA - (i + 1) * 3600000);
+
+  // Histórico de verdade: cada caminho com a sua data.
+  expect(datasDistinguemCaminhos(distintos(45)), "clone completo").toBe(true);
+
+  // Raso puro: uma data para tudo. `Set.size > 1` também pegava este.
+  expect(datasDistinguemCaminhos(repetido(45)), "raso: uma data só").toBe(false);
+
+  // Raso com 3 commits em cima: 42 na fronteira, 3 de verdade. Concentração de
+  // 93,3%. É AQUI que a regra antiga aprovava e a nova reprova.
+  expect(
+    datasDistinguemCaminhos([...repetido(42), ...distintos(3)]),
+    "raso + 3 commits recentes: 93,3% de concentração"
+  ).toBe(false);
+
+  // Raso com 10 em cima: 77,8%. Ainda achatado.
+  expect(
+    datasDistinguemCaminhos([...repetido(35), ...distintos(10)]),
+    "raso + 10 commits recentes: 77,8% de concentração"
+  ).toBe(false);
+
+  // Sem dado nenhum não é evidência de nada, e não pode virar aprovação.
+  expect(datasDistinguemCaminhos([]), "nenhum carimbo").toBe(false);
+  expect(datasDistinguemCaminhos([undefined, undefined]), "só caminhos sem histórico").toBe(false);
+
+  // `undefined` não conta nem a favor nem contra: ele é ausência de dado, não
+  // evidência de achatamento.
+  expect(
+    datasDistinguemCaminhos([...distintos(4), undefined, undefined]),
+    "4 datas distintas com 2 caminhos sem histórico"
+  ).toBe(true);
+
+  // A fronteira exata do critério, para o teto não escorregar sem ninguém ver:
+  // metade repetida passa, um a mais reprova.
+  const metade = [...repetido(10), ...distintos(10)];
+  expect(datasDistinguemCaminhos(metade), `moda em exatamente ${100 * LIMITE_DE_CONCENTRACAO}%`).toBe(true);
+  expect(datasDistinguemCaminhos([...repetido(11), ...distintos(10)]), "moda logo acima do teto").toBe(false);
 });
 
 test("datePublished nunca é depois de dateModified", () => {
@@ -284,10 +323,10 @@ test("o selo 'Atualizado em' está na tela, legível, e diz a data que marca", a
 test("quando o selo 'Publicado em' aparece, ele é um dia DIFERENTE do de atualização", async ({
   page,
 }) => {
-  // O selo de publicação é condicional de propósito: em 31 dos 36 artigos o
-  // primeiro e o último commit caem no mesmo dia, e dois selos com a mesma data
-  // não informam nada. O que este teste prende é a condição — se ela cair, o
-  // primeiro tópico com as duas datas iguais imprime a mesma data duas vezes.
+  // O selo de publicação é condicional de propósito: em 28 dos 36 tópicos a
+  // publicação e a última atualização caem no mesmo dia, e dois selos com a
+  // mesma data não informam nada. O que este teste prende é a condição — se ela
+  // cair, o primeiro tópico com as duas datas iguais imprime a data duas vezes.
   const comOsDois = INDEXAVEIS.filter((t) => {
     const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
     const p = r.datePublished as string | undefined;

--- a/tests/seo-datas-e-autoria.spec.ts
+++ b/tests/seo-datas-e-autoria.spec.ts
@@ -242,31 +242,22 @@ test("o guarda de datas reprova histórico achatado, e não só o caso extremo",
   expect(datasDistinguemCaminhos([...repetido(11), ...distintos(10)]), "moda logo acima do teto").toBe(false);
 });
 
-test("datePublished nunca é depois de dateModified", () => {
-  const errados: string[] = [];
-  const orfaos: string[] = [];
-  let comPublicado = 0;
-  let comModificado = 0;
+test("a página não declara datePublished, porque não mostra data de publicação", () => {
+  // Decisão de 2026-08-08: o selo "Publicado em" saiu da tela. Ele aparecia em
+  // 8 das 47 páginas (só onde os dois dias diferiam), e a doc do Google pede
+  // para MINIMIZAR a presença de outras datas na página.
+  //
+  // O campo tinha de sair junto, e não é preferência: o contrato do
+  // `src/lib/jsonld.ts` é que a marcação reflita o que está na tela, e campo sem
+  // correspondente visível não entra. Este teste é o que impede o campo de
+  // voltar sozinho, sem o selo.
+  const sobrando: string[] = [];
   for (const t of INDEXAVEIS) {
     const rota = rotaDo(t.slug);
     const recurso = doTipo(jsonLd(rota), "LearningResource")!;
-    const pub = recurso.datePublished as string | undefined;
-    const mod = recurso.dateModified as string | undefined;
-    if (mod !== undefined) comModificado += 1;
-    if (pub === undefined) continue;
-    comPublicado += 1;
-    // `datePublished` sozinho é o pior dos casos: significa que o guarda foi
-    // aplicado a um campo e não ao outro.
-    if (mod === undefined) orfaos.push(rota);
-    else if (Date.parse(pub) > Date.parse(mod)) errados.push(`${rota} → ${pub} > ${mod}`);
+    if (recurso.datePublished !== undefined) sobrando.push(rota);
   }
-  expect(orfaos, "datePublished sem dateModified: o guarda pegou só um dos dois").toEqual([]);
-  expect(errados, "publicado depois de atualizado").toEqual([]);
-  // `datePublished` só pode FALTAR em tópico sem `.mdx` próprio — nunca sobrar.
-  expect(
-    comPublicado <= comModificado,
-    `${comPublicado} páginas com datePublished contra ${comModificado} com dateModified`
-  ).toBe(true);
+  expect(sobrando, "datePublished sem o selo 'Publicado em' na tela").toEqual([]);
 });
 
 // ---------------------------------------------------------------------------
@@ -320,57 +311,41 @@ test("o selo 'Atualizado em' está na tela, legível, e diz a data que marca", a
   expect(fonte, "o selo está em font-size 0").toBeGreaterThan(0);
 });
 
-test("quando o selo 'Publicado em' aparece, ele é um dia DIFERENTE do de atualização", async ({
-  page,
-}) => {
-  // O selo de publicação é condicional de propósito: em 28 dos 36 tópicos a
-  // publicação e a última atualização caem no mesmo dia, e dois selos com a
-  // mesma data não informam nada. O que este teste prende é a condição — se ela
-  // cair, o primeiro tópico com as duas datas iguais imprime a data duas vezes.
-  const comOsDois = INDEXAVEIS.filter((t) => {
-    const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
-    const p = r.datePublished as string | undefined;
-    const m = r.dateModified as string | undefined;
-    return p !== undefined && m !== undefined && diaIso(new Date(p)) !== diaIso(new Date(m));
-  });
-  const soUmDia = INDEXAVEIS.filter((t) => {
-    const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
-    const p = r.datePublished as string | undefined;
-    const m = r.dateModified as string | undefined;
-    return p !== undefined && m !== undefined && diaIso(new Date(p)) === diaIso(new Date(m));
-  });
-  test.skip(
-    comOsDois.length === 0 && soUmDia.length === 0,
-    "este build saiu sem datas; nada para conferir na tela."
-  );
-
-  if (comOsDois.length) {
-    const t = comOsDois[0];
+test("o selo 'Publicado em' não está na tela de nenhum tópico", async ({ page }) => {
+  // O par do teste acima, do lado do aluno: uma coisa é o campo não sair no
+  // JSON-LD, outra é o selo não voltar ao HTML. Os dois têm de cair juntos.
+  const comSelo: string[] = [];
+  for (const t of INDEXAVEIS.slice(0, 6)) {
     await page.goto(rotaDo(t.slug));
-    const selo = page.locator(".topic-chips span.chip", { hasText: "Publicado em" });
-    await expect(selo).toHaveCount(1);
-    const tempo = selo.locator("time");
-    const publicado = (await tempo.getAttribute("datetime")) ?? "";
-    const atualizado =
-      (await page
-        .locator(".topic-chips span.chip", { hasText: "Atualizado em" })
-        .locator("time")
-        .getAttribute("datetime")) ?? "";
-    expect(publicado, `${t.slug}: os dois selos mostram o mesmo dia`).not.toBe(atualizado);
-    // Rótulo e valor, como no selo de atualização.
-    expect(((await selo.textContent()) ?? "").replace(/\s+/g, " ").trim()).toBe(
-      `Publicado em ${dataLonga(new Date(publicado))}`
-    );
-    const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
-    expect(diaIso(new Date(r.datePublished as string))).toBe(publicado);
-  }
-  if (soUmDia.length) {
-    const t = soUmDia[0];
-    await page.goto(rotaDo(t.slug));
+    if (await page.locator(".topic-chips span.chip", { hasText: "Publicado em" }).count()) {
+      comSelo.push(t.slug);
+    }
+    // E o de atualização continua lá: este teste não pode passar porque a
+    // página inteira perdeu os selos.
     await expect(
-      page.locator(".topic-chips span.chip", { hasText: "Publicado em" }),
-      `${t.slug}: publicação e atualização no mesmo dia não podem virar dois selos iguais`
-    ).toHaveCount(0);
+      page.locator(".topic-chips span.chip", { hasText: "Atualizado em" }),
+      `${t.slug} perdeu também o selo de atualização`
+    ).toHaveCount(1);
+  }
+  expect(comSelo, "o selo de publicação voltou à tela").toEqual([]);
+});
+
+test("o rodapé aparece em TODA rota, e não só na home", async ({ page }) => {
+  // Ele existia só em `src/app/page.tsx`: a home tinha rodapé e as 34 páginas de
+  // aula tinham zero. Quem chegava numa delas pela busca não tinha caminho
+  // nenhum para descobrir quem publica o material.
+  const rotas = ["/", "/roadmap/", "/sobre/", "/apoie/", "/introducao/", rotaDo(INDEXAVEIS[0].slug)];
+  for (const rota of rotas) {
+    await page.goto(rota);
+    const pe = page.locator("footer.site-foot");
+    await expect(pe, `${rota} sem rodapé`).toHaveCount(1);
+    // Rótulo lido, não elemento contado: rodapé vazio também tem count 1.
+    await expect(pe).toContainText("Feito");
+    await expect(pe).toContainText("pela comunidade, para a comunidade");
+    await expect(pe).toContainText("gratuito para sempre");
+    // Sem links: a barra fixa já leva a tudo, e rodapé que repete o menu é um
+    // segundo lugar para a mesma verdade envelhecer.
+    await expect(pe.locator("a"), `${rota}: o rodapé voltou a ter links`).toHaveCount(0);
   }
 });
 
@@ -467,17 +442,25 @@ test("a /sobre não promete privacidade que o código desmente", async ({ page }
   ).not.toMatch(/nada é enviado para lugar nenhum/i);
 });
 
-test("dá para chegar ao /sobre navegando, no menu e no rodapé", async ({ page }) => {
+test("dá para chegar ao /sobre pelo menu, e ele é o PRIMEIRO item", async ({ page }) => {
   // Rota que existe e ninguém alcança é rota que não existe. Clicar, e não
   // conferir `href`: o `href` certo dentro de um menu que não abre continua
   // sendo uma página inalcançável.
-  await page.goto("/");
-  await page.locator(".site-foot").getByRole("link", { name: "Sobre" }).click();
-  await expect(page).toHaveURL(new RegExp(`${SOBRE}$`));
-  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sobre o Roadmap DSA");
-
+  //
+  // O rodapé saiu desta conta de propósito: ele não tem mais links, porque a
+  // barra é fixa e já leva a tudo. Se um dia alguém devolver links ao rodapé,
+  // é o teste do rodapé que reprova, não este.
   await page.goto("/roadmap/");
   await page.getByRole("button", { name: "Mais opções" }).click();
-  await page.locator(".nav-menu").getByRole("link", { name: /Sobre o projeto/ }).click();
+
+  // Primeiro item, e a ordem é a decisão: "quem escreveu isto?" vem antes de
+  // qualquer link para fora. Leio a ordem renderizada em vez de confiar na
+  // ordem do arquivo, que o CSS pode reordenar (`.foot-links` já fazia isso
+  // com `order: -1`).
+  const itens = page.locator(".nav-menu .menu-item:not(.only-mobile)");
+  await expect(itens.first()).toContainText("Sobre o projeto");
+
+  await itens.first().click();
   await expect(page).toHaveURL(new RegExp(`${SOBRE}$`));
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sobre o Roadmap DSA");
 });

--- a/tests/seo-datas-e-autoria.spec.ts
+++ b/tests/seo-datas-e-autoria.spec.ts
@@ -1,0 +1,400 @@
+import { test, expect } from "@playwright/test";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
+import { comDataUtil } from "../src/lib/datas-do-git";
+import { dataLonga, diaIso } from "../src/lib/format";
+import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
+import { SITE_URL } from "../src/lib/links";
+
+// Quem assina o conteúdo, quando ele foi atualizado, e a página que responde
+// "quem faz isto?". Tudo conferido contra o HTML ENTREGUE, no `out/`.
+//
+// A regra deste arquivo, herdada do `seo-estrutura.spec.ts`: nada de contar
+// `<script>` nem de procurar substring no HTML. O JSON-LD é lido com
+// `JSON.parse` e conferido campo por nome, e o que o aluno lê é conferido no
+// navegador, com o rótulo junto do valor.
+//
+// A guarda das datas NÃO é reescrita aqui: `comDataUtil` é IMPORTADA do módulo
+// que o build usa. Esse guarda já errou duas vezes por ter sido recriado do
+// lado de fora (uma vez perguntando `git rev-parse --is-shallow-repository`,
+// outra lendo `.git/shallow`), e as duas reprovaram um sitemap correto.
+//
+// As três funções de leitura de artefato abaixo são cópia das do
+// `seo-estrutura.spec.ts`, e a cópia é deliberada: unificá-las mexeria naquele
+// arquivo, que outra frente está editando agora. Unificar é PR próprio — e
+// note que o que está duplicado é PARSER, não REGRA: a regra que decide se a
+// data vale (`comDataUtil`) tem um dono só, importado acima.
+
+const OUT = path.join(process.cwd(), "out");
+
+function html(rota: string): string {
+  const f = path.join(OUT, rota.replace(/^\//, ""), "index.html");
+  if (!existsSync(f)) throw new Error(`build sem a rota ${rota} (${f})`);
+  return readFileSync(f, "utf8");
+}
+
+type No = Record<string, unknown>;
+
+function jsonLd(rota: string): No[] {
+  const doc = html(rota);
+  const nos: No[] = [];
+  const re = /<script type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(doc)) !== null) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(m[1]);
+    } catch (e) {
+      throw new Error(`${rota}: JSON-LD inválido (${(e as Error).message})`);
+    }
+    for (const no of Array.isArray(parsed) ? parsed : [parsed]) nos.push(no as No);
+  }
+  return nos;
+}
+
+function doTipo(nos: No[], tipo: string): No | undefined {
+  return nos.find((n) => {
+    const t = n["@type"];
+    return t === tipo || (Array.isArray(t) && t.includes(tipo));
+  });
+}
+
+const INDEXAVEIS = ALL_TOPICS.filter((t) => !isEmptyTopic(t));
+const rotaDo = (slug: string) => `/topico/${slug}/`;
+
+/** O `lastmod` de cada URL do sitemap, por rota. Ausente = o campo não saiu. */
+function lastmodPorRota(): Map<string, string | undefined> {
+  const xml = readFileSync(path.join(OUT, "sitemap.xml"), "utf8");
+  const mapa = new Map<string, string | undefined>();
+  for (const m of xml.matchAll(/<url>([\s\S]*?)<\/url>/g)) {
+    const loc = m[1].match(/<loc>([^<]+)<\/loc>/)![1];
+    mapa.set(loc.replace(SITE_URL, ""), m[1].match(/<lastmod>([^<]+)<\/lastmod>/)?.[1]);
+  }
+  return mapa;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Quem assina
+// ---------------------------------------------------------------------------
+
+test("cada tópico indexável declara o autor, e o autor é a organização da página", () => {
+  // A referência é RESOLVIDA, não comparada com uma string escrita aqui: o
+  // `@id` do `author` tem que ser o `@id` do nó `Organization` que aquela mesma
+  // página emite. Comparar com um literal deixaria passar o dia em que o `@id`
+  // da organização mudasse e o `author` continuasse apontando para o antigo —
+  // que é uma referência quebrada, e o consumidor de JSON-LD lê como "autor
+  // desconhecido".
+  const sem: string[] = [];
+  for (const t of INDEXAVEIS) {
+    const rota = rotaDo(t.slug);
+    const nos = jsonLd(rota);
+    const recurso = doTipo(nos, "LearningResource");
+    const org = doTipo(nos, "Organization");
+    if (!recurso || !org) {
+      sem.push(`${rota} (LearningResource=${!!recurso}, Organization=${!!org})`);
+      continue;
+    }
+    const autor = recurso.author as No | undefined;
+    expect(autor, `${rota} sem author`).toBeTruthy();
+    expect(autor!["@id"], `${rota}: author aponta para um nó que não é a organização`).toBe(
+      org["@id"]
+    );
+    expect(org.name, rota).toBe("Craft & Code Club");
+  }
+  expect(sem, `${sem.length} de ${INDEXAVEIS.length} tópicos sem os dois nós`).toEqual([]);
+});
+
+test("o tópico sem material nenhum não declara autor de coisa alguma", () => {
+  // A outra metade da condicional. Página `noindex` não emite JSON-LD de tópico,
+  // então não pode declarar autoria — se declarasse, o site estaria assinando
+  // uma página que ele mesmo pede para o Google ignorar.
+  const vazios = ALL_TOPICS.filter((t) => isEmptyTopic(t));
+  expect(vazios.length, "o repositório precisa ter ao menos um tópico vazio").toBeGreaterThan(0);
+  for (const t of vazios) {
+    const nos = jsonLd(rotaDo(t.slug));
+    expect(doTipo(nos, "LearningResource"), `${rotaDo(t.slug)}`).toBeUndefined();
+    const comAutor = nos.filter((n) => "author" in n).map((n) => String(n["@type"]));
+    expect(comAutor, `${rotaDo(t.slug)}: nó com author numa página noindex`).toEqual([]);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. As datas: presentes quando informam, ausentes quando não
+// ---------------------------------------------------------------------------
+
+test("as datas do tópico e o lastmod do sitemap contam a MESMA história", () => {
+  // Este é o teste que pega o bug de verdade, e ele não pergunta nada ao git
+  // deste processo — de propósito. Já foi medido que o git do processo do teste
+  // enxerga um histórico diferente do git do processo do build (mesmo job: 17
+  // datas no build, 1 no teste). Então a conferência é ARTEFATO contra
+  // ARTEFATO: o `dateModified` das páginas e o `lastmod` do sitemap saíram do
+  // MESMO processo, do MESMO `git log` e do MESMO guarda.
+  //
+  // Quatro afirmações, e cada uma cai por um defeito diferente:
+  //
+  //   (a) ou todas as páginas têm data, ou nenhuma tem — nunca pela metade;
+  //   (b) a presença bate, página a página, com a do `lastmod` da mesma URL;
+  //   (c) as datas presentes SOBREVIVEM ao `comDataUtil` — é aqui que morre a
+  //       versão sem guarda, que em clone raso carimba as 36 páginas com a data
+  //       do último deploy;
+  //   (d) o valor é o mesmo instante nos dois artefatos.
+  const lastmods = lastmodPorRota();
+  const comData: string[] = [];
+  const semData: string[] = [];
+  const divergentes: string[] = [];
+  const entradas: { rota: string; lastModified?: Date }[] = [];
+
+  for (const t of INDEXAVEIS) {
+    const rota = rotaDo(t.slug);
+    const recurso = doTipo(jsonLd(rota), "LearningResource")!;
+    const modificado = recurso.dateModified as string | undefined;
+    const doSitemap = lastmods.get(rota);
+
+    if (modificado === undefined) semData.push(rota);
+    else comData.push(rota);
+
+    // (b) presença espelhada
+    if (!!modificado !== !!doSitemap) {
+      divergentes.push(`${rota} → dateModified=${modificado} lastmod=${doSitemap}`);
+      continue;
+    }
+    if (!modificado) continue;
+    expect(Number.isNaN(Date.parse(modificado)), `${rota}: ${modificado} não é data`).toBe(false);
+    // (d) mesmo instante
+    if (Date.parse(modificado) !== Date.parse(doSitemap!)) {
+      divergentes.push(`${rota} → dateModified=${modificado}, lastmod=${doSitemap}`);
+    }
+    entradas.push({ rota, lastModified: new Date(modificado) });
+  }
+
+  // (a)
+  expect(
+    semData.length === 0 || comData.length === 0,
+    `datas pela metade: ${comData.length} com dateModified e ${semData.length} sem`
+  ).toBe(true);
+
+  expect(divergentes, "a página e o sitemap discordam sobre a data").toEqual([]);
+
+  // (c) A regra vem do módulo, não daqui. `comDataUtil` devolve as entradas SEM
+  // `lastModified` quando as datas não carregam informação; se ele apagar as
+  // datas que o build imprimiu, o build não devia tê-las impresso.
+  if (entradas.length) {
+    const uteis = comDataUtil(entradas);
+    const apagadas = uteis.filter((e) => e.lastModified === undefined);
+    expect(
+      apagadas.length,
+      `${apagadas.length} das ${entradas.length} páginas carimbadas não passam no ` +
+        "`comDataUtil`: as datas impressas não distinguem uma página da outra, ou seja, " +
+        `é a data do último commit repetida ${entradas.length} vezes`
+    ).toBe(0);
+  }
+});
+
+test("datePublished nunca é depois de dateModified", () => {
+  const errados: string[] = [];
+  const orfaos: string[] = [];
+  let comPublicado = 0;
+  let comModificado = 0;
+  for (const t of INDEXAVEIS) {
+    const rota = rotaDo(t.slug);
+    const recurso = doTipo(jsonLd(rota), "LearningResource")!;
+    const pub = recurso.datePublished as string | undefined;
+    const mod = recurso.dateModified as string | undefined;
+    if (mod !== undefined) comModificado += 1;
+    if (pub === undefined) continue;
+    comPublicado += 1;
+    // `datePublished` sozinho é o pior dos casos: significa que o guarda foi
+    // aplicado a um campo e não ao outro.
+    if (mod === undefined) orfaos.push(rota);
+    else if (Date.parse(pub) > Date.parse(mod)) errados.push(`${rota} → ${pub} > ${mod}`);
+  }
+  expect(orfaos, "datePublished sem dateModified: o guarda pegou só um dos dois").toEqual([]);
+  expect(errados, "publicado depois de atualizado").toEqual([]);
+  // `datePublished` só pode FALTAR em tópico sem `.mdx` próprio — nunca sobrar.
+  expect(
+    comPublicado <= comModificado,
+    `${comPublicado} páginas com datePublished contra ${comModificado} com dateModified`
+  ).toBe(true);
+});
+
+// ---------------------------------------------------------------------------
+// 3. O que o aluno lê
+// ---------------------------------------------------------------------------
+
+/** Um tópico `ready` para os testes de tela, e o `dateModified` que ele imprime. */
+const EXEMPLO = INDEXAVEIS.find((t) => t.status === "ready")!;
+
+test("o selo 'Atualizado em' está na tela, legível, e diz a data que marca", async ({ page }) => {
+  const rota = rotaDo(EXEMPLO.slug);
+  const recurso = doTipo(jsonLd(rota), "LearningResource")!;
+  const marcado = recurso.dateModified as string | undefined;
+  test.skip(
+    marcado === undefined,
+    "este build saiu sem datas (o `git log` dele não distingue caminhos), então não há selo " +
+      "para conferir — e é esse o comportamento certo. O teste das datas acima já provou que " +
+      "o sitemap concorda."
+  );
+
+  await page.goto(rota);
+  // O selo mora em `.topic-chips`, junto do nível e do tempo de leitura: é o
+  // lugar que a marcação diz que ele ocupa.
+  const selo = page.locator(".topic-chips span.chip", { hasText: "Atualizado em" });
+  await expect(selo).toHaveCount(1);
+
+  const tempo = selo.locator("time");
+  await expect(tempo).toBeVisible();
+
+  // Ler o RÓTULO junto do valor, e não só o valor: já passou por esta casa um
+  // card que dizia "descartadas sem ler" somando o elemento que acabara de ser
+  // lido. Comportamento certo com rótulo errado ensina errado do mesmo jeito.
+  const textoDoSelo = ((await selo.textContent()) ?? "").replace(/\s+/g, " ").trim();
+  const iso = (await tempo.getAttribute("datetime")) ?? "";
+  const visivel = ((await tempo.textContent()) ?? "").trim();
+
+  expect(iso, "o <time> sem dateTime não é data para máquina nenhuma").toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  // O texto ao lado do número tem que ser este, e a data por extenso tem que
+  // ser a MESMA que o atributo carrega — texto e `datetime` discordando por um
+  // dia é o defeito que o par `dataLonga`/`diaIso` existe para não ter.
+  expect(textoDoSelo).toBe(`Atualizado em ${visivel}`);
+  expect(visivel).toBe(dataLonga(new Date(iso)));
+  // E a marcação reflete o que está na tela: mesmo dia.
+  expect(diaIso(new Date(marcado!)), "o dateModified do JSON-LD é outro dia").toBe(iso);
+
+  // Medir, não contar: uma suíte desta casa já ficou verde sobre um painel de
+  // 0px de largura e sobre texto renderizado em `font-size: 0`.
+  const caixa = await tempo.boundingBox();
+  expect(caixa!.width, "o selo tem largura zero").toBeGreaterThan(0);
+  const fonte = await tempo.evaluate((el) => parseFloat(getComputedStyle(el).fontSize));
+  expect(fonte, "o selo está em font-size 0").toBeGreaterThan(0);
+});
+
+test("quando o selo 'Publicado em' aparece, ele é um dia DIFERENTE do de atualização", async ({
+  page,
+}) => {
+  // O selo de publicação é condicional de propósito: em 31 dos 36 artigos o
+  // primeiro e o último commit caem no mesmo dia, e dois selos com a mesma data
+  // não informam nada. O que este teste prende é a condição — se ela cair, o
+  // primeiro tópico com as duas datas iguais imprime a mesma data duas vezes.
+  const comOsDois = INDEXAVEIS.filter((t) => {
+    const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
+    const p = r.datePublished as string | undefined;
+    const m = r.dateModified as string | undefined;
+    return p !== undefined && m !== undefined && diaIso(new Date(p)) !== diaIso(new Date(m));
+  });
+  const soUmDia = INDEXAVEIS.filter((t) => {
+    const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
+    const p = r.datePublished as string | undefined;
+    const m = r.dateModified as string | undefined;
+    return p !== undefined && m !== undefined && diaIso(new Date(p)) === diaIso(new Date(m));
+  });
+  test.skip(
+    comOsDois.length === 0 && soUmDia.length === 0,
+    "este build saiu sem datas; nada para conferir na tela."
+  );
+
+  if (comOsDois.length) {
+    const t = comOsDois[0];
+    await page.goto(rotaDo(t.slug));
+    const selo = page.locator(".topic-chips span.chip", { hasText: "Publicado em" });
+    await expect(selo).toHaveCount(1);
+    const tempo = selo.locator("time");
+    const publicado = (await tempo.getAttribute("datetime")) ?? "";
+    const atualizado =
+      (await page
+        .locator(".topic-chips span.chip", { hasText: "Atualizado em" })
+        .locator("time")
+        .getAttribute("datetime")) ?? "";
+    expect(publicado, `${t.slug}: os dois selos mostram o mesmo dia`).not.toBe(atualizado);
+    // Rótulo e valor, como no selo de atualização.
+    expect(((await selo.textContent()) ?? "").replace(/\s+/g, " ").trim()).toBe(
+      `Publicado em ${dataLonga(new Date(publicado))}`
+    );
+    const r = doTipo(jsonLd(rotaDo(t.slug)), "LearningResource")!;
+    expect(diaIso(new Date(r.datePublished as string))).toBe(publicado);
+  }
+  if (soUmDia.length) {
+    const t = soUmDia[0];
+    await page.goto(rotaDo(t.slug));
+    await expect(
+      page.locator(".topic-chips span.chip", { hasText: "Publicado em" }),
+      `${t.slug}: publicação e atualização no mesmo dia não podem virar dois selos iguais`
+    ).toHaveCount(0);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. A rota /sobre
+// ---------------------------------------------------------------------------
+
+const SOBRE = "/sobre/";
+
+test("o /sobre responde, com título, um h1 e o canonical dele", async ({ page }) => {
+  const doc = html(SOBRE);
+  const canonical = doc.match(/<link[^>]*rel="canonical"[^>]*>/)?.[0].match(/href="([^"]*)"/)?.[1];
+  expect(canonical, "o /sobre não declara a própria URL").toBe(`${SITE_URL}${SOBRE}`);
+
+  await page.goto(SOBRE);
+  await expect(page).toHaveTitle(/Sobre o Roadmap DSA/);
+  const h1 = page.getByRole("heading", { level: 1 });
+  await expect(h1).toHaveCount(1);
+  await expect(h1).toHaveText("Sobre o Roadmap DSA");
+});
+
+test("o /sobre está no sitemap, com lastmod na mesma condição das outras rotas", () => {
+  const lastmods = lastmodPorRota();
+  expect([...lastmods.keys()], "o /sobre ficou fora do sitemap").toContain(SOBRE);
+  expect(
+    Object.keys(CONTEUDO_DA_ROTA),
+    "rota no sitemap sem arquivos de conteúdo declarados fica sem lastmod para sempre"
+  ).toContain(SOBRE);
+  // Ou todas as rotas fixas têm data, ou nenhuma tem: uma rota nova entrando
+  // só no `rotasFixas` e não no `CONTEUDO_DA_ROTA` é exatamente o buraco que
+  // deixa UMA URL sem `lastmod` no meio de quarenta com.
+  const dasFixas = Object.keys(CONTEUDO_DA_ROTA).map((r) => lastmods.get(r));
+  const comData = dasFixas.filter(Boolean).length;
+  expect(
+    comData === 0 || comData === dasFixas.length,
+    `${comData} de ${dasFixas.length} rotas fixas com lastmod`
+  ).toBe(true);
+});
+
+test("o /sobre diz a licença dupla, e diz a mesma que o repositório tem", async ({ page }) => {
+  // A afirmação de licença é a que mais custa quando envelhece: este
+  // repositório já teve a home dizendo "open source" sob uma licença que a OSI
+  // não reconhece. O teste lê o texto RENDERIZADO e o compara com os arquivos
+  // de licença do próprio repositório, não com uma string escrita aqui.
+  const licenca = readFileSync(path.join(process.cwd(), "LICENSE"), "utf8");
+  const conteudo = readFileSync(path.join(process.cwd(), "LICENSE-CONTENT"), "utf8");
+  expect(licenca, "o LICENSE deixou de ser MIT; a /sobre precisa mudar junto").toContain("MIT");
+  expect(conteudo, "o LICENSE-CONTENT deixou de ser CC BY-NC-SA").toContain("CC BY-NC-SA 4.0");
+
+  await page.goto(SOBRE);
+  const corpo = page.locator(".intro-wrap");
+  await expect(corpo).toContainText("MIT");
+  await expect(corpo).toContainText("CC BY-NC-SA 4.0");
+  // Os dois links levam aos dois arquivos, e não os dois ao mesmo.
+  await expect(page.getByRole("link", { name: "MIT" })).toHaveAttribute(
+    "href",
+    /\/blob\/main\/LICENSE$/
+  );
+  await expect(page.getByRole("link", { name: "CC BY-NC-SA 4.0" })).toHaveAttribute(
+    "href",
+    /\/blob\/main\/LICENSE-CONTENT$/
+  );
+});
+
+test("dá para chegar ao /sobre navegando, no menu e no rodapé", async ({ page }) => {
+  // Rota que existe e ninguém alcança é rota que não existe. Clicar, e não
+  // conferir `href`: o `href` certo dentro de um menu que não abre continua
+  // sendo uma página inalcançável.
+  await page.goto("/");
+  await page.locator(".site-foot").getByRole("link", { name: "Sobre" }).click();
+  await expect(page).toHaveURL(new RegExp(`${SOBRE}$`));
+  await expect(page.getByRole("heading", { level: 1 })).toHaveText("Sobre o Roadmap DSA");
+
+  await page.goto("/roadmap/");
+  await page.getByRole("button", { name: "Mais opções" }).click();
+  await page.locator(".nav-menu").getByRole("link", { name: /Sobre o projeto/ }).click();
+  await expect(page).toHaveURL(new RegExp(`${SOBRE}$`));
+});

--- a/tests/seo-datas-e-autoria.spec.ts
+++ b/tests/seo-datas-e-autoria.spec.ts
@@ -2,9 +2,12 @@ import { test, expect } from "@playwright/test";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
-import { comDataUtil } from "../src/lib/datas-do-git";
+import {
+  CONTEUDO_DA_ROTA,
+  datasDistinguemCaminhos,
+  LIMITE_DE_CONCENTRACAO,
+} from "../src/lib/datas-do-git";
 import { dataLonga, diaIso } from "../src/lib/format";
-import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
 import { SITE_URL } from "../src/lib/links";
 
 // Quem assina o conteúdo, quando ele foi atualizado, e a página que responde
@@ -15,16 +18,17 @@ import { SITE_URL } from "../src/lib/links";
 // `JSON.parse` e conferido campo por nome, e o que o aluno lê é conferido no
 // navegador, com o rótulo junto do valor.
 //
-// A guarda das datas NÃO é reescrita aqui: `comDataUtil` é IMPORTADA do módulo
-// que o build usa. Esse guarda já errou duas vezes por ter sido recriado do
-// lado de fora (uma vez perguntando `git rev-parse --is-shallow-repository`,
-// outra lendo `.git/shallow`), e as duas reprovaram um sitemap correto.
+// A guarda das datas NÃO é reescrita aqui: `datasDistinguemCaminhos` é
+// IMPORTADA do módulo que o build usa. Esse guarda já errou duas vezes por ter
+// sido recriado do lado de fora (uma vez perguntando
+// `git rev-parse --is-shallow-repository`, outra lendo `.git/shallow`), e as
+// duas reprovaram um sitemap correto.
 //
 // As três funções de leitura de artefato abaixo são cópia das do
 // `seo-estrutura.spec.ts`, e a cópia é deliberada: unificá-las mexeria naquele
 // arquivo, que outra frente está editando agora. Unificar é PR próprio — e
 // note que o que está duplicado é PARSER, não REGRA: a regra que decide se a
-// data vale (`comDataUtil`) tem um dono só, importado acima.
+// data vale tem um dono só, importado acima.
 
 const OUT = path.join(process.cwd(), "out");
 
@@ -135,9 +139,9 @@ test("as datas do tópico e o lastmod do sitemap contam a MESMA história", () =
   //
   //   (a) ou todas as páginas têm data, ou nenhuma tem — nunca pela metade;
   //   (b) a presença bate, página a página, com a do `lastmod` da mesma URL;
-  //   (c) as datas presentes SOBREVIVEM ao `comDataUtil` — é aqui que morre a
-  //       versão sem guarda, que em clone raso carimba as 36 páginas com a data
-  //       do último deploy;
+  //   (c) as datas presentes passam no critério de CONCENTRAÇÃO do módulo — é
+  //       aqui que morre a versão sem guarda, que em clone raso carimba as 36
+  //       páginas com a data do commit-fronteira;
   //   (d) o valor é o mesmo instante nos dois artefatos.
   const lastmods = lastmodPorRota();
   const comData: string[] = [];
@@ -176,18 +180,26 @@ test("as datas do tópico e o lastmod do sitemap contam a MESMA história", () =
 
   expect(divergentes, "a página e o sitemap discordam sobre a data").toEqual([]);
 
-  // (c) A regra vem do módulo, não daqui. `comDataUtil` devolve as entradas SEM
-  // `lastModified` quando as datas não carregam informação; se ele apagar as
-  // datas que o build imprimiu, o build não devia tê-las impresso.
+  // (c) A regra vem do módulo, não daqui — e é a regra de CONCENTRAÇÃO, a mesma
+  // que o build usa para decidir se imprime data. Aplicada aqui às datas que o
+  // build de fato imprimiu: se elas não passam no critério, o build não devia
+  // tê-las impresso.
+  //
+  // `Set.size > 1` não serviria, e essa é a diferença que importa: num clone
+  // raso com alguns commits em cima, os caminhos tocados por esses commits
+  // resolvem para eles e todo o resto resolve para a fronteira. Duas datas
+  // distintas, contagem aprovada, e a maioria das URLs com data fabricada.
   if (entradas.length) {
-    const uteis = comDataUtil(entradas);
-    const apagadas = uteis.filter((e) => e.lastModified === undefined);
+    const carimbos = entradas.map((e) => e.lastModified!.getTime());
+    const porCarimbo = new Map<number, number>();
+    for (const c of carimbos) porCarimbo.set(c, (porCarimbo.get(c) ?? 0) + 1);
+    const moda = Math.max(...porCarimbo.values());
     expect(
-      apagadas.length,
-      `${apagadas.length} das ${entradas.length} páginas carimbadas não passam no ` +
-        "`comDataUtil`: as datas impressas não distinguem uma página da outra, ou seja, " +
-        `é a data do último commit repetida ${entradas.length} vezes`
-    ).toBe(0);
+      datasDistinguemCaminhos(carimbos),
+      `as datas impressas se concentram em poucos carimbos: ${moda} das ${carimbos.length} ` +
+        `páginas dividem a MESMA data (${((100 * moda) / carimbos.length).toFixed(1)}%, teto ` +
+        `de ${100 * LIMITE_DE_CONCENTRACAO}%), ou seja, é a data do commit-fronteira repetida`
+    ).toBe(true);
   }
 });
 

--- a/tests/seo-datas-e-autoria.spec.ts
+++ b/tests/seo-datas-e-autoria.spec.ts
@@ -384,6 +384,38 @@ test("o /sobre diz a licença dupla, e diz a mesma que o repositório tem", asyn
   );
 });
 
+test("a /sobre não promete privacidade que o código desmente", async ({ page }) => {
+  // Esta página já afirmou que "nada é enviado para lugar nenhum" enquanto o
+  // site carregava Google Analytics em produção. O guarda amarra a afirmação ao
+  // CÓDIGO que a desmentiria: enquanto existir um componente que monta o GA, a
+  // página tem que dizer o nome dele. Se o GA sair do projeto, este teste
+  // reprova pedindo que o texto mude junto — é o mesmo desenho do teste de
+  // licença, que lê o `LICENSE` em vez de uma string escrita aqui.
+  const analytics = readFileSync(
+    path.join(process.cwd(), "src", "components", "Analytics.tsx"),
+    "utf8"
+  );
+  const carregaGa = /GoogleAnalytics|AnalyticsDeferred/.test(analytics);
+
+  await page.goto(SOBRE);
+  const corpo = page.locator(".intro-wrap");
+
+  if (carregaGa) {
+    await expect(
+      corpo,
+      "o site monta Google Analytics, então a /sobre precisa dizer isso pelo nome"
+    ).toContainText("Google Analytics");
+  }
+
+  // E a afirmação absoluta não volta. A frase certa é sobre o PROGRESSO; a
+  // errada é sobre o site inteiro, e é uma promessa que o site não cumpre.
+  const texto = ((await corpo.textContent()) ?? "").replace(/\s+/g, " ");
+  expect(
+    texto,
+    "a /sobre voltou a prometer que nada sai do navegador, o que o Analytics desmente"
+  ).not.toMatch(/nada é enviado para lugar nenhum/i);
+});
+
 test("dá para chegar ao /sobre navegando, no menu e no rodapé", async ({ page }) => {
   // Rota que existe e ninguém alcança é rota que não existe. Clicar, e não
   // conferir `href`: o `href` certo dentro de um menu que não abre continua

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 import { LINKS, SITE_URL } from "../src/lib/links";
 import {
+  atualizacaoDoTopico,
   caminhosDatados,
   CONTEUDO_DA_ROTA,
   datasDistinguemCaminhos,
   LIMITE_DE_CONCENTRACAO,
+  ultimaAlteracao,
 } from "../src/lib/datas-do-git";
 
 // Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
@@ -255,7 +257,13 @@ function dataDoGit(arquivo: string): string {
   return iso;
 }
 
-/** A data esperada de uma rota: o mais recente dos arquivos que a alimentam. */
+/**
+ * O mais recente dos arquivos citados — usado como PISO da data de uma rota,
+ * não como valor esperado. A distinção importa: a regra de datação do build
+ * considera mais coisas do que estes arquivos (o intervalo do tópico dentro do
+ * `roadmap.ts`, por exemplo), então exigir igualdade seria recriar a regra aqui
+ * — e foi recriando que este arquivo reprovou três URLs corretas.
+ */
 function dataEsperada(arquivos: readonly string[]): number | undefined {
   const ms = arquivos
     .map((a) => Date.parse(dataDoGit(a)))
@@ -302,9 +310,19 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
     expect(Number.isNaN(Date.parse(d)), `${d} não é uma data`).toBe(false);
   }
   if (presentes.length) {
-    // O guarda que sobrevive a qualquer ambiente, e o que de fato importa: 40
-    // URLs com o MESMO carimbo são a data do último commit repetida 40 vezes,
-    // que é o `lastmod` que o Google aprendeu a ignorar.
+    // [PROPRIEDADE] O guarda que sobrevive a qualquer ambiente, e o que de fato
+    // importa: 40 URLs com o MESMO carimbo são a data do último commit repetida
+    // 40 vezes, que é o `lastmod` que o Google aprendeu a ignorar.
+    //
+    // É `Set.size > 1`, e NÃO o critério de concentração do módulo, embora ele
+    // esteja importado logo ali. A diferença é onde cada um se aplica:
+    // concentração denuncia git cego sobre CAMINHOS BRUTOS (é assim que o
+    // `test.skip` abaixo a usa), mas a data de uma URL é AGREGADA, e datas
+    // agregadas podem convergir por um motivo legítimo — um commit em lote no
+    // `roadmap.ts` (renomear um campo em todos os tópicos) coloca as 36 páginas
+    // na mesma data, o que dá 87,8% de concentração num build perfeitamente
+    // correto. `Set.size > 1` não tem esse falso positivo e mata o caso que
+    // importa aqui, o carimbo único de build.
     expect(
       new Set(presentes).size,
       `as ${presentes.length} URLs saíram com o mesmo lastmod (${presentes[0]}), que é a data do último commit repetida`
@@ -368,31 +386,98 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const sem = blocos.filter((_, i) => !lastmods[i]).map((b) => b.match(/<loc>([^<]+)<\/loc>/)![1]);
   expect(sem, `${sem.length} URLs sem lastmod com o histórico do Git disponível`).toEqual([]);
 
-  const errados: string[] = [];
+  // -------------------------------------------------------------------------
+  // Cada asserção daqui para baixo está ETIQUETADA com o que ela guarda:
+  //
+  //   [PROPRIEDADE] vale para qualquer regra de datação honesta, e continua
+  //                 valendo se a regra mudar amanhã;
+  //   [FIAÇÃO]      prova que o XML carrega o que o módulo calculou. Só isso —
+  //                 não julga se o módulo calcula bem.
+  //
+  // A etiqueta não é enfeite, é a correção de um defeito real deste bloco. Ele
+  // RECRIAVA a regra de datação: comparava cada `lastmod` com
+  // `git log -1 -- content/topics/<slug>.mdx`, com o `roadmap.ts` de reserva.
+  // Quando a regra do build passou a datar o tópico pelo INTERVALO DE LINHAS
+  // dele dentro do `roadmap.ts` (`git log -L`), esta cópia não acompanhou e
+  // reprovou três URLs cujas datas estavam certas — `quick-sort` e `shell-sort`
+  // (o commit que tirou o `isNew: true` delas, ou seja, o selo NOVO saindo da
+  // página) e `binary-numbers` (o commit que reescreveu a descrição). É
+  // exatamente a armadilha que o `sitemap.ts` documenta — "recriar a condição
+  // aqui é o que fez o buraco existir" —, desta vez do lado do teste.
+  //
+  // O conserto NÃO é trocar a fórmula copiada pela fórmula nova: isso deixaria
+  // o bloco inteiro tautológico, e o `lastmod` poderia virar carimbo de build
+  // com a suíte verde. O conserto é separar as duas perguntas e dizer qual é
+  // qual.
+  // -------------------------------------------------------------------------
+
+  // Todos os carimbos de commit do histórico deste repositório. Uma chamada.
+  const carimbosDeCommit = new Set(
+    execFileSync("git", ["log", "--format=%cI"], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 })
+      .split("\n")
+      .map((l) => Date.parse(l.trim()))
+      .filter((n) => !Number.isNaN(n))
+  );
+  const maisNovoDoHistorico = Math.max(...carimbosDeCommit);
+
+  const inventadas: string[] = [];
+  const noFuturo: string[] = [];
+  const velhasDemais: string[] = [];
+  const fiacao: string[] = [];
+
   for (const [i, bloco] of blocos.entries()) {
     const loc = bloco.match(/<loc>([^<]+)<\/loc>/)![1];
     const lastmod = lastmods[i]!;
-    if (Number.isNaN(Date.parse(lastmod))) {
-      errados.push(`${loc} → ${lastmod} não é uma data`);
+    const ms = Date.parse(lastmod);
+    if (Number.isNaN(ms)) {
+      inventadas.push(`${loc} → ${lastmod} não é uma data`);
       continue;
     }
-    // Toda URL é conferida, fixa ou de tópico. Antes só as de tópico eram, e as
-    // quatro fixas atravessavam a suíte sem que ninguém olhasse a data delas.
     const slug = loc.match(/\/topico\/([^/]+)\//)?.[1];
     const rota = loc.replace(SITE_URL, "");
-    // Tópico: a data é a do artigo, com o `roadmap.ts` de reserva para quem
-    // ainda não tem artigo — a mesma escolha, e o mesmo porquê, do `sitemap.ts`.
-    const arquivos = slug
-      ? dataDoGit(`content/topics/${slug}.mdx`)
-        ? [`content/topics/${slug}.mdx`]
-        : ["content/roadmap.ts"]
-      : CONTEUDO_DA_ROTA[rota as keyof typeof CONTEUDO_DA_ROTA];
-    const esperada = dataEsperada(arquivos);
-    if (esperada !== undefined && Date.parse(lastmod) !== esperada) {
-      errados.push(`${loc} → ${lastmod}, o Git diz ${new Date(esperada).toISOString()}`);
+
+    // [PROPRIEDADE] O carimbo é de um commit que EXISTE. Nenhuma regra honesta
+    // inventa um instante: ela escolhe um commit. É o que mata o `new Date()`
+    // do momento do build, o `Date.now()` arredondado e qualquer valor
+    // fabricado — e mata sem saber nada sobre QUAL commit deveria ser, que é o
+    // que deixa esta asserção sobreviver à próxima mudança de regra.
+    if (!carimbosDeCommit.has(ms)) inventadas.push(`${loc} → ${lastmod}`);
+
+    // [PROPRIEDADE] Nada é mais novo que o commit mais novo do histórico.
+    if (ms > maisNovoDoHistorico) noFuturo.push(`${loc} → ${lastmod}`);
+
+    // [PROPRIEDADE] A página não pode ser mais VELHA que o conteúdo que ela
+    // serve. É um piso, não uma igualdade, de propósito: ele continua correto
+    // se a regra passar a considerar mais entradas (foi o que aconteceu agora,
+    // quando o intervalo do `roadmap.ts` entrou na conta), e teria pegado o
+    // furo inverso — datar a página antes do próprio artigo.
+    const piso = dataEsperada(
+      slug ? [`content/topics/${slug}.mdx`] : CONTEUDO_DA_ROTA[rota as keyof typeof CONTEUDO_DA_ROTA]
+    );
+    if (piso !== undefined && ms < piso) {
+      velhasDemais.push(`${loc} → ${lastmod}, mais velho que ${new Date(piso).toISOString()}`);
+    }
+
+    // [FIAÇÃO] O XML carrega o que o módulo calculou. Esta é a única asserção
+    // do bloco que fala da fórmula, e ela é declaradamente circular: prova o
+    // encanamento (sitemap → XML), não a regra. Se um dia ela for a única que
+    // sobrar, o bloco não guarda mais nada.
+    const doModulo = slug
+      ? atualizacaoDoTopico(slug)
+      : ultimaAlteracao(...CONTEUDO_DA_ROTA[rota as keyof typeof CONTEUDO_DA_ROTA]);
+    if (doModulo && doModulo.getTime() !== ms) {
+      fiacao.push(`${loc} → XML ${lastmod}, módulo ${doModulo.toISOString()}`);
     }
   }
-  expect(errados, "lastmod que não bate com o commit do arquivo").toEqual([]);
+
+  expect(
+    inventadas,
+    `${inventadas.length} lastmod que não são o carimbo de nenhum commit do histórico ` +
+      "(data fabricada: carimbo de build, relógio da máquina, valor arredondado)"
+  ).toEqual([]);
+  expect(noFuturo, "lastmod depois do commit mais novo do repositório").toEqual([]);
+  expect(velhasDemais, "lastmod mais velho que o conteúdo que a página serve").toEqual([]);
+  expect(fiacao, "o XML não carrega a data que o módulo calculou").toEqual([]);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -31,7 +31,12 @@ import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
 
 const OUT = path.join(process.cwd(), "out");
 
-const ROTAS_FIXAS = ["/", "/introducao/", "/roadmap/", "/apoie/"] as const;
+// As rotas fixas saem do PRÓPRIO `sitemap.ts`, e não de uma lista à mão aqui.
+// Era à mão, e a lista de cima explica no que dá: rota nova entrava no site sem
+// entrar na cobertura. Pior no caso do sitemap, onde a lista à mão do teste e a
+// do build DIVERGEM em silêncio — o teste que compara as duas passa a comparar
+// a rota nova consigo mesma ausente dos dois lados.
+const ROTAS_FIXAS = Object.keys(CONTEUDO_DA_ROTA);
 const ROTAS_TOPICO = ALL_TOPICS.map((t) => `/topico/${t.slug}/`);
 const TODAS_AS_ROTAS = [...ROTAS_FIXAS, ...ROTAS_TOPICO];
 

--- a/tests/seo-estrutura.spec.ts
+++ b/tests/seo-estrutura.spec.ts
@@ -4,7 +4,12 @@ import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { ALL_TOPICS, isEmptyTopic } from "../content/roadmap";
 import { LINKS, SITE_URL } from "../src/lib/links";
-import { CONTEUDO_DA_ROTA } from "../src/app/sitemap";
+import {
+  caminhosDatados,
+  CONTEUDO_DA_ROTA,
+  datasDistinguemCaminhos,
+  LIMITE_DE_CONCENTRACAO,
+} from "../src/lib/datas-do-git";
 
 // Estrutura de SEO do site inteiro: canonical, sitemap e dados estruturados.
 //
@@ -333,10 +338,15 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   // 22 datas distintas e moda de 6 (14,3%); no job achatado a moda era 39 de 42
   // (92,9%). O corte em 50% fica longe dos dois, e cobre o caso antigo — git
   // que resolve UMA data para tudo tem moda de 100%.
-  const caminhosConferidos = [
-    ...ALL_TOPICS.filter((t) => !isEmptyTopic(t)).map((t) => `content/topics/${t.slug}.mdx`),
-    ...Object.values(CONTEUDO_DA_ROTA).flat(),
-  ];
+  // A REGRA vem do módulo de produção (`datasDistinguemCaminhos`), e o conjunto
+  // de caminhos também (`caminhosDatados`). Este bloco já foi a única casa do
+  // critério de concentração; hoje o build usa o mesmo, e manter a cópia daqui
+  // seria voltar a ter duas versões da mesma regra — o erro que este arquivo
+  // documenta três vezes.
+  //
+  // O que continua sendo daqui é a MENSAGEM: os números abaixo existem para o
+  // diagnóstico do skip, não para decidir nada.
+  const caminhosConferidos = caminhosDatados();
   const porData = new Map<string, number>();
   for (const caminho of caminhosConferidos) {
     const d = dataDoGit(caminho);
@@ -345,11 +355,12 @@ test("o lastmod do sitemap vem do Git, ou não existe", () => {
   const resolvidos = [...porData.values()].reduce((a, b) => a + b, 0);
   const moda = porData.size ? Math.max(...porData.values()) : 0;
   test.skip(
-    resolvidos === 0 || moda / resolvidos > 0.5,
+    !datasDistinguemCaminhos(caminhosConferidos.map((c) => Date.parse(dataDoGit(c)))),
     `o git deste processo devolve a mesma data para ${moda} dos ${resolvidos} caminhos ` +
-      `conferidos (${porData.size} data(s) distinta(s) ao todo): ele achata o histórico no ` +
-      "commit-fronteira e não pode servir de referência. As invariantes do artefato acima " +
-      "já foram conferidas."
+      `conferidos (${porData.size} data(s) distinta(s) ao todo, ` +
+      `concentração ${resolvidos ? ((100 * moda) / resolvidos).toFixed(1) : "0"}% contra o teto ` +
+      `de ${100 * LIMITE_DE_CONCENTRACAO}%): ele achata o histórico no commit-fronteira e não ` +
+      "pode servir de referência. As invariantes do artefato acima já foram conferidas."
   );
 
   // Daqui para baixo o git deste processo enxerga o histórico, então dá para


### PR DESCRIPTION
## Para quem lê o site

- Cada página de tópico passa a mostrar **"Atualizado em `<data>`"** ao lado do
  nível e do tempo de leitura, com `<time datetime>` para máquina. Em **4**
  tópicos aparece também **"Publicado em"**, quando o dia é outro — nos outros
  31 as duas datas caem no mesmo dia, e dois selos idênticos seriam ruído.
- Nasce a rota **`/sobre`**, ligada no menu `⋯` e no rodapé: o que o guia é, os
  canais da comunidade, a licença dupla (**código MIT, conteúdo CC BY-NC-SA
  4.0**, lidos do `LICENSE` e do `LICENSE-CONTENT`, não digitados), como
  contribuir, e que é gratuito.

## A data vem do Git, e some quando não presta

Não há campo `updatedAt` para alguém lembrar de atualizar — data que depende de
disciplina humana envelhece errado e passa a mentir, o que é pior do que não
existir.

E a guarda veio junto com a lógica: **se o `git log` do build não distinguir um
caminho do outro** (clone raso), o selo não aparece e os campos não saem. É o
mesmo guarda que o `lastmod` já usa, e agora é o **mesmo código** — dois
predicados para uma decisão foi como o buraco do sitemap nasceu.

## Refatoração primeiro, sozinha, e provada

A derivação de data saiu do `sitemap.ts` para `src/lib/datas-do-git.ts`, em
commit próprio (`3c691ec`), antes de qualquer coisa que mude comportamento.

Provado rodando o `sitemap()` **de antes** e o **de depois** no mesmo processo,
contra o mesmo repositório:

```
URLs antes: 40   depois: 40
com lastModified antes: 40   depois: 40
datas distintas antes: 21   depois: 21
IDÊNTICO: a saída serializada do sitemap é a mesma nos dois.
```

## Autoria: a organização, e por quê

`author` aponta por `@id` para o nó `Organization` que o layout já emite. A base
é factual, não preferência:

- os **34** vídeos que alimentam os tópicos têm `ownerChannelName: "Craft & Code Club"`;
- **nenhuma** das 34 descrições cita o nome de uma pessoa;
- o `git log` do repositório tem **uma** conta humana.

Nomear alguém seria invenção. Trocar por uma `Person` depois custa **uma
constante** (`AUTOR`, em `src/lib/jsonld.ts`) — e o nome tem que aparecer na
tela junto, senão vira marcação sem lastro, que é o que o contrato do arquivo
proíbe.

## O que isto faz por busca, e o que não faz

**Faz:** o Google documenta que, quando consegue determinar a data de uma
página, **pode exibi-la no resultado**, e recomenda para isso
`datePublished`/`dateModified` num subtipo de `CreativeWork` — que é o caso do
nosso `LearningResource`. A ordem que a doc pede é o inverso do folclore: **1)**
data visível e rotulada, **2)** a marcação, **3)** as duas batendo. É o que este
PR faz, nessa ordem.
https://developers.google.com/search/docs/appearance/publication-dates

**Não faz:**

- **Não gera rich result.** O de artigo só vale para `Article`, `NewsArticle` e
  `BlogPosting`; `LearningResource` não está na galeria.
- **Não é sinal de ranqueamento.** A doc fala de *exibição*, não de posição.
- **E-E-A-T não é o argumento.** É conceito das diretrizes dos **avaliadores
  humanos**, não um sinal computado. `author` entra aqui porque o site afirmava
  autoria em três lugares soltos e não tinha onde apontar.

## O que ficou marcado para o Wilson

Dois blocos `{/* … */}` no JSX da `/sobre`, cada um dizendo o que falta e por que
não foi chutado:

1. **A história da comunidade** — quando começou, quem tocava, quem toca hoje,
   qual o tamanho. Nada disso está escrito no repositório. O `LICENSE` diz
   "Copyright © 2026", que é ano de copyright e não data de fundação.
2. **A chamada final** — qual canal enfatizar. Não é fato, então não é do agente.

Todo o resto da página sai de fonte: números do `roadmap.ts`, canais do `LINKS`,
licenças dos arquivos de licença.

## Como provar que os testes prestam

**Executadas, não sugeridas** — cada uma com `npm run build` antes:

| quebra | efeito medido |
|---|---|
| apagar `author: AUTOR,` | 1 falha: *"cada tópico indexável declara o autor"* |
| apagar o spread de `dateModified` | 2 falhas: *"as datas do tópico e o lastmod contam a MESMA história"* e *"datePublished nunca é depois de dateModified"* |
| renomear o selo para "Última atualização" | 2 falhas: *"o selo está na tela, legível, e diz a data que marca"* e a do selo "Publicado em" |

O teste do selo **lê o texto e mede o `font-size`**, então `style={{fontSize:0}}`
também o derruba — contar elemento não bastaria.

## Sobre rodar a suíte nesta máquina

O flake local é alto e **pré-existente**: a `main` limpa, recém-construída,
falhou **14** de 693 nesta máquina; esta branch falhou **10** numa rodada e
**13** noutra, com **zero sobreposição** entre as três listas. Rodados
isoladamente, os mesmos specs passam (76/76). O sinal que vale é o do CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUbtzKsXafUrmiFM3gPMYz