### PR TITLE
chore(viz): todo botão declara que é botão, e o lint impede o próximo

### DIFF
--- a/content/visualizers/AStarVisualizer.tsx
+++ b/content/visualizers/AStarVisualizer.tsx
@@ -243,13 +243,13 @@ export function AStarVisualizer() {
 
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className={`bigo-chip${mode === "astar" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("astar"); }} aria-pressed={mode === "astar"}>A*: f = g + h</button>
-          <button className={`bigo-chip${mode === "dijkstra" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("dijkstra"); }} aria-pressed={mode === "dijkstra"}>Dijkstra: f = g</button>
-          <button className={`bigo-chip na${mode === "greedy" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("greedy"); }} aria-pressed={mode === "greedy"}>Guloso: f = h</button>
+          <button type="button" className={`bigo-chip${mode === "astar" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("astar"); }} aria-pressed={mode === "astar"}>A*: f = g + h</button>
+          <button type="button" className={`bigo-chip${mode === "dijkstra" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("dijkstra"); }} aria-pressed={mode === "dijkstra"}>Dijkstra: f = g</button>
+          <button type="button" className={`bigo-chip na${mode === "greedy" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("greedy"); }} aria-pressed={mode === "greedy"}>Guloso: f = h</button>
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/ArraysCrescimento.tsx
+++ b/content/visualizers/ArraysCrescimento.tsx
@@ -257,6 +257,7 @@ export function ArraysCrescimento() {
         <div className="arr-tabs" role="group" aria-label="Estratégia de crescimento">
           {STRATEGIES.map((e) => (
             <button
+              type="button"
               key={e.key}
               className={`arr-tab${e.key === strategy ? " on" : ""}`}
               aria-pressed={e.key === strategy}
@@ -291,6 +292,7 @@ export function ArraysCrescimento() {
             <div className="arr-tabs">
               {INITIAL_CAPS.map((c) => (
                 <button
+                  type="button"
                   key={c}
                   className={`arr-tab${c === cap0 ? " on" : ""}`}
                   aria-pressed={c === cap0}

--- a/content/visualizers/ArraysOperacoes.tsx
+++ b/content/visualizers/ArraysOperacoes.tsx
@@ -423,7 +423,7 @@ export function ArraysOperacoes() {
               }}
             />
           </label>
-          <button className="viz-btn" onClick={randomize}>
+          <button type="button" className="viz-btn" onClick={randomize}>
             Sortear
           </button>
         </div>
@@ -431,6 +431,7 @@ export function ArraysOperacoes() {
         <div className="arr-tabs" role="group" aria-label="Operação">
           {OPS.map((o) => (
             <button
+              type="button"
               key={o}
               className={`arr-tab${o === op ? " on" : ""}`}
               aria-pressed={o === op}
@@ -506,33 +507,34 @@ export function ArraysOperacoes() {
             fora da tela — exatamente o que a casca existe para impedir. */}
         <div className="viz-controls">
           <span className="arr-presets-rot">Compare:</span>
-          <button className="viz-btn" onClick={() => pickOp("insert", 0)}>
+          <button type="button" className="viz-btn" onClick={() => pickOp("insert", 0)}>
             inserir no começo
           </button>
-          <button className="viz-btn" onClick={() => pickOp("insert", 3)}>
+          <button type="button" className="viz-btn" onClick={() => pickOp("insert", 3)}>
             inserir no meio
           </button>
-          <button className="viz-btn" onClick={() => pickOp("push-end")}>
+          <button type="button" className="viz-btn" onClick={() => pickOp("push-end")}>
             inserir no fim
           </button>
-          <button className="viz-btn" onClick={() => pickOp("remove", 0)}>
+          <button type="button" className="viz-btn" onClick={() => pickOp("remove", 0)}>
             remover o primeiro
           </button>
         </div>
 
         <div className="viz-controls">
           <span className="arr-presets-rot">Casos de borda:</span>
-          <button className="viz-btn" onClick={() => preset([42], "remove", 0)} title="Um elemento só, removendo a posição 0">
+          <button type="button" className="viz-btn" onClick={() => preset([42], "remove", 0)} title="Um elemento só, removendo a posição 0">
             n = 1, remover o único
           </button>
           <button
+            type="button"
             className="viz-btn"
             onClick={() => preset(DEFAULT_NUMS, "insert", DEFAULT_NUMS.length)}
             title="Inserir na posição igual ao tamanho é inserir no fim"
           >
             k = n, inserir logo após o último
           </button>
-          <button className="viz-btn" onClick={() => preset(DEFAULT_NUMS, "remove", DEFAULT_NUMS.length - 1)}>
+          <button type="button" className="viz-btn" onClick={() => preset(DEFAULT_NUMS, "remove", DEFAULT_NUMS.length - 1)}>
             remover a última posição
           </button>
         </div>

--- a/content/visualizers/ArraysVisualizer.tsx
+++ b/content/visualizers/ArraysVisualizer.tsx
@@ -213,13 +213,13 @@ export function ArraysVisualizer() {
           {/* Os presets ficam AQUI, e não na linha de controles, porque com um
               array de 1 elemento não há linha do tempo e o rodapé some inteiro —
               levar o "20 inteiros" junto deixaria o aluno sem volta. */}
-          <button className="viz-btn" onClick={randomize}>
+          <button type="button" className="viz-btn" onClick={randomize}>
             Sortear
           </button>
-          <button className="viz-btn" onClick={preset20}>
+          <button type="button" className="viz-btn" onClick={preset20}>
             20 inteiros
           </button>
-          <button className="viz-btn" onClick={restore}>
+          <button type="button" className="viz-btn" onClick={restore}>
             Voltar ao padrão
           </button>
         </div>
@@ -230,6 +230,7 @@ export function ArraysVisualizer() {
             <div className="arr-tabs">
               {ELEMENT_SIZES.map((t) => (
                 <button
+                  type="button"
                   key={t.key}
                   className={`arr-tab${t.key === sizeKey ? " on" : ""}`}
                   aria-pressed={t.key === sizeKey}
@@ -242,6 +243,7 @@ export function ArraysVisualizer() {
             </div>
           </div>
           <button
+            type="button"
             className={`viz-btn arr-toggle${cache ? " on" : ""}`}
             aria-pressed={cache}
             onClick={() => setCache((v) => !v)}

--- a/content/visualizers/BSTVisualizer.tsx
+++ b/content/visualizers/BSTVisualizer.tsx
@@ -264,7 +264,7 @@ export function BSTVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => changePreset(pr.key)} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => changePreset(pr.key)} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}
@@ -276,10 +276,10 @@ export function BSTVisualizer() {
           <div className="viz-field">
             <span>O que mostrar</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${mode === "inserir" ? " on" : ""}`} onClick={() => changeMode("inserir")} aria-pressed={mode === "inserir"}>
+              <button type="button" className={`sub-modo-btn${mode === "inserir" ? " on" : ""}`} onClick={() => changeMode("inserir")} aria-pressed={mode === "inserir"}>
                 construir
               </button>
-              <button className={`sub-modo-btn${mode === "buscar" ? " on" : ""}`} onClick={() => changeMode("buscar")} aria-pressed={mode === "buscar"}>
+              <button type="button" className={`sub-modo-btn${mode === "buscar" ? " on" : ""}`} onClick={() => changeMode("buscar")} aria-pressed={mode === "buscar"}>
                 buscar
               </button>
             </div>

--- a/content/visualizers/BacktrackingPoda.tsx
+++ b/content/visualizers/BacktrackingPoda.tsx
@@ -137,6 +137,7 @@ export function BacktrackingPoda() {
         <div className="bigo-chips">
           {TAMANHOS.map((t) => (
             <button
+              type="button"
               key={t}
               className={`bigo-chip${n === t ? " on" : ""}`}
               onClick={() => {
@@ -218,6 +219,7 @@ export function BacktrackingPoda() {
           <div className="bt-rainhas-topo">
             {com.solucoes.map((_, k) => (
               <button
+                type="button"
                 key={k}
                 className={`bigo-chip${k === Math.min(qual, com.solucoes.length - 1) ? " on" : ""}`}
                 onClick={() => setQual(k)}

--- a/content/visualizers/BacktrackingSudoku.tsx
+++ b/content/visualizers/BacktrackingSudoku.tsx
@@ -297,6 +297,7 @@ export function BacktrackingSudoku() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => changePreset(pr.key)}

--- a/content/visualizers/BacktrackingVisualizer.tsx
+++ b/content/visualizers/BacktrackingVisualizer.tsx
@@ -285,7 +285,7 @@ export function BacktrackingVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {MODES.map((m) => (
-            <button key={m} className={`bigo-chip${mode === m ? " on" : ""}`} onClick={() => changeMode(m)} aria-pressed={mode === m}>
+            <button type="button" key={m} className={`bigo-chip${mode === m ? " on" : ""}`} onClick={() => changeMode(m)} aria-pressed={mode === m}>
               {MODE_NAMES[m]}
             </button>
           ))}

--- a/content/visualizers/BellmanFordVisualizer.tsx
+++ b/content/visualizers/BellmanFordVisualizer.tsx
@@ -197,7 +197,7 @@ export function BellmanFordVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "cycle" ? " na" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "cycle" ? " na" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/BigOChartVisualizer.tsx
+++ b/content/visualizers/BigOChartVisualizer.tsx
@@ -336,6 +336,7 @@ export function BigOChartVisualizer() {
             const on = activeKeys.has(f.key);
             return (
               <button
+                type="button"
                 key={f.key}
                 className={`bigo-chip${on ? " on" : ""}`}
                 style={on ? { borderColor: f.color, color: f.color } : undefined}
@@ -409,10 +410,11 @@ export function BigOChartVisualizer() {
             style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
           />
         </div>
-        <button className="viz-btn" onClick={() => setLogScale((v) => !v)}>
+        <button type="button" className="viz-btn" onClick={() => setLogScale((v) => !v)}>
           Escala: {logScale ? "logarítmica" : "linear"}
         </button>
         <button
+          type="button"
           className="viz-btn"
           onClick={() => {
             setActiveKeys(new Set(DEFAULT_KEYS));

--- a/content/visualizers/BigOCounterVisualizer.tsx
+++ b/content/visualizers/BigOCounterVisualizer.tsx
@@ -266,6 +266,7 @@ export function BigOCounterVisualizer() {
             const on = i === algIndex;
             return (
               <button
+                type="button"
                 key={a.key}
                 className={`bigo-chip${on ? " on" : ""}`}
                 style={on ? { borderColor: a.cor, color: a.cor } : undefined}

--- a/content/visualizers/BinarioBases.tsx
+++ b/content/visualizers/BinarioBases.tsx
@@ -89,7 +89,7 @@ export function BinarioBases() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {VALUES.map((v) => (
-            <button key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
+            <button type="button" key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
               {thousands(v)}
             </button>
           ))}

--- a/content/visualizers/BinarioComplemento.tsx
+++ b/content/visualizers/BinarioComplemento.tsx
@@ -270,6 +270,7 @@ export function BinarioComplemento() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => pickPreset(pr.key)}

--- a/content/visualizers/BinarioConversor.tsx
+++ b/content/visualizers/BinarioConversor.tsx
@@ -91,6 +91,7 @@ export function BinarioConversor() {
         <div className="bigo-chips">
           {PRESETS.map((p) => (
             <button
+              type="button"
               key={p.key}
               className={`bigo-chip${value === p.value ? " on" : ""}`}
               onClick={() => setValue(p.value)}
@@ -116,6 +117,7 @@ export function BinarioConversor() {
               const exp = N - 1 - k;
               return (
                 <button
+                  type="button"
                   key={k}
                   className={`bn-bit${b ? " on" : ""}`}
                   onClick={() => toggleBit(k)}

--- a/content/visualizers/BinarioDivisoes.tsx
+++ b/content/visualizers/BinarioDivisoes.tsx
@@ -196,6 +196,7 @@ export function BinarioDivisoes() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => changePreset(pr.key)}

--- a/content/visualizers/BinarioFaixa.tsx
+++ b/content/visualizers/BinarioFaixa.tsx
@@ -109,6 +109,7 @@ export function BinarioFaixa() {
         <div className="bigo-chips">
           {MILESTONES.map((m) => (
             <button
+              type="button"
               key={m.value}
               className={`bigo-chip${value === m.value ? " on" : ""}`}
               onClick={() => setValue(m.value)}
@@ -269,11 +270,11 @@ export function BinarioFaixa() {
           continua se explicando sozinha onde quer que esteja. */}
       <VizFooter viz={viz}>
         <div className="bn-passeio">
-          <button className="viz-btn" onClick={() => walk(-1)} aria-label="Padrão anterior">
+          <button type="button" className="viz-btn" onClick={() => walk(-1)} aria-label="Padrão anterior">
             ‹ menos 1
           </button>
           <span className="bn-passeio-txt">andar pelos padrões vizinhos</span>
-          <button className="viz-btn" onClick={() => walk(1)} aria-label="Próximo padrão">
+          <button type="button" className="viz-btn" onClick={() => walk(1)} aria-label="Próximo padrão">
             mais 1 ›
           </button>
         </div>

--- a/content/visualizers/BinarioTresFormas.tsx
+++ b/content/visualizers/BinarioTresFormas.tsx
@@ -114,7 +114,7 @@ export function BinarioTresFormas() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {VALUES.map((v) => (
-            <button key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
+            <button type="button" key={v} className={`bigo-chip${value === v ? " on" : ""}`} onClick={() => setValue(v)} aria-pressed={value === v}>
               negar {v}
             </button>
           ))}

--- a/content/visualizers/BinaryHeapVisualizer.tsx
+++ b/content/visualizers/BinaryHeapVisualizer.tsx
@@ -483,6 +483,7 @@ export function BinaryHeapVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => pickPreset(pr.key)}
@@ -499,13 +500,13 @@ export function BinaryHeapVisualizer() {
           <div className="viz-field">
             <span>Operação</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${mode === "insert" ? " on" : ""}`} onClick={() => pickMode("insert")} aria-pressed={mode === "insert"}>
+              <button type="button" className={`sub-modo-btn${mode === "insert" ? " on" : ""}`} onClick={() => pickMode("insert")} aria-pressed={mode === "insert"}>
                 inserir
               </button>
-              <button className={`sub-modo-btn${mode === "remove" ? " on" : ""}`} onClick={() => pickMode("remove")} aria-pressed={mode === "remove"}>
+              <button type="button" className={`sub-modo-btn${mode === "remove" ? " on" : ""}`} onClick={() => pickMode("remove")} aria-pressed={mode === "remove"}>
                 remover o topo
               </button>
-              <button className={`sub-modo-btn${mode === "build" ? " on" : ""}`} onClick={() => pickMode("build")} aria-pressed={mode === "build"}>
+              <button type="button" className={`sub-modo-btn${mode === "build" ? " on" : ""}`} onClick={() => pickMode("build")} aria-pressed={mode === "build"}>
                 construir de uma vez
               </button>
             </div>
@@ -513,10 +514,10 @@ export function BinaryHeapVisualizer() {
           <div className="viz-field">
             <span>Regra</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${kind === "min" ? " on" : ""}`} onClick={() => pickKind("min")} aria-pressed={kind === "min"}>
+              <button type="button" className={`sub-modo-btn${kind === "min" ? " on" : ""}`} onClick={() => pickKind("min")} aria-pressed={kind === "min"}>
                 min-heap
               </button>
-              <button className={`sub-modo-btn${kind === "max" ? " on" : ""}`} onClick={() => pickKind("max")} aria-pressed={kind === "max"}>
+              <button type="button" className={`sub-modo-btn${kind === "max" ? " on" : ""}`} onClick={() => pickKind("max")} aria-pressed={kind === "max"}>
                 max-heap
               </button>
             </div>

--- a/content/visualizers/BinaryTreeFormatos.tsx
+++ b/content/visualizers/BinaryTreeFormatos.tsx
@@ -231,6 +231,7 @@ export function BinaryTreeFormatos() {
         <div className="bigo-chips">
           {PRESETS.map((p) => (
             <button
+              type="button"
               key={p.key}
               className={`bigo-chip${preset === p.key ? " on" : ""}`}
               onClick={() => apply(p)}

--- a/content/visualizers/BuscaBinariaFronteira.tsx
+++ b/content/visualizers/BuscaBinariaFronteira.tsx
@@ -291,7 +291,7 @@ export function BuscaBinariaFronteira() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => changePreset(pr.key)} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => changePreset(pr.key)} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}
@@ -303,13 +303,13 @@ export function BuscaBinariaFronteira() {
           <div className="viz-field">
             <span>O que eu quero saber</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${mode === "first" ? " on" : ""}`} onClick={() => changeMode("first")} aria-pressed={mode === "first"}>
+              <button type="button" className={`sub-modo-btn${mode === "first" ? " on" : ""}`} onClick={() => changeMode("first")} aria-pressed={mode === "first"}>
                 primeira ocorrência
               </button>
-              <button className={`sub-modo-btn${mode === "last" ? " on" : ""}`} onClick={() => changeMode("last")} aria-pressed={mode === "last"}>
+              <button type="button" className={`sub-modo-btn${mode === "last" ? " on" : ""}`} onClick={() => changeMode("last")} aria-pressed={mode === "last"}>
                 última ocorrência
               </button>
-              <button className={`sub-modo-btn${mode === "insert" ? " on" : ""}`} onClick={() => changeMode("insert")} aria-pressed={mode === "insert"}>
+              <button type="button" className={`sub-modo-btn${mode === "insert" ? " on" : ""}`} onClick={() => changeMode("insert")} aria-pressed={mode === "insert"}>
                 onde entraria
               </button>
             </div>

--- a/content/visualizers/BuscaBinariaOverflow.tsx
+++ b/content/visualizers/BuscaBinariaOverflow.tsx
@@ -122,7 +122,7 @@ export function BuscaBinariaOverflow() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((p) => (
-            <button key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => aplicar(p)} aria-pressed={presetKey === p.key}>
+            <button type="button" key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => aplicar(p)} aria-pressed={presetKey === p.key}>
               {p.rotulo}
             </button>
           ))}
@@ -160,10 +160,10 @@ export function BuscaBinariaOverflow() {
           <div className="viz-field">
             <span>Tipo do inteiro</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${limitado ? " on" : ""}`} onClick={() => setLimitado(true)} aria-pressed={limitado}>
+              <button type="button" className={`sub-modo-btn${limitado ? " on" : ""}`} onClick={() => setLimitado(true)} aria-pressed={limitado}>
                 32 bits (Java, C#, Go int32)
               </button>
-              <button className={`sub-modo-btn${!limitado ? " on" : ""}`} onClick={() => setLimitado(false)} aria-pressed={!limitado}>
+              <button type="button" className={`sub-modo-btn${!limitado ? " on" : ""}`} onClick={() => setLimitado(false)} aria-pressed={!limitado}>
                 sem limite (Python)
               </button>
             </div>

--- a/content/visualizers/BuscaBinariaVisualizer.tsx
+++ b/content/visualizers/BuscaBinariaVisualizer.tsx
@@ -219,6 +219,7 @@ export function BuscaBinariaVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}

--- a/content/visualizers/DijkstraVisualizer.tsx
+++ b/content/visualizers/DijkstraVisualizer.tsx
@@ -194,7 +194,7 @@ export function DijkstraVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.negative ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.negative ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/GrafoDfsBfs.tsx
+++ b/content/visualizers/GrafoDfsBfs.tsx
@@ -207,16 +207,16 @@ export function GrafoDfsBfs() {
 
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className={`bigo-chip${mode === "bfs" ? " on" : ""}`} onClick={() => pickMode("bfs")} aria-pressed={mode === "bfs"}>
+          <button type="button" className={`bigo-chip${mode === "bfs" ? " on" : ""}`} onClick={() => pickMode("bfs")} aria-pressed={mode === "bfs"}>
             BFS (fila)
           </button>
-          <button className={`bigo-chip${isDfs ? " on" : ""}`} onClick={() => pickMode("dfs")} aria-pressed={isDfs}>
+          <button type="button" className={`bigo-chip${isDfs ? " on" : ""}`} onClick={() => pickMode("dfs")} aria-pressed={isDfs}>
             DFS (pilha)
           </button>
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/GrafoRepresentacao.tsx
+++ b/content/visualizers/GrafoRepresentacao.tsx
@@ -157,7 +157,7 @@ export function GrafoRepresentacao() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((p) => (
-            <button key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => applyPreset(p)} aria-pressed={presetKey === p.key}>
+            <button type="button" key={p.key} className={`bigo-chip${presetKey === p.key ? " on" : ""}`} onClick={() => applyPreset(p)} aria-pressed={presetKey === p.key}>
               {p.label}
             </button>
           ))}
@@ -167,10 +167,10 @@ export function GrafoRepresentacao() {
           <div className="viz-field">
             <span>Tipo</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${directed ? "" : " on"}`} onClick={() => changeDirected(false)} aria-pressed={!directed}>
+              <button type="button" className={`sub-modo-btn${directed ? "" : " on"}`} onClick={() => changeDirected(false)} aria-pressed={!directed}>
                 não dirigido
               </button>
-              <button className={`sub-modo-btn${directed ? " on" : ""}`} onClick={() => changeDirected(true)} aria-pressed={directed}>
+              <button type="button" className={`sub-modo-btn${directed ? " on" : ""}`} onClick={() => changeDirected(true)} aria-pressed={directed}>
                 dirigido
               </button>
             </div>
@@ -247,6 +247,7 @@ export function GrafoRepresentacao() {
                     {row.map((v, j) => (
                       <td key={j}>
                         <button
+                          type="button"
                           className={`gr-cel${v ? " on" : ""}${i === j ? " diag" : ""}`}
                           onClick={() => toggleEdge(i, j)}
                           disabled={i === j}

--- a/content/visualizers/HashTableBuscaVisualizer.tsx
+++ b/content/visualizers/HashTableBuscaVisualizer.tsx
@@ -262,13 +262,14 @@ export function HashTableBuscaVisualizer() {
               }}
             />
           </label>
-          <button className="viz-btn" onClick={shuffle}>
+          <button type="button" className="viz-btn" onClick={shuffle}>
             Sortear
           </button>
         </div>
 
         <div className="bigo-chips">
           <button
+            type="button"
             className={`bigo-chip${!bad ? " on" : ""}`}
             aria-pressed={!bad}
             onClick={() => {
@@ -280,6 +281,7 @@ export function HashTableBuscaVisualizer() {
             Hash que distribui
           </button>
           <button
+            type="button"
             className={`bigo-chip${bad ? " on" : ""}`}
             aria-pressed={bad}
             onClick={() => {
@@ -295,7 +297,7 @@ export function HashTableBuscaVisualizer() {
         <div className="ht-presets">
           <span>Cenários</span>
           {PRESETS.map((pr) => (
-            <button className="viz-btn" key={pr.label} onClick={() => applyPreset(pr)}>
+            <button type="button" className="viz-btn" key={pr.label} onClick={() => applyPreset(pr)}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/HashTableVisualizer.tsx
+++ b/content/visualizers/HashTableVisualizer.tsx
@@ -459,13 +459,14 @@ export function HashTableVisualizer() {
               <option value={16}>16</option>
             </select>
           </label>
-          <button className="viz-btn" onClick={shuffle}>
+          <button type="button" className="viz-btn" onClick={shuffle}>
             Sortear
           </button>
         </div>
 
         <div className="bigo-chips">
           <button
+            type="button"
             className={`bigo-chip${chained ? " on" : ""}`}
             aria-pressed={chained}
             onClick={() => {
@@ -477,6 +478,7 @@ export function HashTableVisualizer() {
             Encadeamento
           </button>
           <button
+            type="button"
             className={`bigo-chip${!chained ? " on" : ""}`}
             aria-pressed={!chained}
             onClick={() => {
@@ -488,6 +490,7 @@ export function HashTableVisualizer() {
             Sondagem linear
           </button>
           <button
+            type="button"
             className={`bigo-chip${resizes ? " on" : ""}`}
             aria-pressed={resizes}
             onClick={() => {
@@ -503,7 +506,7 @@ export function HashTableVisualizer() {
         <div className="ht-presets">
           <span>Cenários</span>
           {PRESETS.map((pr) => (
-            <button className="viz-btn" key={pr.label} onClick={() => applyPreset(pr)}>
+            <button type="button" className="viz-btn" key={pr.label} onClick={() => applyPreset(pr)}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/HeapIndicesVisualizer.tsx
+++ b/content/visualizers/HeapIndicesVisualizer.tsx
@@ -189,7 +189,7 @@ export function HeapIndicesVisualizer() {
             <span>Filhos por nó (k)</span>
             <div className="sub-modo">
               {[2, 3, 4].map((v) => (
-                <button key={v} className={`sub-modo-btn${k === v ? " on" : ""}`} onClick={() => setK(v)} aria-pressed={k === v}>
+                <button type="button" key={v} className={`sub-modo-btn${k === v ? " on" : ""}`} onClick={() => setK(v)} aria-pressed={k === v}>
                   {v === 2 ? "2 (binário)" : v}
                 </button>
               ))}
@@ -254,7 +254,7 @@ export function HeapIndicesVisualizer() {
           </div>
           <div className="hp-arr">
             {arr.map((v, idx) => (
-              <button key={idx} className={`hp-cel botao ${classeDe(idx)}`} onClick={() => setSel(idx)} aria-pressed={idx === i} aria-label={`Índice ${idx}, valor ${v}`}>
+              <button type="button" key={idx} className={`hp-cel botao ${classeDe(idx)}`} onClick={() => setSel(idx)} aria-pressed={idx === i} aria-label={`Índice ${idx}, valor ${v}`}>
                 <i>{idx}</i>
                 {v}
               </button>
@@ -265,6 +265,7 @@ export function HeapIndicesVisualizer() {
         <div className="hp-formulas">
           {linhas.map((l) => (
             <button
+              type="button"
               key={l.chave}
               className={`hp-formula${l.existe ? "" : " fora"}${l.chave === "pai" ? " pai" : " filho"}`}
               onClick={() => l.existe && irPara(l.destino)}

--- a/content/visualizers/HeapSortEstabilidade.tsx
+++ b/content/visualizers/HeapSortEstabilidade.tsx
@@ -198,6 +198,7 @@ export function HeapSortEstabilidade() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => setPresetKey(pr.key)}

--- a/content/visualizers/HeapSortVisualizer.tsx
+++ b/content/visualizers/HeapSortVisualizer.tsx
@@ -312,6 +312,7 @@ export function HeapSortVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => {

--- a/content/visualizers/IntervalsSobreposicaoVisualizer.tsx
+++ b/content/visualizers/IntervalsSobreposicaoVisualizer.tsx
@@ -274,7 +274,7 @@ export function IntervalsSobreposicaoVisualizer() {
             <input className="viz-input k" type="number" min={0} max={20} value={lenB}
               onChange={(e) => { pause(); setLenB(Math.min(20, Math.max(0, parseInt(e.target.value, 10) || 0))); }} />
           </label>
-          <button className="viz-btn" onClick={() => { pause(); setClosed((v) => !v); }} aria-pressed={closed}>
+          <button type="button" className="viz-btn" onClick={() => { pause(); setClosed((v) => !v); }} aria-pressed={closed}>
             Bordas: {closed ? "[início, fim]" : "[início, fim)"}
           </button>
         </div>
@@ -282,7 +282,7 @@ export function IntervalsSobreposicaoVisualizer() {
         <div className="iv-presets">
           <span className="iv-presets-lbl">Cenários</span>
           {scenarios.map((c) => (
-            <button key={c.name} className={`iv-preset${viz.step === Math.min(steps.length - 1, Math.max(0, c.t)) ? " on" : ""}`} onClick={() => goTo(c.t)}>
+            <button type="button" key={c.name} className={`iv-preset${viz.step === Math.min(steps.length - 1, Math.max(0, c.t)) ? " on" : ""}`} onClick={() => goTo(c.t)}>
               {c.name}
             </button>
           ))}
@@ -367,7 +367,7 @@ export function IntervalsSobreposicaoVisualizer() {
           1 e nada mais. Quem devolve A, a duração de B e o modelo de borda ao
           padrão é o botão ao lado — o rodapé não promete o que não faz. */}
       <VizFooter viz={viz} color={color}>
-        <button className="viz-btn" onClick={backToDefaults}>Voltar ao padrão</button>
+        <button type="button" className="viz-btn" onClick={backToDefaults}>Voltar ao padrão</button>
       </VizFooter>
     </figure>
   );

--- a/content/visualizers/IntervalsSweepVisualizer.tsx
+++ b/content/visualizers/IntervalsSweepVisualizer.tsx
@@ -280,8 +280,9 @@ export function IntervalsSweepVisualizer() {
               placeholder="[9,12], [10,13], [11,14]"
             />
           </label>
-          <button className="viz-btn" onClick={randomize}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={randomize}>Sortear</button>
           <button
+            type="button"
             className="viz-btn"
             aria-pressed={exitFirst}
             onClick={() => { viz.reset(); setExitFirst((v) => !v); }}
@@ -294,6 +295,7 @@ export function IntervalsSweepVisualizer() {
           <span className="iv-presets-lbl">Cenários</span>
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.name}
               className={`iv-preset${input === pr.ivs ? " on" : ""}`}
               onClick={() => { viz.reset(); setInput(pr.ivs); }}

--- a/content/visualizers/IntervalsVisualizer.tsx
+++ b/content/visualizers/IntervalsVisualizer.tsx
@@ -614,6 +614,7 @@ export function IntervalsVisualizer({ mode: initialMode = "merge" }: { mode?: Mo
             const on = i === modeIndex;
             return (
               <button
+                type="button"
                 key={m.key}
                 className={`bigo-chip${on ? " on" : ""}`}
                 style={on ? { borderColor: m.color, color: m.color } : undefined}
@@ -648,13 +649,14 @@ export function IntervalsVisualizer({ mode: initialMode = "merge" }: { mode?: Mo
               />
             </label>
           )}
-          <button className="viz-btn" onClick={randomize}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={randomize}>Sortear</button>
         </div>
 
         <div className="iv-presets">
           <span className="iv-presets-lbl">Cenários</span>
           {mode.presets.map((pr) => (
             <button
+              type="button"
               key={pr.name}
               className={`iv-preset${input === pr.ivs && (!pr.incoming || incomingInput === pr.incoming) ? " on" : ""}`}
               onClick={() => applyPreset(pr)}

--- a/content/visualizers/LinkedListFloyd.tsx
+++ b/content/visualizers/LinkedListFloyd.tsx
@@ -288,6 +288,7 @@ export function LinkedListFloyd() {
           <div className="bigo-chips">
             {PRESETS.map((pr) => (
               <button
+                type="button"
                 key={pr.key}
                 className={`bigo-chip${preset === pr.key ? " on" : ""}`}
                 onClick={() => applyPreset(pr)}

--- a/content/visualizers/LinkedListReversao.tsx
+++ b/content/visualizers/LinkedListReversao.tsx
@@ -192,6 +192,7 @@ export function LinkedListReversao() {
           <div className="bigo-chips">
             {PRESETS.map((pr) => (
               <button
+                type="button"
                 key={pr.key}
                 className={`bigo-chip${preset === pr.key ? " on" : ""}`}
                 onClick={() => applyPreset(pr)}

--- a/content/visualizers/LinkedListVisualizer.tsx
+++ b/content/visualizers/LinkedListVisualizer.tsx
@@ -505,6 +505,7 @@ export function LinkedListVisualizer() {
           <div className="bigo-chips">
             {OPS.map((o) => (
               <button
+                type="button"
                 key={o.key}
                 className={`bigo-chip${op === o.key ? " on" : ""}`}
                 onClick={() => onOpChange(o.key)}
@@ -519,11 +520,11 @@ export function LinkedListVisualizer() {
         <div className="ll-grupo">
           <span className="ll-grupo-rot">Estrutura</span>
           <div className="bigo-chips">
-            <button className={`bigo-chip${sentinel ? " on" : ""}`} onClick={toggleSentinel} aria-pressed={sentinel}>
+            <button type="button" className={`bigo-chip${sentinel ? " on" : ""}`} onClick={toggleSentinel} aria-pressed={sentinel}>
               <span className="sw" style={{ background: sentinel ? "#a78bfa" : "#3a4a60" }} />
               nó sentinela
             </button>
-            <button className={`bigo-chip${hasTail ? " on" : ""}`} onClick={toggleTail} aria-pressed={hasTail}>
+            <button type="button" className={`bigo-chip${hasTail ? " on" : ""}`} onClick={toggleTail} aria-pressed={hasTail}>
               <span className="sw" style={{ background: hasTail ? "#34d399" : "#3a4a60" }} />
               ponteiro de cauda
             </button>
@@ -535,6 +536,7 @@ export function LinkedListVisualizer() {
           <div className="bigo-chips">
             {PRESETS.map((pr) => (
               <button
+                type="button"
                 key={pr.key}
                 className={`bigo-chip${preset === pr.key ? " on" : ""}`}
                 onClick={() => applyPreset(pr)}
@@ -563,7 +565,7 @@ export function LinkedListVisualizer() {
               <input className="viz-input k" type="number" value={value} onChange={(e) => onValueChange(e.target.value)} />
             </label>
           ) : null}
-          <button className="viz-btn" onClick={shuffle}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="ll-svg-wrap">

--- a/content/visualizers/MergeEmpate.tsx
+++ b/content/visualizers/MergeEmpate.tsx
@@ -185,6 +185,7 @@ export function MergeEmpate() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => setPresetKey(pr.key)}

--- a/content/visualizers/MergeSortNiveis.tsx
+++ b/content/visualizers/MergeSortNiveis.tsx
@@ -73,7 +73,7 @@ export function MergeSortNiveis() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {SIZES.map((t) => (
-            <button key={t} className={`bigo-chip${n === t ? " on" : ""}`} onClick={() => setN(t)} aria-pressed={n === t}>
+            <button type="button" key={t} className={`bigo-chip${n === t ? " on" : ""}`} onClick={() => setN(t)} aria-pressed={n === t}>
               n = {t}
             </button>
           ))}

--- a/content/visualizers/MergeSortVisualizer.tsx
+++ b/content/visualizers/MergeSortVisualizer.tsx
@@ -273,6 +273,7 @@ export function MergeSortVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => changePreset(pr.key)}

--- a/content/visualizers/MstVisualizer.tsx
+++ b/content/visualizers/MstVisualizer.tsx
@@ -236,12 +236,12 @@ export function MstVisualizer() {
 
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className={`bigo-chip${mode === "kruskal" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("kruskal"); }} aria-pressed={mode === "kruskal"}>Kruskal: ordena arestas</button>
-          <button className={`bigo-chip${mode === "prim" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("prim"); }} aria-pressed={mode === "prim"}>Prim: cresce de um vértice</button>
+          <button type="button" className={`bigo-chip${mode === "kruskal" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("kruskal"); }} aria-pressed={mode === "kruskal"}>Kruskal: ordena arestas</button>
+          <button type="button" className={`bigo-chip${mode === "prim" ? " on" : ""}`} onClick={() => { viz.reset(); setMode("prim"); }} aria-pressed={mode === "prim"}>Prim: cresce de um vértice</button>
         </div>
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>{pr.label}</button>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}`} onClick={() => { viz.reset(); setPresetKey(pr.key); }} aria-pressed={presetKey === pr.key}>{pr.label}</button>
           ))}
         </div>
         <p className="tt-legenda-arvore">{preset.hint}</p>

--- a/content/visualizers/NAryTreeVisualizer.tsx
+++ b/content/visualizers/NAryTreeVisualizer.tsx
@@ -323,6 +323,7 @@ export function NAryTreeVisualizer() {
         <div className="bigo-chips">
           {(["pre", "post", "level"] as Order[]).map((o) => (
             <button
+              type="button"
               key={o}
               className={`bigo-chip${order === o && !inOrderNote ? " on" : ""}`}
               onClick={() => pickOrder(o)}
@@ -332,6 +333,7 @@ export function NAryTreeVisualizer() {
             </button>
           ))}
           <button
+            type="button"
             className={`bigo-chip na${inOrderNote ? " on" : ""}`}
             onClick={() => setInOrderNote((v) => !v)}
             aria-pressed={inOrderNote}
@@ -353,6 +355,7 @@ export function NAryTreeVisualizer() {
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {TREES.map((a) => (
             <button
+              type="button"
               key={a.key}
               className={`bigo-chip${treeKey === a.key ? " on" : ""}`}
               onClick={() => pickTree(a.key)}

--- a/content/visualizers/OrdenacaoBasicaCorrida.tsx
+++ b/content/visualizers/OrdenacaoBasicaCorrida.tsx
@@ -81,6 +81,7 @@ export function OrdenacaoBasicaCorrida() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => setPresetKey(pr.key)}

--- a/content/visualizers/OrdenacaoBasicaEstabilidade.tsx
+++ b/content/visualizers/OrdenacaoBasicaEstabilidade.tsx
@@ -217,6 +217,7 @@ export function OrdenacaoBasicaEstabilidade() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => setPresetKey(pr.key)}

--- a/content/visualizers/OrdenacaoBasicaVisualizer.tsx
+++ b/content/visualizers/OrdenacaoBasicaVisualizer.tsx
@@ -385,6 +385,7 @@ export function OrdenacaoBasicaVisualizer() {
         <div className="bigo-chips">
           {ALGOS.map((k) => (
             <button
+              type="button"
               key={k}
               className={`bigo-chip${algo === k ? " on" : ""}`}
               onClick={() => changeAlgo(k)}
@@ -397,6 +398,7 @@ export function OrdenacaoBasicaVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => changePreset(pr.key)}

--- a/content/visualizers/PrefixSumGrade2D.tsx
+++ b/content/visualizers/PrefixSumGrade2D.tsx
@@ -304,12 +304,12 @@ export function PrefixSumGrade2D() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.label} className="bigo-chip" onClick={() => applyPreset(pr)}>
+            <button type="button" key={pr.label} className="bigo-chip" onClick={() => applyPreset(pr)}>
               {pr.label}
             </button>
           ))}
-          <button className="bigo-chip" onClick={shuffle}>Sortear valores</button>
-          <button className="bigo-chip" onClick={toggleSize}>
+          <button type="button" className="bigo-chip" onClick={shuffle}>Sortear valores</button>
+          <button type="button" className="bigo-chip" onClick={toggleSize}>
             {rows === 5 ? "Aumentar para 8 × 8" : "Voltar para 5 × 5"}
           </button>
         </div>
@@ -337,6 +337,7 @@ export function PrefixSumGrade2D() {
                       if (anchor && anchor.r === r && anchor.c === c) cls += " ancora";
                       return (
                         <button
+                          type="button"
                           key={`m-${r}-${c}`}
                           className={cls}
                           onClick={() => pick(r, c)}

--- a/content/visualizers/PrefixSumTradeoff.tsx
+++ b/content/visualizers/PrefixSumTradeoff.tsx
@@ -282,15 +282,15 @@ export function PrefixSumTradeoff() {
 
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
-          <button className="bigo-chip" onClick={() => setRawQ(1)}>
+          <button type="button" className="bigo-chip" onClick={() => setRawQ(1)}>
             <span className="sw" style={{ background: BRUTE_COLOR }} />
             Uma consulta só
           </button>
-          <button className="bigo-chip" onClick={() => setRawQ(turningPoint)}>
+          <button type="button" className="bigo-chip" onClick={() => setRawQ(turningPoint)}>
             <span className="sw" style={{ background: "#93a9c2" }} />
             No ponto de virada
           </button>
-          <button className="bigo-chip" onClick={() => setRawQ(qMax)}>
+          <button type="button" className="bigo-chip" onClick={() => setRawQ(qMax)}>
             <span className="sw" style={{ background: PREFIX_COLOR }} />
             Muitas consultas
           </button>
@@ -384,7 +384,7 @@ export function PrefixSumTradeoff() {
             style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
           />
         </div>
-        <button className="viz-btn" onClick={() => { setArrayIndex(4); setSliceIndex(1); setRawQ(21); }}>↺ Reiniciar</button>
+        <button type="button" className="viz-btn" onClick={() => { setArrayIndex(4); setSliceIndex(1); setRawQ(21); }}>↺ Reiniciar</button>
       </VizFooter>
     </figure>
   );

--- a/content/visualizers/PrefixSumVisualizer.tsx
+++ b/content/visualizers/PrefixSumVisualizer.tsx
@@ -304,7 +304,7 @@ export function PrefixSumVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.label} className="bigo-chip" onClick={() => applyPreset(pr)}>
+            <button type="button" key={pr.label} className="bigo-chip" onClick={() => applyPreset(pr)}>
               {pr.label}
             </button>
           ))}
@@ -333,7 +333,7 @@ export function PrefixSumVisualizer() {
               onChange={(e) => { viz.reset(); setRawJ(parseInt(e.target.value, 10) || 0); }}
             />
           </label>
-          <button className="viz-btn" onClick={shuffle}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="viz-vars-head">nums, o array de entrada</div>
@@ -414,7 +414,7 @@ export function PrefixSumVisualizer() {
           enxerga nó de texto JSX quebrado em várias linhas, e o que ele não vê
           ele não protege. */}
       <VizFooter viz={viz}>
-        <button className="viz-btn" onClick={jumpToQuery}>Pular para a consulta</button>
+        <button type="button" className="viz-btn" onClick={jumpToQuery}>Pular para a consulta</button>
       </VizFooter>
     </figure>
   );

--- a/content/visualizers/QueueDequeMonotonico.tsx
+++ b/content/visualizers/QueueDequeMonotonico.tsx
@@ -289,6 +289,7 @@ export function QueueDequeMonotonico() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -308,7 +309,7 @@ export function QueueDequeMonotonico() {
             <span>k</span>
             <input className="viz-input k" type="number" min={1} max={12} value={k} onChange={(e) => onKChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={shuffle}>
+          <button type="button" className="viz-btn" onClick={shuffle}>
             Sortear
           </button>
         </div>

--- a/content/visualizers/QueueDuasPilhas.tsx
+++ b/content/visualizers/QueueDuasPilhas.tsx
@@ -274,6 +274,7 @@ export function QueueDuasPilhas() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -288,13 +289,13 @@ export function QueueDuasPilhas() {
           <div className="viz-field grow">
             <span>roteiro de operações</span>
             <div className="fila-botoes">
-              <button className="viz-btn" onClick={() => append({ kind: "enq", value: nextLetter(script) })}>
+              <button type="button" className="viz-btn" onClick={() => append({ kind: "enq", value: nextLetter(script) })}>
                 + enfileirar {nextLetter(script)}
               </button>
-              <button className="viz-btn" onClick={() => append({ kind: "deq" })}>
+              <button type="button" className="viz-btn" onClick={() => append({ kind: "deq" })}>
                 + desenfileirar
               </button>
-              <button className="viz-btn" disabled={!script.length} onClick={undo}>
+              <button type="button" className="viz-btn" disabled={!script.length} onClick={undo}>
                 ← desfazer
               </button>
             </div>

--- a/content/visualizers/QueueVisualizer.tsx
+++ b/content/visualizers/QueueVisualizer.tsx
@@ -449,6 +449,7 @@ export function QueueVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           <button
+            type="button"
             className={`bigo-chip${mode === "ingenua" ? " on" : ""}`}
             onClick={() => changeMode("ingenua")}
             aria-pressed={mode === "ingenua"}
@@ -457,6 +458,7 @@ export function QueueVisualizer() {
             fila ingênua
           </button>
           <button
+            type="button"
             className={`bigo-chip${mode === "circular" ? " on" : ""}`}
             onClick={() => changeMode("circular")}
             aria-pressed={mode === "circular"}
@@ -469,6 +471,7 @@ export function QueueVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -487,16 +490,16 @@ export function QueueVisualizer() {
           <div className="viz-field grow">
             <span>roteiro de operações</span>
             <div className="fila-botoes">
-              <button className="viz-btn" onClick={() => append({ kind: "enq", value: nextLetter(script) })}>
+              <button type="button" className="viz-btn" onClick={() => append({ kind: "enq", value: nextLetter(script) })}>
                 + enfileirar {nextLetter(script)}
               </button>
-              <button className="viz-btn" onClick={() => append({ kind: "deq" })}>
+              <button type="button" className="viz-btn" onClick={() => append({ kind: "deq" })}>
                 + desenfileirar
               </button>
-              <button className="viz-btn" disabled={!script.length} onClick={undo}>
+              <button type="button" className="viz-btn" disabled={!script.length} onClick={undo}>
                 ← desfazer
               </button>
-              <button className="viz-btn" disabled={!script.length} onClick={clear}>
+              <button type="button" className="viz-btn" disabled={!script.length} onClick={clear}>
                 limpar
               </button>
             </div>

--- a/content/visualizers/QuickSortPivo.tsx
+++ b/content/visualizers/QuickSortPivo.tsx
@@ -188,6 +188,7 @@ export function QuickSortPivo() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => setPresetKey(pr.key)}

--- a/content/visualizers/QuickSortTresVias.tsx
+++ b/content/visualizers/QuickSortTresVias.tsx
@@ -244,6 +244,7 @@ export function QuickSortTresVias() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => setPresetKey(pr.key)}

--- a/content/visualizers/QuickSortVisualizer.tsx
+++ b/content/visualizers/QuickSortVisualizer.tsx
@@ -354,6 +354,7 @@ export function QuickSortVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => pickPreset(pr.key)}

--- a/content/visualizers/README.md
+++ b/content/visualizers/README.md
@@ -591,14 +591,26 @@ o que está vendo no DOM e no CSS, não para digitar à mão.
 | `.viz-atalhos` | no rodapé | dica das teclas; some no celular |
 | `.viz-toggle-codigo` | no botão do cabeçalho | estado visual pelo `aria-expanded` |
 
-**`data-anim` nunca vira `"on"` numa peça `collapsible: false`.** Quem o acende
-é o efeito de medição, e ele sai na primeira linha quando não há bloco para
-recolher (`src/lib/visualizer.tsx:265`): sem decisão a tomar não há recolhimento
-a congelar, e o atributo fica em `"off"` para sempre. Não é defeito — as
-transições que ele desliga são as do bloco que a peça não tem —, mas é contrato,
-porque **boa parte dos specs da série usa `data-anim="on"` como sinal de "a
-casca terminou de medir"**, e esse helper nunca resolve aqui. Numa peça sem
-bloco, espere por outra coisa: um rótulo do próprio miolo, ou o `⤢ Expandir`.
+**`data-anim` nunca vira `"on"` numa peça `collapsible: false`.** Ele não quer
+dizer "a casca hidratou": quer dizer "a **medição** terminou", e a medição só
+existe quando há bloco para recolher. Quem acende é o `setAnimate(true)` no fim
+do efeito de medição (`src/lib/visualizer.tsx:436`), e o efeito **sai na primeira
+linha** quando `collapsible` é falso (`:420`). Sem decisão a tomar não há
+recolhimento a congelar, e o atributo fica em `"off"` para sempre.
+
+Não é defeito — as transições que ele desliga são as do bloco que a peça não tem
+—, mas é **armadilha de teste**, e a mina está posta: 18 asserções em 16 specs
+esperam `data-anim="on"` como sinal de "a casca terminou de medir", sob **seis
+nomes de helper diferentes** (`pronta`, `abrir`, `abrirTopico`,
+`medicaoTerminou`, `passo`, `figuraDe`). Nenhuma delas aponta hoje para peça
+`collapsible: false`, então ninguém pisou nela ainda — mas copiar qualquer um
+desses helpers para uma peça sem bloco mata o spec num timeout de 10 s **antes da
+primeira asserção de verdade**, e o erro que aparece ("expected on, received
+off") não diz nada sobre bloco recolhível.
+
+Numa peça sem bloco, espere por outra coisa: um rótulo do próprio miolo, ou o
+`⤢ Expandir`. O único ponto da suíte que afirma o `"off"` em vez de esperar pelo
+`"on"` é `tests/viz-binary-numbers.spec.ts:208`, e ele é o exemplo a copiar.
 
 **Não edite o bloco `viz-fit` do `globals.css` para acomodar um visualizador
 específico.** Ele é compartilhado por todos; regra que estende base compartilhada
@@ -875,8 +887,10 @@ Os itens 2, 3 e 4 — os três que falam do bloco recolhível — não existem q
 `collapsible: false`. No lugar deles, prove que a ausência tem o rótulo certo:
 **nenhum botão pode prometer esconder um bloco que o visualizador não tem.** E
 não copie para essas peças o helper que espera `data-anim="on"` para saber que a
-casca terminou: ali o atributo nunca vira `"on"` (§4), e o teste morre num
-timeout antes da primeira asserção.
+casca terminou — seja ele `pronta`, `abrir`, `abrirTopico`, `medicaoTerminou`,
+`passo` ou `figuraDe`, que são os seis nomes com que ele aparece na suíte. Ali o
+atributo nunca vira `"on"` (§4), e o teste morre num timeout antes da primeira
+asserção. Copie `tests/viz-binary-numbers.spec.ts:208`, que espera o `"off"`.
 
 E o inverso do item 6, que morde antes de você escrever teste nenhum: **adaptar
 uma peça quebra o teste de quem veio antes**. Pôr `viz-fit` numa figura faz um

--- a/content/visualizers/RecursionArvoreVisualizer.tsx
+++ b/content/visualizers/RecursionArvoreVisualizer.tsx
@@ -304,6 +304,7 @@ export function RecursionArvoreVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -322,10 +323,10 @@ export function RecursionArvoreVisualizer() {
           <div className="viz-field">
             <span>Memoização</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${withMemo ? "" : " on"}`} onClick={() => { if (withMemo) toggleMemo(); }} aria-pressed={!withMemo}>
+              <button type="button" className={`sub-modo-btn${withMemo ? "" : " on"}`} onClick={() => { if (withMemo) toggleMemo(); }} aria-pressed={!withMemo}>
                 desligada
               </button>
-              <button className={`sub-modo-btn${withMemo ? " on" : ""}`} onClick={() => { if (!withMemo) toggleMemo(); }} aria-pressed={withMemo}>
+              <button type="button" className={`sub-modo-btn${withMemo ? " on" : ""}`} onClick={() => { if (!withMemo) toggleMemo(); }} aria-pressed={withMemo}>
                 ligada
               </button>
             </div>

--- a/content/visualizers/RecursionVisualizer.tsx
+++ b/content/visualizers/RecursionVisualizer.tsx
@@ -503,6 +503,7 @@ export function RecursionVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -519,6 +520,7 @@ export function RecursionVisualizer() {
             <div className="sub-modo">
               {MODES.map((m, i) => (
                 <button
+                  type="button"
                   key={m.key}
                   className={`sub-modo-btn${i === modeIndex ? " on" : ""}`}
                   onClick={() => pickMode(i)}

--- a/content/visualizers/ShellSortGaps.tsx
+++ b/content/visualizers/ShellSortGaps.tsx
@@ -233,7 +233,7 @@ export function ShellSortGaps() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {TAMANHOS.map((t) => (
-            <button key={t} className={`bigo-chip${n === t ? " on" : ""}`} onClick={() => setN(t)} aria-pressed={n === t}>
+            <button type="button" key={t} className={`bigo-chip${n === t ? " on" : ""}`} onClick={() => setN(t)} aria-pressed={n === t}>
               n = {t}
             </button>
           ))}
@@ -241,6 +241,7 @@ export function ShellSortGaps() {
         <div className="bigo-chips">
           {FORMAS.map((f) => (
             <button
+              type="button"
               key={f.key}
               className={`bigo-chip${forma === f.key ? " on" : ""}`}
               onClick={() => setForma(f.key)}

--- a/content/visualizers/ShellSortSubsequencias.tsx
+++ b/content/visualizers/ShellSortSubsequencias.tsx
@@ -115,6 +115,7 @@ export function ShellSortSubsequencias() {
         <div className="bigo-chips">
           {GAPS.map((g, k) => (
             <button
+              type="button"
               key={g}
               className={`bigo-chip${rodadaIdx === k ? " on" : ""}`}
               onClick={() => setRodadaIdx(k)}

--- a/content/visualizers/ShellSortVisualizer.tsx
+++ b/content/visualizers/ShellSortVisualizer.tsx
@@ -279,6 +279,7 @@ export function ShellSortVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => changePreset(pr.key)}

--- a/content/visualizers/SkipListInsercao.tsx
+++ b/content/visualizers/SkipListInsercao.tsx
@@ -679,6 +679,7 @@ export function SkipListInsercao() {
       <div {...viz.bodyProps}>
         <div className="arr-tabs" style={{ marginBottom: 16 }}>
           <button
+            type="button"
             className={`arr-tab${inserting ? " on" : ""}`}
             onClick={() => switchMode("inserir")}
             aria-pressed={inserting}
@@ -686,6 +687,7 @@ export function SkipListInsercao() {
             Inserir
           </button>
           <button
+            type="button"
             className={`arr-tab${!inserting ? " on" : ""}`}
             onClick={() => switchMode("remover")}
             aria-pressed={!inserting}
@@ -697,6 +699,7 @@ export function SkipListInsercao() {
         <div className="bigo-chips">
           {PRESETS[mode].map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -726,7 +729,7 @@ export function SkipListInsercao() {
                   style={{ accentColor: "var(--ccc-accent)", width: 150 }}
                 />
               </label>
-              <button className="viz-btn" onClick={rollHeight}>
+              <button type="button" className="viz-btn" onClick={rollHeight}>
                 Lançar a moeda
               </button>
             </>

--- a/content/visualizers/SkipListNiveis.tsx
+++ b/content/visualizers/SkipListNiveis.tsx
@@ -139,6 +139,7 @@ export function SkipListNiveis() {
         <div className="bigo-chips">
           {PS.map((op) => (
             <button
+              type="button"
               key={op.value}
               className={`bigo-chip${p === op.value ? " on" : ""}`}
               onClick={() => {
@@ -233,10 +234,11 @@ export function SkipListNiveis() {
             style={{ accentColor: "var(--ccc-accent)", width: "100%" }}
           />
         </div>
-        <button className="viz-btn" onClick={rollCoins}>
+        <button type="button" className="viz-btn" onClick={rollCoins}>
           Sortear {thousands(n)} moedas
         </button>
         <button
+          type="button"
           className="viz-btn"
           onClick={() => {
             setIN(3);

--- a/content/visualizers/SkipListVisualizer.tsx
+++ b/content/visualizers/SkipListVisualizer.tsx
@@ -404,6 +404,7 @@ export function SkipListVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -423,7 +424,7 @@ export function SkipListVisualizer() {
             <span>procurar</span>
             <input className="viz-input k" type="number" value={target} onChange={(e) => onTargetChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={shuffleHeights}>
+          <button type="button" className="viz-btn" onClick={shuffleHeights}>
             Sortear alturas
           </button>
         </div>

--- a/content/visualizers/SlidingWindowForcaBruta.tsx
+++ b/content/visualizers/SlidingWindowForcaBruta.tsx
@@ -221,11 +221,11 @@ export function SlidingWindowForcaBruta() {
         </div>
 
         <div className="bigo-chips">
-          <button className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 3)}>k pequeno (3)</button>
-          <button className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 6)}>k grande (6)</button>
-          <button className="bigo-chip" onClick={() => applyPreset([4, 4, 4, 4, 4, 4, 4, 4], 3)}>tudo igual</button>
-          <button className="bigo-chip" onClick={() => applyPreset([9], 1)}>um elemento</button>
-          <button className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 12)}>k maior que n</button>
+          <button type="button" className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 3)}>k pequeno (3)</button>
+          <button type="button" className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 6)}>k grande (6)</button>
+          <button type="button" className="bigo-chip" onClick={() => applyPreset([4, 4, 4, 4, 4, 4, 4, 4], 3)}>tudo igual</button>
+          <button type="button" className="bigo-chip" onClick={() => applyPreset([9], 1)}>um elemento</button>
+          <button type="button" className="bigo-chip" onClick={() => applyPreset(DEFAULT_ARRAY, 12)}>k maior que n</button>
         </div>
 
         <div className="viz-cells">

--- a/content/visualizers/SlidingWindowVisualizer.tsx
+++ b/content/visualizers/SlidingWindowVisualizer.tsx
@@ -409,6 +409,7 @@ export function SlidingWindowVisualizer({ variant = "fixed" }: { variant?: Varia
         <div className="bigo-chips">
           {presets.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${presetKey === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -428,7 +429,7 @@ export function SlidingWindowVisualizer({ variant = "fixed" }: { variant?: Varia
             <span>{K_LABEL[mode]}</span>
             <input className="viz-input k" type="number" value={k} onChange={(e) => onKChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={shuffle}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="viz-cells">

--- a/content/visualizers/StackCallStackVisualizer.tsx
+++ b/content/visualizers/StackCallStackVisualizer.tsx
@@ -232,6 +232,7 @@ export function StackCallStackVisualizer() {
         <div className="bigo-chips">
           {MODES.map((m) => (
             <button
+              type="button"
               key={m.key}
               className={`bigo-chip${mode === m.key ? " on" : ""}`}
               onClick={() => change(() => setMode(m.key))}
@@ -268,7 +269,7 @@ export function StackCallStackVisualizer() {
           {/* O `↺` do rodapé é só `viz.reset()`: ele volta ao passo 0 e não
               desfaz a base e o expoente que o aluno montou. O caminho de volta
               ao estado inicial é este botão, e o rótulo dele diz isso. */}
-          <button className="viz-btn" onClick={() => change(() => { setX(X_DEFAULT); setN(N_DEFAULT); })}>
+          <button type="button" className="viz-btn" onClick={() => change(() => { setX(X_DEFAULT); setN(N_DEFAULT); })}>
             ↺ Voltar ao 2³
           </button>
         </div>

--- a/content/visualizers/StackMonotonicaVisualizer.tsx
+++ b/content/visualizers/StackMonotonicaVisualizer.tsx
@@ -267,6 +267,7 @@ export function StackMonotonicaVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -282,7 +283,7 @@ export function StackMonotonicaVisualizer() {
             <span>Array (inteiros de 0 a 99)</span>
             <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={shuffle}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="pl-arena">

--- a/content/visualizers/StackVisualizer.tsx
+++ b/content/visualizers/StackVisualizer.tsx
@@ -270,6 +270,7 @@ export function StackVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -285,7 +286,7 @@ export function StackVisualizer() {
             <span>Expressão (só ( ) [ ] {"{"} {"}"} )</span>
             <input className="viz-input" value={expr} onChange={(e) => onExprChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={shuffle}>Sortear válida</button>
+          <button type="button" className="viz-btn" onClick={shuffle}>Sortear válida</button>
         </div>
 
         <div className="pl-arena">

--- a/content/visualizers/StringsBytesVisualizer.tsx
+++ b/content/visualizers/StringsBytesVisualizer.tsx
@@ -203,7 +203,7 @@ export function StringsBytesVisualizer() {
               onChange={(e) => setText(Array.from(e.target.value).slice(0, MAX_CP).join(""))}
             />
           </label>
-          <button className="viz-btn" onClick={() => setText(DEFAULT_TEXT)}>
+          <button type="button" className="viz-btn" onClick={() => setText(DEFAULT_TEXT)}>
             ↺ Reiniciar
           </button>
         </div>
@@ -211,6 +211,7 @@ export function StringsBytesVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.label}
               className={`bigo-chip${text === pr.text ? " on" : ""}`}
               onClick={() => setText(pr.text)}
@@ -227,6 +228,7 @@ export function StringsBytesVisualizer() {
             const loses = e.key === "ascii" && lost > 0;
             return (
               <button
+                type="button"
                 key={e.key}
                 className={`str-enc${on ? " on" : ""}${loses ? " perde" : ""}`}
                 onClick={() => setEnc(e.key)}

--- a/content/visualizers/StringsRotateVisualizer.tsx
+++ b/content/visualizers/StringsRotateVisualizer.tsx
@@ -337,6 +337,7 @@ export function StringsRotateVisualizer() {
             const on = m.key === mode;
             return (
               <button
+                type="button"
                 key={m.key}
                 className={`bigo-chip${on ? " on" : ""}`}
                 style={on ? { borderColor: m.color, color: m.color } : undefined}
@@ -362,7 +363,7 @@ export function StringsRotateVisualizer() {
             <span>goal</span>
             <input className="viz-input" value={goal} onChange={(e) => apply(s, e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={pickRandom}>
+          <button type="button" className="viz-btn" onClick={pickRandom}>
             Sortear
           </button>
         </div>
@@ -370,6 +371,7 @@ export function StringsRotateVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.label}
               className={`bigo-chip${s === pr.s && goal === pr.goal ? " on" : ""}`}
               onClick={() => apply(pr.s, pr.goal)}

--- a/content/visualizers/StringsVisualizer.tsx
+++ b/content/visualizers/StringsVisualizer.tsx
@@ -259,6 +259,7 @@ export function StringsVisualizer() {
             const on = m.key === mode;
             return (
               <button
+                type="button"
                 key={m.key}
                 className={`bigo-chip${on ? " on" : ""}`}
                 style={on ? { borderColor: m.color, color: m.color } : undefined}
@@ -277,7 +278,7 @@ export function StringsVisualizer() {
             <span>Palavra a montar, um caractere por volta</span>
             <input className="viz-input" value={word} onChange={(e) => onWordChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={pickRandom}>
+          <button type="button" className="viz-btn" onClick={pickRandom}>
             Sortear
           </button>
         </div>
@@ -285,6 +286,7 @@ export function StringsVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.label}
               className={`bigo-chip${word === pr.text ? " on" : ""}`}
               onClick={() => onWordChange(pr.text)}

--- a/content/visualizers/SubTypesVisualizer.tsx
+++ b/content/visualizers/SubTypesVisualizer.tsx
@@ -139,10 +139,10 @@ export function SubTypesVisualizer() {
           <div className="viz-field">
             <span>Origem</span>
             <div className="sub-modo">
-              <button className={`sub-modo-btn${mode === "array" ? " on" : ""}`} onClick={() => pickMode("array")}>
+              <button type="button" className={`sub-modo-btn${mode === "array" ? " on" : ""}`} onClick={() => pickMode("array")}>
                 Array
               </button>
-              <button className={`sub-modo-btn${mode === "string" ? " on" : ""}`} onClick={() => pickMode("string")}>
+              <button type="button" className={`sub-modo-btn${mode === "string" ? " on" : ""}`} onClick={() => pickMode("string")}>
                 String
               </button>
             </div>
@@ -220,10 +220,10 @@ export function SubTypesVisualizer() {
           atalhos e sem barra de progresso. */}
       <VizFooter viz={viz}>
         <span className="sub-exemplos-label">Tente:</span>
-        <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([1, 2])}>colado</button>
-        <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([0, 2])}>com buraco</button>
-        <button className="viz-btn" disabled={n < 3} onClick={() => setPicks([2, 0])}>fora de ordem</button>
-        <button className="viz-btn" disabled={empty} onClick={() => setPicks([])} style={{ marginLeft: "auto" }}>↺ Limpar</button>
+        <button type="button" className="viz-btn" disabled={n < 3} onClick={() => setPicks([1, 2])}>colado</button>
+        <button type="button" className="viz-btn" disabled={n < 3} onClick={() => setPicks([0, 2])}>com buraco</button>
+        <button type="button" className="viz-btn" disabled={n < 3} onClick={() => setPicks([2, 0])}>fora de ordem</button>
+        <button type="button" className="viz-btn" disabled={empty} onClick={() => setPicks([])} style={{ marginLeft: "auto" }}>↺ Limpar</button>
       </VizFooter>
     </figure>
   );

--- a/content/visualizers/TailRecursionForma.tsx
+++ b/content/visualizers/TailRecursionForma.tsx
@@ -215,6 +215,7 @@ export function TailRecursionForma() {
         <div className="bigo-chips">
           {CASES.map((item, k) => (
             <button
+              type="button"
               key={item.key}
               className={`bigo-chip${k === viz.step ? " on" : ""}`}
               aria-pressed={k === viz.step}
@@ -231,6 +232,7 @@ export function TailRecursionForma() {
 
         <div className="bigo-chips">
           <button
+            type="button"
             className={`bigo-chip${training ? " on" : ""}`}
             aria-pressed={training}
             onClick={() => {
@@ -254,7 +256,7 @@ export function TailRecursionForma() {
           ) : (
             <>
               <span className="tr-selo">? decida antes de revelar</span>
-              <button className="viz-btn" onClick={() => setRevealedFor(viz.step)}>
+              <button type="button" className="viz-btn" onClick={() => setRevealedFor(viz.step)}>
                 Revelar veredito
               </button>
             </>

--- a/content/visualizers/TailRecursionTrampolim.tsx
+++ b/content/visualizers/TailRecursionTrampolim.tsx
@@ -260,6 +260,7 @@ export function TailRecursionTrampolim() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               aria-pressed={preset === pr.key}
@@ -275,7 +276,7 @@ export function TailRecursionTrampolim() {
             <span>Lista de números</span>
             <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={randomize}>
+          <button type="button" className="viz-btn" onClick={randomize}>
             Sortear
           </button>
         </div>

--- a/content/visualizers/TailRecursionVisualizer.tsx
+++ b/content/visualizers/TailRecursionVisualizer.tsx
@@ -347,6 +347,7 @@ export function TailRecursionVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               aria-pressed={preset === pr.key}
@@ -362,13 +363,14 @@ export function TailRecursionVisualizer() {
             <span>Lista de números</span>
             <input className="viz-input" value={input} onChange={(e) => onInputChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={randomize}>
+          <button type="button" className="viz-btn" onClick={randomize}>
             Sortear
           </button>
         </div>
 
         <div className="bigo-chips">
           <button
+            type="button"
             className={`bigo-chip${tco ? " on" : ""}`}
             aria-pressed={tco}
             onClick={() => {
@@ -380,6 +382,7 @@ export function TailRecursionVisualizer() {
             Elixir, Scala, Kotlin (com TCO)
           </button>
           <button
+            type="button"
             className={`bigo-chip${!tco ? " on" : ""}`}
             aria-pressed={!tco}
             onClick={() => {

--- a/content/visualizers/TopoSortVisualizer.tsx
+++ b/content/visualizers/TopoSortVisualizer.tsx
@@ -181,7 +181,7 @@ export function TopoSortVisualizer() {
       <div {...viz.bodyProps}>
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
-            <button key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "cycle" ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
+            <button type="button" key={pr.key} className={`bigo-chip${presetKey === pr.key ? " on" : ""}${pr.key === "cycle" ? " na" : ""}`} onClick={() => pickPreset(pr.key)} aria-pressed={presetKey === pr.key}>
               {pr.label}
             </button>
           ))}

--- a/content/visualizers/TreeTraversalVisualizer.tsx
+++ b/content/visualizers/TreeTraversalVisualizer.tsx
@@ -357,6 +357,7 @@ export function TreeTraversalVisualizer() {
         <div className="bigo-chips">
           {ORDERS.map((o) => (
             <button
+              type="button"
               key={o}
               className={`bigo-chip${order === o ? " on" : ""}`}
               onClick={() => pickOrder(o)}
@@ -369,6 +370,7 @@ export function TreeTraversalVisualizer() {
         <div className="bigo-chips" style={{ marginTop: 2 }}>
           {TREES.map((a) => (
             <button
+              type="button"
               key={a.key}
               className={`bigo-chip${treeKey === a.key ? " on" : ""}`}
               onClick={() => pickTree(a.key)}

--- a/content/visualizers/TwoPointersCiclo.tsx
+++ b/content/visualizers/TwoPointersCiclo.tsx
@@ -271,6 +271,7 @@ export function TwoPointersCiclo() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}

--- a/content/visualizers/TwoPointersPalindromo.tsx
+++ b/content/visualizers/TwoPointersPalindromo.tsx
@@ -192,6 +192,7 @@ export function TwoPointersPalindromo() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}

--- a/content/visualizers/TwoPointersVisualizer.tsx
+++ b/content/visualizers/TwoPointersVisualizer.tsx
@@ -173,6 +173,7 @@ export function TwoPointersVisualizer() {
         <div className="bigo-chips">
           {PRESETS.map((pr) => (
             <button
+              type="button"
               key={pr.key}
               className={`bigo-chip${preset === pr.key ? " on" : ""}`}
               onClick={() => applyPreset(pr)}
@@ -192,7 +193,7 @@ export function TwoPointersVisualizer() {
             <span>alvo</span>
             <input className="viz-input k" type="number" value={target} onChange={(e) => onTargetChange(e.target.value)} />
           </label>
-          <button className="viz-btn" onClick={shuffle}>Sortear</button>
+          <button type="button" className="viz-btn" onClick={shuffle}>Sortear</button>
         </div>
 
         <div className="viz-cells">

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,27 @@ export default [
       // É a família que já virou bug neste repositório. Sobe para ERRO, que é o
       // ponto de ter lint: código novo não entra com dependência faltando.
       "react-hooks/exhaustive-deps": "error",
+
+      // O padrão do HTML para `<button>` é `type="submit"`. Hoje o defeito é
+      // LATENTE — `<form` aparece zero vezes no `out/` —, mas o dia em que
+      // alguém puser um formulário na página, todo botão de visualizador
+      // dentro dele passa a enviar a página em vez de avançar o passo.
+      //
+      // O passivo foi medido pela AST antes de ligar a regra: 196 tags em 78
+      // arquivos de `content/visualizers/`, todas consertadas no commit
+      // anterior. Por isso ela entra como ERRO e não como aviso: o que uma
+      // varredura em massa não faz é impedir o 197º, e é exatamente isso que
+      // se compra aqui.
+      //
+      // (Contar com `grep -c "<button"` daria 199, porque ele conta LINHA e
+      // inclui `<button>` escrito dentro de string de exemplo de código que o
+      // aluno lê na tela. A régua é a AST.)
+      //
+      // Limite conhecido: a regra lê só os atributos escritos na tag e não
+      // enxerga através de `{...spread}`. As duas tags da casca em
+      // `src/lib/visualizer.tsx` recebem o `type` do objeto espalhado e têm
+      // `eslint-disable-next-line` com o motivo escrito ao lado.
+      "react/button-has-type": "error",
     },
   },
 

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -770,7 +770,17 @@ export function VizHeader({
         {viz.total > 1 && (
           <span className="viz-step">passo {viz.step + 1} de {viz.total}</span>
         )}
+        {/* O `type="button"` destes dois vem do objeto espalhado, e o tipo dele
+            é o literal `type: "button"` (veja `blockButtonProps` e
+            `expandButtonProps` no tipo `Visualizer`): tirar ou trocar reprova
+            no `tsc`. A regra `react/button-has-type` lê só os atributos
+            escritos na tag e não enxerga através do `{...spread}`, então
+            acusaria os dois de falta. Quem guarda de verdade é o teste que lê
+            a PROPRIEDADE `type` no DOM, em `tests/check-alinhado.spec.ts`
+            (seletor `.viz-expand`). */}
+        {/* eslint-disable-next-line react/button-has-type */}
         {viz.collapsible && <button {...viz.blockButtonProps} />}
+        {/* eslint-disable-next-line react/button-has-type */}
         <button {...viz.expandButtonProps} />
       </div>
     </div>

--- a/src/lib/visualizer.tsx
+++ b/src/lib/visualizer.tsx
@@ -414,6 +414,9 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
   //   1 — congela a animação e abre o blockName, que é o pior caso de altura;
   //   2 — mede o layout já estável e decide.
   useIsomorphicLayoutEffect(() => {
+    // A linha abaixo é o motivo de `data-anim` ficar em `"off"` para sempre numa
+    // peça `collapsible: false`: o efeito sai antes de chegar ao
+    // `setAnimate(true)` lá embaixo. Veja a nota no `figureProps`.
     if (!collapsible || !fontsReady || manualChoice.current !== null) return;
     if (measuredRound.current === measureTick) return;
     if (!measuring || !open) { setMeasuring(true); setOpen(true); return; }
@@ -708,6 +711,20 @@ export function useVisualizer(options: VisualizerOptions): Visualizer {
     figureProps: {
       className: "viz viz-fit",
       "data-codigo": open ? "on" : "off",
+      // ATENÇÃO, QUEM ESTÁ ESCREVENDO SPEC: este atributo NÃO é um sinal de "a
+      // casca hidratou". Ele é "a MEDIÇÃO terminou", e a medição só existe
+      // quando há bloco para recolher. Quem acende o `animate` é o
+      // `requestAnimationFrame` no fim do efeito de medição, e esse efeito sai
+      // na primeira linha quando `collapsible` é falso — então numa peça
+      // `collapsible: false` o valor é `"off"` para sempre, e um
+      // `toHaveAttribute("data-anim", "on")` ali morre num timeout de 10s antes
+      // da primeira asserção de verdade. Não é defeito: as transições que ele
+      // desliga são as do bloco que a peça não tem. Numa peça sem bloco, espere
+      // por outra coisa — um rótulo do próprio miolo, ou o `⤢ Expandir`.
+      // O contrato está em `content/visualizers/README.md`, §4. Quem o prende é
+      // `tests/viz-binary-numbers.spec.ts:208`
+      // (`toHaveAttribute("data-anim", "off")`, na peça das bases numéricas), o
+      // único ponto da suíte que afirma o `"off"` em vez de esperar pelo `"on"`.
       "data-anim": animate && !measuring ? "on" : "off",
       ref: figureRef,
       tabIndex: -1,

--- a/tests/botao-declara-que-e-botao.spec.ts
+++ b/tests/botao-declara-que-e-botao.spec.ts
@@ -1,0 +1,184 @@
+import { test, expect, type Page } from "@playwright/test";
+import { ALL_TOPICS } from "../content/roadmap";
+
+// Todo `<button>` do site declara `type="button"`.
+//
+// O DEFEITO
+// ---------
+// O padrão do HTML para `<button>` é `type="submit"`. Hoje isso é LATENTE — não
+// existe um `<form>` no site inteiro —, mas é defeito à espera do primeiro
+// formulário: no dia em que um aparecer, cada botão de visualizador dentro dele
+// passa a ENVIAR A PÁGINA em vez de avançar o passo, e o sintoma (a página
+// recarrega sozinha ao clicar em "Próximo") não parece com a causa.
+//
+// A varredura que fechou o passivo foi feita pela AST do TypeScript: 196 tags em
+// 78 arquivos de `content/visualizers/`, mais os 2 da casca em
+// `src/lib/visualizer.tsx`, que já tinham `type` pelo objeto espalhado.
+//
+// `grep -c "<button"` não serve de régua, e o desvio é medível aqui mesmo: em
+// `src/` ele conta 17 e a AST conta 14 tags de verdade. Os 3 de diferença são
+// `<button>` escrito em COMENTÁRIO (`Shell.tsx:362`, `visualizer.tsx:168` e
+// `:818`). Ele também conta `<button>` dentro de string de exemplo de código —
+// texto que o aluno LÊ na tela, e que não é tag nenhuma. Em `content/` os dois
+// números batem hoje por sorte, não por propriedade.
+//
+// POR QUE ESTE ARQUIVO EXISTE, SE A REGRA DE LINT JÁ ESTÁ LIGADA
+// --------------------------------------------------------------
+// `react/button-has-type` (ligada como erro no `eslint.config.mjs`) impede o
+// 197º botão escrito à mão. Ela **não** enxerga duas coisas:
+//
+//   1. `{...spread}`. Os dois botões da casca (`⤢ Expandir` e
+//      `Mostrar código`) recebem as props de `blockButtonProps` /
+//      `expandButtonProps`, e a regra lê só o que está escrito na tag — tanto
+//      que os dois carregam um `eslint-disable-next-line` com o motivo ao lado.
+//      Nenhuma varredura de TEXTO no código-fonte prova que eles estão certos,
+//      e eles se repetem em toda peça de todo tópico. Só o DOM prova;
+//   2. o que sai do build. Lint lê fonte; o aluno recebe HTML.
+//
+// Por isso as duas asserções aqui leem o ENTREGUE: a primeira o HTML do `out/`,
+// a segunda a PROPRIEDADE `type` no DOM — que é a que o navegador consulta na
+// hora de decidir se o clique envia, e que devolve `"submit"` sozinha quando o
+// atributo falta.
+//
+// COMO SABER SE ESTE TESTE PRESTA
+// -------------------------------
+// Prova de quebra, sem `git checkout --` (que apagaria o conserto junto): tire o
+// ` type="button"` de UMA tag, por exemplo o "Sortear" de
+// `content/visualizers/IntervalsVisualizer.tsx` (`<button type="button"
+// className="viz-btn" onClick={randomize}>`), rode `npm run test:build` e
+// espere ver `/topico/intervals/` na lista de reprovadas, com o rótulo
+// "Sortear" no relatório. `npm test` sozinho não serve: ele exercita o `out/`
+// da build anterior, que ainda tem o atributo.
+
+/** Rotas fixas do site, fora as de tópico. */
+const ROTAS_FIXAS = ["/", "/roadmap/", "/introducao/", "/sobre/", "/apoie/"];
+
+const ROTAS = [...ROTAS_FIXAS, ...ALL_TOPICS.map((t) => `/topico/${t.slug}/`)];
+
+/**
+ * Pisos de contagem. Eles NÃO são o teste — o teste é o `type` lido. Existem
+ * porque um seletor errado casa com zero elementos, e "nenhum botão errado
+ * entre zero botões" é verde vazio, que é o jeito mais comum de uma varredura
+ * mentir. Ficam bem abaixo do medido para não reprovarem quando um artigo
+ * ganhar ou perder uma peça.
+ */
+// Medido no `out/` da `main` de hoje: 4.705 tags em 52 rotas, e 65 na rota mais
+// magra (`/`, `/introducao/`, `/sobre/` e `/apoie/`, que só têm o chassi). Os
+// pisos ficam bem abaixo disso.
+const PISO_HTML_TOTAL = 3000;
+const PISO_HTML_ROTA = 40;
+const PISO_DOM_ROTA = 40;
+
+/**
+ * As tags `<button>` de abertura do HTML, com o `<script>` fora.
+ *
+ * O `<script>` sai porque o payload do Next carrega o HTML da página outra vez,
+ * dentro de string JavaScript: contá-lo dobraria tudo e faria o piso mentir. E
+ * `<button` escrito num bloco de código do artigo chega como `&lt;button`, então
+ * exemplo de código não entra aqui — que é exatamente a diferença entre esta
+ * régua e o `grep`.
+ */
+function tagsDeBotao(html: string): string[] {
+  const semScript = html.replace(/<script\b[\s\S]*?<\/script>/gi, "");
+  return semScript.match(/<button\b[^>]*>/gi) ?? [];
+}
+
+test("no HTML entregue, nenhum <button> sai sem type", async ({ request }) => {
+  const errados: string[] = [];
+  const magros: string[] = [];
+  let total = 0;
+
+  for (const rota of ROTAS) {
+    const resposta = await request.get(rota);
+    expect(resposta.status(), `${rota} não respondeu 200`).toBe(200);
+    const tags = tagsDeBotao(await resposta.text());
+    total += tags.length;
+    if (tags.length < PISO_HTML_ROTA) magros.push(`${rota} → ${tags.length} tags`);
+    for (const tag of tags) {
+      // Só `type="button"` passa. `submit` e `reset` explícitos reprovam do
+      // mesmo jeito: nenhum dos dois tem o que fazer num site sem formulário, e
+      // aceitá-los deixaria o defeito voltar com o atributo escrito.
+      if (!/\stype=["']button["']/i.test(tag)) errados.push(`${rota}  ${tag.slice(0, 160)}`);
+    }
+  }
+
+  expect(
+    magros,
+    `estas rotas trouxeram menos de ${PISO_HTML_ROTA} botões no HTML — ou o build está sem os visualizadores, ou a régua parou de casar, e aí o verde é vazio`
+  ).toEqual([]);
+  expect(
+    total,
+    `a varredura achou ${total} tags <button> no HTML de ${ROTAS.length} rotas, menos que o piso de ${PISO_HTML_TOTAL}`
+  ).toBeGreaterThanOrEqual(PISO_HTML_TOTAL);
+  expect(
+    errados,
+    'sem `type="button"` o padrão do HTML é `submit`, e dentro de um <form> o clique envia a página'
+  ).toEqual([]);
+  console.log(`HTML entregue: ${total} tags <button> conferidas em ${ROTAS.length} rotas`);
+});
+
+/**
+ * Lê a PROPRIEDADE `type` de todo `<button>` do documento e devolve só os
+ * errados, com o nome acessível junto — para o relatório dizer QUAL botão, e não
+ * só quantos.
+ */
+async function varrerDom(page: Page, onde: string, piso: number) {
+  const achado = await page.evaluate(() => {
+    const els = Array.from(document.querySelectorAll("button"));
+    return {
+      total: els.length,
+      errados: els
+        .filter((el) => el.type !== "button")
+        .map(
+          (el) =>
+            `${el.getAttribute("aria-label") ?? el.textContent?.trim().slice(0, 32) ?? "?"} [${el.className}] → type="${el.type}"`
+        ),
+    };
+  });
+  expect(
+    achado.total,
+    `${onde}: só ${achado.total} botões no DOM, menos que o piso de ${piso} — a varredura estaria verde por vazio`
+  ).toBeGreaterThanOrEqual(piso);
+  expect(
+    achado.errados,
+    `${onde}: a propriedade \`type\` destes botões é \`submit\`, e é ela que o navegador consulta na hora de decidir se o clique envia`
+  ).toEqual([]);
+  console.log(`${onde.padEnd(52)} ${achado.total} botões`);
+  return achado.total;
+}
+
+/**
+ * Rotas com peças de perfis diferentes: uma com várias figuras na mesma página,
+ * uma cujo miolo troca de conjunto de botões quando o aluno muda de modo, e uma
+ * de gráfico, que monta os controles em outro caminho.
+ */
+const ROTAS_DOM = ["/topico/two-pointers/", "/topico/intervals/", "/topico/big-o/"];
+
+test("no DOM, a propriedade type de todo <button> é 'button' — inclusive nos que só existem depois do clique", async ({
+  page,
+}) => {
+  for (const rota of ROTAS_DOM) {
+    await page.goto(rota);
+    // A casca do visualizador só chega ao DOM depois da hidratação; sem esperar,
+    // a varredura passaria por não achar nada (e o piso acusaria).
+    await expect(page.locator(".viz-expand").first()).toBeVisible();
+    await varrerDom(page, `${rota} (depois de hidratar)`, PISO_DOM_ROTA);
+  }
+
+  // As duas montagens que o HTML estático NÃO tem.
+  await page.goto("/topico/two-pointers/");
+  const primeira = page.locator("article figure.viz").first();
+
+  // 1 · o bloco de código, que a casca só põe no DOM quando o aluno pede.
+  const codigo = primeira.getByRole("button", { name: /código$/ });
+  if (await codigo.count()) {
+    await codigo.first().click();
+    await varrerDom(page, "/topico/two-pointers/ (código à mostra)", PISO_DOM_ROTA);
+  }
+
+  // 2 · o painel expandido, montado no clique com uma segunda cópia do
+  // cabeçalho, dos controles e do miolo da peça.
+  await primeira.getByRole("button", { name: "⤢ Expandir" }).click();
+  await expect(page.locator(".viz-overlay figure.viz")).toBeVisible();
+  await varrerDom(page, "/topico/two-pointers/ (painel expandido)", PISO_DOM_ROTA);
+});


### PR DESCRIPTION
Fecha o item 12 do backlog: os `<button>` sem `type` e a nota do `data-anim` que
apontava para uma linha que não existe mais.

## 12.1 · 196 botões que não diziam que eram botões

Em HTML o padrão de `<button>` é `type="submit"`. As **196** tags de
`content/visualizers/` não declaravam `type`, então bastava um `<form>` aparecer
para o clique em "Próximo" recarregar a página em vez de avançar o passo. Hoje é
**latente** — `<form>` aparece zero vezes no `out/` da `main` — e foi por isso
que sobreviveu tanto tempo.

### A régua, e por que não é o `grep`

Contagem por **AST do TypeScript**: 196 tags em 78 arquivos. Dá para medir o
desvio do `grep` aqui mesmo: em `src/`, `grep -c "<button"` conta **17** e a AST
conta **14** — as três de diferença são `<button>` escrito em **comentário**
(`Shell.tsx:362`, `visualizer.tsx:168`, `:818`). Ele também conta linha, e conta
`<button>` dentro de string de exemplo de código, que é texto que o aluno lê.

### O que fecha de vez

Varredura em massa fecha o passivo e não impede o próximo.
**`react/button-has-type` ligada como erro** impede: um `<button>` sem `type`
passa a reprovar o `npm run lint`, que o CI já roda no job de guardas. O plugin
já vinha no `eslint-config-next` — **nenhuma dependência nova**.

Antes do conserto a regra acusava **198 em 79 arquivos**; depois, **0 erros**,
com os mesmos 6 avisos de baseline.

### O limite da regra, declarado em vez de escondido

Ela lê só os atributos escritos na tag e **não enxerga através do `{...spread}`**.
Os dois botões da casca recebem o `type` de `blockButtonProps`/`expandButtonProps`
e ganharam `eslint-disable-next-line` com o motivo ao lado. Duplicar o atributo
na tag calaria a regra e criaria uma segunda fonte da verdade para o que o tipo
já garante — os dois objetos declaram o **literal** `type: "button"`, e mexer
neles reprova no `tsc`. E a diretiva não fica órfã: o
`reportUnusedDisableDirectives` do ESLint 9 está ativo e acusa no dia em que ela
deixar de ser necessária.

### A prova

Lint lê fonte; o aluno recebe HTML. E lint é cego para spread. O spec lê o
entregue nos dois níveis:

1. o **HTML do `out/`**, rota a rota — **4.739 tags conferidas em 52 rotas**. O
   `<script>` sai antes da varredura, e `<button>` dentro de bloco de código do
   artigo chega como `&lt;button` e não entra: é a diferença entre esta régua e o `grep`;
2. a **propriedade `type` no DOM**, que é a que o navegador consulta na hora de
   decidir se o clique envia — depois de hidratar, e também no bloco de código e
   no painel expandido, que não existem no HTML estático.

Cada varredura tem piso de contagem, porque "nenhum botão errado entre zero
botões" é verde vazio.

**Prova de quebra, executada:** tirei o ` type="button"` do botão `Sortear` em
`IntervalsVisualizer.tsx`. Os dois níveis reprovam, e o relatório nomeia o
culpado:

```
Error: /topico/intervals/ (depois de hidratar): a propriedade `type` destes
botões é `submit`, e é ela que o navegador consulta…
  + "Sortear [viz-btn] → type=\"submit\""
  + "/topico/intervals/  <button class=\"viz-btn\">"
2 failed
```

E o lint pega sozinho, antes do build:
`652:11  error  Missing an explicit type attribute for button  react/button-has-type`

## 12.2 · a nota do `data-anim` apontava para o vazio

O contrato dizia `src/lib/visualizer.tsx:265`, e essa linha hoje é outra coisa.
Os endereços certos são **`:420`** (o guarda que faz o efeito de medição sair
antes de decidir) e **`:436`** (o `setAnimate(true)` que acende o atributo).
Endereço errado num contrato é pior que endereço nenhum.

`data-anim` não quer dizer "a casca hidratou": quer dizer "a **medição**
terminou", e a medição só existe quando há bloco para recolher. Em peça
`collapsible: false` o valor é `"off"` para sempre. Não é defeito de produto, é
**armadilha de teste** — e a mina está posta: **18 asserções em 16 specs**
esperam `data-anim="on"` sob seis nomes de helper. Nenhuma aponta hoje para peça
sem bloco: mina desviada, não pisada.

Quem escreve spec não lê o README antes; lê depois que o teste estourou, e o que
faz é `grep data-anim`. Por isso a nota longa ficou **colada na linha que produz
o atributo**, com o guarda apontando de volta.

### O helper: reportado, não feito

Custo medido: 17 arquivos, ~80 linhas. Mas o argumento não é o custo, é a forma.
Só **4 dos 18** sites têm forma de espera pura; os outros 14 vivem dentro de
rotinas por tópico que também fazem viewport, `goto` e `fonts.ready` — a
duplicação que dói é a rotina, não a asserção. E um helper "espere
`data-anim=on`" **centraliza a espera errada**. O que pagaria é um helper que
*diagnostica*: lê se a figura tem `.viz-toggle-codigo` e falha na hora com a
causa, em vez de 10s de timeout. PR próprio, com prova de quebra própria.

## O que este PR não muda

Nenhuma letra do que o aluno lê.

```
guarda:idioma, content/ (78 arquivos):  TELA intacta
  SUMIRAM: nenhuma / APARECERAM: nenhuma
  único literal de CÓDIGO alterado: 'button'
guarda:idioma, src/ (34 arquivos):      SUMIRAM: nenhuma / APARECERAM: nenhuma
```

E, arquivo a arquivo: removendo `type="button"` e normalizando espaço em branco,
os 78 são **idênticos** aos da `main`.

Suíte inteira na branch: **714 passed**. As falhas restantes são o flake desta
máquina — rodadas isoladas, `seo-datas-e-autoria` e `mobile` dão 38/38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUbtzKsXafUrmiFM3gPMYz