### PR TITLE
fix(ui): o botão do percurso principal se chama pelo nome

### DIFF
--- a/src/app/introducao/page.tsx
+++ b/src/app/introducao/page.tsx
@@ -80,7 +80,7 @@ export default function IntroducaoPage() {
 
       <div className="hero-actions" style={{ marginTop: 28 }}>
         <Link href="/roadmaps/fundamentos/big-o" className="btn btn-primary">Começar por Big O</Link>
-        <Link href="/roadmaps/fundamentos" className="btn">Ver os Fundamentos</Link>
+        <Link href="/roadmaps/fundamentos" className="btn">Roadmap Fundamentos</Link>
       </div>
 
       <div className="cta-card discord" style={{ marginTop: 44 }}>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -8,7 +8,11 @@ export default function NotFound() {
       <p className="lead" style={{ margin: "0 auto 28px" }}>
         O tópico que você procura não existe (ainda). Volte para os Fundamentos, ou veja o índice completo.
       </p>
-      <Link href="/roadmaps/fundamentos" className="btn btn-primary">Ver o roadmap</Link>
+      {/* "Ver o roadmap" tinha dois defeitos no mesmo rótulo: descrevia o
+          gesto em vez do destino, e o "o" prometia um roadmap único num site
+          que hoje tem vários. Nomear resolve os dois, com o mesmo rótulo do
+          botão da home. */}
+      <Link href="/roadmaps/fundamentos" className="btn btn-primary">Roadmap Fundamentos</Link>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,7 +76,12 @@ export default function Home() {
           <Link href="/roadmaps/fundamentos/big-o" className="btn btn-primary">
             Começar por Big O
           </Link>
-          <Link href="/roadmaps/fundamentos" className="btn">Ver os Fundamentos</Link>
+          {/* O rótulo NOMEIA o destino em vez de descrever o gesto: quem chega
+              na home não sabe o que são "os Fundamentos", e "Ver os
+              Fundamentos" não dizia que do outro lado do clique tem um
+              roadmap. O par de botões fica com as duas portas explicadas: um
+              tópico para começar, e o percurso inteiro. */}
+          <Link href="/roadmaps/fundamentos" className="btn">Roadmap Fundamentos</Link>
         </div>
       </section>
 

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -19,6 +19,41 @@ test("nav do topo abre os Fundamentos e um tópico", async ({ page }) => {
   await expect(page).toHaveURL(/roadmaps\/fundamentos\/two-pointers/);
 });
 
+// O botão que leva ao percurso principal NOMEIA o destino.
+//
+// Ele já disse "Ver os Fundamentos" (home e introdução) e "Ver o roadmap"
+// (404): três rótulos que descreviam o gesto e não o lugar, e o do 404 ainda
+// prometia um roadmap definido num site que hoje tem vários. Quem chega pela
+// home não sabe o que são "os Fundamentos" antes de clicar.
+//
+// O guarda é de mão dupla, porque o conserto tem uma armadilha vizinha: a
+// palavra "Fundamentos" também é o ITEM DA BARRA DO TOPO, e renomeá-lo junto
+// levaria a navegação embora. Por isso o teste cobra o rótulo novo nos três
+// botões E cobra que o item da barra continue exatamente "Fundamentos".
+const BOTOES_DO_ROADMAP_PRINCIPAL = ["/", "/introducao/", "/404.html"];
+
+test("o botão para o percurso principal se chama pelo nome, e a barra do topo não", async ({
+  page,
+}) => {
+  for (const rota of BOTOES_DO_ROADMAP_PRINCIPAL) {
+    await page.goto(rota);
+    const botao = page.locator("a.btn", { hasText: "Roadmap Fundamentos" });
+    await expect(botao, `${rota}: o botão do percurso principal sumiu ou mudou de nome`).toHaveCount(1);
+    await expect(botao).toHaveAttribute("href", /\/roadmaps\/fundamentos\/?$/);
+    await expect(
+      page.locator("a.btn", { hasText: /^Ver os Fundamentos$|^Ver o roadmap$/ }),
+      `${rota}: voltou um rótulo que descreve o gesto em vez do destino`
+    ).toHaveCount(0);
+  }
+
+  // A barra do topo é outra coisa: item de navegação, não chamada para ação.
+  await page.goto("/");
+  const naBarra = page.locator(".nav-left a", { hasText: /^Fundamentos$/ });
+  await expect(naBarra, "o item da barra do topo deixou de se chamar 'Fundamentos'").toHaveCount(1);
+  await naBarra.click();
+  await expect(page).toHaveURL(/\/roadmaps\/fundamentos/);
+});
+
 test("página de tópico traz vídeo e problemas com links externos certos", async ({ page }) => {
   await page.goto("/topicos/sliding-window/");
   // A seção do vídeo chega como FACHADA: o `<iframe>` só nasce no clique


### PR DESCRIPTION
## O que muda

O CTA secundário do hero deixa de dizer **"Ver os Fundamentos"** e passa a dizer **"Roadmap Fundamentos"**, como pedido na issue.

O rótulo antigo descrevia o gesto, não o destino. Quem cai na home pela primeira vez não sabe o que são "os Fundamentos" antes de clicar, e a palavra sozinha não contava que do outro lado tem um roadmap inteiro: o botão primário ao lado ("Começar por Big O") entrega um tópico, e o secundário precisava dizer que entrega o percurso. O nome novo usa o vocabulário do próprio site, onde os Fundamentos são um roadmap como os outros.

## Onde

A mesma chamada aparece em três lugares, e os três mudam juntos para o botão não trocar de nome conforme a página:

| Arquivo | Antes | Depois |
| --- | --- | --- |
| `src/app/page.tsx` (hero da home) | Ver os Fundamentos | **Roadmap Fundamentos** |
| `src/app/introducao/page.tsx` (par irmão no fim da introdução) | Ver os Fundamentos | **Roadmap Fundamentos** |
| `src/app/not-found.tsx` (404) | Ver o roadmap | **Roadmap Fundamentos** |

O 404 entrou porque tinha os dois defeitos no mesmo rótulo: o gesto no lugar do destino **e** o artigo definido prometendo um roadmap único, coisa que deixou de ser verdade quando a vitrine ganhou vários.

## O que NÃO mudou, de propósito

- **O item "Fundamentos" da barra do topo e do menu `⋯`** (`Shell.tsx`) e o título da barra lateral. São navegação, não chamada para ação: o nome curto é o que os identifica na fileira Início / Fundamentos / Roadmaps / Tópicos, e renomear ali levaria a navegação junto (`tests/navegacao.spec.ts` casa esse item com `exact: true`).
- **Os dois "Ver tudo →" da home** (`link-btn`). São o par de cabeçalhos de seção "Comece por aqui" e "Além dos Fundamentos"; significam "veja a lista inteira destes cards", não "vá para o roadmap", e são lidos como par.
- **O link em prosa do `/sobre/`** e o "Fundamentos" dentro do parágrafo do `/roadmaps/`. São frases, não botões: "Roadmap Fundamentos ou começar pela introdução" não é português.

## Teste

Um guarda novo em `tests/navegacao.spec.ts`, de mão dupla, porque o conserto tem uma armadilha do lado: ele cobra o rótulo novo nos três botões (`/`, `/introducao/`, `/404.html`), cobra que o `href` continue indo para `/roadmaps/fundamentos`, cobra que os rótulos antigos não voltem, **e** cobra que o item da barra do topo continue se chamando exatamente "Fundamentos" e ainda navegando.

## Verificação

- `npx tsc --noEmit`, `npm run build`, `npm test` (765 passando), `npm run lint` (0 erros, os 6 avisos de `set-state-in-effect` já existiam) e `scripts/guarda-ancoras.py`.
- Conferência na tela em 1440x900, 390x844 e 360x780, nas três rotas: `document.body.scrollWidth === window.innerWidth` nos três (0 overflow), o botão continua numa linha só (43px de altura, texto não cortado) e o par do hero segue lado a lado no desktop e empilhado no celular, como antes.

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)