### PR TITLE
fix(topics): o artigo é autocontido, sem citar quem estava no encontro

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,7 +70,7 @@ jobs:
   # entra no caminho crítico do PR.
   guardas:
     runs-on: ubuntu-latest
-    name: Guardas (lint e idioma na tela)
+    name: Guardas (lint, idioma na tela e âncoras no artigo)
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -111,6 +111,18 @@ jobs:
             exit 0
           fi
           python3 scripts/testa-guarda-idioma.py
+
+      # PORTÃO. O artigo é autocontido: nenhuma prosa em `content/topics/*.mdx`
+      # pode exigir ter assistido à gravação («no encontro apareceu», «o Fulano
+      # perguntou»). O link e o embed do vídeo continuam permitidos — eles são o
+      # reforço que a regra promete, e nem moram no `.mdx`.
+      #
+      # Portão, e não relatório, porque aqui a resposta certa é sempre a mesma:
+      # o corpus limpo. O guarda também sai 2 se uma exceção declarada parou de
+      # casar qualquer linha, que é o jeito de uma exceção morta virar barulho
+      # em vez de buraco.
+      - name: Âncoras na gravação nos artigos
+        run: npm run guarda:ancoras
 
       # RELATÓRIO, não portão — e a distinção é o ponto.
       #

--- a/content/topics/filas.mdx
+++ b/content/topics/filas.mdx
@@ -245,7 +245,7 @@ Quando escolher a lista? Quando a fila não pode ter teto. Pense num serviço qu
 
 ## Fila com duas pilhas
 
-Este é o quebra-cabeça favorito das entrevistas, e foi a tarefa de casa deixada no encontro: **construir uma fila usando só pilhas**. Parece impossível, porque pilha é LIFO e fila é FIFO, exatamente o contrário.
+Este é o quebra-cabeça favorito das entrevistas, e vale como exercício de casa: **construir uma fila usando só pilhas**. Parece impossível, porque pilha é LIFO e fila é FIFO, exatamente o contrário.
 
 A sacada é geométrica: se você despejar uma pilha dentro de outra, a ordem **inverte**. E LIFO invertido é FIFO.
 
@@ -433,7 +433,7 @@ Antes de abrir o LeetCode, use os visualizadores para **prever antes de rodar**.
 Depois, na ordem:
 
 1. **Implement Queue using Stacks (232)** para fixar o amortizado que você acabou de ver na tela. Os quatro métodos estão na seção das duas pilhas, inclusive o `peek` que precisa virar e o `empty` que olha as duas listas.
-2. **Number of Students Unable to Eat Lunch (1700)**, uma fila e uma pilha interagindo, no espírito do problema de distribuir um item por vez que apareceu no encontro. Cuidado com o critério de parada: quando ninguém mais quer o item do topo, acabou, e o jeito de detectar isso é contar quantas voltas seguidas a fila deu sem ninguém aceitar. Depois de resolver com a fila, resolva de novo contando quantos querem cada tipo: some as preferências uma vez e a simulação inteira vira O(n), sem fila nenhuma. Saber que a estrutura não era obrigatória é parte do aprendizado.
+2. **Number of Students Unable to Eat Lunch (1700)**, uma fila e uma pilha interagindo, no espírito do problema de distribuir um item por vez. Cuidado com o critério de parada: quando ninguém mais quer o item do topo, acabou, e o jeito de detectar isso é contar quantas voltas seguidas a fila deu sem ninguém aceitar. Depois de resolver com a fila, resolva de novo contando quantos querem cada tipo: some as preferências uma vez e a simulação inteira vira O(n), sem fila nenhuma. Saber que a estrutura não era obrigatória é parte do aprendizado.
 3. **Design Circular Queue (622)** é este artigo virando código, com `inicio`, `fim` e o `% capacidade`. O único ponto fora do texto é a interface: lá os métodos devolvem `true`/`false` em vez de levantar exceção, e o `Rear()` é `dados[(fim - 1 + cap) % cap]`.
 4. **Design Circular Deque (641)** é o mesmo, agora com inserção e remoção nas duas pontas, ou seja, com o `(i - 1 + cap) % cap` em campo.
 5. **Sliding Window Maximum (239)** é o deque monotônico do último visualizador. Teste sua solução com `k = 1`, com `k = n` e com todos os valores iguais antes de submeter.

--- a/content/topics/hash-table.mdx
+++ b/content/topics/hash-table.mdx
@@ -45,7 +45,7 @@ A peça que dá nome à estrutura. Ela recebe a chave e devolve um número. Depo
 </Cartao>
 </Colunas>
 
-Vamos construir uma função de hash bem ingênua, a mesma do encontro: **some o código ASCII de cada caractere da chave**. Para `"Ana"`, com `A = 65`, `n = 110` e `a = 97`:
+Vamos construir uma função de hash bem ingênua: **some o código ASCII de cada caractere da chave**. Para `"Ana"`, com `A = 65`, `n = 110` e `a = 97`:
 
 ```text
 65 + 110 + 97 = 272
@@ -57,7 +57,7 @@ O problema é que 272 não é um índice de um array de 5 posições. A segunda 
 272 % 5 = 2
 ```
 
-Pronto: `"Ana"` mora no bucket 2. Sem percorrer nada, sem comparar nada com nada. Aplicando a mesma receita nos cinco nomes do encontro, numa tabela de 5 posições:
+Pronto: `"Ana"` mora no bucket 2. Sem percorrer nada, sem comparar nada com nada. Aplicando a mesma receita em cinco nomes, numa tabela de 5 posições:
 
 | Chave | Soma ASCII | Resto por 5 | Bucket |
 | --- | --- | --- | --- |
@@ -92,7 +92,7 @@ Depois pare de assistir e mexa nele. Troque a lista de chaves pelo seu nome e o 
 
 Olhe de novo a tabela de cima. `"Lia"` dá 278 e cai no bucket 3. `"Leo"` dá 288 e cai... no bucket 3 também. Isso é uma **colisão**, e não é bug nem azar: é uma consequência matemática inevitável. Você está espremendo infinitas chaves possíveis em um número finito de posições, então duas chaves vão disputar o mesmo endereço mais cedo ou mais tarde.
 
-Existem duas famílias de solução, e o encontro passou pelas duas.
+Existem duas famílias de solução, e vale conhecer as duas.
 
 ### Encadeamento: cada bucket vira uma corrente
 
@@ -320,7 +320,7 @@ Sobre `hashtable` e `hashmap`: no dia a dia os dois nomes são usados de forma i
 
 ### A regra de ouro: hash e igualdade andam juntos
 
-Este é o erro que mais aparece em código de produção, e o encontro simulou ele ao vivo. Imagine um objeto `Pessoa(nome, idade)` em que:
+Este é o erro que mais aparece em código de produção. Imagine um objeto `Pessoa(nome, idade)` em que:
 
 - `hashCode()` usa **só o nome**;
 - `equals()` usa **nome e idade**.
@@ -383,7 +383,7 @@ Por fim, o preço fixo em memória. Manter o fator de carga em 0,75 significa ac
 
 **Chave mutável é chave perdida.** Se você insere um objeto e depois muda um campo que participa do hash, o objeto continua fisicamente no bucket antigo, mas a busca passa a calcular um bucket novo. O item vira um fantasma: está no mapa e não é encontrado. Use chaves imutáveis, ou nunca mexa nelas depois de inserir.
 
-**A ordem não é uma promessa.** Uma tabela hash não tem ordem: a posição vem do hash, não da hora em que você inseriu. No exemplo do encontro, `"Ana"` entrou primeiro e foi parar no bucket 2, enquanto `"Bob"` entrou depois e ficou no 0. Algumas implementações **acrescentam** essa garantia (o `dict` do Python desde a 3.7, o `LinkedHashMap` do Java), mas isso é um extra dessas implementações, não uma propriedade da estrutura. Se você precisa de ordem, diga isso no tipo que escolher.
+**A ordem não é uma promessa.** Uma tabela hash não tem ordem: a posição vem do hash, não da hora em que você inseriu. No exemplo acima, `"Ana"` entrou primeiro e foi parar no bucket 2, enquanto `"Bob"` entrou depois e ficou no 0. Algumas implementações **acrescentam** essa garantia (o `dict` do Python desde a 3.7, o `LinkedHashMap` do Java), mas isso é um extra dessas implementações, não uma propriedade da estrutura. Se você precisa de ordem, diga isso no tipo que escolher.
 
 **Remover com sondagem linear não é apagar.** Zerar o slot corta a trilha de sondagem e some com chaves que estão lá. É o caso do `"Leo"` e da `"Eva"` que a gente destrinchou na seção de colisão, e a saída é a lápide.
 
@@ -411,7 +411,7 @@ def tem_duplicado(nums):
     return False
 ```
 
-**2. Quantas vezes cada coisa aparece?** É o mapa de frequência, o padrão mais comum de todos. No encontro ele apareceu de um jeito instrutivo: contando letras com um array de 26 posições, em que a "função de hash" é `ord(c) - ord('A')`.
+**2. Quantas vezes cada coisa aparece?** É o mapa de frequência, o padrão mais comum de todos. Há uma versão instrutiva dele: contar letras com um array de 26 posições, em que a "função de hash" é `ord(c) - ord('A')`.
 
 ```python
 texto = "CRAFTCODECLUB"

--- a/content/topics/listas-ligadas.mdx
+++ b/content/topics/listas-ligadas.mdx
@@ -34,12 +34,12 @@ Três coisas importam nesse trecho:
 - **A casca não é a estrutura.** A estrutura de dados é o nó apontando para o nó. A classe em volta é só a interface das operações, e é por isso que no LeetCode você quase nunca recebe uma `ListaEncadeada`: recebe direto a `cabeca` e vira nela.
 
 <Callout>
-Vale a distinção que apareceu no encontro: **fila, pilha e dicionário são tipos abstratos de dados (ADT)**, ou seja, um contrato de operações. Lista encadeada e array são **estruturas de dados**, ou seja, uma forma concreta de guardar os bytes. Uma fila pode ser feita com lista encadeada ou com array, e quem usa não deveria precisar saber qual. É a mesma relação entre uma interface e a classe que a implementa.
+Vale a distinção: **fila, pilha e dicionário são tipos abstratos de dados (ADT)**, ou seja, um contrato de operações. Lista encadeada e array são **estruturas de dados**, ou seja, uma forma concreta de guardar os bytes. Uma fila pode ser feita com lista encadeada ou com array, e quem usa não deveria precisar saber qual. É a mesma relação entre uma interface e a classe que a implementa.
 </Callout>
 
 ## Contígua ou espalhada: onde cada estrutura mora na memória
 
-Essa seção é o coração do trade-off, e o desenho do encontro explica melhor que qualquer definição.
+Essa seção é o coração do trade-off, e olhar a memória explica melhor que qualquer definição.
 
 Para alocar um array de 4 posições, o sistema precisa de **4 espaços consecutivos livres**. Se a memória estiver picotada, com buracos de 1 e 2 posições espalhados, não adianta ter espaço sobrando no total: o array não cabe. E quando ele enche, a saída é achar um bloco maior em outro lugar e **copiar tudo**.
 
@@ -139,7 +139,7 @@ Sempre O(n), e sem chance de melhorar. Num array ordenado você pularia para o m
 
 ## A tabela de custos, operação por operação
 
-Esta é a tabela que a galera preencheu ao vivo no encontro, linha por linha. Vale colar na parede, porque quase toda decisão de usar (ou não usar) lista encadeada está nela.
+Esta é a tabela que fecha o assunto, linha por linha. Vale colar na parede, porque quase toda decisão de usar (ou não usar) lista encadeada está nela.
 
 <LinkedListOperacoes />
 
@@ -281,12 +281,12 @@ class ListaComSentinela:
 Conte os `if`: zero. Volte ao visualizador da seção de operações, ligue o chip **nó sentinela** e escolha "Remover o primeiro". O painel de código encolhe de 8 para 5 linhas e o caminho especial some, porque agora remover o primeiro nó é igual a remover qualquer outro. O preço é um nó a mais na memória e um salto a mais em cada operação, que é o que o contador de "nós percorridos" mostra.
 
 <Callout>
-**Sentinela e ponteiro auxiliar não são a mesma coisa**, e no encontro essa confusão apareceu bonita. O **sentinela** é um nó de verdade, alocado na memória, que fica parado guardando a ponta da lista. O **ponteiro auxiliar** (o `atual` do laço de busca, às vezes chamado de dummy pointer) é só uma variável que caminha: você reatribui ele o tempo todo e joga fora no fim. Um marca um lugar, o outro anda.
+**Sentinela e ponteiro auxiliar não são a mesma coisa**, e a confusão entre os dois é das mais comuns. O **sentinela** é um nó de verdade, alocado na memória, que fica parado guardando a ponta da lista. O **ponteiro auxiliar** (o `atual` do laço de busca, às vezes chamado de dummy pointer) é só uma variável que caminha: você reatribui ele o tempo todo e joga fora no fim. Um marca um lugar, o outro anda.
 </Callout>
 
 Numa lista **simplesmente** encadeada, só o sentinela da frente vale a pena: chegar no fim já é fácil, basta procurar o `None`. Numa lista **duplamente** encadeada, vale ter os dois, um sentinela de cabeça e um de cauda, e aí a lista vazia deixa de ser `None`: são os dois sentinelas apontando um para o outro. Toda inserção e toda remoção passam a ser sempre "no meio", sem uma exceção sequer para tratar. É exatamente o que o LRU cache da seção anterior faz.
 
-O exemplo que motivou tudo isso no encontro foi um problema de LeetCode: **remover o k-ésimo nó contando de trás para frente**. A solução esbarra num caso chato, o de quando o nó a remover é justamente o primeiro, que obriga um `if` só para devolver `cabeca.prox`. Com sentinela, esse `if` desaparece e o código fica com um caminho só. É o LeetCode 19 da lista de problemas do fim desta página, e ele usa três coisas ao mesmo tempo: sentinela, ponteiro auxiliar e dois ponteiros com uma distância fixa entre eles, que é o assunto de duas seções à frente.
+O exemplo que motiva tudo isso é um problema de LeetCode: **remover o k-ésimo nó contando de trás para frente**. A solução esbarra num caso chato, o de quando o nó a remover é justamente o primeiro, que obriga um `if` só para devolver `cabeca.prox`. Com sentinela, esse `if` desaparece e o código fica com um caminho só. É o LeetCode 19 da lista de problemas do fim desta página, e ele usa três coisas ao mesmo tempo: sentinela, ponteiro auxiliar e dois ponteiros com uma distância fixa entre eles, que é o assunto de duas seções à frente.
 
 ### O sentinela como cabeça de obra: montando uma lista nova
 
@@ -381,7 +381,7 @@ Continua sendo O(n), e é bom deixar isso claro: o ganho não é de complexidade
 Escolha o caso **"Sem ciclo: 6 nós (acha o meio)"** e rode até o fim. O rápido sai da lista, o laço acaba, e repare onde o lento parou: no **nó 3**. Depois rode "Sem ciclo: 5 nós": o lento para no **nó 2**. Nos dois casos ele para em `n // 2`.
 
 <Callout tipo="aviso">
-Com um número **par** de nós existem dois meios, e este laço sempre devolve o **segundo** deles: numa lista de 6 nós (índices 0 a 5), os meios são o 2 e o 3, e você recebe o 3. O enunciado do LeetCode 876 pede exatamente esse. Se o seu problema pedir o primeiro meio, mude a condição para `while rapido.prox is not None and rapido.prox.prox is not None`, lembrando de tratar a lista vazia antes, porque essa versão não sobrevive a uma cabeça `None`. Antes de escrever qualquer código, pergunte qual meio o problema quer: no encontro, alguém resumiu isso perfeitamente com "se o cliente pede o pacote do meio e são seis pacotes, qual deles ele quer?".
+Com um número **par** de nós existem dois meios, e este laço sempre devolve o **segundo** deles: numa lista de 6 nós (índices 0 a 5), os meios são o 2 e o 3, e você recebe o 3. O enunciado do LeetCode 876 pede exatamente esse. Se o seu problema pedir o primeiro meio, mude a condição para `while rapido.prox is not None and rapido.prox.prox is not None`, lembrando de tratar a lista vazia antes, porque essa versão não sobrevive a uma cabeça `None`. Antes de escrever qualquer código, pergunte qual meio o problema quer: se o cliente pede o pacote do meio e são seis pacotes, qual deles ele quer?
 </Callout>
 
 ### A mesma ideia com distância fixa: o k-ésimo de trás para frente
@@ -494,7 +494,7 @@ A lista de problemas no fim desta página vai do mais direto ao mais difícil, e
 
 - **LeetCode 206 (Reverse Linked List)** é a dança dos três ponteiros, pura. Resolva na mão, no papel, antes de digitar. Depois escreva a versão recursiva e compare o consumo de pilha.
 - **LeetCode 876 (Middle of the Linked List)** é o rápido e lento da seção do meio da lista. Teste com 5 e com 6 nós e confirme qual dos dois meios o enunciado quer.
-- **LeetCode 19 (Remove Nth Node From End of List)** junta três coisas de uma vez: o sentinela para o caso da cabeça, o ponteiro auxiliar e os dois ponteiros com `k` nós de distância. O código está na seção do rápido e lento, mas tente antes de olhar, e refaça a tabela de `frente` e `tras` com a sua própria lista. É o problema que estava sendo discutido no encontro.
+- **LeetCode 19 (Remove Nth Node From End of List)** junta três coisas de uma vez: o sentinela para o caso da cabeça, o ponteiro auxiliar e os dois ponteiros com `k` nós de distância. O código está na seção do rápido e lento, mas tente antes de olhar, e refaça a tabela de `frente` e `tras` com a sua própria lista.
 - **LeetCode 142 (Linked List Cycle II)** é a fase 2 do Floyd. Se ele parecer mágico, volte ao visualizador e rode a conta `μ = n · λ - k` com os números que aparecem na tela.
 - **LeetCode 146 (LRU Cache)** é a lista duplamente encadeada com sentinelas nas duas pontas, casada com um dicionário. É difícil, é longo, e é o problema que mais parece com código de produção nesta lista inteira. O esqueleto está na seção da lista dupla; o que ele não te dá é a disciplina de rodar `get` e `put` na mão até a ordem da lista bater com a ordem de uso.
 

--- a/content/topics/pilhas.mdx
+++ b/content/topics/pilhas.mdx
@@ -6,7 +6,7 @@ A pilha é a estrutura que você usa desde o primeiro dia de programação sem n
 
 Uma pilha é uma coleção com uma regra única: **o último que entra é o primeiro que sai**. É o LIFO, de *last in, first out*. Não existe entrar no meio, não existe sair pelo fundo, não existe olhar o terceiro elemento. Só existe o topo.
 
-A melhor imagem disso apareceu no encontro da comunidade e vale mais que qualquer definição. Você está no supermercado:
+A melhor imagem disso vale mais que qualquer definição. Você está no supermercado:
 
 <Colunas>
 <Cartao titulo="A fila do caixa é FIFO">
@@ -94,7 +94,7 @@ class Pilha:
         self.items = novo
 ```
 
-Três detalhes desse código apareceram na discussão do encontro e valem mais que o código em si.
+Três detalhes desse código valem mais que o código em si.
 
 **A capacidade inicial 4 não é aleatória.** É o número que aparece em implementações reais de array dinâmico, porque é pequeno o bastante para não desperdiçar e grande o bastante para evitar as primeiras cópias: a `List<T>` do .NET começa em 4 e vai para 8, 16, 32, e a `list` do CPython também salta para 4 no primeiro `append`. Nem todo mundo usa 4, a `ArrayList` do Java começa em 10, mas o formato é sempre o mesmo, um bloco pequeno que dobra.
 
@@ -135,7 +135,7 @@ O `push` inteiro é uma linha porque a operação é literalmente "crie um nó c
 
 A conta não fecha só de vantagens. Cada item deixou de ser um valor solto e virou um objeto com um campo a mais. Em uma máquina de 64 bits, são 8 bytes só do ponteiro `proximo`, mais o cabeçalho do objeto, para cada elemento. E os nós ficam espalhados pela memória, então some o prêmio de cache que o array tinha.
 
-Também some o acesso ao meio. No array, `items[3]` é uma conta; na lista ligada, chegar no quarto nó é andar por três ponteiros. A analogia que a comunidade usou é a do telefone sem fio: **você só enxerga quem está de mãos dadas com você**. O terceiro nó não faz ideia de que o primeiro existe.
+Também some o acesso ao meio. No array, `items[3]` é uma conta; na lista ligada, chegar no quarto nó é andar por três ponteiros. A analogia é a do telefone sem fio: **você só enxerga quem está de mãos dadas com você**. O terceiro nó não faz ideia de que o primeiro existe.
 
 Só que, para uma pilha, isso não custa nada: o contrato dela é acessar só o topo. A limitação da lista ligada cai justamente onde a pilha não precisa de nada.
 
@@ -151,7 +151,7 @@ Na vida real você quase nunca implementa isso na mão, e vale saber o que a lin
 
 ## Parênteses balanceados: o primeiro problema de verdade
 
-Este é o problema que a comunidade resolveu ao vivo no encontro, e é o **LeetCode 20**: dada uma string com `(`, `)`, `[`, `]`, `{` e `}`, diga se ela está balanceada. Três regras no enunciado:
+Este é o problema clássico da pilha, o **LeetCode 20**: dada uma string com `(`, `)`, `[`, `]`, `{` e `}`, diga se ela está balanceada. Três regras no enunciado:
 
 1. toda abertura fecha com o **mesmo tipo**;
 2. o fechamento vem na **ordem correta**;
@@ -189,7 +189,7 @@ def valida(s):
     return not pilha                          # sobrou aberto?
 ```
 
-O dicionário `pares` tem o fechamento como **chave** e a abertura como valor, e essa escolha foi debatida no encontro. O raciocínio: quando você lê uma abertura, não há nada a verificar, você só empilha. É no fechamento que existe uma pergunta, e a pergunta é "qual abertura eu esperava aqui?". Mapear fechamento para abertura responde isso em O(1). O caminho contrário é uma chave fraca, porque não há decisão a tomar na abertura.
+O dicionário `pares` tem o fechamento como **chave** e a abertura como valor, e essa escolha merece um parágrafo. O raciocínio: quando você lê uma abertura, não há nada a verificar, você só empilha. É no fechamento que existe uma pergunta, e a pergunta é "qual abertura eu esperava aqui?". Mapear fechamento para abertura responde isso em O(1). O caminho contrário é uma chave fraca, porque não há decisão a tomar na abertura.
 
 Existem duas variações que aparecem muito e valem conhecer:
 
@@ -212,7 +212,7 @@ Toda linguagem mantém uma pilha para executar o seu programa. Quando `a()` cham
 
 **Ler o stack trace substitui um monte de código defensivo.** É comum ver `try/catch` espalhado por todo canto só para acrescentar mensagens do tipo "cheguei aqui", quando o próprio rastro já diz exatamente por onde a execução passou. E não são só funções: atribuições, operações matemáticas e até o `print` acontecem sobre essa mesma pilha.
 
-Quando uma função chama a si mesma, a call stack fica visível. O exercício do encontro foi calcular uma potência de **três jeitos** e mostrar que os passos são sempre os mesmos: um laço simples, uma recursão, e uma pilha explícita escrita na mão.
+Quando uma função chama a si mesma, a call stack fica visível. O exercício aqui é calcular uma potência de **três jeitos** e ver que os passos são sempre os mesmos: um laço simples, uma recursão, e uma pilha explícita escrita na mão.
 
 ```python
 def potencia_laco(x, n):      # 1. sem pilha nenhuma, O(1) de espaço
@@ -411,6 +411,6 @@ A ordem abaixo é a dos problemas listados no fim desta página, e ela é propos
 4. **Evaluate Reverse Polish Notation (150)** é a avaliação de expressão da seção anterior, código pronto e tudo. Os dois pontos que reprovam: a ordem dos `pop`, porque o primeiro é o operando da direita, e a divisão, que precisa truncar em direção ao zero (`int(a / b)` em Python, nunca `//`).
 5. **Daily Temperatures (739)** é a pilha monotônica com uma linha de diferença: grave a distância `i - j` em vez do valor. É o mesmo array do visualizador, então dá para conferir o caminho passo a passo antes de escrever qualquer código.
 
-Um roteiro que funciona para os cinco: escreva a força bruta primeiro, calcule o Big O dela e só então pergunte o que a pilha economiza. Foi assim que o encontro chegou na solução dos parênteses, e é assim que o padrão fica na cabeça em vez de virar decoreba.
+Um roteiro que funciona para os cinco: escreva a força bruta primeiro, calcule o Big O dela e só então pergunte o que a pilha economiza. Foi assim que a solução dos parênteses apareceu nesta página, e é assim que o padrão fica na cabeça em vez de virar decoreba.
 
 Daqui, dois caminhos se abrem. Um é a estrutura irmã, a [fila](/topico/filas), que troca LIFO por FIFO e resolve a outra metade dos problemas de ordem. O outro é a [recursão](/topico/recursao), que é a call stack desta página vista de dentro, e a porta de entrada para árvores e grafos.

--- a/content/topics/prefix-sum.mdx
+++ b/content/topics/prefix-sum.mdx
@@ -4,7 +4,7 @@ Prefix Sum é a técnica que troca **memória por tempo, de propósito**: você 
 
 ## O problema: recalcular a mesma soma toda vez
 
-No encontro o problema apareceu assim: uma classe recebe um array de números no construtor e, de tempos em tempos, recebe uma requisição com dois índices, o início e o fim, e precisa devolver a soma daquele intervalo.
+O problema aparece assim: uma classe recebe um array de números no construtor e, de tempos em tempos, recebe uma requisição com dois índices, o início e o fim, e precisa devolver a soma daquele intervalo.
 
 ```python
 nums = [10, 30, 20, 45, 60, 40, 50]
@@ -25,7 +25,7 @@ def soma(nums, i, j):
     return total
 ```
 
-O problema não é a soma, é a **repetição**. Cada consulta custa O(j - i + 1), que no pior caso é O(n). Com `q` consultas o total vira **O(q × n)**. Como resumiram no encontro: se quem chama mandar 1 milhão de requisições pegando o array inteiro, você percorre o array 1 milhão de vezes, sempre refazendo somas que já fez.
+O problema não é a soma, é a **repetição**. Cada consulta custa O(j - i + 1), que no pior caso é O(n). Com `q` consultas o total vira **O(q × n)**. Em números: se quem chama mandar 1 milhão de requisições pegando o array inteiro, você percorre o array 1 milhão de vezes, sempre refazendo somas que já fez.
 
 Coloque números de verdade nisso: um array de 100.000 posições e 1.000.000 de consultas cobrindo, em média, 500 elementos cada. São **500 milhões** de operações. Guarde esse número, ele volta na seção do trade-off.
 
@@ -40,7 +40,7 @@ nums = [10,  30,  20,  45,  60,  40,  50]
 P    = [10,  40,  60, 105, 165, 205, 255]
 ```
 
-`P[k]` é a soma de `nums[0]` até `nums[k]`. Foi essa a tabela montada na tela do encontro: 10, depois 10 + 30 = 40, depois 40 + 20 = 60, e assim por diante até 255, que é o array inteiro. Daí o nome: cada posição guarda a soma do **prefixo** que termina ali.
+`P[k]` é a soma de `nums[0]` até `nums[k]`. É essa a tabela: 10, depois 10 + 30 = 40, depois 40 + 20 = 60, e assim por diante até 255, que é o array inteiro. Daí o nome: cada posição guarda a soma do **prefixo** que termina ali.
 
 Agora a parte que faz tudo funcionar. Qualquer intervalo é a **diferença entre dois prefixos**:
 
@@ -53,10 +53,10 @@ soma(1, 4) = P[4] - P[0]       = 155
 
 Você tira, do prefixo que termina no **fim** do intervalo, o prefixo que termina **logo antes** do começo dele. O que sobra é exatamente o pedaço do meio, e a conta foi uma subtração só, não quatro somas.
 
-A fórmula geral fica `soma(i, j) = P[j] - P[i-1]`, e aí aparece a primeira armadilha, que apareceu também no encontro: quando `i` é 0, esse `P[-1]` não existe. Você precisa de um `if` para tratar o começo do array, e é justamente esse `if` que costuma sumir na pressa de uma entrevista.
+A fórmula geral fica `soma(i, j) = P[j] - P[i-1]`, e aí aparece a primeira armadilha: quando `i` é 0, esse `P[-1]` não existe. Você precisa de um `if` para tratar o começo do array, e é justamente esse `if` que costuma sumir na pressa de uma entrevista.
 
 <Callout>
-No encontro apareceu um contorno esperto: usar `P[j] - P[i] + nums[i]`, ou seja, tirar o prefixo do próprio começo do intervalo e devolver o elemento que foi tirado a mais. Com o exemplo: 165 - 40 + 30 = 155. Funciona para qualquer `i`, sem `if`, mas custa um acesso extra ao array original, e só serve se você ainda tiver esse array por perto.
+Existe um contorno esperto: usar `P[j] - P[i] + nums[i]`, ou seja, tirar o prefixo do próprio começo do intervalo e devolver o elemento que foi tirado a mais. Com o exemplo: 165 - 40 + 30 = 155. Funciona para qualquer `i`, sem `if`, mas custa um acesso extra ao array original, e só serve se você ainda tiver esse array por perto.
 </Callout>
 
 ## A sentinela e a fórmula que dispensa o if
@@ -125,9 +125,9 @@ def prefixar(nums):
         nums[k] += nums[k - 1]
 ```
 
-A versão in-place derruba a complexidade de espaço para O(1) extra, e no encontro ela apareceu como uma boa carta para entrevista: "vai ter complexidade de memória, mas eu posso neutralizar usando a própria entrada". O contraponto veio junto, e é honesto: em produção você normalmente **não pode** sobrescrever o que chegou, porque outra parte do sistema ainda precisa dos valores originais.
+A versão in-place derruba a complexidade de espaço para O(1) extra, e ela é uma boa carta para entrevista: "vai ter complexidade de memória, mas eu posso neutralizar usando a própria entrada". O contraponto é honesto: em produção você normalmente **não pode** sobrescrever o que chegou, porque outra parte do sistema ainda precisa dos valores originais.
 
-Se o problema é orientado a objeto, como o do encontro (e como o LeetCode 303), o pré-processamento vai para o construtor e a consulta fica trivial:
+Se o problema é orientado a objeto (como o LeetCode 303), o pré-processamento vai para o construtor e a consulta fica trivial:
 
 ```python
 class SomaDeIntervalo:
@@ -140,7 +140,7 @@ class SomaDeIntervalo:
         return self.p[j + 1] - self.p[i]
 ```
 
-E se os dados chegam aos poucos, em vez de todos de uma vez? Essa pergunta apareceu no encontro, e a resposta é que a tabela cresce junto com o stream. Não é preciso ter o array inteiro para começar:
+E se os dados chegam aos poucos, em vez de todos de uma vez? A resposta é que a tabela cresce junto com o stream. Não é preciso ter o array inteiro para começar:
 
 ```python
 class SomaEmStream:
@@ -177,7 +177,7 @@ def ponto_de_equilibrio(nums):
     return -1
 ```
 
-Duas passadas O(n) e **O(1) de espaço extra**: é a versão que o entrevistador quer ouvir depois que você mostrou a tabela. É esse o esqueleto do LeetCode 724 (achar o índice pivô) e do 2270 (contar de quantas formas dá para cortar o array), e foi exatamente o que o encontro construiu ao vivo, montando o prefixo primeiro e comparando os dois lados numa segunda varredura.
+Duas passadas O(n) e **O(1) de espaço extra**: é a versão que o entrevistador quer ouvir depois que você mostrou a tabela. É esse o esqueleto do LeetCode 724 (achar o índice pivô) e do 2270 (contar de quantas formas dá para cortar o array), e a construção é sempre a mesma: monte o prefixo primeiro e compare os dois lados numa segunda varredura.
 
 <Callout tipo="aviso">
 Cuidado com quem entra na esquerda. No 724 o próprio `k` **não** conta para nenhum dos lados; no 2270 o corte é entre `k` e `k + 1`, então `k` fica na esquerda. Um deslocamento de uma casa aqui passa nos exemplos do enunciado e falha nos casos de teste escondidos.
@@ -196,7 +196,7 @@ As duas contas se cruzam quando `q × m = n + q`, ou seja, quando `q = n / (m - 
 
 Volte ao número que ficou guardado lá em cima: `n` de 100.000, `q` de 1.000.000 e `m` de 500. A força bruta faz 500.000.000 de operações; o prefixo faz 100.000 + 1.000.000 = 1.100.000. São **mais de 450 vezes menos operações**, pagas com 100.001 inteiros de memória a mais.
 
-E o contrário também é verdade, e foi dito de forma bem direta no encontro: se você vai fazer **uma** consulta só, pegue o intervalo e some. Não monte tabela nenhuma. Prefix Sum é um investimento, e investimento só faz sentido quando existe um "depois".
+E o contrário também é verdade, e vale dizer de forma bem direta: se você vai fazer **uma** consulta só, pegue o intervalo e some. Não monte tabela nenhuma. Prefix Sum é um investimento, e investimento só faz sentido quando existe um "depois".
 
 <PrefixSumTradeoff />
 
@@ -214,7 +214,7 @@ O trade-off tem duas pontas, e a de memória é real. A força bruta gasta O(1) 
 
 ## Prefix Sum ou Sliding Window?
 
-Esse foi o melhor debate do encontro, e ele vale mais que a técnica isolada. O problema da discussão: dado um array e um `k`, achar a **maior média** entre todos os subarrays de `k` elementos (é o LeetCode 643).
+Esse é o melhor debate do assunto, e ele vale mais que a técnica isolada. O problema: dado um array e um `k`, achar a **maior média** entre todos os subarrays de `k` elementos (é o LeetCode 643).
 
 Três soluções, todas corretas:
 
@@ -234,7 +234,7 @@ Montar a tabela e usar `p[i+1] - p[i-k+1]` em cada posição.
 
 A terceira é a janela fixa: soma um elemento pela direita, tira um pela esquerda, e pronto. **O(n)** de tempo e **O(1)** de espaço, que ganha das duas.
 
-O critério que saiu do encontro é o mais útil que existe para escolher entre elas, e cabe em uma pergunta:
+O critério mais útil que existe para escolher entre elas cabe em uma pergunta:
 
 **O acesso é linear ou aleatório?**
 
@@ -269,7 +269,7 @@ Resposta 3, e conferindo na mão: `[1, -1]`, `[1, -1, 0]` e `[0]`. Repare em dua
 
 ## Não é só soma: saldo, estoque e a variação de um período
 
-Um dos melhores momentos do encontro foi quando o exemplo saiu do array de inteiros e virou um caso de negócio. Um empréstimo de 90, pago em seis parcelas:
+A técnica fica mais concreta quando o exemplo sai do array de inteiros e vira um caso de negócio. Um empréstimo de 90, pago em seis parcelas:
 
 | Mês | Parcela paga | Saldo devedor no início do mês |
 | --- | --- | --- |
@@ -369,7 +369,7 @@ A última linha é a saída para o caso que o Prefix Sum não cobre, e vale guar
 
 **Assumir que o array não muda.** Prefix Sum vale para entrada **imutável**. Se `nums[k]` mudar, toda a tabela da posição `k` em diante fica errada e refazer custa O(n). Quando o problema mistura atualizações e consultas, a técnica certa é outra: **Fenwick Tree** (BIT) ou **segment tree**, que fazem as duas coisas em O(log n). O nome do LeetCode 303 entrega isso de propósito: "Range Sum Query, **Immutable**".
 
-**Inicializar a resposta com zero quando há negativos.** Isso aconteceu ao vivo no encontro: no problema da maior média, `melhor = 0` fazia a solução falhar num array com todos os valores negativos, porque nenhuma média conseguia superar o zero. O certo é `float("-inf")`.
+**Inicializar a resposta com zero quando há negativos.** No problema da maior média, `melhor = 0` faz a solução falhar num array com todos os valores negativos, porque nenhuma média consegue superar o zero. O certo é `float("-inf")`.
 
 **Esperar que a tabela seja crescente.** Ela só é crescente se todos os valores forem positivos. Com negativos ela sobe e desce, e isso está certo. Quem depende de a tabela ser ordenada (para fazer busca binária nela, por exemplo) precisa checar essa hipótese antes.
 
@@ -397,12 +397,12 @@ Depois clique em **Sortear** umas cinco vezes e, a cada uma, diga o resultado da
 
 No visualizador da matriz, o exercício é o mesmo com uma pergunta a mais: escolha um retângulo qualquer com dois cliques e responda **quais quatro células da tabela** vão acender, e com que sinal, antes de clicar em Rodar. Se você consegue apontar as quatro, você entendeu inclusão e exclusão.
 
-Depois, os problemas na ordem em que eles constroem a técnica: comece pelo **303**, que é literalmente a classe do encontro; siga para o **724**, o ponto de equilíbrio, que é onde entra o `direita = total - esquerda`; o **643** é onde você vai sentir na pele a diferença entre prefixo e janela; o **2270** é o mesmo par esquerda/direita, agora contando cortes; o **304** fecha a extensão 2D com as quatro leituras; e o **560** é a versão com hash, o pulo do gato para arrays com negativos.
+Depois, os problemas na ordem em que eles constroem a técnica: comece pelo **303**, que é literalmente a classe montada acima; siga para o **724**, o ponto de equilíbrio, que é onde entra o `direita = total - esquerda`; o **643** é onde você vai sentir na pele a diferença entre prefixo e janela; o **2270** é o mesmo par esquerda/direita, agora contando cortes; o **304** fecha a extensão 2D com as quatro leituras; e o **560** é a versão com hash, o pulo do gato para arrays com negativos.
 
 <Callout>
 Uma leitura que ajuda a fixar: os cinco primeiros são o mesmo `p[j+1] - p[i]` vestido de roupas diferentes. Se num deles você travar, volte ao visualizador desta página, monte a entrada do enunciado na mão e veja quais duas células você precisaria ler. Quase sempre o problema não é a técnica, é o índice.
 </Callout>
 
-Uma dica de estudo que saiu no fim do encontro e vale para o roadmap inteiro: se num problema fácil você passar mais de 10 minutos sem sequer identificar a técnica, vá para o editorial e estude a solução. O tempo rende muito mais fechando o buraco de conhecimento do que insistindo. E, de tempos em tempos, refaça um problema fácil de cada técnica só para o padrão continuar fresco na cabeça.
+Uma dica de estudo que vale para o roadmap inteiro: se num problema fácil você passar mais de 10 minutos sem sequer identificar a técnica, vá para o editorial e estude a solução. O tempo rende muito mais fechando o buraco de conhecimento do que insistindo. E, de tempos em tempos, refaça um problema fácil de cada técnica só para o padrão continuar fresco na cabeça.
 
 Daqui, os vizinhos naturais: [Sliding Window](/topico/sliding-window), quando o acesso é linear e dá para economizar memória; [Two Pointers](/topico/two-pointers), o outro jeito de trocar um laço aninhado por uma varredura; [Tabelas Hash](/topico/hash-table), para a versão com negativos; e [Big O](/topico/big-o), se a conta de "quando compensa pré-processar" ainda parecer abstrata. Vale também revisitar [subarray, substring, subsequence e subset](/topico/subarray-substring-subsequence-subset): Prefix Sum só resolve o que é **contíguo**.

--- a/content/topics/recursao-funcional.mdx
+++ b/content/topics/recursao-funcional.mdx
@@ -8,7 +8,7 @@ Antes da recursão de cauda vem uma pergunta mais básica: por que linguagem fun
 
 Numa linguagem mutável, `x = 1` escreve o valor 1 num endereço de memória e `x = 2` volta no **mesmo endereço** e sobrescreve. Numa linguagem imutável, o segundo comando escreve o 2 em **outro endereço**, e o 1 continua lá até o garbage collector perceber que ninguém mais aponta para ele. Nada é alterado: tudo o que parece alteração é uma cópia nova.
 
-No encontro isso apareceu de um jeito que ninguém esquece. Em Elixir, se você cria uma função anônima que imprime `x` quando `x` vale 2, depois reatribui `x = 4` e chama a função de novo, ela ainda imprime **2**: a função ficou apontando para o endereço antigo, que nunca mudou.
+Há um jeito de ver isso que ninguém esquece. Em Elixir, se você cria uma função anônima que imprime `x` quando `x` vale 2, depois reatribui `x = 4` e chama a função de novo, ela ainda imprime **2**: a função ficou apontando para o endereço antigo, que nunca mudou.
 
 A consequência prática é o que interessa aqui. Este laço, que é o pão com manteiga de qualquer linguagem imperativa, simplesmente não existe no mundo funcional:
 
@@ -35,13 +35,13 @@ def dobrar([]), do: []
 def dobrar([head | tail]), do: [head * 2 | dobrar(tail)]
 ```
 
-E não adianta fugir para os módulos prontos. No encontro, o Tiago abriu o código-fonte do `Enum.map` do Elixir, que chama o `lists:map` do Erlang, e lá dentro estava exatamente a mesma coisa: um caso para lista vazia, um caso para `[head | tail]`, e uma chamada recursiva. O `for` do Elixir (que é uma list comprehension, não um laço) desce no mesmo lugar. **Não tem mágica**: o açúcar sintático existe para você não reescrever isso toda vez, mas embaixo é sempre recursão.
+E não adianta fugir para os módulos prontos. Abra o código-fonte do `Enum.map` do Elixir, que chama o `lists:map` do Erlang, e lá dentro está exatamente a mesma coisa: um caso para lista vazia, um caso para `[head | tail]`, e uma chamada recursiva. O `for` do Elixir (que é uma list comprehension, não um laço) desce no mesmo lugar. **Não tem mágica**: o açúcar sintático existe para você não reescrever isso toda vez, mas embaixo é sempre recursão.
 
 O que nos traz ao problema. Se toda travessia é recursão, uma lista de 1 milhão de elementos vira 1 milhão de chamadas empilhadas. A saída não está em evitar a recursão, está na **forma** de escrever a chamada.
 
 ## A pilha que cresce e a conta que espera
 
-Este é o exemplo do encontro, somar os números de uma lista:
+O exemplo canônico é somar os números de uma lista:
 
 ```python
 def soma(nums):
@@ -62,9 +62,9 @@ soma([2, 3, 4])     -> 2 + 7 = 9
 soma([1, 2, 3, 4])  -> 1 + 9 = 10
 ```
 
-O desenho que o Giovani fez na tela durante o encontro explica melhor que qualquer parágrafo: cada chamada é uma caixa **dentro** da anterior. Enquanto a mais interna não termina, todas as de fora continuam vivas, com o escopo delas inteiro na memória, esperando um valor que ainda não existe.
+Um desenho explica melhor que qualquer parágrafo: cada chamada é uma caixa **dentro** da anterior. Enquanto a mais interna não termina, todas as de fora continuam vivas, com o escopo delas inteiro na memória, esperando um valor que ainda não existe.
 
-Isso custa dos dois lados. Como o Nelson resumiu: se empilhar custa 1 e desempilhar custa 1, uma recursão sobre 10 elementos custa 20. Se desse para não empilhar, custaria 10.
+Isso custa dos dois lados: se empilhar custa 1 e desempilhar custa 1, uma recursão sobre 10 elementos custa 20. Se desse para não empilhar, custaria 10.
 
 <Callout tipo="aviso">
 Em Python o teto é baixo e concreto: o limite padrão é de **1.000 chamadas** empilhadas. Uma lista de 1.000 números já derruba a função acima com `RecursionError`. E `sys.setrecursionlimit(100000)` não é conserto, é mudar a parede de lugar: acima de um certo ponto quem estoura é a pilha real do interpretador, e aí o processo morre sem exceção nenhuma.
@@ -85,18 +85,18 @@ return soma(resto, acc + nums[0])   # não sobrou: a conta já aconteceu no argu
 
 A diferença parece cosmética e não é. Na primeira linha, a soma acontece **depois** que a chamada volta, então o frame tem que sobreviver. Na segunda, `acc + nums[0]` é avaliado **antes**, para montar o argumento; quando a chamada acontece, o frame atual já não tem mais nada a fazer no mundo.
 
-Vale separar dois termos que o encontro tratou com cuidado, porque eles são confundidos o tempo todo:
+Vale separar dois termos com cuidado, porque eles são confundidos o tempo todo:
 
 - **Tail call** (chamada de cauda): a última instrução da função é chamar **outra** função.
 - **Tail recursion** (recursão de cauda): a última instrução é chamar **ela mesma**.
 
-Foi pergunta do Giovani no encontro, e a resposta é a que importa: a otimização vale para os dois casos, porque o que ela usa não é o fato de ser recursiva, é o fato de **não sobrar nada para fazer** no frame atual.
+A pergunta natural aqui é se a otimização vale para os dois casos, e a resposta é sim: o que ela usa não é o fato de ser recursiva, é o fato de **não sobrar nada para fazer** no frame atual.
 
 Passeie pelos sete casos do classificador abaixo antes de seguir:
 
 <TailRecursionForma />
 
-Compare o **caso 1** com o **caso 2**: é a mesma função, o mesmo resultado, e o veredito muda por causa de onde a soma está escrita. O **caso 4** é a distinção de nomes na tela: a última instrução chama **outra** função, não a si mesma, e o selo verde continua lá. Olhe o **caso 5**, o fibonacci ingênuo: nem a primeira nem a segunda chamada estão em posição de cauda, porque `fib(n - 1)` tem que voltar para o `+` acontecer. E repare no **caso 6**: um `if` antes não atrapalha nada, o que conta é a última instrução executada em **cada caminho**. Guarde o **caso 7**, ele volta no fim da página como o contraexemplo mais interessante do encontro.
+Compare o **caso 1** com o **caso 2**: é a mesma função, o mesmo resultado, e o veredito muda por causa de onde a soma está escrita. O **caso 4** é a distinção de nomes na tela: a última instrução chama **outra** função, não a si mesma, e o selo verde continua lá. Olhe o **caso 5**, o fibonacci ingênuo: nem a primeira nem a segunda chamada estão em posição de cauda, porque `fib(n - 1)` tem que voltar para o `+` acontecer. E repare no **caso 6**: um `if` antes não atrapalha nada, o que conta é a última instrução executada em **cada caminho**. Guarde o **caso 7**, ele volta no fim da página como o contraexemplo mais interessante do assunto.
 
 ## O acumulador: fazer a conta na ida
 
@@ -185,7 +185,7 @@ Nove contra menos quinze, com a mesma lista. A recursão comum associa **da dire
 
 ### O acumulador não precisa ser um número
 
-Esta foi a parte mais bonita do encontro. O Tiago validou parênteses em Elixir sem escrever um único `if`: o acumulador é uma **pilha**, e cada cláusula da função trata um caso.
+E aqui está a parte mais bonita do assunto: dá para validar parênteses em Elixir sem escrever um único `if`. O acumulador é uma **pilha**, e cada cláusula da função trata um caso.
 
 ```elixir
 def valido?(texto), do: validar(String.graphemes(texto), [])
@@ -206,7 +206,7 @@ Guarde o formato, porque ele é a solução do **Valid Parentheses** do LeetCode
 
 **Tail call optimization** (TCO) é o que o compilador faz quando enxerga uma chamada em posição de cauda: em vez de empilhar um frame novo, ele **reaproveita o frame atual**, trocando só os parâmetros. Na prática, é quase um `goto` para o começo da própria função.
 
-O modelo mental do Giovani no encontro estava certo, e o Tiago só ajustou um detalhe: não é que o frame anterior seja ignorado, é que ele é **substituído**. Como ninguém precisa mais dele (não sobrou conta nenhuma para fazer ali), a linguagem pode escrever a chamada nova por cima.
+Vale ajustar um detalhe do modelo mental mais comum: não é que o frame anterior seja ignorado, é que ele é **substituído**. Como ninguém precisa mais dele (não sobrou conta nenhuma para fazer ali), a linguagem pode escrever a chamada nova por cima.
 
 O efeito é o que a gente viu: a complexidade de espaço cai de O(n) para O(1), e a recursão deixa de ter teto. Uma lista de 1 milhão de elementos passa sem stack overflow, porque o número de frames nunca muda.
 
@@ -292,17 +292,17 @@ Não é de graça: cada salto aloca uma closure, o que deixa o trampolim mais le
 
 ## De cauda nem sempre é mais rápido
 
-A pergunta que o Tiago deixou em aberto no fim do encontro é a melhor parte do assunto: recursão de cauda é **sempre** mais rápida? Não.
+A pergunta que fica em aberto no fim é a melhor parte do assunto: recursão de cauda é **sempre** mais rápida? Não.
 
-Volte ao **caso 7** do classificador, dobrar os valores de uma lista. A versão de cauda existe: o acumulador é a lista nova. Só que, ao ir consumindo `head` e colocando o resultado na frente do acumulador, ela monta a lista **ao contrário**: `[1, 2, 3, 4]` sai como `[8, 6, 4, 2]`. Para devolver na ordem certa, precisa de um `reverse` no fim, ou seja, **uma passada extra sobre a lista inteira**. No benchmark do encontro, essa versão de cauda ficou mais lenta que a recursão comum, que já constrói na ordem certa na volta.
+Volte ao **caso 7** do classificador, dobrar os valores de uma lista. A versão de cauda existe: o acumulador é a lista nova. Só que, ao ir consumindo `head` e colocando o resultado na frente do acumulador, ela monta a lista **ao contrário**: `[1, 2, 3, 4]` sai como `[8, 6, 4, 2]`. Para devolver na ordem certa, precisa de um `reverse` no fim, ou seja, **uma passada extra sobre a lista inteira**. Num benchmark simples, essa versão de cauda fica mais lenta que a recursão comum, que já constrói na ordem certa na volta.
 
-E mesmo onde a de cauda ganha, o ganho pode ser modesto. Somando uma lista de 1.000 números, a versão comum ficou só **1,14 vez mais lenta** que a de cauda no encontro. Não é a diferença que o folclore promete.
+E mesmo onde a de cauda ganha, o ganho pode ser modesto. Somando uma lista de 1.000 números, a versão comum fica só **1,14 vez mais lenta** que a de cauda. Não é a diferença que o folclore promete.
 
 <Callout tipo="aviso">
 Cuidado com a leitura do benchmark do fibonacci, onde a diferença foi de **436 vezes**. Ela não veio da otimização de pilha: veio da **complexidade**. A versão ingênua é O(2ⁿ) e a de acumulador é O(n). Trocar 2.692.537 chamadas por 31 explica tudo sozinho, TCO ou não.
 </Callout>
 
-A regra prática que saiu do encontro é boa o bastante para decidir no dia a dia:
+A regra prática é boa o bastante para decidir no dia a dia:
 
 <Colunas>
 <Cartao titulo="Prefira a de cauda quando...">
@@ -313,7 +313,7 @@ Você está fazendo um **map** sobre uma lista ligada e precisa preservar a orde
 </Cartao>
 </Colunas>
 
-Isso não é opinião de comunidade: o guia de eficiência do Erlang lista "funções de cauda são muito mais rápidas que funções recursivas comuns" na seção **Myths of Erlang Performance**, ao lado de outros mitos clássicos como "list comprehension é lenta" e "string é lenta".
+Isso não é opinião solta: o guia de eficiência do Erlang lista "funções de cauda são muito mais rápidas que funções recursivas comuns" na seção **Myths of Erlang Performance**, ao lado de outros mitos clássicos como "list comprehension é lenta" e "string é lenta".
 
 O que a recursão de cauda garante mesmo é **memória**: O(1) de pilha, sem teto de profundidade. Velocidade é outra conversa, e essa se mede.
 
@@ -325,7 +325,7 @@ O que a recursão de cauda garante mesmo é **memória**: O(1) de pilha, sem tet
 
 **Acumulador com valor inicial errado.** É 0 para soma, 1 para produto, `[]` para lista. Para máximo, **não use 0**: com uma lista de negativos a resposta sai errada. Comece com o primeiro elemento (e trate a lista vazia como caso separado).
 
-**A ordem das cláusulas importa.** Em Elixir, se a cláusula genérica vier antes da específica, ela engole tudo e as de baixo nunca rodam. Vá do mais específico para o mais genérico. E, como o Giovani perguntou no encontro, faltar uma cláusula não é erro de compilação: aparece só em produção, como `FunctionClauseError`, quando chega o valor que ninguém previu.
+**A ordem das cláusulas importa.** Em Elixir, se a cláusula genérica vier antes da específica, ela engole tudo e as de baixo nunca rodam. Vá do mais específico para o mais genérico. E vale a pergunta que quase todo mundo faz na primeira vez: faltar uma cláusula não é erro de compilação, aparece só em produção, como `FunctionClauseError`, quando chega o valor que ninguém previu.
 
 **Confundir os dois nomes.** Tail call é a última instrução ser uma chamada, qualquer chamada. Tail recursion é o caso particular em que essa chamada é para a própria função. TCO é o que a linguagem faz com qualquer um dos dois.
 

--- a/content/topics/recursao.mdx
+++ b/content/topics/recursao.mdx
@@ -103,7 +103,7 @@ Esse pico de frames é a resposta para uma pergunta que costuma cair em entrevis
 
 A pilha não é infinita, e isso é de propósito. Se ela crescesse enquanto houvesse memória, um programa com recursão descontrolada roubaria memória dos outros processos e do sistema operacional. A linguagem corta antes: em CPython o limite padrão é **1000 níveis**, e passar disso levanta `RecursionError: maximum recursion depth exceeded`.
 
-No encontro a galera rodou um Tribonacci recursivo ao vivo só para ver quebrar, e o estouro veio por volta da chamada 996, porque o interpretador já usa alguns frames antes do seu código começar.
+Rode um Tribonacci recursivo só para ver quebrar: o estouro vem por volta da chamada 996, porque o interpretador já usa alguns frames antes do seu código começar.
 
 O visualizador acima tem um campo **limite da pilha** justamente para isso. Escolha o preset **fatorial(10) com limite 6**: o código está correto, o caso base existe, e mesmo assim estoura. A causa não é bug de lógica, é profundidade demais.
 
@@ -142,7 +142,7 @@ O código é lindo, tem exatamente a mesma forma da definição matemática, e �
 
 Comece pelo preset **fib(4): a primeira subárvore refeita** e avance passo a passo. São 9 chamadas para um resultado que vale 3, e você vê o `fib(2)` amarelo aparecendo pela segunda vez, agora tendo que expandir os dois filhos de novo. Depois vá para **fib(6): 25 chamadas** e rode até o fim: a árvore fica quase toda amarela, porque quase tudo ali é recálculo. Por último, **fib(8): o retrabalho fica óbvio**, com 67 chamadas e 58 delas repetidas.
 
-Agora a conta que ficou em aberto no encontro. Alguém perguntou se O(2ⁿ) é literalmente o número de chamadas: com `n = 13`, seriam 2¹³ = 8.192 chamadas? A resposta curta é não, e dá para ser exato. Contando as chamadas de `fib(n)` ingênuo:
+Agora a conta que costuma ficar em aberto. Uma pergunta natural é se O(2ⁿ) é literalmente o número de chamadas: com `n = 13`, seriam 2¹³ = 8.192 chamadas? A resposta curta é não, e dá para ser exato. Contando as chamadas de `fib(n)` ingênuo:
 
 ```
 T(0) = T(1) = 1
@@ -319,7 +319,7 @@ Não é a posição da palavra `fatorial` na linha que muda a classificação, �
 
 Volte ao visualizador da pilha e escolha o preset **fatorial(5) em cauda**. Compare com o clássico: os frames somem no mesmo ritmo, o número de chamadas é o mesmo, o pico de frames é o mesmo. **Em Python a recursão de cauda não economiza um byte.** Ela só carrega o rótulo "nada pendente", e é esse rótulo que uma linguagem com *tail call optimization* aproveita para reaproveitar o frame em vez de empilhar um novo, transformando a recursão em iteração no compilador. Linguagens funcionais tratam isso como básico; Python, Java e C# não fazem.
 
-Esse é o assunto do encontro seguinte, e ele tem página própria: [Recursão em Programação Funcional](/topico/recursao-funcional).
+Esse é o assunto do tópico seguinte, e ele tem página própria: [Recursão em Programação Funcional](/topico/recursao-funcional).
 
 ### Recursão estrutural: lista, árvore e JSON são o mesmo código
 
@@ -476,6 +476,6 @@ Duas coisas para não errar: `nova_cabeca` atravessa a subida inteira sem mudar 
 
 **Pow(x, n) (50).** Fecha o ciclo com o pulo de O(n) para O(log n). Os três detalhes que fazem falhar: expoente zero, expoente negativo, e a chamada duplicada na mesma linha. Guarde a metade numa variável.
 
-Uma dica de ritmo que a comunidade usa: em problema Fácil, se em 10 minutos você não achou a sacada, vá para as dicas e o editorial. Ficar uma hora travado não treina nada; ler a solução, fechar e reescrever do zero no dia seguinte treina muito.
+Uma dica de ritmo que funciona: em problema Fácil, se em 10 minutos você não achou a sacada, vá para as dicas e o editorial. Ficar uma hora travado não treina nada; ler a solução, fechar e reescrever do zero no dia seguinte treina muito.
 
 Quando estes estiverem confortáveis, os próximos passos naturais são [Recursão em Programação Funcional](/topico/recursao-funcional), para entender a otimização de cauda de verdade, e [Percursos em Árvore](/topico/tree-traversals), onde a recursão deixa de ser exercício e vira ferramenta de trabalho.

--- a/content/topics/skip-list.mdx
+++ b/content/topics/skip-list.mdx
@@ -8,7 +8,7 @@ Antes de entender por que a skip list existe, vale olhar o que ela veio conserta
 
 O **array ordenado** é imbatível para ler: com o índice em mãos, `nums[i]` custa O(1), e a [busca binária](/topico/busca-binaria) acha qualquer valor em O(log n). O buraco aparece na hora de mexer. Como o array ocupa posições contíguas na memória, remover o elemento da posição 500 de um array de 1.000 obriga os 499 seguintes a andarem uma casa para trás. Inserir é a mesma coisa ao contrário. Sempre O(n).
 
-**Um parêntese honesto**, porque ele veio da própria galera no encontro: aquele O(1) do array é acesso **por índice**. Se você tem só o valor e precisa descobrir onde ele está, o array não te dá nada de graça, é O(n) igual à lista, ou O(log n) se ele estiver ordenado. Comparar "array O(1)" com "lista O(n)" sem esse detalhe é comparar coisas diferentes. Para busca por chave em O(1) o caminho é outro, é a [tabela hash](/topico/hash-table), que em compensação não guarda ordem nenhuma.
+**Um parêntese honesto**, antes de seguir: aquele O(1) do array é acesso **por índice**. Se você tem só o valor e precisa descobrir onde ele está, o array não te dá nada de graça, é O(n) igual à lista, ou O(log n) se ele estiver ordenado. Comparar "array O(1)" com "lista O(n)" sem esse detalhe é comparar coisas diferentes. Para busca por chave em O(1) o caminho é outro, é a [tabela hash](/topico/hash-table), que em compensação não guarda ordem nenhuma.
 
 A **[lista encadeada](/topico/listas-ligadas)** inverte o jogo. Como cada nó vive por conta própria na memória e só guarda um ponteiro para o vizinho, remover é trocar duas setas de lugar: O(1), sem deslocar massa nenhuma. O buraco é chegar lá. Para acessar o elemento 536 você passa pelos 535 anteriores, um por um. E, o mais importante para este tópico: **não existe busca binária em lista encadeada**. Busca binária precisa pular direto para o meio, e numa lista o meio só existe depois de n/2 passos. O ganho evapora.
 
@@ -47,7 +47,7 @@ class No:
         self.forward = [None] * altura   # um ponteiro por nível em que ele vive
 ```
 
-Repare no que **não** está aí: não existe ponteiro para o nó anterior, nem ponteiro para o nível de baixo. Descer um nível é só trocar o índice de `forward` no **mesmo** nó. Foi a dúvida que mais rendeu no encontro, e ela fecha quando você percebe que o `i` do laço é o **nível**, não a posição.
+Repare no que **não** está aí: não existe ponteiro para o nó anterior, nem ponteiro para o nível de baixo. Descer um nível é só trocar o índice de `forward` no **mesmo** nó. É a dúvida que mais rende aqui, e ela fecha quando você percebe que o `i` do laço é o **nível**, não a posição.
 
 ## A busca: começa no topo e desce em escada
 
@@ -122,7 +122,7 @@ Isso tem uma consequência que surpreende: a skip list **não é determinística
 
 Inserir tem um detalhe que a busca não tem. Para religar os ponteiros, você precisa saber **quem era o vizinho da esquerda do novo nó em cada nível**, e não só no nível 0. A boa notícia é que a busca já passa por todos eles: toda vez que ela desce um degrau, o nó onde ela estava é exatamente o candidato daquele nível.
 
-Basta anotar. É o vetor `update`, que a galera do encontro apelidou de *bread crumb*: um rastro com **um candidato por nível**, na volta.
+Basta anotar. É o vetor `update`, o *bread crumb*: um rastro com **um candidato por nível**, na volta.
 
 <SkipListInsercao />
 
@@ -233,7 +233,7 @@ custo = math.log(n, 1 / p) / p + 1 / (1 - p)
 
 Com n = 1.048.576 e p = 0,5 isso dá `20 / 0,5 + 2 = 42`. As duas parcelas contam histórias diferentes: a primeira é a **altura**, e ela é log n; a segunda é a **largura**, quantos passos horizontais você dá antes de cair um degrau, e ela é constante. Aumentar p faz a torre crescer (mais níveis para descer) e a caminhada encurtar (menos passos horizontais antes de cair um degrau). É esse cabo de guerra que a próxima experiência mede.
 
-Agora faça a experiência que o encontro não fez. Troque o **p para 0,25** com n = 1.024 e compare os quatro cartões:
+Agora faça a experiência que quase ninguém faz. Troque o **p para 0,25** com n = 1.024 e compare os quatro cartões:
 
 | p | Níveis | Comparações na busca | Ponteiros no total |
 | --- | --- | --- | --- |
@@ -266,7 +266,7 @@ O `k` da consulta por faixa é a quantidade de elementos devolvidos, e é ele qu
 
 ## Skip List na vida real
 
-O tema entrou na pauta da comunidade por causa de um capítulo de system design sobre **leaderboards**, e não por acaso.
+O tema costuma entrar pela porta do system design, num capítulo sobre **leaderboards**, e não por acaso.
 
 Pense num ranking de milhões de jogadores. Você precisa de quatro coisas ao mesmo tempo: manter tudo ordenado por pontuação, achar um jogador específico rápido, mover um jogador que acabou de pular da posição 4.756 para a terceira, e responder "quais são os 10 jogadores em volta de mim". Um array ordenado morre no terceiro requisito, porque mover um jogador desloca milhares de posições. Uma tabela hash morre no primeiro e no quarto, porque não guarda ordem. A skip list entrega os quatro, e o quarto quase de graça: depois de achar o jogador, os vizinhos são só andar para a frente no nível 0.
 
@@ -309,7 +309,7 @@ O preço é honesto: toda inserção e toda remoção precisam **corrigir os spa
 
 **Com dataset pequeno, não compensa.** Uma skip list de 12 elementos gasta o dobro de ponteiros de uma lista comum para economizar quatro comparações. Ordenar ou varrer um punhado de itens é instantâneo com qualquer coisa. Esta estrutura faz sentido em escala, quando o log n de fato separa você do n.
 
-**O `i` do laço é o nível, não a posição.** Foi a dúvida que mais tomou tempo do encontro, e ela derruba quem lê o código rápido demais. `for nivel in range(self.nivel_max, -1, -1)` não percorre elementos, percorre **andares**, e o `while` de dentro é que anda para os lados. Quem lê `atual.forward[nivel]` como "o elemento na posição nivel" trava e não desatola.
+**O `i` do laço é o nível, não a posição.** É a dúvida que mais toma tempo, e ela derruba quem lê o código rápido demais. `for nivel in range(self.nivel_max, -1, -1)` não percorre elementos, percorre **andares**, e o `while` de dentro é que anda para os lados. Quem lê `atual.forward[nivel]` como "o elemento na posição nivel" trava e não desatola.
 
 **Não pare no nível em que encontrou.** É tentador testar a igualdade dentro do laço e sair correndo quando o valor bate num nível alto. Funciona, mas dobra o número de comparações no caminho todo para economizar num caso raro, e enche o código de saídas. O `buscar` deste artigo desce **sempre** até o nível 0 e testa a igualdade uma vez só, no fim. Simplicidade é o produto que a skip list vende.
 

--- a/content/topics/sliding-window.mdx
+++ b/content/topics/sliding-window.mdx
@@ -148,7 +148,7 @@ O enunciado fala de **subsequence, subset ou permutação**. Esses não exigem a
 
 Se você ficou em dúvida entre os termos, vale a leitura de [Subarray, Substring, Subsequence e Subset](/topico/subarray-substring-subsequence-subset), que separa os quatro com exemplos.
 
-Há também uma distinção fina, que veio de uma observação do Giovani no encontro, e que arruma a cabeça de vez:
+Há também uma distinção fina que arruma a cabeça de vez:
 
 <Callout>
 **Janela deslizante se importa com tudo que está dentro dela. [Two Pointers](/topico/two-pointers) só se importa com onde os ponteiros estão.**
@@ -179,7 +179,7 @@ Esse raciocínio tem nome: **análise amortizada**. Um passo isolado pode custar
 
 **Números negativos quebram a janela variável.** Toda a lógica depende de "encolher pela esquerda só melhora". Com valores negativos, remover um elemento pode **aumentar** a soma, e uma janela maior pode ter soma menor que uma pequena. O `while` deixa de fazer sentido, porque encolher não garante voltar a ser válida. Nesse caso o caminho costuma ser [Prefix Sum](/topico/prefix-sum) com hashmap.
 
-**Não ordene o array.** É a armadilha que o Eduardo levantou no encontro: ordenar destrói a adjacência, e subarray é definido por adjacência. Depois do `sort`, o pedaço que você achou não existe mais no array original. Ordenar é livre em problema de **subset**; é proibido em problema de **subarray**.
+**Não ordene o array.** É a armadilha mais cara desta técnica: ordenar destrói a adjacência, e subarray é definido por adjacência. Depois do `sort`, o pedaço que você achou não existe mais no array original. Ordenar é livre em problema de **subset**; é proibido em problema de **subarray**.
 
 **A resposta atualizada no lugar errado.** Para "a maior janela válida", atualize depois do `while`. Para "a menor janela válida", atualize dentro. Trocar os dois dá um resultado plausível e errado, do tipo que passa nos exemplos do enunciado e falha no caso 47.
 

--- a/content/topics/strings.mdx
+++ b/content/topics/strings.mdx
@@ -60,7 +60,7 @@ O array de 26 só vale quando o enunciado **garante** `a-z`. Se entrar maiúscul
 
 Comece pelo caso simples. Em **ASCII** cada caractere ocupa 1 byte e existem 128 deles, o que cobre o alfabeto inglês, os dígitos e a pontuação. `"CCC"` são 3 bytes, e ponto.
 
-Agora rode a mesma string nos outros encodings. No visualizador abaixo, o padrão já é `CCC`: repare que ASCII e UTF-8 dão 3 bytes, UTF-16 dá **6** e UTF-32 dá **12**. É exatamente o que o `Encoding.ASCII.GetBytes`, o `Encoding.Unicode.GetBytes` e o `Encoding.UTF32.GetBytes` devolveram no encontro.
+Agora rode a mesma string nos outros encodings. No visualizador abaixo, o padrão já é `CCC`: repare que ASCII e UTF-8 dão 3 bytes, UTF-16 dá **6** e UTF-32 dá **12**. É exatamente o que o `Encoding.ASCII.GetBytes`, o `Encoding.Unicode.GetBytes` e o `Encoding.UTF32.GetBytes` devolvem em C#.
 
 <StringsBytesVisualizer />
 
@@ -78,7 +78,7 @@ Clique nos exemplos, um por um, e acompanhe os quatro contadores de cima:
 | joia | 1 | 2 | 4 |
 | família | 7 | 11 | 25 |
 
-O emoji da família é o exemplo que apareceu no encontro e vale guardar: em C#, `"👨‍👩‍👧‍👦".Length` devolve **11**, porque `Length` conta unidades UTF-16. `new StringInfo(s).LengthInTextElements` devolve **1**, porque conta o que a pessoa vê. No Python, `len` devolve **7**, porque conta code points. Nenhum dos três está errado, eles respondem a perguntas diferentes.
+O emoji da família é o exemplo que vale guardar: em C#, `"👨‍👩‍👧‍👦".Length` devolve **11**, porque `Length` conta unidades UTF-16. `new StringInfo(s).LengthInTextElements` devolve **1**, porque conta o que a pessoa vê. No Python, `len` devolve **7**, porque conta code points. Nenhum dos três está errado, eles respondem a perguntas diferentes.
 
 <Callout tipo="aviso">
 Isso deixa de ser curiosidade no dia em que você trunca um texto para caber num limite. Cortar por bytes parte um caractere no meio e produz aquele losango com interrogação. Cortar por code point desmonta a família em pedaços. Para "os primeiros 20 caracteres que a pessoa vê", o corte tem que ser por **grafema**, e isso quase sempre pede biblioteca (ICU, `Intl.Segmenter`, `StringInfo`, o pacote `regex` do Python).
@@ -111,7 +111,7 @@ Nada foi acrescentado ao fim de `"CCC"`, tanto que `t` não mudou. O runtime alo
 
 ## O laço que concatena, e o O(n²) escondido
 
-Concatenar duas strings de tamanhos n e m custa **O(n + m)** em tempo e em espaço: aloca uma string nova de n + m e copia as duas para dentro dela. No encontro a gente abriu o código do `String.Concat` do .NET e é literalmente isso: mede os dois tamanhos, aloca o total, copia a primeira, copia a segunda depois dela, devolve a nova.
+Concatenar duas strings de tamanhos n e m custa **O(n + m)** em tempo e em espaço: aloca uma string nova de n + m e copia as duas para dentro dela. O código do `String.Concat` do .NET é literalmente isso: mede os dois tamanhos, aloca o total, copia a primeira, copia a segunda depois dela, devolve a nova.
 
 O problema não é uma concatenação. É esta:
 
@@ -140,7 +140,7 @@ Use os atalhos abaixo do campo (`CCC`, `CRAFTCODE`, `CRAFTCODECLUB`, `entrada va
 | 1.000 | 500.500 | 1.000 |
 | 10.000 | 50.005.000 | 10.000 |
 
-Com 10 mil caracteres, o laço ingênuo copia **5.000 vezes** mais do que o necessário. E o custo não para no tempo: cada volta joga uma string inteira no lixo. Num benchmark que a galera trouxe no encontro, a mesma montagem levava **25 segundos** com concatenação e ficava colada no zero com o builder.
+Com 10 mil caracteres, o laço ingênuo copia **5.000 vezes** mais do que o necessário. E o custo não para no tempo: cada volta joga uma string inteira no lixo. Num benchmark simples, a mesma montagem leva **25 segundos** com concatenação e fica colada no zero com o builder.
 
 <Callout tipo="aviso">
 Esse padrão raramente aparece com um nome tão óbvio quanto `s = s + c`. Ele se disfarça de `csv += linha + "\n"` montando um relatório, de `sql += " AND " + filtro` montando uma query, de `mensagem += erro + "; "` juntando erros de validação. É a mesma armadilha com outra roupa.
@@ -175,7 +175,7 @@ Duas finezas que valem saber:
 
 **Diga a capacidade quando você souber.** `new StringBuilder(4096)` ou `builder.Grow(n)` evitam a série de realocações do buffer interno. É o mesmo raciocínio de já criar a lista com o tamanho certo, e a diferença aparece quando o volume é grande.
 
-**O builder não é grátis, ele é amortizado.** No `ToString()` ainda existe uma alocação do tamanho final e uma cópia de todos os caracteres. Trocar duas concatenações por um builder não ganha nada, e ainda deixa o código mais feio. Para juntar dois ou três pedaços, use interpolação: `f"{nome} tem {idade} anos"` no Python, `$"..."` no C#. No .NET, o compilador transforma a interpolação num handler que já monta a string de uma vez só, e no encontro deu para ver isso no código intermediário gerado.
+**O builder não é grátis, ele é amortizado.** No `ToString()` ainda existe uma alocação do tamanho final e uma cópia de todos os caracteres. Trocar duas concatenações por um builder não ganha nada, e ainda deixa o código mais feio. Para juntar dois ou três pedaços, use interpolação: `f"{nome} tem {idade} anos"` no Python, `$"..."` no C#. No .NET, o compilador transforma a interpolação num handler que já monta a string de uma vez só, e dá para ver isso no código intermediário gerado.
 
 ### Quando a saída é mais de uma string ao mesmo tempo
 
@@ -255,7 +255,7 @@ def eh_palindromo(s):
 
 Repare no que ficou de fora: nenhum `s[::-1]`, nenhum `s[e:d]`, nenhuma alocação. Cada comparação lê memória que já existe. Escrever `s == s[::-1]` dá a mesma resposta e aloca uma string inteira para isso. É o [Two Pointers](/topico/two-pointers) aplicado a texto, e é por isso que os dois tópicos andam colados.
 
-Esta é a tabela que junta tudo. Ela é a comparação que abriu o encontro, entre o que um array de caracteres faz e o que uma string imutável faz:
+Esta é a tabela que junta tudo. Ela compara o que um array de caracteres faz e o que uma string imutável faz:
 
 | Operação | Lista de caracteres | String imutável | Por quê |
 | --- | --- | --- | --- |
@@ -270,7 +270,7 @@ Repare na linha de comparação: **comparar duas strings não é O(1)**. Ela par
 
 ## Rotate String: da força bruta ao truque de uma linha
 
-O [LeetCode 796](https://leetcode.com/problems/rotate-string/) foi o problema que a gente resolveu no encontro, e ele existe para castigar exatamente o hábito de concatenar em laço. Um *shift* pega o caractere mais à esquerda e joga para a direita: `abcde` vira `bcdea`. Dado `s` e `goal`, responda se dá para chegar em `goal` fazendo shifts em `s`.
+O [LeetCode 796](https://leetcode.com/problems/rotate-string/) existe para castigar exatamente o hábito de concatenar em laço. Um *shift* pega o caractere mais à esquerda e joga para a direita: `abcde` vira `bcdea`. Dado `s` e `goal`, responda se dá para chegar em `goal` fazendo shifts em `s`.
 
 A primeira solução que vem à cabeça é rotacionar e comparar, até dar a volta completa:
 
@@ -287,7 +287,7 @@ def rotate_string(s, goal):
 
 Aquele `s[1:]` já é uma string nova com n-1 caracteres copiados, e a concatenação aloca mais uma, de n. São `2n - 1` cópias por rotação e até n rotações: **n(2n - 1)** cópias no pior caso, que é O(n²).
 
-A primeira melhora, e a que apareceu no encontro antes de alguém lembrar do truque, é aplicar o que a seção anterior ensinou: pare de materializar a string em toda volta. Gire na lista de caracteres e só monte a string na hora de comparar.
+A primeira melhora, antes de lembrar do truque, é aplicar o que a seção anterior ensinou: pare de materializar a string em toda volta. Gire na lista de caracteres e só monte a string na hora de comparar.
 
 ```python
 def rotate_string(s, goal):
@@ -301,7 +301,7 @@ def rotate_string(s, goal):
     return False
 ```
 
-Continua **O(n²)**, e vale entender por quê: o `join` custa O(n) por volta, a comparação custa O(n) por volta, e até o `pop(0)` custa O(n), porque desloca a lista inteira uma casa para a esquerda. O que muda é a **pressão de memória**: uma string nova por rotação em vez de duas, e o shift virou movimentação de ponteiros dentro de um buffer que já existe. É a versão que o encontro chamou de "já ganha muito numa entrevista", porque mostra que você enxergou a alocação.
+Continua **O(n²)**, e vale entender por quê: o `join` custa O(n) por volta, a comparação custa O(n) por volta, e até o `pop(0)` custa O(n), porque desloca a lista inteira uma casa para a esquerda. O que muda é a **pressão de memória**: uma string nova por rotação em vez de duas, e o shift virou movimentação de ponteiros dentro de um buffer que já existe. É a versão que já ganha muito numa entrevista, porque mostra que você enxergou a alocação.
 
 O truque é perceber que **todas as rotações de `s` já moram dentro de `s + s`**. Com `abcde`, o dobrado é `abcdeabcde`, e ali dentro estão `abcde`, `bcdea`, `cdeab`, `deabc` e `eabcd`, cada uma começando numa posição:
 
@@ -342,9 +342,9 @@ São até `n - m + 1` pontos de partida e até m comparações em cada um: **O(n
 
 KMP e rolling hash existem justamente para derrubar isso para **O(n + m)**, reaproveitando o que a tentativa anterior já provou em vez de recomeçar do zero. É a mesma ideia da [Sliding Window](/topico/sliding-window): não recalcular o que já foi calculado.
 
-E fica o recado honesto que apareceu no encontro: o truque do `s + s` é bem característico deste problema, difícil de inventar do zero na hora. Numa entrevista, a versão com a lista de caracteres, que já mostra preocupação com alocação, e o teste de tamanho no começo, que descarta o caso impossível de graça, já contam muito a seu favor.
+E fica o recado honesto: o truque do `s + s` é bem característico deste problema, difícil de inventar do zero na hora. Numa entrevista, a versão com a lista de caracteres, que já mostra preocupação com alocação, e o teste de tamanho no começo, que descarta o caso impossível de graça, já contam muito a seu favor.
 
-Curiosidade que também saiu no encontro: esse deslocamento circular do alfabeto é a **cifra de César**, a primeira criptografia registrada, que empurrava cada letra três casas para a direita. Ela funcionava não por ser forte, mas porque quase ninguém sabia ler e ninguém tinha máquina para testar os 25 deslocamentos possíveis. Hoje o seu laço testa todos eles em microssegundos, e é exatamente isso que este problema pede.
+Uma curiosidade: esse deslocamento circular do alfabeto é a **cifra de César**, a primeira criptografia registrada, que empurrava cada letra três casas para a direita. Ela funcionava não por ser forte, mas porque quase ninguém sabia ler e ninguém tinha máquina para testar os 25 deslocamentos possíveis. Hoje o seu laço testa todos eles em microssegundos, e é exatamente isso que este problema pede.
 
 ## As armadilhas que pegam todo mundo
 
@@ -354,7 +354,7 @@ Curiosidade que também saiu no encontro: esse deslocamento circular do alfabeto
 
 **Comparar não é uma operação.** `a == b` é O(n). Comparar dentro de um laço que também é O(n) dá O(n²), mesmo sem nenhuma concatenação à vista.
 
-**Assumir ASCII.** O código funciona na sua máquina, com nomes em inglês, e quebra com `João`, com chinês tradicional ou com um emoji no campo de nome. Misturar bytes de encodings diferentes é como concatenar dois arrays com tipos diferentes: o tamanho até fecha, o conteúdo vira lixo. Foi o caso real que apareceu no encontro, uma integração com uma transportadora de Taiwan em que tudo chega em chinês tradicional: se você trata os bytes como se fossem do seu encoding, o texto sai embaralhado e o bug só aparece em produção.
+**Assumir ASCII.** O código funciona na sua máquina, com nomes em inglês, e quebra com `João`, com chinês tradicional ou com um emoji no campo de nome. Misturar bytes de encodings diferentes é como concatenar dois arrays com tipos diferentes: o tamanho até fecha, o conteúdo vira lixo. É o caso real de uma integração com uma transportadora de Taiwan em que tudo chega em chinês tradicional: se você trata os bytes como se fossem do seu encoding, o texto sai embaralhado e o bug só aparece em produção.
 
 **`á` pode não ser igual a `á`.** O Unicode deixa escrever o mesmo caractere de dois jeitos: um code point só (`á` = U+00E1, a forma NFC) ou a letra mais um acento combinante (`a` + U+0301, a forma NFD). Os dois desenham exatamente a mesma coisa na tela, e `==` diz que são diferentes, porque compara code point a code point. Antes de comparar, ordenar, deduplicar ou usar texto como chave, **normalize**: `unicodedata.normalize("NFC", s)` no Python, `s.Normalize()` no C#, `s.normalize("NFC")` no JavaScript. É o bug clássico de um nome digitado no macOS não bater com o mesmo nome vindo do Windows.
 
@@ -394,7 +394,7 @@ A lista de problemas logo abaixo está na ordem de resolver, do mais direto ao m
 
 - **Reverse String**: os dois índices trocando no array de caracteres, com O(1) de espaço extra. Se você usar `s[::-1]` ou `reversed()`, resolveu o exercício e perdeu a aula.
 - **Valid Anagram**: o contador de frequência da primeira seção. Resolva com o array de 26 e depois responda: o que muda se a entrada puder ter acento ou emoji?
-- **Rotate String**: o problema do encontro. Escreva as três versões (laço ingênuo, lista de caracteres, `goal in s + s`) e compare os contadores no visualizador acima antes de olhar o editorial.
+- **Rotate String**: o problema desta página. Escreva as três versões (laço ingênuo, lista de caracteres, `goal in s + s`) e compare os contadores no visualizador acima antes de olhar o editorial.
 - **Find the Index of the First Occurrence**: implemente a busca ingênua na mão, com o `range(n - m + 1)` certo, em vez de chamar `find`. É o pré-requisito para entender KMP depois.
 - **Zigzag Conversion**: o padrão de k builders da seção do builder, mais o `k == 1` que quase todo mundo esquece.
 - **Longest Palindromic Substring**: junta tudo. A saída ingênua é gerar todas as substrings e testar cada uma, O(n³). O caminho bom é **expandir a partir do centro**: cada posição é um centro em potencial, e você abre para os dois lados enquanto os caracteres baterem.

--- a/content/topics/two-pointers.mdx
+++ b/content/topics/two-pointers.mdx
@@ -4,7 +4,7 @@ Two Pointers é o primeiro truque que transforma um O(n²) em O(n) **sem gastar 
 
 ## Uma técnica, não um algoritmo
 
-Vale começar pela distinção que apareceu no encontro, porque ela muda o jeito de estudar o assunto. Um **algoritmo** é uma sequência definida de passos: o Bubble Sort é sempre o Bubble Sort, o Merge Sort é sempre o Merge Sort. Two Pointers não é isso, e também não é uma estrutura de dados, porque não diz nada sobre como os dados ficam organizados na memória. É uma **técnica**: um jeito de abordar o problema, que aparece com formatos bem diferentes dependendo do que você precisa responder.
+Vale começar por uma distinção que muda o jeito de estudar o assunto. Um **algoritmo** é uma sequência definida de passos: o Bubble Sort é sempre o Bubble Sort, o Merge Sort é sempre o Merge Sort. Two Pointers não é isso, e também não é uma estrutura de dados, porque não diz nada sobre como os dados ficam organizados na memória. É uma **técnica**: um jeito de abordar o problema, que aparece com formatos bem diferentes dependendo do que você precisa responder.
 
 A definição é curta: você mantém **dois índices apontando para posições diferentes** e move cada um segundo uma regra que depende do que está lendo. O ganho vem sempre da mesma coisa: **a cada passo você elimina possibilidades sem precisar testá-las**.
 
@@ -29,7 +29,7 @@ Em entrevista, **diga o nome da especialização**. Sliding Window é Two Pointe
 
 ## O que custa testar todos os pares
 
-O problema motivador é o mesmo do encontro: dado um array **ordenado** e um `alvo`, existem dois números que somam o alvo?
+O problema motivador é o clássico: dado um array **ordenado** e um `alvo`, existem dois números que somam o alvo?
 
 A primeira solução que vem à cabeça testa todo mundo com todo mundo:
 
@@ -60,7 +60,7 @@ A regra cabe em três linhas. Um ponteiro na primeira posição, outro na últim
 - Soma **menor** que o alvo: o único jeito de aumentar é trocar o número pequeno por um maior, então **avance a esquerda**.
 - Soma **igual** ao alvo: achou, pode devolver.
 
-Com o array do encontro, `[1, 2, 3, 6, 8, 10, 20, 21]` e alvo 16, a busca inteira cabe em seis somas:
+Com o array `[1, 2, 3, 6, 8, 10, 20, 21]` e alvo 16, a busca inteira cabe em seis somas:
 
 | Passo | Conta | Soma | Decisão |
 | --- | --- | --- | --- |
@@ -113,12 +113,12 @@ Cada passo elimina uma **linha ou uma coluna inteira** da tabela de pares, e nã
 Esse mesmo raciocínio explica por que a ordenação é obrigatória. Num array desordenado, "a soma ficou grande" não diz **qual** dos dois lados é o culpado, e mover qualquer um dos ponteiros pode descartar a resposta certa.
 </Callout>
 
-Sobre o custo, dois pontos que apareceram no encontro:
+Sobre o custo, dois pontos:
 
 - **Tempo O(n).** Cada índice é visitado no máximo uma vez, e os dois ponteiros juntos percorrem o array inteiro. Como cada iteração move um dos dois, o laço roda no máximo `n - 1` vezes. Na prática cada ponteiro anda **metade** do array, mas `n/2` é O(n): a constante cai, como em qualquer conta de [Big O](/topico/big-o).
 - **Espaço O(1).** Não existe estrutura auxiliar, só duas variáveis inteiras. Sejam 10 elementos ou 1 milhão, o consumo extra é o mesmo.
 
-Vale guardar a ressalva que o Nelson fez ali: a notação assintótica não conta tudo. Dois algoritmos O(n) podem ter constantes bem diferentes, e andar metade do array é, na vida real, duas vezes mais rápido que andar o array inteiro. O Big O classifica a curva, não cronometra o relógio.
+Vale guardar a ressalva: a notação assintótica não conta tudo. Dois algoritmos O(n) podem ter constantes bem diferentes, e andar metade do array é, na vida real, duas vezes mais rápido que andar o array inteiro. O Big O classifica a curva, não cronometra o relógio.
 
 ### O mesmo argumento sem soma nenhuma: Container With Most Water
 
@@ -170,9 +170,9 @@ def e_palindromo_ingenuo(s):
     return limpa == limpa[::-1]
 ```
 
-Correto e legível, mas com dois custos escondidos. Primeiro, **string em Python é imutável**: cada concatenação cria uma string nova, e `limpa[::-1]` cria mais uma. A memória extra vira O(n), justamente o que a técnica prometia evitar. Segundo, foi por aí que a discussão do encontro andou em círculos: você troca espaço, depois vírgula, depois dois pontos, e sempre falta um caractere novo.
+Correto e legível, mas com dois custos escondidos. Primeiro, **string em Python é imutável**: cada concatenação cria uma string nova, e `limpa[::-1]` cria mais uma. A memória extra vira O(n), justamente o que a técnica prometia evitar. Segundo, é por aí que a limpeza anda em círculos: você troca espaço, depois vírgula, depois dois pontos, e sempre falta um caractere novo.
 
-A saída é **não tocar na string**. Se o caractere atual não interessa, pule só aquele ponteiro e deixe o outro parado. Foi aqui que o encontro chegou no insight principal: **os dois ponteiros não precisam andar no mesmo ritmo**.
+A saída é **não tocar na string**. Se o caractere atual não interessa, pule só aquele ponteiro e deixe o outro parado. É aqui que está o insight principal: **os dois ponteiros não precisam andar no mesmo ritmo**.
 
 ```python
 def e_palindromo(s):
@@ -201,7 +201,7 @@ O visualizador começa com a frase do Panamá, que tem 30 caracteres. Rode até 
 - Antes de clicar em **0P**, responda: `"0P"` é palíndromo? A resposta é não, `0` é diferente de `p`. Guarde isso, o próximo bloco explica por que essa entrada é famosa.
 
 <Callout tipo="aviso">
-**A pegadinha do `% 32`.** Durante o encontro apareceu um atalho para comparar letras ignorando a caixa: na tabela ASCII, `A` é 65 e `a` é 97, e como `65 % 32` e `97 % 32` dão os dois 1, o resto da divisão por 32 "normalizaria" a caixa de graça. Funciona para as 26 letras, mas o conjunto do problema tem **36 símbolos**, contando os 10 dígitos. E aí `P` vale 80 e `0` vale 48, que dão **16 os dois**. É exatamente por isso que o LeetCode tem `"0P"` entre os casos de teste: o atalho responde "é palíndromo" e a resposta certa é "não é". Micro-otimização que muda o resultado não é otimização, é bug.
+**A pegadinha do `% 32`.** Existe um atalho tentador para comparar letras ignorando a caixa: na tabela ASCII, `A` é 65 e `a` é 97, e como `65 % 32` e `97 % 32` dão os dois 1, o resto da divisão por 32 "normalizaria" a caixa de graça. Funciona para as 26 letras, mas o conjunto do problema tem **36 símbolos**, contando os 10 dígitos. E aí `P` vale 80 e `0` vale 48, que dão **16 os dois**. É exatamente por isso que o LeetCode tem `"0P"` entre os casos de teste: o atalho responde "é palíndromo" e a resposta certa é "não é". Micro-otimização que muda o resultado não é otimização, é bug.
 </Callout>
 
 ## Mesma direção: o leitor e o escritor
@@ -276,7 +276,7 @@ O mesmo par lento e rápido resolve outro clássico: **achar o meio da lista**. 
 
 Toda a construção acima depende de o array estar ordenado. E quando ele não está?
 
-Aí você tem uma escolha, e o encontro passou justamente por ela. O Two Sum clássico (o de array desordenado) tem a solução com [tabela hash](/topico/hash-table): você percorre uma vez guardando o complemento de cada número, e responde em O(n). Rápido, mas gasta O(n) de memória.
+Aí você tem uma escolha. O Two Sum clássico (o de array desordenado) tem a solução com [tabela hash](/topico/hash-table): você percorre uma vez guardando o complemento de cada número, e responde em O(n). Rápido, mas gasta O(n) de memória.
 
 A alternativa é **ordenar e aplicar dois ponteiros**:
 
@@ -291,10 +291,10 @@ A leitura da tabela é a parte que importa. Ordenar **piora** o tempo, porque ne
 Duas ressalvas honestas sobre essa última linha. A primeira: o O(1) da terceira linha vale para o **par de ponteiros**, e supõe uma ordenação in-place. O `nums.sort()` do Python usa Timsort, que no pior caso pede O(n) de área temporária, então se a pergunta for exatamente "quanta memória extra", diga "O(1) além da ordenação" em vez de só "O(1)". A segunda: ordenar **modifica a entrada**. Se quem chamou a função ainda precisa do array original, você acabou de estragá-lo, e o `sorted(nums)` que resolve isso já custa O(n) de memória.
 
 <Callout tipo="aviso">
-**A técnica é O(n), o seu algoritmo pode não ser.** Foi o alerta do Nelson no encontro: dizer "usei two pointers, logo é O(n)" está errado se você ordenou antes. O custo total é o do **maior** termo, e nesse caso o maior termo é o `sort`. Analise o algoritmo inteiro, não o pedaço bonito dele.
+**A técnica é O(n), o seu algoritmo pode não ser.** Dizer "usei two pointers, logo é O(n)" está errado se você ordenou antes. O custo total é o do **maior** termo, e nesse caso o maior termo é o `sort`. Analise o algoritmo inteiro, não o pedaço bonito dele.
 </Callout>
 
-E tem a armadilha que só aparece quando você roda: o [Two Sum](https://leetcode.com/problems/two-sum/) original pede os **índices originais** dos dois números. Ordenar destrói exatamente essa informação, e foi o que aconteceu ao vivo no encontro: os valores encontrados estavam certos, os índices devolvidos estavam errados. Duas saídas honestas:
+E tem a armadilha que só aparece quando você roda: o [Two Sum](https://leetcode.com/problems/two-sum/) original pede os **índices originais** dos dois números. Ordenar destrói exatamente essa informação, e o sintoma é sempre o mesmo: os valores encontrados estão certos, os índices devolvidos estão errados. Duas saídas honestas:
 
 - Se o problema pede os **valores** (ou só um verdadeiro/falso), pode ordenar à vontade.
 - Se o problema pede os **índices**, ordene uma lista de pares `(valor, indice)`. Só que isso aloca uma cópia do array, o espaço volta a ser O(n), e aí o hash costuma ser melhor mesmo.
@@ -356,7 +356,7 @@ Esse é o padrão "**fixa um, dois ponteiros no resto**", e ele escala. O 4Sum �
 
 **Mover os dois ponteiros quando só um devia andar.** É o erro do palíndromo com pontuação. Se um lado tem um caractere para ignorar, quem anda é ele, sozinho. Fechar os dois de uma vez desalinha a comparação e passa pelos testes fáceis, quebrando só nos difíceis.
 
-**Errar a inicialização da direita.** `direita = len(nums)` estoura o índice na primeira leitura. É sempre `len(nums) - 1`, e esse foi literalmente o primeiro erro que apareceu ao vivo no encontro.
+**Errar a inicialização da direita.** `direita = len(nums)` estoura o índice na primeira leitura. É sempre `len(nums) - 1`, e esse é literalmente o primeiro erro que aparece quando se escreve o laço.
 
 **Esquecer os duplicados no 3Sum.** Quando o problema pede triplas ou pares **únicos**, o array ordenado coloca os valores repetidos lado a lado, e o laço vai gerar a mesma resposta várias vezes. A correção é pular os valores iguais ao anterior depois de registrar uma solução.
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "screenshots": "bash scripts/smoke-screenshots.sh",
     "lint": "eslint .",
     "guarda:commit": "base=${GUARDA_BASE:-origin/main}; git rev-parse --verify -q \"$base\" >/dev/null || { echo \"guarda:commit: a ref base '$base' não existe. Rode 'git fetch' ou aponte outra em GUARDA_BASE (ex.: upstream/main).\" >&2; exit 2; }; test \"$(git rev-list --count \"$base\"..HEAD)\" -gt 0 || { echo \"guarda:commit: 0 commits em $base..HEAD - NADA foi checado.\" >&2; exit 2; }; git log --format=%s \"$base\"..HEAD | python3 scripts/guarda-commit.py",
-    "guarda:idioma": "python3 scripts/guarda-idioma.py"
+    "guarda:idioma": "python3 scripts/guarda-idioma.py",
+    "guarda:ancoras": "python3 scripts/guarda-ancoras.py"
   },
   "dependencies": {
     "@mdx-js/loader": "^3.1.0",

--- a/scripts/guarda-ancoras.py
+++ b/scripts/guarda-ancoras.py
@@ -1,0 +1,304 @@
+#!/usr/bin/env python3
+"""Guarda das âncoras na gravação: o artigo tem que ser autocontido.
+
+    python3 scripts/guarda-ancoras.py                  # content/topics/*.mdx
+    python3 scripts/guarda-ancoras.py <arquivo|dir>…   # só o que você mandar
+    python3 scripts/guarda-ancoras.py --lentes         # imprime as lentes e as exceções
+
+A regra, do `CLAUDE.md` do repositório de controle e da memória
+`artigo-dsa-autocontido`:
+
+> O artigo é autocontido. A gravação é insumo, e o leitor não viu o vídeo. Nada
+> de "no encontro apareceu", "foi desenhado no quadro" ou rótulo de preset do
+> tipo "A árvore do encontro". Uma ideia boa entra pelo mérito, como o exemplo
+> do artigo. Quem assiste ganha reforço; quem só lê recebe o valor inteiro.
+
+O link e o embed da gravação **não** são violação: eles são o reforço que a
+regra promete, e nem moram aqui (o vídeo é metadado, em `content/roadmap.ts`).
+O que este guarda procura é a PROSA que exige ter assistido.
+
+POR QUE TRÊS LENTES, E NÃO UM GREP
+----------------------------------
+O primeiro inventário deste problema foi feito com um `grep` por "encontro" e
+irmãos, e ele erra por baixo de duas formas diferentes, as duas medidas:
+
+  1. **A âncora sem palavra de gravação.** Duas das doze linhas que citavam
+     alguém pelo nome não diziam "encontro", "aula" nem "vídeo" em lugar nenhum
+     — «Como o Nelson resumiu:» e «a ressalva que o Nelson fez ali». Só uma
+     varredura por NOME ou por VERBO DE FALA as encontra.
+  2. **O filtro de falso positivo comendo achado de verdade.** O `grep -v` que
+     tirava o "encontro" do ciclo de Floyd casava `o encontro foi`, e com isso
+     engolia TRÊS âncoras reais de uma vez: «O exercício do encontro foi…»
+     (`pilhas.mdx`), «O exemplo que motivou tudo isso no encontro foi…»
+     (`listas-ligadas.mdx`) e «Um dos melhores momentos do encontro foi…»
+     (`prefix-sum.mdx`). É por isso que aqui as exceções são DADO DECLARADO,
+     com motivo escrito ao lado, e não um `|` a mais escondido num regex: uma
+     exceção que ninguém consegue ler é uma exceção que ninguém revisa.
+
+E é por isso que `EXCECOES` é conferida de volta: se uma exceção deixa de casar
+qualquer linha do corpus, o guarda sai 2. Exceção morta é um buraco aberto
+esperando o dia em que uma frase nova cair dentro dele sem ninguém perceber.
+
+Códigos de saída:
+
+    0   varreu pelo menos um arquivo e não achou âncora
+    1   achou âncora
+    2   NÃO CONSEGUIU VARRER (nenhum `.mdx` no caminho), ou uma exceção morreu
+
+O 2 é o mesmo contrato dos outros guardas desta pasta: *não conseguiu olhar* é
+erro do guarda, e nunca pode sair 0 — porque 0 quer dizer "olhei e está limpo".
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+RAIZ = Path(__file__).resolve().parent.parent
+PADRAO = RAIZ / "content" / "topics"
+
+
+class Lente(NamedTuple):
+    nome: str
+    porque: str
+    padrao: re.Pattern[str]
+
+
+class Excecao(NamedTuple):
+    nome: str
+    motivo: str
+    padrao: re.Pattern[str]
+
+
+def _r(fonte: str) -> re.Pattern[str]:
+    return re.compile(fonte, re.IGNORECASE | re.VERBOSE)
+
+
+# ---------------------------------------------------------------------------
+# LENTE 1 — palavra de gravação.
+#
+# A mais óbvia e a que acha a maioria. "quadro" sozinho está FORA de propósito:
+# no corpus ele quase sempre é o frame da pilha de chamadas ("um quadro na pilha
+# de chamadas", "dez quadros na pilha") ou uma tabela ("o quadro de
+# complexidade"). Ficam só as formas que não têm outro sentido possível.
+# ---------------------------------------------------------------------------
+GRAVACAO = _r(r"""
+    \b encontros? \b
+  | \b aulas? \b
+  | \b lives? \b
+  | \b grava(?: ção | ções ) \b
+  | \b meetup \b
+  | \b transmiss(?: ão | ões ) \b
+  | \b v[ií]deos? \b
+  | \b a \s+ galera \b
+  | \b ao \s+ vivo \b
+  | \b tela \s+ compartilhada \b
+  | \b quadro \s+ branco \b
+  | \b tarefa \s+ de \s+ casa \b
+  | \b comunidade \b
+""")
+
+# ---------------------------------------------------------------------------
+# LENTE 2 — nome próprio de quem participou.
+#
+# É a ponta mais afiada do problema: um leitor que chega pelo Google encontra um
+# argumento cuja autoridade é uma pessoa que ele não conhece, numa conversa que
+# ele não viu. A lista é explícita porque **precisa** ser: sobrenome de
+# pesquisador (Dijkstra, Floyd, Knuth, Pugh, Kahn, Lomuto…) é referência técnica
+# legítima e aparece o tempo todo. Quem entrar na comunidade e for citado num
+# artigo entra aqui — e sai do artigo no mesmo PR.
+# ---------------------------------------------------------------------------
+NOMES_DA_COMUNIDADE = ("Tiago", "Giovani", "Eduardo", "Nelson", "Wilson")
+NOME = re.compile(r"\b(?:%s)\b" % "|".join(NOMES_DA_COMUNIDADE))
+
+# ---------------------------------------------------------------------------
+# LENTE 3 — verbo de fala com sujeito humano.
+#
+# A rede que pega o nome que ninguém cadastrou ainda, e a âncora anônima («e
+# alguém resumiu isso perfeitamente com…»). O sujeito tem que ser gente: `o
+# Fulano`, `alguém`, `a galera`, `a gente`.
+#
+# **A caixa alta do nome é sensível DE PROPÓSITO**, e a primeira versão desta
+# lente errou justamente aí: compilada com `IGNORECASE`, a classe `[A-Z]` casava
+# minúscula e o sujeito virava qualquer coisa — «a leitura atual **trouxe** para
+# o L1» (`arrays.mdx`) e «o que este artigo **mediu**» (`ordenacao-basica.mdx`)
+# entraram como âncora. Por isso só os pronomes fechados ganham `(?i:…)`.
+#
+# Verbo de ESCRITA fica de fora ("escreveu", "montou") porque no artigo o sujeito
+# costuma ser **você** — «se você escreveu `esq = meio`» — e a lente viraria ruído.
+# ---------------------------------------------------------------------------
+SUJEITO_HUMANO = r"""(?:
+      (?i: algu[ée]m | a \s+ galera | a \s+ comunidade | o \s+ pessoal | a \s+ gente )
+    | [OoAa] \s+ [A-ZÁÉÍÓÚÂÊÔÃÕÇ][a-zà-ÿ]{2,}
+)"""
+VERBO_DE_FALA = r"""(?i:
+      mostrou | perguntou | comentou | trouxe | lembrou | falou | disse
+    | contou | explicou | apontou | sugeriu | levantou | prop[oô]s | observou
+    | notou | resumiu | debateu | alertou | questionou | apelidou | desenhou
+    | validou | mediu | ajustou | abriu | rodou | preencheu | resolveu | fez
+    | resumiram | perguntaram | mostraram | trouxeram | levantaram
+)"""
+# Sem `IGNORECASE` na compilação: a distinção de caixa é o que segura a lente.
+FALA = re.compile(
+    rf"\b {SUJEITO_HUMANO} \s+ (?: \w+ \s+ ){{0,2}} {VERBO_DE_FALA} \b", re.VERBOSE
+)
+
+LENTES = (
+    Lente("gravação", "a palavra só existe porque houve um encontro gravado", GRAVACAO),
+    Lente("nome", "autoridade que o leitor não conhece, de uma conversa que ele não viu", NOME),
+    Lente("fala", "relato do que alguém disse, e não a ideia pelo mérito", FALA),
+)
+
+# ---------------------------------------------------------------------------
+# AS EXCEÇÕES, uma por linha, com o motivo ao lado.
+#
+# Elas são DADO, e não um `|` escondido num regex, porque quem revisa este
+# arquivo daqui a um ano precisa conseguir discordar de cada uma. Cada exceção
+# tem que continuar casando alguma coisa no corpus (ver `varrer`): a exceção que
+# ninguém usa mais é buraco esperando frase nova.
+# ---------------------------------------------------------------------------
+EXCECOES = (
+    Excecao(
+        "floyd",
+        "o 'encontro' da lebre e da tartaruga é termo técnico do ciclo de Floyd, "
+        "nada a ver com a gravação. É o falso positivo mais fácil de cometer aqui: "
+        "numa varredura ingênua ele sozinho infla o número em 10 linhas",
+        # A exceção é por CO-OCORRÊNCIA, e não por lista de frases feitas, e isso
+        # é o conserto de um defeito medido. O `grep -v` do inventário listava as
+        # formas uma a uma (`o encontro foi`, `momento do encontro`, …) e a forma
+        # `o encontro foi` engolia TRÊS âncoras reais de outros artigos — as três
+        # citadas no topo deste arquivo. Exigir vocabulário de ciclo na MESMA
+        # linha não engole nenhuma das três (nenhuma fala de ciclo), e ainda pega
+        # a décima ocorrência, que nenhuma lista de frases previa:
+        # «um nó apontando para si mesmo (encontro na primeira iteração)».
+        _r(r"""
+            (?= .* \b encontro \b )
+            .* (?: \b ciclos? \b | \b lebre \b | \b tartaruga \b | λ | μ )
+        """),
+    ),
+    Excecao(
+        "verbo-encontrar",
+        "'encontro' como 1ª pessoa do verbo encontrar: «quando eu encontro um fechamento»",
+        _r(r"\b eu \s+ encontro \b"),
+    ),
+    Excecao(
+        "animacao-ao-vivo",
+        "'ao vivo' sobre a ANIMAÇÃO do visualizador («o painel mostra isso ao vivo», "
+        "«as três contas rodando ao vivo»), e não sobre a gravação",
+        _r(r"(?: mostra | rodando | sendo \s+ \w+ | acontecendo | veja ) [^.]{0,60} ao \s+ vivo"),
+    ),
+    Excecao(
+        "perdeu-a-aula",
+        "«resolveu o exercício e perdeu a aula» é a expressão de perder a lição, "
+        "não de faltar ao encontro",
+        _r(r"perdeu \s+ a \s+ aula"),
+    ),
+)
+
+
+class Achado(NamedTuple):
+    arquivo: Path
+    linha: int
+    lentes: tuple[str, ...]
+    trecho: str
+
+
+def alvos(argumentos: list[str]) -> list[Path]:
+    """Os `.mdx` a varrer. Sem argumento, os artigos do roadmap."""
+    caminhos = [Path(a) for a in argumentos] or [PADRAO]
+    achados: list[Path] = []
+    for c in caminhos:
+        if c.is_dir():
+            achados += sorted(c.glob("*.mdx"))
+        elif c.is_file():
+            achados.append(c)
+        else:
+            print(f"guarda-ancoras: caminho inexistente: {c}", file=sys.stderr)
+            raise SystemExit(2)
+    return achados
+
+
+def varrer(arquivos: list[Path]) -> tuple[list[Achado], set[str]]:
+    """Devolve os achados e o nome das exceções que de fato foram usadas."""
+    achados: list[Achado] = []
+    vivas: set[str] = set()
+
+    for arq in arquivos:
+        for n, linha in enumerate(arq.read_text(encoding="utf-8").splitlines(), 1):
+            casou = tuple(le.nome for le in LENTES if le.padrao.search(linha))
+            if not casou:
+                continue
+            perdoada = False
+            for exc in EXCECOES:
+                if exc.padrao.search(linha):
+                    vivas.add(exc.nome)
+                    perdoada = True
+            if not perdoada:
+                achados.append(Achado(arq, n, casou, linha.strip()))
+
+    return achados, vivas
+
+
+def imprimir_lentes() -> None:
+    print("LENTES (o que faz uma linha ser suspeita)\n")
+    for le in LENTES:
+        print(f"  {le.nome:<10} {le.porque}")
+        print(f"  {'':<10} {le.padrao.pattern.strip()[:110].replace(chr(10), ' ')}…\n")
+    print("EXCEÇÕES (o que NÃO é violação, e por quê)\n")
+    for ex in EXCECOES:
+        print(f"  {ex.nome:<18} {ex.motivo}")
+    print()
+
+
+def main(argv: list[str]) -> int:
+    if "--lentes" in argv:
+        imprimir_lentes()
+        return 0
+
+    arquivos = alvos(argv)
+    if not arquivos:
+        print(
+            "guarda-ancoras: nenhum .mdx para varrer. Isso NÃO é 'passou': o guarda "
+            "não olhou nada.",
+            file=sys.stderr,
+        )
+        return 2
+
+    achados, vivas = varrer(arquivos)
+
+    # A conferência das exceções só faz sentido sobre o corpus inteiro: rodar o
+    # guarda num arquivo só deixaria quase todas "mortas" por construção.
+    corpus_inteiro = not [a for a in argv if not a.startswith("-")]
+    if corpus_inteiro:
+        mortas = [e.nome for e in EXCECOES if e.nome not in vivas]
+        if mortas:
+            print(
+                "guarda-ancoras: exceção declarada que não casa mais nada: "
+                + ", ".join(mortas)
+                + "\n  Ou o texto que a justificava saiu (então apague a exceção), ou "
+                "ela nunca funcionou. Exceção morta é buraco aberto.",
+                file=sys.stderr,
+            )
+            return 2
+
+    if achados:
+        print(f"{len(achados)} linha(s) ancorada(s) na gravação:\n")
+        for a in achados:
+            print(f"  {a.arquivo.name}:{a.linha}  [{'+'.join(a.lentes)}]")
+            print(f"     {a.trecho[:160]}")
+        print(
+            "\nO artigo é autocontido: a ideia entra pelo mérito, não pela procedência.\n"
+            "  «o Fulano perguntou…»  ->  «uma pergunta natural aqui é…»\n"
+            "  «o Beltrano mostrou…»  ->  «vale reparar que…»\n"
+            "Se a frase só existia como relato do encontro e não carrega nada, ela sai.\n"
+            "Se for falso positivo de verdade, declare a exceção em EXCECOES com o motivo."
+        )
+        return 1
+
+    print(f"guarda-ancoras: {len(arquivos)} arquivo(s) varrido(s), nenhuma âncora.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/testa-guarda-idioma.py
+++ b/scripts/testa-guarda-idioma.py
@@ -1,22 +1,23 @@
 #!/usr/bin/env python3
-"""Suíte dos guardas: o de idioma e o de header de commit.
+"""Suíte dos guardas: o de idioma, o de header de commit e o de âncoras.
 
-    python3 scripts/testa-guarda-idioma.py                      # roda os guardas atuais
-    python3 scripts/testa-guarda-idioma.py --guarda <p>         # roda OUTRO guarda-idioma
-    python3 scripts/testa-guarda-idioma.py --guarda-commit <p>  # roda OUTRO guarda-commit
-    python3 scripts/testa-guarda-idioma.py -v                   # imprime a saída de cada caso
+    python3 scripts/testa-guarda-idioma.py                       # roda os guardas atuais
+    python3 scripts/testa-guarda-idioma.py --guarda <p>          # roda OUTRO guarda-idioma
+    python3 scripts/testa-guarda-idioma.py --guarda-commit <p>   # roda OUTRO guarda-commit
+    python3 scripts/testa-guarda-idioma.py --guarda-ancoras <p>  # roda OUTRO guarda-ancoras
+    python3 scripts/testa-guarda-idioma.py -v                    # imprime a saída de cada caso
 
 Os `--guarda*` existem para a prova de quebra: aponte para uma cópia da versão
 anterior e veja os casos passarem verdes com a aula estragada (ou com o guarda
 cego). Um guarda que você nunca viu falhar não é guarda.
 
 **O nome do arquivo ficou menor que o conteúdo, e é de propósito.** Ele cobre os
-DOIS guardas porque é este caminho que o portão da CI chama
+TRÊS guardas porque é este caminho que o portão da CI chama
 (`.github/workflows/tests.yml`, passo "Suíte do próprio guarda de idioma");
 renomear exigiria mexer no workflow, e uma suíte que a CI não roda protege
 menos que um nome errado.
 
-A suíte tem dois blocos:
+A suíte tem três blocos:
 
   FIXTURES — pares de arquivo em `fixtures-guarda-idioma/<caso>/`, com extensão
     `.tsx.txt` de propósito: o `tsconfig.json` inclui `**/*.tsx`, então fixture
@@ -30,6 +31,13 @@ A suíte tem dois blocos:
     O `guarda-commit.py` saía 0 e MUDO sem o pipe (dez agentes "rodaram o
     guarda" e nenhum guarda rodou), e o `guarda-idioma.py` saía 0 com dois
     diretórios sem um `.tsx` dentro.
+
+  ÂNCORAS — uma LINHA DE PROSA por caso, contra o `guarda-ancoras.py`, que
+    varre `content/topics/*.mdx` atrás de texto que só faz sentido para quem
+    assistiu à gravação. Metade dos casos existe para o guarda NÃO reprovar: o
+    "encontro" da lebre e da tartaruga, o "ao vivo" da animação, o "perdeu a
+    aula". A outra metade são âncoras de verdade que a varredura anterior (um
+    `grep` com `grep -v`) deixava passar.
 """
 import subprocess
 import sys
@@ -135,6 +143,64 @@ CASOS_CLI = [
      "diretório COM fonte e sem mudança de tela continua saindo 0"),
 ]
 
+# ---------------------------------------------------------------------------
+# Bloco 3: o guarda das âncoras na gravação (`guarda-ancoras.py`).
+#
+# Aqui o caso é UMA LINHA de prosa, e não um par de arquivos, porque é assim que
+# a âncora aparece: uma oração de procedência no meio de um parágrafo que, sem
+# ela, continua de pé. Cada caso vira um `.mdx` de uma linha num diretório
+# temporário e o guarda é chamado nele.
+#
+# Os casos 5 e 6 são a razão de o guarda existir em vez de um `grep`: os dois
+# passavam VERDES pelo filtro de falso positivo da versão anterior desta
+# varredura, que era um `grep -v` com as frases do ciclo de Floyd listadas uma a
+# uma. Um guarda que você nunca viu falhar não é guarda — e um filtro de falso
+# positivo que você nunca viu engolir achado de verdade é pior ainda.
+# ---------------------------------------------------------------------------
+# (nome, linha de prosa, deve_reprovar, o que o caso prova)
+CASOS_ANCORAS = [
+    ("ancora-classica",
+     "No encontro o problema apareceu assim: uma classe recebe um array.",
+     True, "a forma mais comum: oração de procedência (lente da gravação)"),
+    ("ancora-sem-palavra-de-gravacao",
+     "Isso custa dos dois lados. Como o Nelson resumiu: empilhar custa 1.",
+     True, "cita a PESSOA sem dizer 'encontro': só as lentes de nome e de fala pegam"),
+    ("ancora-com-nome-nao-cadastrado",
+     "Vale guardar a ressalva que o Anacleto fez ali: a constante importa.",
+     True, "nome que ninguém cadastrou: quem pega é a lente do VERBO DE FALA"),
+    ("floyd-nao-e-violacao",
+     "O encontro acontece no nó 5, na 5ª iteração, e o ciclo tem 5 nós.",
+     False, "o 'encontro' da lebre e da tartaruga é termo técnico, não procedência"),
+    ("o-encontro-foi-nao-e-floyd",
+     "O exercício do encontro foi calcular uma potência de três jeitos.",
+     True, "o `grep -v 'o encontro foi'` do inventário ENGOLIA esta linha real"),
+    ("ancora-numa-linha-que-fala-de-lento",
+     "O código está na seção do rápido e lento. É o problema que estava "
+     "sendo discutido no encontro.",
+     True, "co-ocorrência com 'lento' engolia a âncora; só 'ciclo'/λ/μ perdoam"),
+    ("animacao-ao-vivo-passa",
+     "O painel de array do visualizador mostra isso ao vivo: clique num nó.",
+     False, "'ao vivo' sobre a ANIMAÇÃO não é a gravação"),
+    ("perdeu-a-aula-passa",
+     "Se você usar `reversed()`, resolveu o exercício e perdeu a aula.",
+     False, "'perdeu a aula' é perder a lição, não faltar ao encontro"),
+    ("verbo-encontrar-passa",
+     "Quando eu encontro um fechamento, ele tem que casar com a abertura.",
+     False, "'encontro' como 1ª pessoa do verbo encontrar"),
+    ("sujeito-nao-humano-passa",
+     "A que está destacada é a que a leitura atual trouxe para o L1.",
+     False, "sujeito minúsculo não é gente: a lente de fala é sensível à CAIXA"),
+    ("artigo-como-sujeito-passa",
+     "O motivo é o que este artigo mediu, e a conta fecha com as constantes.",
+     False, "'o que este artigo mediu' entrava como âncora com `IGNORECASE`"),
+    ("comunidade-como-autoridade",
+     "A analogia que a comunidade usou é a do telefone sem fio.",
+     True, "'a comunidade' como autoridade é âncora, mesmo sem a palavra 'encontro'"),
+    ("sobrenome-de-pesquisador-passa",
+     "As entradas são pequenas o bastante para o Dijkstra resolver sozinho.",
+     False, "sobrenome de pesquisador é referência técnica, não gente do encontro"),
+]
+
 FONTE_DE_TESTE = 'export const Rotulo = () => <span>passo 1 de 7</span>;\n'
 
 
@@ -187,23 +253,71 @@ def rodar_cli(guardas: dict, tmp: Path, verboso: bool) -> list[str]:
     return falhas
 
 
+def rodar_ancoras(guarda: Path, tmp: Path, verboso: bool) -> list[str]:
+    """Bloco 3. Uma linha de prosa por caso. Devolve os nomes que falharam."""
+    print("  -- âncoras na gravação (uma linha de prosa por caso) --")
+    falhas = []
+    for nome, linha, deve_reprovar, oquê in CASOS_ANCORAS:
+        artigo = tmp / f"{nome}.mdx"
+        artigo.write_text(linha + "\n", encoding="utf-8")
+        r = subprocess.run(
+            [sys.executable, str(guarda), str(artigo)], capture_output=True, text=True
+        )
+        if r.returncode not in (0, 1):
+            print(f"  ERRO   {nome:<38} o guarda saiu {r.returncode}, não 0 nem 1")
+            for l in (r.stdout + r.stderr).rstrip().splitlines():
+                print(f"         | {l[:160]}")
+            falhas.append(nome)
+            continue
+        reprovou = r.returncode == 1
+        ok = reprovou == deve_reprovar
+        nota = "" if ok else ("passou VERDE com a âncora no artigo"
+                              if deve_reprovar else "reprovou um falso positivo conhecido")
+        print(f"  {'ok  ' if ok else 'FALHA'}  {nome:<38} "
+              f"{'reprova' if deve_reprovar else 'passa':<8} {oquê}")
+        if nota:
+            print(f"         -> {nota}")
+        if verboso or not ok:
+            for l in (r.stdout + r.stderr).rstrip().splitlines():
+                print(f"         | {l[:160]}")
+        if not ok:
+            falhas.append(nome)
+
+    # E o corpus de verdade, que é o comando que a CI roda. Ele é o único que
+    # exercita a conferência das EXCEÇÕES: se uma exceção declarada parou de
+    # casar qualquer linha dos artigos, o guarda sai 2 e este caso acusa.
+    r = subprocess.run([sys.executable, str(guarda)], capture_output=True, text=True)
+    ok = r.returncode == 0
+    print(f"  {'ok  ' if ok else 'FALHA'}  {'corpus-limpo-e-excecoes-vivas':<38} "
+          f"{'sai 0':<8} os artigos do roadmap não têm âncora e nenhuma exceção morreu")
+    if verboso or not ok:
+        for l in (r.stdout + r.stderr).rstrip().splitlines():
+            print(f"         | {l[:160]}")
+    if not ok:
+        falhas.append("corpus-limpo-e-excecoes-vivas")
+    return falhas
+
+
 def main() -> int:
     argv = sys.argv[1:]
     verboso = "-v" in argv or "--verbose" in argv
     # Sem o caminho depois do flag isto era um IndexError com traceback e
     # código 1 — o MESMO código de "um caso reprovou". Erro de uso não pode
     # ser confundido com resultado de teste, então sai 2.
-    if any(f in argv and argv.index(f) + 1 >= len(argv) for f in ("--guarda", "--guarda-commit")):
-        print("uso: testa-guarda-idioma.py [--guarda <p>] [--guarda-commit <p>] [-v]",
-              file=sys.stderr)
+    if any(f in argv and argv.index(f) + 1 >= len(argv)
+           for f in ("--guarda", "--guarda-commit", "--guarda-ancoras")):
+        print("uso: testa-guarda-idioma.py [--guarda <p>] [--guarda-commit <p>] "
+              "[--guarda-ancoras <p>] [-v]", file=sys.stderr)
         return 2
     guardas = {
         "idioma": caminho_do_flag(argv, "--guarda", AQUI / "guarda-idioma.py"),
         "commit": caminho_do_flag(argv, "--guarda-commit", AQUI / "guarda-commit.py"),
+        "ancoras": caminho_do_flag(argv, "--guarda-ancoras", AQUI / "guarda-ancoras.py"),
     }
 
-    print(f"guarda-idioma: {guardas['idioma']}")
-    print(f"guarda-commit: {guardas['commit']}\n")
+    print(f"guarda-idioma:  {guardas['idioma']}")
+    print(f"guarda-commit:  {guardas['commit']}")
+    print(f"guarda-ancoras: {guardas['ancoras']}\n")
     falhas = []
     print("  -- fixtures (o texto de tela) --")
     for pasta, deve_reprovar, oquê in CASOS:
@@ -244,14 +358,17 @@ def main() -> int:
         tmp = Path(bruto)
         preparar_tmp(tmp)
         falhas += rodar_cli(guardas, tmp, verboso)
+        print()
+        falhas += rodar_ancoras(guardas["ancoras"], tmp, verboso)
 
-    total = len(CASOS) + len(CASOS_CLI)
+    total = len(CASOS) + len(CASOS_CLI) + len(CASOS_ANCORAS) + 1
     print()
     if falhas:
         print(f"{len(falhas)} de {total} casos FALHARAM: {', '.join(falhas)}")
         return 1
     print(f"{total} de {total} casos ok "
-          f"({len(CASOS)} fixtures + {len(CASOS_CLI)} de linha de comando)")
+          f"({len(CASOS)} fixtures + {len(CASOS_CLI)} de linha de comando "
+          f"+ {len(CASOS_ANCORAS) + 1} de âncora na gravação)")
     return 0
 
 


### PR DESCRIPTION
Fecha o item 13 do backlog. O #66 já cobriu a categoria **A** (rótulos de preset)
e a **C** (prosa dentro do `TailRecursionForma`); aqui sai a **B**, a prosa dos
artigos que só faz sentido para quem assistiu ao encontro.

**O link e o embed da gravação continuam onde estavam.** Eles são o reforço que a
regra promete, e nem moram no `.mdx`. O que sai é o texto que **exige** ter
assistido.

## O que mudou

**91 linhas em 11 artigos**, com prioridade nas **12 que citavam pessoas da
comunidade pelo nome**. É o caso que dói mais: um leitor que chega pelo Google
encontrava um argumento cuja autoridade é alguém que ele não conhece, numa
conversa que ele não viu.

| antes | depois |
|---|---|
| «No encontro, **o Tiago abriu** o código-fonte do `Enum.map`…» | «**Abra** o código-fonte do `Enum.map`…» |
| «**Foi pergunta do Giovani no encontro**, e a resposta é a que importa…» | «**A pergunta natural aqui é** se a otimização vale para os dois casos…» |
| «É a armadilha que **o Eduardo levantou no encontro**: ordenar destrói…» | «É a armadilha **mais cara desta técnica**: ordenar destrói…» |
| «Vale guardar a ressalva **que o Nelson fez ali**…» | «Vale guardar a ressalva…» |

O **`recursao-funcional.mdx` foi reescrita de seção**, não conserto de linha: a
espinha da página era *"o que o Tiago mostrou e o que o Giovani perguntou"*, com
quatro seções abrindo por atribuição. O conteúdo técnico está inteiro — Elixir,
`Enum.map` → `lists:map`, as seis cláusulas de `validar/2`, a tabela de nove
linguagens, o `1,14`, o `2.692.537`, o `436`. O que muda é **de quem a ideia é**.

## A contagem não bateu com o inventário, e o motivo importa

O placar do inventário diz **87**, a tabela dele soma **89**, e o comando de
regeneração devolve **70**. A medição de hoje dá **91**. As diferenças vêm de
dois buracos, os dois medidos:

1. **Âncora sem palavra de gravação.** «Como o Nelson resumiu», «a ressalva que o
   Nelson fez ali», «a analogia que a comunidade usou» — nenhum `grep` por
   "encontro"/"aula"/"vídeo" alcança. Só uma lente por **nome próprio** ou por
   **verbo de fala** as acha.
2. **O filtro de falso positivo comendo achado de verdade.** O `grep -v` que
   tirava o "encontro" do ciclo de Floyd casava a sequência `o encontro foi` e
   engolia **inteiras** três âncoras reais, em `pilhas.mdx:215`,
   `listas-ligadas.mdx:289` e `prefix-sum.mdx:272`. Zero sobreviventes em cada.

| lente | achou | só ela achou |
|---|---:|---:|
| palavra de gravação | 89 | 70 |
| nome próprio da comunidade | 12 | 0 |
| verbo de fala com sujeito humano | 17 | 0 |

## O guarda que impede a próxima

`scripts/guarda-ancoras.py` (+ `npm run guarda:ancoras`, + portão no job de
guardas do CI, + 14 casos na suíte do guarda que o CI já roda). Três lentes, e as
**exceções são dado declarado com o motivo ao lado** — não regex escondido. Ele
**sai 2 se uma exceção parar de casar qualquer linha**, porque exceção morta é
buraco aberto.

A exceção do Floyd é por **co-ocorrência com vocabulário de ciclo**, e isso é
conserto medido: a lista de frases engolia três âncoras reais, a versão por
co-ocorrência não engole nenhuma.

**Prova de quebra, executada:**

```
contra origin/main   → 91 linha(s) ancorada(s) na gravação   exit=1
contra esta branch   → 36 arquivos, nenhuma âncora           exit=0

âncora inventada em big-o.mdx, nome fora da lista e SEM palavra de gravação:
  «Como o Anacleto lembrou, a curva importa mais que o relógio.»
  → 1 linha(s) ancorada(s) na gravação: big-o.mdx:7 [fala]   exit=1
```

Reprovou pela lente de fala **sozinha**, que é a que o inventário não tinha.

## Nada técnico mudou

Diff `main` × branch em nove extrações, **todas vazias**: blocos de código,
código inline, números na prosa, expressões e Big O, destinos de link, negritos,
títulos, linhas de tabela e componentes JSX.

`guarda:idioma` contra a `main`: **`SUMIRAM: nenhuma / APARECERAM: nenhuma`** em
87 arquivos — este PR não encosta em texto de tela de visualizador, que é a
fronteira dele.

## Falsos positivos conferidos e mantidos

O **"encontro" do ciclo de Floyd** (10 linhas, uma a mais que o inventário
previa: `two-pointers:378` não estava lá), «quando eu **encontro** um
fechamento» (verbo, 1ª pessoa), o **"ao vivo"** da animação, «**perdeu a aula**»
no sentido de perder a lição, e todo sobrenome de pesquisador — Dijkstra, Floyd,
Knuth, Pugh, Kahn, Lomuto, Ciura, Hibbard, Gauss, Guido van Rossum. É por isso
que a lente de nome próprio é uma **lista fechada** de nomes da comunidade, e não
"qualquer nome próprio".

Suíte inteira na branch: **716 passed**. Rodados isolados, `seo`,
`rotulo-de-preset-e-artigo` e `viz-merge-sort` dão 29/29 — o resto é o flake
desta máquina.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PUbtzKsXafUrmiFM3gPMYz