### PR TITLE
fix(apoie): credencial nova da APOIA.se, nome curto e varredura de segredo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,27 @@
 # Apoiadores (APOIA.se), lidos em tempo de build pela página /apoie.
 #
-# Sem estas variáveis, a lista de apoiadores fica vazia e a página mostra o
-# convite "seja o primeiro". Com elas, os nomes aparecem do apoio mais recente
-# para o mais antigo. Copie para .env.local e preencha (o .env.local é ignorado
-# pelo git). No GitHub, configure os dois como secrets do repositório.
+# Sem estas variáveis o muro de apoiadores sai da lista de plano B escrita em
+# src/app/apoie/apoiadores.ts, e o build avisa no log que caiu nela. Com elas,
+# os nomes vêm da API, do apoio mais recente para o mais antigo. Copie este
+# arquivo para .env.local e preencha (o .env.local é ignorado pelo git). No
+# GitHub, os três são secrets do repositório.
+#
+# A credencial é a da API pública da APOIA.se, pedida à Central de Suporte:
+# https://suporte.apoia.se/hc/pt-br/articles/7598596260251-API-Publica-da-APOIA-se
+# Documentação (v0.1):
+# https://apoiase.notion.site/APOIA-se-API-4b87651821884061a7532abfd7f26087
 
-# Token Bearer do painel da APOIA.se (dashboard-api-v1). Expira de tempos em
-# tempos: se a lista sumir, gere um token novo e atualize aqui e no secret.
-APOIASE_TOKEN=
+# Chave da campanha. Vai no header `x-api-key`.
+APOIASE_KEY=
 
-# Id numérico da campanha (aparece na URL do painel da APOIA.se).
-APOIASE_CAMPAIGN_ID=
+# Segredo da campanha (é um JWT). Vai no header `Authorization: Bearer <...>`.
+# Não é intercambiável com a chave: trocar os dois de lugar devolve 401.
+APOIASE_SECRET=
+
+# Id da campanha. A doc diz que a chave já é "a chave correspondente a sua
+# campanha", então dependendo da rota ele é redundante; o código o manda na
+# query quando existe, e funciona sem ele.
+APOIASE_CAMPAIGN=
 
 # ---------------------------------------------------------------------------
 # Google Analytics 4 (opcional, e de propósito).

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -55,10 +55,19 @@ jobs:
       - name: Build with Next.js
         run: npm run build
         env:
-          # Apoiadores vêm da APOIA.se no build. Sem os secrets, a lista fica
-          # vazia e a página mostra o convite "seja o primeiro".
-          APOIASE_TOKEN: ${{ secrets.APOIASE_TOKEN }}
-          APOIASE_CAMPAIGN_ID: ${{ secrets.APOIASE_CAMPAIGN_ID }}
+          # Apoiadores vêm da APOIA.se no build. A chave vai no header
+          # `x-api-key` e o segredo no `Authorization: Bearer` (doc v0.1 da
+          # APOIA.se); ver `src/app/apoie/apoiadores.ts`.
+          #
+          # Estes três nomes substituem `APOIASE_TOKEN`/`APOIASE_CAMPAIGN_ID`,
+          # que o workflow injetava e que NUNCA existiram como secret: o build
+          # caía calado na lista de plano B, e era por isso que a página
+          # publicada mostrava 3 apoiadores com 5 apoios na campanha. Sem os
+          # secrets o comportamento continua o mesmo, com uma diferença que é o
+          # ponto: agora o log do build diz que caiu.
+          APOIASE_KEY: ${{ secrets.APOIASE_KEY }}
+          APOIASE_SECRET: ${{ secrets.APOIASE_SECRET }}
+          APOIASE_CAMPAIGN: ${{ secrets.APOIASE_CAMPAIGN }}
           # Google Analytics só no build da `main`. Este mesmo job roda em PR,
           # e o deploy de preview do Cloudflare é um site público de verdade:
           # sem este recorte, cada PR mandaria pageview para a propriedade de

--- a/.github/workflows/cloudflare-pages-deploy.yml
+++ b/.github/workflows/cloudflare-pages-deploy.yml
@@ -165,6 +165,26 @@ jobs:
       # exercitar um build diferente do que o `deploy` publica.
       - name: Run tests
         run: npm test
+        env:
+          # A credencial entra AQUI, num job que não constrói nada, por um motivo
+          # só: `tests/segredo-nao-vai-para-o-cliente.spec.ts` tem duas metades, e
+          # a segunda procura o VALOR literal do segredo dentro do `out/`. Sem as
+          # variáveis ela se declara `skip`, e a metade mais conclusiva da
+          # varredura nunca rodaria em lugar nenhum — só na máquina de quem tem
+          # `.env.local`, que é justamente quem não precisa dela.
+          #
+          # Com elas, o artefato que ACABOU de ser construído com a credencial de
+          # verdade é conferido contra a credencial de verdade, no caminho entre o
+          # build e o deploy. É a diferença entre "nenhuma forma conhecida de
+          # segredo aparece" e "este segredo não aparece".
+          #
+          # O teste nunca imprime o valor (a mensagem de falha cita o NOME da
+          # variável e o arquivo), e o Actions ainda mascara secret no log por
+          # cima disso. Este job não roda em pull_request, então PR de fork
+          # continua sem ver nada.
+          APOIASE_KEY: ${{ secrets.APOIASE_KEY }}
+          APOIASE_SECRET: ${{ secrets.APOIASE_SECRET }}
+          APOIASE_CAMPAIGN: ${{ secrets.APOIASE_CAMPAIGN }}
 
       - name: Upload report on failure
         if: failure()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,17 @@ Site estático (`out/`) publicado no **Cloudflare Pages** via **Wrangler**. O de
 deploy, e todo PR precisa da aprovação de um mantenedor antes do merge. Deploy local:
 `npx wrangler pages deploy out --project-name <nome>`. Não há `wrangler.toml`: o nome do projeto
 vem de `--project-name` (no CI, do secret). Secrets: `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`,
-`CLOUDFLARE_PROJECT_NAME` (e, para apoiadores, `APOIASE_TOKEN` / `APOIASE_CAMPAIGN_ID`).
+`CLOUDFLARE_PROJECT_NAME` (e, para apoiadores, `APOIASE_KEY` / `APOIASE_SECRET` /
+`APOIASE_CAMPAIGN`).
+
+**Credencial da APOIA.se: três nomes, e nenhum é intercambiável.** `APOIASE_KEY` vai no header
+`x-api-key`, `APOIASE_SECRET` no `Authorization: Bearer` (é um JWT) e `APOIASE_CAMPAIGN` é o id da
+campanha. Sem os dois primeiros, o muro de `/apoie` sai da lista de plano B de
+`src/app/apoie/apoiadores.ts` **e o build avisa no log** — o `return` calado dessa mesma linha é o
+que fez a página publicada mostrar 3 apoiadores com 5 apoios na campanha, por meses, sem nada
+denunciar. A varredura que prova que credencial nenhuma chega ao `out/` é
+`tests/segredo-nao-vai-para-o-cliente.spec.ts`; ela lê os 1.242 arquivos do build, HTML, chunks e
+payload RSC, e entra com 0 ocorrência em 16 regras.
 
 ## Analytics
 

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -26,6 +26,13 @@
 // abaixo isola essa incerteza numa função só, `backersUrl()`, e degrada com
 // elegância enquanto ela não for confirmada com o suporte da APOIA.se.
 //
+// MEDIDO NA CI, com a credencial de verdade (PR #96): o `/backers` daqui devolve
+// **404**. Sem credencial nenhuma, o mesmo host devolve **403** em QUALQUER
+// caminho, inclusive nos que não existem (é AWS API Gateway barrando antes de
+// rotear). A diferença entre os dois códigos é o sinal: 404 quer dizer que a
+// chave passou pelo portão e que o caminho é que não existe. A credencial está
+// certa; a rota de listagem é que não existe mesmo.
+//
 // POR QUE A PÁGINA MOSTRAVA 3 COM 5 APOIOS NA CAMPANHA
 //
 // Não era cache, nem paginação, nem filtro de status: a versão anterior deste

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -67,25 +67,88 @@ const NAME_PARTICLES = new Set([
   "de", "da", "do", "das", "dos", "e", "di", "du", "del", "della", "la", "van", "von",
 ]);
 
-// Sigla do avatar do card: "Cristiano Cunha" vira "CC", "Ana" vira "A".
-// Espalha (`[...]`) em vez de indexar para não cortar caractere fora do BMP.
+/** Índices das palavras que são nome de verdade (partícula não conta). */
+function realNameIndexes(parts: string[]): number[] {
+  const out: number[] = [];
+  parts.forEach((p, i) => {
+    if (!NAME_PARTICLES.has(p.toLowerCase())) out.push(i);
+  });
+  return out;
+}
+
+/**
+ * O nome como ele aparece no card: primeiro e último, e só.
+ *
+ * "Maria Aparecida da Silva Souza" vira "Maria Souza". O muro tem cards
+ * estreitos (dois por linha a 390px) e nome de quatro palavras quebrava em três
+ * linhas, desalinhando a fileira inteira.
+ *
+ * Três regras que não são óbvias, e cada uma existe por um caso concreto:
+ *
+ * · PARTÍCULA NÃO É NOME. "João da Silva" tem DOIS nomes, não três, e sai
+ *   inteiro. Contar "da" como palavra faria o corte disparar em quem já cabia,
+ *   e devolveria "João Silva" sem necessidade nenhuma.
+ * · A PARTÍCULA COLADA NO SOBRENOME VAI JUNTO. "Maria Aparecida da Silva" vira
+ *   "Maria da Silva", não "Maria Silva". O corte é para caber no card, não para
+ *   reescrever o nome de ninguém, e "da Silva" é o sobrenome da pessoa.
+ * · ESPAÇO NÃO É SEPARADOR CONFIÁVEL. Nome digitado à mão vem com espaço duplo e
+ *   espaço nas pontas; `split(/\s+/)` depois do `trim()` resolve os dois, e o
+ *   `\s` do JavaScript já cobre o espaço não separável que vem de formulário.
+ *
+ * Nome de uma palavra só e nome que é só partícula voltam como estão, apenas com
+ * o espaçamento normalizado: melhor um nome estranho do que um nome destruído.
+ */
+export function shortenName(name: string): string {
+  const parts = name.trim().split(/\s+/).filter((p) => p.length > 0);
+  if (parts.length === 0) return "";
+
+  const reais = realNameIndexes(parts);
+  // Dois nomes ou menos: não há o que cortar, e mexer só estragaria.
+  if (reais.length <= 2) return parts.join(" ");
+
+  const primeiro = reais[0];
+  const ultimo = reais[reais.length - 1];
+
+  // Anda para trás sobre as partículas coladas no sobrenome ("da Silva"), sem
+  // nunca passar por cima do primeiro nome.
+  let inicioDoSobrenome = ultimo;
+  while (
+    inicioDoSobrenome - 1 > primeiro &&
+    NAME_PARTICLES.has(parts[inicioDoSobrenome - 1].toLowerCase())
+  ) {
+    inicioDoSobrenome--;
+  }
+
+  return [parts[primeiro], ...parts.slice(inicioDoSobrenome, ultimo + 1)].join(" ");
+}
+
+/**
+ * Sigla do avatar do card: "Cristiano Cunha" vira "CC", "Ana" vira "A".
+ * Espalha (`[...]`) em vez de indexar para não cortar caractere fora do BMP.
+ */
 export function initials(name: string): string {
-  const parts = name
-    .trim()
-    .split(/\s+/)
-    .filter((p) => p.length > 0 && !NAME_PARTICLES.has(p.toLowerCase()));
-  if (parts.length === 0) return "?";
-  const first = [...parts[0]][0] ?? "";
-  const last = parts.length > 1 ? ([...parts[parts.length - 1]][0] ?? "") : "";
+  const parts = name.trim().split(/\s+/).filter((p) => p.length > 0);
+  const reais = realNameIndexes(parts);
+  if (reais.length === 0) return "?";
+  const first = [...parts[reais[0]]][0] ?? "";
+  const last = reais.length > 1 ? ([...parts[reais[reais.length - 1]]][0] ?? "") : "";
   return (first + last).toUpperCase();
 }
 
-// Remove nomes repetidos preservando a ordem (o primeiro a aparecer prevalece).
+/**
+ * Encurta os nomes e tira os repetidos, preservando a ordem de chegada.
+ *
+ * A ORDEM DAS DUAS OPERAÇÕES É O PONTO. Encurtar DEPOIS de deduplicar deixaria
+ * passar "Wilson Neto" e "Wilson Gomes Neto" como duas pessoas, que é justamente
+ * o par que o muro precisa juntar quando o nome do painel for mais completo que
+ * o daqui. Deduplicar sobre o nome JÁ encurtado é o que faz os dois virarem uma
+ * chave só.
+ */
 function normalizeSupporters(list: Supporter[]): Supporter[] {
   const seen = new Set<string>();
   const out: Supporter[] = [];
   for (const s of list) {
-    const name = s.name.trim();
+    const name = shortenName(s.name);
     const key = name.toLowerCase();
     if (!key || seen.has(key)) continue;
     seen.add(key);

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -143,19 +143,26 @@ export function initials(name: string): string {
 }
 
 /**
- * Encurta os nomes e tira os repetidos, preservando a ordem de chegada.
+ * Tira os repetidos preservando a ordem de chegada, pelo nome COMPLETO.
  *
- * A ORDEM DAS DUAS OPERAÇÕES É O PONTO. Encurtar DEPOIS de deduplicar deixaria
- * passar "Wilson Neto" e "Wilson Gomes Neto" como duas pessoas, que é justamente
- * o par que o muro precisa juntar quando o nome do painel for mais completo que
- * o daqui. Deduplicar sobre o nome JÁ encurtado é o que faz os dois virarem uma
- * chave só.
+ * ⚠️ NÃO deduplique pelo nome encurtado, por mais tentador que pareça juntar
+ * "Wilson Neto" com "Wilson Gomes Neto". Encurtar antes de comparar apaga
+ * gente: "Maria Aparecida Silva" e "Maria Beatriz Silva" são duas pessoas e
+ * viram a mesma chave "Maria Silva", então uma delas some do muro E da contagem
+ * do painel de gratidão, que sai da mesma lista. Perder um apoiador é bem pior
+ * que mostrar a mesma pessoa duas vezes.
+ *
+ * O encurtamento é de APRESENTAÇÃO e acontece na página (`shortenName` no
+ * `page.tsx`); aqui em baixo o dado guarda a identidade que a API deu.
+ *
+ * A chave normaliza espaço e caixa porque "  maria   souza " e "Maria Souza"
+ * são a mesma inscrição digitada duas vezes, e isso é repetição de verdade.
  */
-function normalizeSupporters(list: Supporter[]): Supporter[] {
+export function normalizeSupporters(list: Supporter[]): Supporter[] {
   const seen = new Set<string>();
   const out: Supporter[] = [];
   for (const s of list) {
-    const name = shortenName(s.name);
+    const name = s.name.trim().replace(/\s+/g, " ");
     const key = name.toLowerCase();
     if (!key || seen.has(key)) continue;
     seen.add(key);

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -12,7 +12,8 @@
 // CREDENCIAL (env local e secret no GitHub), os três nomes:
 //   APOIASE_KEY       vai no header `x-api-key`
 //   APOIASE_SECRET    vai no header `Authorization: Bearer <...>` (é um JWT)
-//   APOIASE_CAMPAIGN  id da campanha
+//   APOIASE_CAMPAIGN  id da campanha, um ObjectId do Mongo (24 hex), não um
+//                     número: quem tratar isso como inteiro erra em silêncio
 //
 // O par chave/segredo é o da API PÚBLICA da APOIA.se, documentada em
 // https://apoiase.notion.site/APOIA-se-API-4b87651821884061a7532abfd7f26087
@@ -32,6 +33,32 @@
 // rotear). A diferença entre os dois códigos é o sinal: 404 quer dizer que a
 // chave passou pelo portão e que o caminho é que não existe. A credencial está
 // certa; a rota de listagem é que não existe mesmo.
+//
+// DE ONDE VEIO O FORMATO DOS CAMPOS LIDOS AQUI EMBAIXO
+//
+// Do bundle de produção do PAINEL DO CRIADOR (`dashboard.apoia.se`), que consome
+// uma API interna, `dashboard-api-v1.apoia.se`, com três rotas de relatório:
+//
+//     GET /api/reports/backers/total/<CAMPAIGN_ID>    -> { total, totalPages }
+//     GET /api/reports/backers/<CAMPAIGN_ID>?page=N   -> { backers, campaignRewards }
+//     GET /api/reports/backers/csv/<CAMPAIGN_ID>      -> CSV
+//
+// Autenticação lá é só `Authorization: Bearer`, SEM `x-api-key`: é um esquema
+// diferente do da API pública, não a mesma credencial com outra URL.
+//
+// Cada apoiador vem com `name`, `email`, `supportValue`, `supportStatus`,
+// `supportActive`, `supportPrivate`, `firstSupportDate`, `supportLastModified`,
+// `paymentMethod`, `rewardChosen`, `addressDelivery` e `timesSupportCreation`.
+// É esse contrato que `pickTime`, `isActive` e `isPublic` leem. Antes disto o
+// código procurava `created_at`, `first_support_at` e `support_status`, que não
+// existem: a ordenação era um no-op e o filtro de status nunca casava.
+//
+// ⚠️ ESSA ROTA INTERNA NÃO ESTÁ LIGADA, DE PROPÓSITO. `backersUrl()` continua
+// apontando para a API pública. Usar API interna e não documentada de terceiro é
+// decisão do dono do projeto (termos de uso, estabilidade, token de sessão que
+// expira e precisa de renovação manual), e ela ainda não foi tomada. O que este
+// arquivo faz é chegar com o parsing e a proteção de privacidade CERTOS antes de
+// qualquer fio ser ligado: no dia da decisão, muda a URL e mais nada.
 //
 // POR QUE A PÁGINA MOSTRAVA 3 COM 5 APOIOS NA CAMPANHA
 //
@@ -214,9 +241,10 @@ export function apoiaseHeaders(key: string, secret: string): Record<string, stri
  * QUANDO O SUPORTE DA APOIA.se CONFIRMAR A ROTA, é esta função que muda, e só
  * ela.
  */
-function backersUrl(campaign?: string): string {
+function backersUrl(campaign?: string, page = 1): string {
   const url = new URL("/backers", API_BASE);
   if (campaign) url.searchParams.set("campaign", campaign);
+  url.searchParams.set("page", String(page));
   return url.toString();
 }
 
@@ -230,8 +258,8 @@ function nestedName(v: unknown): string | undefined {
   return undefined;
 }
 
-// A resposta da listagem não está documentada, então lemos o nome de forma
-// defensiva, tentando as chaves mais prováveis.
+// O nome. O campo real do relatório é `name`; o resto é rede de segurança para
+// formato diferente, e não custa nada manter.
 function pickName(b: Raw): string | null {
   const direct = [b.name, b.nome, b.backer_name, b.supporter_name, b.apoiador].find(
     (v): v is string => typeof v === "string" && v.trim().length > 0
@@ -240,30 +268,87 @@ function pickName(b: Raw): string | null {
   return s.length ? s : null;
 }
 
-// Timestamp do apoio, para ordenar do mais recente para o mais antigo. Sem data,
-// vira 0 e preserva a ordem que a API já devolveu.
+/**
+ * Timestamp do apoio, para ordenar do mais recente para o mais antigo.
+ *
+ * ⚠️ OS CAMPOS SÃO camelCase, e isso já esteve errado aqui. A versão anterior
+ * procurava `created_at`, `first_support_at` e `status_changed_at`, que NÃO
+ * existem no relatório: os reais são `firstSupportDate` e `supportLastModified`.
+ * Nenhuma chave casava, todo apoio virava 0, e o `.sort()` logo abaixo era um
+ * no-op silencioso — a lista saía na ordem em que a API mandou e ninguém tinha
+ * como perceber, porque ordem errada não quebra nada, só mente.
+ *
+ * `firstSupportDate` primeiro, de propósito: o muro conta desde quando a pessoa
+ * apoia, não quando o registro dela foi mexido pela última vez.
+ */
 function pickTime(b: Raw): number {
   const raw = [
-    b.status_changed_at,
-    b.statusChangedAt,
-    b.created_at,
+    b.firstSupportDate,
+    b.supportLastModified,
+    // Rede de segurança para outros formatos. Não são os campos do relatório.
     b.createdAt,
-    b.subscribed_at,
-    b.first_support_at,
+    b.created_at,
     b.date,
-    b.updated_at,
   ].find((v) => typeof v === "string" || typeof v === "number");
   if (raw === undefined) return 0;
   const t = Date.parse(String(raw));
   return Number.isNaN(t) ? 0 : t;
 }
 
-// Sem status, assume ativo. Com status, descarta apoios claramente encerrados.
-function isActive(b: Raw): boolean {
-  const raw = [b.status, b.status_atual, b.support_status].find((v) => typeof v === "string");
-  const status = typeof raw === "string" ? raw.toLowerCase() : "";
-  if (!status) return true;
-  return !/cancel|inativ|inactive|expir|encerrad|refund|falh|failed/.test(status);
+/**
+ * Os únicos valores de `supportStatus` que valem um card no muro.
+ *
+ * O vocabulário observado no relatório é `complete`, `blocked`, `locked`,
+ * `incomplete` e `closed_campaign`, e só o primeiro é um apoio saudável.
+ *
+ * LISTA DE PERMISSÃO, e não de proibição: a versão anterior perguntava se o
+ * status casava `/cancel|inativ|expir|.../`, e NENHUM dos quatro estados ruins
+ * casa com isso. `blocked`, `locked` e `closed_campaign` passariam como ativos,
+ * e `incomplete` passaria duas vezes (não casa a proibição e ainda contém a
+ * palavra "complete", que pegaria uma comparação por substring). Por isso a
+ * comparação é exata.
+ */
+const SUPPORT_STATUS_PUBLICAVEL = new Set(["complete"]);
+
+/**
+ * O apoio está ativo?
+ *
+ * Lê `supportStatus` (camelCase, o campo real) e `supportActive`. Sem nenhum dos
+ * dois, assume ativo: quem não declara estado nenhum já não passa pelo filtro de
+ * privacidade abaixo, que é o fail-closed de verdade.
+ */
+export function isActive(b: Raw): boolean {
+  if (b.supportActive === false) return false;
+
+  const raw = [b.supportStatus, b.status, b.support_status].find((v) => typeof v === "string");
+  if (typeof raw !== "string") return true;
+  return SUPPORT_STATUS_PUBLICAVEL.has(raw.trim().toLowerCase());
+}
+
+/**
+ * Esta pessoa AUTORIZOU aparecer no muro?
+ *
+ * ⚠️ FAIL-CLOSED, e é a regra mais importante do arquivo. A APOIA.se deixa o
+ * apoiador marcar o apoio como privado (`supportPrivate: true`), e o muro é uma
+ * página pública e indexada. Publicar quem pediu para não aparecer não é bug de
+ * dado, é incidente de privacidade, e não tem desfazer: sai no HTML, no payload
+ * RSC e no cache do Google.
+ *
+ * Então a pergunta não é "é privado?", é "está explicitamente declarado como NÃO
+ * privado?". Campo ausente, nulo, string, número ou qualquer coisa que não seja
+ * o booleano `false` significa NÃO PUBLICA. O custo de errar para este lado é um
+ * nome a menos no muro; para o outro lado, é publicar alguém contra a vontade
+ * dela.
+ *
+ * Consequência esperada e desejada: uma resposta que não traga `supportPrivate`
+ * esvazia o muro e o faz cair no plano B, com aviso no log. Muro vazio conserta
+ * em cinco minutos; nome publicado indevidamente, não.
+ */
+export function isPublic(b: Raw): boolean {
+  const declarado = [b.supportPrivate, b.support_private, b.isPrivate, b.private].find(
+    (v) => v !== undefined
+  );
+  return declarado === false;
 }
 
 function toList(json: unknown): Raw[] {
@@ -278,18 +363,87 @@ function toList(json: unknown): Raw[] {
 }
 
 /**
- * Só o NOME sai daqui, e isso é uma decisão de privacidade, não um detalhe de
- * tipo. A resposta da APOIA.se pode trazer e-mail, valor apoiado e data: nada
- * disso pode chegar ao HTML, que é público e fica indexado. `Supporter` tem um
- * campo só justamente para não haver caminho por onde o resto passe.
+ * Uma página da listagem: os apoiadores e quantas páginas existem ao todo.
+ *
+ * `totalPages` vem na própria resposta do relatório, o que dispensa a chamada
+ * separada de contagem. Sem o campo, assume uma página só.
  */
-function toSupporters(raw: Raw[]): Supporter[] {
+export function readPage(json: unknown): { backers: Raw[]; totalPages: number } {
+  const backers = toList(json);
+  let totalPages = 1;
+  if (json && typeof json === "object") {
+    const t = (json as Raw).totalPages;
+    if (typeof t === "number" && Number.isFinite(t) && t >= 1) totalPages = Math.floor(t);
+  }
+  return { backers, totalPages };
+}
+
+/**
+ * Teto de páginas. Não é o limite da API, é o limite da nossa paciência: um
+ * `totalPages` absurdo (ou um campo que mude de significado) não pode virar um
+ * laço infinito segurando o build.
+ */
+const MAX_PAGES = 20;
+
+/**
+ * Junta todas as páginas, chamando `carregar` uma vez por página.
+ *
+ * A versão anterior fazia UMA requisição e pronto: com a campanha passando de
+ * uma página, o muro mostraria só a primeira fatia e diria que aquilo era o
+ * total. Silencioso de novo, porque uma lista curta parece uma lista.
+ *
+ * Recebe o carregador por parâmetro (em vez de chamar `fetch` aqui dentro) para
+ * a concatenação poder ser exercitada sem rede.
+ */
+export async function collectAllPages(
+  carregar: (page: number) => Promise<unknown>,
+  maxPages: number = MAX_PAGES
+): Promise<Raw[]> {
+  const primeira = readPage(await carregar(1));
+  const total = Math.min(primeira.totalPages, maxPages);
+  if (primeira.totalPages > maxPages) {
+    console.warn(
+      `[apoia.se] a listagem diz ter ${primeira.totalPages} páginas e o teto é ${maxPages}. ` +
+        `Lendo só as primeiras: o muro pode sair incompleto.`
+    );
+  }
+
+  const todos = [...primeira.backers];
+  for (let page = 2; page <= total; page++) {
+    todos.push(...readPage(await carregar(page)).backers);
+  }
+  return todos;
+}
+
+/**
+ * Da resposta crua para os nomes do muro.
+ *
+ * Só o NOME sai daqui, e isso é decisão de privacidade, não detalhe de tipo. O
+ * relatório traz `email`, `supportValue`, `paymentMethod` e `addressDelivery`, e
+ * nada disso pode chegar ao HTML, que é público e indexado. `Supporter` tem um
+ * campo só justamente para não haver caminho por onde o resto passe.
+ *
+ * A ordem dos filtros é a ordem do risco: privacidade primeiro.
+ */
+export function toSupporters(raw: Raw[]): Supporter[] {
   return raw
+    .filter(isPublic)
     .filter(isActive)
     .map((b) => ({ name: pickName(b), t: pickTime(b) }))
     .filter((b): b is { name: string; t: number } => b.name !== null)
     .sort((a, b) => b.t - a.t) // mais recente primeiro
     .map((b) => ({ name: b.name }));
+}
+
+/** Resposta HTTP não-ok, com o endereço e sem nada do cabeçalho. */
+class RespostaHttp extends Error {
+  constructor(
+    readonly status: number,
+    readonly url: string
+  ) {
+    super(`HTTP ${status}`);
+    this.name = "RespostaHttp";
+  }
 }
 
 export async function fetchSupporters(): Promise<Supporter[]> {
@@ -307,40 +461,44 @@ export async function fetchSupporters(): Promise<Supporter[]> {
     return normalizeSupporters(FALLBACK_SUPPORTERS);
   }
 
-  const url = backersUrl(campaign);
-  try {
-    const res = await fetch(url, {
-      headers: apoiaseHeaders(key, secret),
-      signal: AbortSignal.timeout(8000),
-    });
-    if (!res.ok) {
-      // A URL entra no aviso, o header nunca: é o que separa um log útil de um
-      // log que publica a credencial no console da CI.
-      console.warn(
-        `[apoia.se] ${res.status} em ${url}. A rota de listagem ainda não foi confirmada com o ` +
-          `suporte da APOIA.se (a doc v0.1 só tem /backers/charges/<email>). Muro no plano B.`
-      );
-      return normalizeSupporters(FALLBACK_SUPPORTERS);
-    }
+  const headers = apoiaseHeaders(key, secret);
+  const carregar = async (page: number): Promise<unknown> => {
+    const url = backersUrl(campaign, page);
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(8000) });
+    // A URL entra no erro, o header nunca: é o que separa um log útil de um log
+    // que publica a credencial no console da CI.
+    if (!res.ok) throw new RespostaHttp(res.status, url);
+    return res.json();
+  };
 
-    const raw = toList(await res.json());
+  try {
+    const raw = await collectAllPages(carregar);
     const muro = normalizeSupporters(toSupporters(raw));
 
-    if (raw.length > 0 && muro.length === 0) {
-      console.warn(
-        `[apoia.se] ${raw.length} apoios recebidos e nenhum nome reconhecido. O formato da resposta ` +
-          `não é o esperado: ajuste pickName().`
-      );
-    }
     if (muro.length === 0) {
-      console.warn("[apoia.se] a API não devolveu nome nenhum. Muro no plano B.");
+      // Os três motivos possíveis, separados, porque o conserto de cada um é
+      // diferente. O do meio é o que mais assusta e é o comportamento correto:
+      // sem `supportPrivate: false` declarado, ninguém é publicado.
+      const publicos = raw.filter(isPublic).length;
+      const ativos = raw.filter(isPublic).filter(isActive).length;
+      console.warn(
+        `[apoia.se] ${raw.length} apoios recebidos e nenhum nome no muro: ${publicos} autorizaram ` +
+          `aparecer (supportPrivate: false), ${ativos} desses estão ativos. Muro no plano B.`
+      );
       return normalizeSupporters(FALLBACK_SUPPORTERS);
     }
 
     console.log(`[apoia.se] ${raw.length} apoios recebidos, ${muro.length} nomes no muro.`);
     return muro;
   } catch (err) {
-    console.warn(`[apoia.se] falha ao buscar apoiadores em ${url}. Muro no plano B.`, err);
+    if (err instanceof RespostaHttp) {
+      console.warn(
+        `[apoia.se] ${err.status} em ${err.url}. A rota de listagem ainda não foi confirmada com o ` +
+          `suporte da APOIA.se (a doc v0.1 só tem /backers/charges/<email>). Muro no plano B.`
+      );
+      return normalizeSupporters(FALLBACK_SUPPORTERS);
+    }
+    console.warn("[apoia.se] falha ao buscar apoiadores. Muro no plano B.", err);
     return normalizeSupporters(FALLBACK_SUPPORTERS);
   }
 }

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -2,22 +2,39 @@
 //
 // PARCEIROS são mantidos à mão nesta lista (poucos, empresas).
 //
-// APOIADORES: por enquanto também são mantidos à mão, em MANUAL_SUPPORTERS.
-// A integração com a APOIA.se ainda não foi aprovada por eles, então quem
-// publica um apoio novo adiciona o nome na lista abaixo, no mesmo PR (o mais
-// recente primeiro). O código da API continua aqui e liga sozinho quando as
-// variáveis de ambiente existirem: fetchSupporters() junta as duas fontes, a
-// manual primeiro, sem repetir nome. Lista vazia e API muda cai no convite
-// "seja o primeiro" automaticamente. Nada aqui quebra o build.
+// APOIADORES: a página /apoie tenta a API da APOIA.se durante o `next build` e,
+// se não conseguir, cai na lista FALLBACK_SUPPORTERS aqui de baixo. A chamada
+// roda no servidor, na máquina que constrói o site; o navegador recebe só os
+// nomes já prontos no HTML. Quem prova que a credencial não escapa junto é
+// `tests/segredo-nao-vai-para-o-cliente.spec.ts`, que varre os 1.242 arquivos
+// do `out/`.
 //
-// Configuração (env local e secret no GitHub):
-//   APOIASE_TOKEN        token Bearer do painel da APOIA.se (dashboard)
-//   APOIASE_CAMPAIGN_ID  id numérico da campanha (aparece na URL do painel)
+// CREDENCIAL (env local e secret no GitHub), os três nomes:
+//   APOIASE_KEY       vai no header `x-api-key`
+//   APOIASE_SECRET    vai no header `Authorization: Bearer <...>` (é um JWT)
+//   APOIASE_CAMPAIGN  id da campanha
 //
-// Observação: a API pública "oficial" da APOIA.se só valida uma pessoa por vez
-// (checa se fulano apoia). Quem devolve a lista completa é a API do painel
-// (dashboard-api-v1), abaixo. O token do painel expira de tempos em tempos: se a
-// lista sumir, gere um token novo e atualize o secret.
+// O par chave/segredo é o da API PÚBLICA da APOIA.se, documentada em
+// https://apoiase.notion.site/APOIA-se-API-4b87651821884061a7532abfd7f26087
+// (v0.1). O formato dos dois headers acima está copiado de lá, literalmente.
+//
+// ⚠️ LIMITE CONHECIDO, E É O NÓ DESTA PÁGINA. A doc v0.1 descreve UMA rota só,
+// `GET /backers/charges/<email>`, que responde `{isBacker, isPaidThisMonth,
+// thisMonthPaidValue}` para UM e-mail por vez. Ela não devolve nome, não devolve
+// lista, e o site não tem (nem quer ter) os e-mails dos apoiadores. Ou seja: a
+// rota de LISTAGEM que esta página precisa não está documentada. O que está
+// abaixo isola essa incerteza numa função só, `backersUrl()`, e degrada com
+// elegância enquanto ela não for confirmada com o suporte da APOIA.se.
+//
+// POR QUE A PÁGINA MOSTRAVA 3 COM 5 APOIOS NA CAMPANHA
+//
+// Não era cache, nem paginação, nem filtro de status: a versão anterior deste
+// arquivo lia `APOIASE_TOKEN` e `APOIASE_CAMPAIGN_ID`, e NENHUM DOS DOIS existia
+// como secret do repositório (`gh secret list` trazia só os quatro do
+// Cloudflare). O build caía no primeiro `return` e renderizava a lista escrita à
+// mão, que tinha exatamente três nomes. E caía CALADO: aquele `return` era o
+// único caminho de saída sem um aviso, então nada no log do build denunciava que
+// a integração nunca tinha rodado. Agora ele avisa como todos os outros.
 
 export type Supporter = { name: string };
 export type Partner = { name: string; url?: string };
@@ -26,16 +43,26 @@ export const PARTNERS: Partner[] = [
   // { name: "Empresa X", url: "https://empresa.com" },
 ];
 
-// Apoiadores mantidos à mão, do apoio mais recente para o mais antigo.
-// Aparecem antes de qualquer nome que venha da API.
-const MANUAL_SUPPORTERS: Supporter[] = [
+/**
+ * Plano B do muro, do apoio mais recente para o mais antigo.
+ *
+ * PLANO B, e não "lista manual que se soma à API": a diferença é o defeito que
+ * esta versão conserta. Antes estes nomes eram sempre colados na FRENTE do que a
+ * API devolvesse, e isso cobrava dois preços. A ordem por recência ia embora
+ * (três nomes fixos na frente de todo mundo), e o "sem repetir nome" dependia da
+ * grafia bater caractere a caractere com a do painel: "Wilson Neto" aqui contra
+ * "Wilson Gomes Neto" lá são duas chaves diferentes, e a mesma pessoa apareceria
+ * em dois cards. Agora a API, quando responde, é a fonte; esta lista entra
+ * quando ela não responde, e nunca junto.
+ */
+const FALLBACK_SUPPORTERS: Supporter[] = [
   { name: "Cristiano Cunha" },
   { name: "Wilson Neto" },
   { name: "Eduarda Martins" },
 ];
 
-// Partículas de nome ("Maria da Silva") não valem como inicial: a sigla sai de
-// primeiro + último nome de verdade.
+// Partículas de nome ("Maria da Silva") não são nome: nem contam para decidir se
+// o nome é comprido, nem valem como inicial da sigla.
 const NAME_PARTICLES = new Set([
   "de", "da", "do", "das", "dos", "e", "di", "du", "del", "della", "la", "van", "von",
 ]);
@@ -54,19 +81,67 @@ export function initials(name: string): string {
 }
 
 // Remove nomes repetidos preservando a ordem (o primeiro a aparecer prevalece).
-function dedupeByName(list: Supporter[]): Supporter[] {
+function normalizeSupporters(list: Supporter[]): Supporter[] {
   const seen = new Set<string>();
   const out: Supporter[] = [];
   for (const s of list) {
-    const key = s.name.trim().toLowerCase();
+    const name = s.name.trim();
+    const key = name.toLowerCase();
     if (!key || seen.has(key)) continue;
     seen.add(key);
-    out.push(s);
+    out.push({ name });
   }
   return out;
 }
 
-const API_BASE = "https://dashboard-api-v1.apoia.se/api/reports/backers";
+// ---------------------------------------------------------------------------
+// A API da APOIA.se
+// ---------------------------------------------------------------------------
+
+const API_BASE = "https://api.apoia.se";
+
+/**
+ * Os dois headers de autenticação, exatamente como a doc v0.1 os escreve.
+ *
+ * Esta é a parte CONFIRMADA da integração, e por isso está numa função pura,
+ * exportada e coberta por teste: dá para provar que o header é montado certo sem
+ * rede, sem credencial e sem depender de a rota de listagem existir.
+ *
+ * Não são intercambiáveis: `x-api-key` leva a CHAVE e o `Authorization` leva o
+ * SEGREDO. Trocar os dois de lugar devolve 401, e é um erro que só aparece em
+ * produção, porque o build local não tem credencial nenhuma.
+ */
+export function apoiaseHeaders(key: string, secret: string): Record<string, string> {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "x-api-key": key,
+    Authorization: `Bearer ${secret}`,
+  };
+}
+
+/**
+ * ⚠️ A ÚNICA PARTE CHUTADA DESTE ARQUIVO, e está isolada aqui de propósito.
+ *
+ * A doc v0.1 não tem rota de listagem (ver o cabeçalho do arquivo). Procurei em:
+ * a doc oficial no Notion, o artigo "API Pública da APOIA.se" da Central de
+ * Suporte, e integrações de terceiros no GitHub (`SouJunior/stars-api`,
+ * `vjpixel/diaria-studio`) — as três só conhecem `/backers/charges/<email>`.
+ *
+ * O caminho abaixo é a hipótese mais provável dentro da família `/backers/`, com
+ * a campanha na query porque a doc diz que a chave já é "a chave correspondente
+ * a sua campanha" (ou seja, a campanha pode ser implícita na credencial). Se
+ * estiver errado, o build recebe 403/404, avisa no log e o muro sai do plano B:
+ * o site não quebra e ninguém vê erro.
+ *
+ * QUANDO O SUPORTE DA APOIA.se CONFIRMAR A ROTA, é esta função que muda, e só
+ * ela.
+ */
+function backersUrl(campaign?: string): string {
+  const url = new URL("/backers", API_BASE);
+  if (campaign) url.searchParams.set("campaign", campaign);
+  return url.toString();
+}
 
 type Raw = Record<string, unknown>;
 
@@ -78,7 +153,7 @@ function nestedName(v: unknown): string | undefined {
   return undefined;
 }
 
-// A API do painel não é versionada publicamente, então lemos o nome de forma
+// A resposta da listagem não está documentada, então lemos o nome de forma
 // defensiva, tentando as chaves mais prováveis.
 function pickName(b: Raw): string | null {
   const direct = [b.name, b.nome, b.backer_name, b.supporter_name, b.apoiador].find(
@@ -118,46 +193,77 @@ function toList(json: unknown): Raw[] {
   if (Array.isArray(json)) return json as Raw[];
   if (json && typeof json === "object") {
     const o = json as Raw;
-    for (const key of ["backers", "data", "apoiadores", "results"]) {
+    for (const key of ["backers", "data", "apoiadores", "results", "items"]) {
       if (Array.isArray(o[key])) return o[key] as Raw[];
     }
   }
   return [];
 }
 
-export async function fetchSupporters(): Promise<Supporter[]> {
-  const token = process.env.APOIASE_TOKEN;
-  const campaign = process.env.APOIASE_CAMPAIGN_ID;
-  if (!token || !campaign) return dedupeByName(MANUAL_SUPPORTERS);
+/**
+ * Só o NOME sai daqui, e isso é uma decisão de privacidade, não um detalhe de
+ * tipo. A resposta da APOIA.se pode trazer e-mail, valor apoiado e data: nada
+ * disso pode chegar ao HTML, que é público e fica indexado. `Supporter` tem um
+ * campo só justamente para não haver caminho por onde o resto passe.
+ */
+function toSupporters(raw: Raw[]): Supporter[] {
+  return raw
+    .filter(isActive)
+    .map((b) => ({ name: pickName(b), t: pickTime(b) }))
+    .filter((b): b is { name: string; t: number } => b.name !== null)
+    .sort((a, b) => b.t - a.t) // mais recente primeiro
+    .map((b) => ({ name: b.name }));
+}
 
+export async function fetchSupporters(): Promise<Supporter[]> {
+  const key = process.env.APOIASE_KEY;
+  const secret = process.env.APOIASE_SECRET;
+  const campaign = process.env.APOIASE_CAMPAIGN;
+
+  if (!key || !secret) {
+    // O aviso É o conserto de metade desta issue: sem ele, "a página mostra 3"
+    // e "a integração nunca rodou" são indistinguíveis no log do build.
+    console.warn(
+      "[apoia.se] sem APOIASE_KEY e/ou APOIASE_SECRET no ambiente: o muro de apoiadores sai da " +
+        "lista de plano B (src/app/apoie/apoiadores.ts). Cadastre os dois como secrets do repositório."
+    );
+    return normalizeSupporters(FALLBACK_SUPPORTERS);
+  }
+
+  const url = backersUrl(campaign);
   try {
-    const res = await fetch(`${API_BASE}/${encodeURIComponent(campaign)}`, {
-      headers: { Authorization: `Bearer ${token}`, Accept: "application/json" },
+    const res = await fetch(url, {
+      headers: apoiaseHeaders(key, secret),
       signal: AbortSignal.timeout(8000),
     });
     if (!res.ok) {
-      console.warn(`[apoia.se] resposta HTTP ${res.status}. Mostrando só a lista manual de apoiadores.`);
-      return dedupeByName(MANUAL_SUPPORTERS);
+      // A URL entra no aviso, o header nunca: é o que separa um log útil de um
+      // log que publica a credencial no console da CI.
+      console.warn(
+        `[apoia.se] ${res.status} em ${url}. A rota de listagem ainda não foi confirmada com o ` +
+          `suporte da APOIA.se (a doc v0.1 só tem /backers/charges/<email>). Muro no plano B.`
+      );
+      return normalizeSupporters(FALLBACK_SUPPORTERS);
     }
 
     const raw = toList(await res.json());
-    const names = raw
-      .filter(isActive)
-      .map((b) => ({ name: pickName(b), t: pickTime(b) }))
-      .filter((b): b is { name: string; t: number } => b.name !== null)
-      .sort((a, b) => b.t - a.t) // mais recente primeiro
-      .map((b) => ({ name: b.name }));
+    const muro = normalizeSupporters(toSupporters(raw));
 
-    // Diagnóstico: veio gente mas não reconhecemos o campo do nome. Sinaliza que
-    // o formato da API mudou e o mapeamento em pickName precisa de ajuste.
-    if (raw.length > 0 && names.length === 0) {
-      console.warn(`[apoia.se] recebeu ${raw.length} apoios mas não reconheceu os campos de nome. Ajuste pickName().`);
+    if (raw.length > 0 && muro.length === 0) {
+      console.warn(
+        `[apoia.se] ${raw.length} apoios recebidos e nenhum nome reconhecido. O formato da resposta ` +
+          `não é o esperado: ajuste pickName().`
+      );
     }
-    // A lista manual vem primeiro e vence o desempate: quem já está aqui não
-    // aparece duas vezes quando a API passar a devolver o mesmo nome.
-    return dedupeByName([...MANUAL_SUPPORTERS, ...names]);
+    if (muro.length === 0) {
+      console.warn("[apoia.se] a API não devolveu nome nenhum. Muro no plano B.");
+      return normalizeSupporters(FALLBACK_SUPPORTERS);
+    }
+
+    console.log(`[apoia.se] ${raw.length} apoios recebidos, ${muro.length} nomes no muro.`);
+    return muro;
   } catch (err) {
-    console.warn("[apoia.se] falha ao buscar apoiadores. Mostrando só a lista manual.", err);
-    return dedupeByName(MANUAL_SUPPORTERS);
+    console.warn(`[apoia.se] falha ao buscar apoiadores em ${url}. Muro no plano B.`, err);
+    return normalizeSupporters(FALLBACK_SUPPORTERS);
   }
 }

--- a/src/app/apoie/page.tsx
+++ b/src/app/apoie/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import { LINKS } from "@/lib/links";
 import { pageMetadata } from "@/lib/seo";
-import { fetchSupporters, initials, PARTNERS } from "./apoiadores";
+import { fetchSupporters, initials, PARTNERS, shortenName } from "./apoiadores";
 
 // Era `export const metadata` estático e, por isso, sem canonical nem `og:url` —
 // a quarta das 48 rotas que não diziam qual era a própria URL. Título e descrição
@@ -106,11 +106,28 @@ export default async function ApoiePage() {
               </ul>
             </div>
 
+            {/* O nome encurta AQUI, na apresentação, e não na lista.
+                `supporters` guarda o nome completo, que é a identidade que a
+                API deu e a chave que já separou duas pessoas homônimas de
+                primeiro e último nome ("Maria Aparecida Silva" e "Maria
+                Beatriz Silva" mostram as duas "Maria Silva", e são duas). Se o
+                corte acontecesse antes, uma delas sumiria do muro e da
+                contagem do painel, que sai desta mesma lista. */}
             <div className="apoiadores-grid">
-              {supporters.map((a) => (
-                <div key={a.name} className="apoiador-card">
+              {supporters.map((a, i) => (
+                // Chave pelo índice, e as duas alternativas estão descartadas por
+                // medição, não por gosto. Pelo nome ENCURTADO, dois homônimos de
+                // primeiro e último nome colidiriam. Pelo nome COMPLETO, ele iria
+                // parar no payload RSC: `key` é serializado, e medi que
+                // "Cristiano Cunha" aparece 2x no `__next.apoie.__PAGE__.txt`
+                // (uma delas é a chave). Publicar o nome inteiro num arquivo
+                // servido, logo depois de decidir mostrar só o primeiro e o
+                // último, é o contrário do que esta tela combinou.
+                // Índice serve porque a lista é montada uma vez, no servidor, e
+                // não reordena nem muda depois: não há reconciliação para fazer.
+                <div key={i} className="apoiador-card">
                   <span className="apoiador-avatar" aria-hidden="true">{initials(a.name)}</span>
-                  <span className="apoiador-nome">{a.name}</span>
+                  <span className="apoiador-nome">{shortenName(a.name)}</span>
                 </div>
               ))}
               <a

--- a/tests/navegacao.spec.ts
+++ b/tests/navegacao.spec.ts
@@ -60,10 +60,15 @@ test("página de apoio mostra apoiadores, parceiros e o link de doação", async
   await expect(page.getByRole("link", { name: /Quero apoiar/ }).first()).toHaveAttribute("href", /apoia\.se\/craftcodeclub/);
 });
 
-// O muro é montado da lista manual em apoiadores.ts enquanto a API da APOIA.se
-// não libera os nomes. O que o teste prende é o contrato do muro, não os nomes:
-// um card por apoiador, mais o card-convite, e a contagem do painel batendo com
-// a quantidade de cards (já saiu "3 pessoas" com quatro nomes na lista).
+// O muro sai da API da APOIA.se no build e, sem credencial no ambiente, da lista
+// de plano B em apoiadores.ts. O que o teste prende é o contrato do muro, e não
+// os nomes: um card por apoiador, mais o card-convite, e a contagem do painel
+// batendo com a quantidade de cards (já saiu "3 pessoas" com quatro nomes na
+// lista). Prender nome aqui reprovaria no dia em que a API começasse a
+// responder, que é o dia em que tudo está finalmente certo.
+//
+// A regra do nome ("Maria Aparecida da Silva Souza" vira "Maria Souza") tem
+// teste próprio em `nome-no-muro-de-apoiadores.spec.ts`.
 test("muro de apoiadores: um card por pessoa, contagem batendo e convite no fim", async ({ page }) => {
   await page.goto("/apoie/");
   const cards = page.locator(".apoiador-card:not(.apoiador-card-cta)");

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -1,9 +1,14 @@
 import { test, expect } from "@playwright/test";
 import {
   apoiaseHeaders,
+  collectAllPages,
   initials,
+  isActive,
+  isPublic,
   normalizeSupporters,
+  readPage,
   shortenName,
+  toSupporters,
 } from "../src/app/apoie/apoiadores";
 
 /**
@@ -138,6 +143,162 @@ test("a lista guarda o nome completo, e a ordem de chegada", () => {
     { name: "Ana" },
   ]);
   expect(muro).toEqual([{ name: "Maria Aparecida da Silva Souza" }, { name: "Ana" }]);
+});
+
+// ---------------------------------------------------------------------------
+// O contrato REAL do relatório de apoiadores
+// ---------------------------------------------------------------------------
+//
+// Os dados abaixo estão no formato do relatório do painel do criador, que é de
+// onde o `apoiadores.ts` lê. Antes de conhecê-lo, o código procurava
+// `created_at`, `first_support_at` e `support_status`: nomes que não existem.
+// Nada quebrava, e era esse o problema. Cada teste desta seção é um dos campos
+// que estavam errados.
+//
+// Nenhum dado aqui é de pessoa real.
+
+/** Um apoiador no formato do relatório, com o mínimo que o muro consome. */
+function apoiador(over: Record<string, unknown> = {}) {
+  return {
+    name: "Fulano de Teste",
+    email: "fulano@exemplo.invalid",
+    supportValue: 10,
+    supportStatus: "complete",
+    supportActive: true,
+    supportPrivate: false,
+    firstSupportDate: "2026-01-15T10:00:00.000Z",
+    supportLastModified: "2026-02-01T10:00:00.000Z",
+    paymentMethod: "credit_card",
+    ...over,
+  };
+}
+
+test("quem apoia em modo privado NUNCA aparece no muro", () => {
+  // A regra mais importante do arquivo. O muro é página pública e indexada, e
+  // publicar quem marcou o apoio como privado não é bug de dado, é incidente de
+  // privacidade, e não tem desfazer.
+  const muro = toSupporters([
+    apoiador({ name: "Publica Silva", supportPrivate: false }),
+    apoiador({ name: "Privada Souza", supportPrivate: true }),
+  ]);
+  expect(muro.map((s) => s.name)).toEqual(["Publica Silva"]);
+});
+
+test("sem `supportPrivate: false` declarado, ninguém é publicado (fail-closed)", () => {
+  // O ponto NÃO é "esconder quem é privado", é "só publicar quem autorizou".
+  // Campo ausente, nulo, string ou qualquer coisa que não seja o booleano
+  // `false` significa não publica. O custo de errar assim é um nome a menos no
+  // muro; errar para o outro lado publica alguém contra a vontade dela.
+  expect(isPublic(apoiador({ supportPrivate: false }))).toBe(true);
+
+  for (const valor of [undefined, null, "false", "no", 0, "", true]) {
+    const b = apoiador();
+    delete (b as Record<string, unknown>).supportPrivate;
+    if (valor !== undefined) (b as Record<string, unknown>).supportPrivate = valor;
+    expect(isPublic(b), `supportPrivate = ${JSON.stringify(valor)} não pode publicar`).toBe(false);
+  }
+
+  // E o efeito na lista inteira: resposta sem o campo esvazia o muro, o que faz
+  // a página cair no plano B com aviso. É o comportamento desejado.
+  const semCampo = apoiador();
+  delete (semCampo as Record<string, unknown>).supportPrivate;
+  expect(toSupporters([semCampo])).toEqual([]);
+});
+
+test("apoio bloqueado, travado, incompleto ou de campanha encerrada não vai ao muro", () => {
+  // O vocabulário real de `supportStatus`. A versão anterior perguntava se o
+  // status casava /cancel|inativ|expir|.../, e NENHUM destes quatro casa: os
+  // quatro passariam como ativos. `incomplete` é o mais traiçoeiro, porque
+  // contém a palavra "complete".
+  for (const status of ["blocked", "locked", "incomplete", "closed_campaign"]) {
+    expect(isActive(apoiador({ supportStatus: status })), `status ${status}`).toBe(false);
+    expect(toSupporters([apoiador({ supportStatus: status })]), `status ${status}`).toEqual([]);
+  }
+
+  expect(isActive(apoiador({ supportStatus: "complete" }))).toBe(true);
+  // `supportActive: false` derruba mesmo com status bom.
+  expect(isActive(apoiador({ supportStatus: "complete", supportActive: false }))).toBe(false);
+
+  // O campo é camelCase. Ler `support_status` era ler um campo que não existe.
+  const muro = toSupporters([
+    apoiador({ name: "Ativa Lima", supportStatus: "complete" }),
+    apoiador({ name: "Bloqueada Costa", supportStatus: "blocked" }),
+  ]);
+  expect(muro.map((s) => s.name)).toEqual(["Ativa Lima"]);
+});
+
+test("a ordem do muro é por `firstSupportDate`, do mais recente para o mais antigo", () => {
+  // Este é o defeito silencioso: procurando `created_at`, todo timestamp virava
+  // 0, o `.sort()` não trocava nada de lugar e a lista saía na ordem em que a
+  // API mandou. Ordem errada não quebra nada, só mente.
+  const muro = toSupporters([
+    apoiador({ name: "Antiga Alves", firstSupportDate: "2025-03-01T00:00:00.000Z" }),
+    apoiador({ name: "Recente Rocha", firstSupportDate: "2026-08-01T00:00:00.000Z" }),
+    apoiador({ name: "Meio Moraes", firstSupportDate: "2026-01-01T00:00:00.000Z" }),
+  ]);
+  expect(muro.map((s) => s.name)).toEqual(["Recente Rocha", "Meio Moraes", "Antiga Alves"]);
+});
+
+test("a paginação junta todas as páginas, e não só a primeira", () => {
+  // Sem paginar, uma campanha com mais de uma página mostraria a primeira fatia
+  // e diria que aquilo era o total. Silencioso de novo: lista curta parece lista.
+  const paginas: Record<number, unknown> = {
+    1: { backers: [apoiador({ name: "Um Um" })], totalPages: 3 },
+    2: { backers: [apoiador({ name: "Dois Dois" })], totalPages: 3 },
+    3: { backers: [apoiador({ name: "Tres Tres" })], totalPages: 3 },
+  };
+  const pedidas: number[] = [];
+
+  return collectAllPages(async (page) => {
+    pedidas.push(page);
+    return paginas[page];
+  }).then((todos) => {
+    expect(pedidas).toEqual([1, 2, 3]);
+    expect(todos).toHaveLength(3);
+    expect(toSupporters(todos).map((s) => s.name)).toEqual(["Um Um", "Dois Dois", "Tres Tres"]);
+  });
+});
+
+test("uma página só não vira três requisições, e o teto segura `totalPages` absurdo", async () => {
+  let chamadas = 0;
+  const uma = await collectAllPages(async () => {
+    chamadas++;
+    return { backers: [apoiador()], totalPages: 1 };
+  });
+  expect(chamadas).toBe(1);
+  expect(uma).toHaveLength(1);
+
+  // `totalPages` absurdo não pode virar laço infinito segurando o build.
+  let pedidas = 0;
+  const limitado = await collectAllPages(async () => {
+    pedidas++;
+    return { backers: [apoiador()], totalPages: 9999 };
+  }, 4);
+  expect(pedidas).toBe(4);
+  expect(limitado).toHaveLength(4);
+});
+
+test("readPage aceita o formato do relatório e também uma lista crua", () => {
+  expect(readPage({ backers: [apoiador()], totalPages: 7 }).totalPages).toBe(7);
+  expect(readPage({ backers: [apoiador()], totalPages: 7 }).backers).toHaveLength(1);
+  // Sem `totalPages`, assume uma página. Lista crua também vale.
+  expect(readPage([apoiador(), apoiador()])).toEqual({
+    backers: [apoiador(), apoiador()],
+    totalPages: 1,
+  });
+  expect(readPage(null)).toEqual({ backers: [], totalPages: 1 });
+});
+
+test("nada além do nome sai do parsing", () => {
+  // O relatório traz e-mail, valor, meio de pagamento e endereço de entrega. O
+  // muro publica nome, e só. `Supporter` tem um campo só para não haver caminho
+  // por onde o resto passe, e este teste é a prova de que continua não havendo.
+  const muro = toSupporters([
+    apoiador({ name: "Unica Pessoa", email: "segredo@exemplo.invalid", supportValue: 500 }),
+  ]);
+  expect(muro).toEqual([{ name: "Unica Pessoa" }]);
+  expect(JSON.stringify(muro)).not.toContain("@");
+  expect(JSON.stringify(muro)).not.toContain("500");
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from "@playwright/test";
-import { apoiaseHeaders, initials, shortenName } from "../src/app/apoie/apoiadores";
+import {
+  apoiaseHeaders,
+  initials,
+  normalizeSupporters,
+  shortenName,
+} from "../src/app/apoie/apoiadores";
 
 /**
  * O nome que o card mostra, e o header que a integração manda.
@@ -91,6 +96,48 @@ test("a sigla do avatar acompanha o nome já encurtado", () => {
   for (const [entrada, esperado] of casos) {
     expect(initials(shortenName(entrada)), `entrada: ${JSON.stringify(entrada)}`).toBe(esperado);
   }
+});
+
+// ---------------------------------------------------------------------------
+// normalizeSupporters: quem some do muro, e quem não pode sumir
+// ---------------------------------------------------------------------------
+
+test("duas pessoas com o mesmo primeiro e último nome continuam sendo duas", () => {
+  // O defeito que este teste prende (achado na review do PR #96): deduplicar
+  // pelo nome JÁ encurtado apaga gente. "Maria Aparecida Silva" e "Maria
+  // Beatriz Silva" viram a mesma chave "Maria Silva", e uma das duas some do
+  // muro E da contagem do painel de gratidão, que sai da mesma lista.
+  //
+  // O muro mostra "Maria Silva" duas vezes, e está certo: são duas apoiadoras.
+  // Perder uma é bem pior que repetir um rótulo.
+  const muro = normalizeSupporters([
+    { name: "Maria Aparecida Silva" },
+    { name: "Maria Beatriz Silva" },
+  ]);
+  expect(muro).toHaveLength(2);
+  expect(muro.map((s) => shortenName(s.name))).toEqual(["Maria Silva", "Maria Silva"]);
+});
+
+test("o mesmo nome digitado duas vezes vira um card só", () => {
+  // Repetição de verdade: mesma inscrição, espaçamento e caixa diferentes.
+  const muro = normalizeSupporters([
+    { name: "Cristiano Cunha" },
+    { name: "  cristiano   CUNHA " },
+    { name: "Eduarda Martins" },
+  ]);
+  expect(muro).toEqual([{ name: "Cristiano Cunha" }, { name: "Eduarda Martins" }]);
+});
+
+test("a lista guarda o nome completo, e a ordem de chegada", () => {
+  // O encurtamento é de apresentação e mora no `page.tsx`. Se ele voltar para
+  // cá, o teste de cima volta a reprovar, que é o ponto.
+  const muro = normalizeSupporters([
+    { name: "Maria Aparecida da Silva Souza" },
+    { name: "" },
+    { name: "   " },
+    { name: "Ana" },
+  ]);
+  expect(muro).toEqual([{ name: "Maria Aparecida da Silva Souza" }, { name: "Ana" }]);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect } from "@playwright/test";
+import { apoiaseHeaders, initials, shortenName } from "../src/app/apoie/apoiadores";
+
+/**
+ * O nome que o card mostra, e o header que a integração manda.
+ *
+ * POR QUE ESTE ARQUIVO EXISTE
+ *
+ * Duas partes da página `/apoie/` são funções puras e nenhuma tinha teste:
+ *
+ * · `shortenName()`, que corta "Maria Aparecida da Silva Souza" em "Maria
+ *   Souza". Ele não é `split(" ")[0] + split(" ").at(-1)`, e a distância entre
+ *   as duas coisas é justamente onde os nomes brasileiros moram: partícula no
+ *   meio, partícula colada no sobrenome, nome de uma palavra só, espaço duplo
+ *   vindo de formulário. Cada caso abaixo é um jeito de a versão ingênua errar.
+ *
+ * · `apoiaseHeaders()`, que monta os dois headers da API da APOIA.se. Esta é a
+ *   ÚNICA parte da integração que dá para provar sem rede e sem credencial, e
+ *   provar aqui vale porque o erro que ela evita (trocar chave e segredo de
+ *   lugar) só apareceria no build da `main`, em produção, como um 401 mudo.
+ *
+ * O muro renderizado tem teste em `navegacao.spec.ts` ("muro de apoiadores");
+ * aqui é a regra, não a tela.
+ */
+
+// ---------------------------------------------------------------------------
+// shortenName
+// ---------------------------------------------------------------------------
+
+test("nome com mais de dois nomes fica só com o primeiro e o último", () => {
+  const casos: [string, string][] = [
+    // O caso da issue #94, literal.
+    ["Maria Aparecida da Silva Souza", "Maria Souza"],
+    ["Ana Beatriz de Souza Lima", "Ana Lima"],
+    ["José Carlos Pereira", "José Pereira"],
+    ["Wilson Gomes Neto", "Wilson Neto"],
+  ];
+  for (const [entrada, esperado] of casos) {
+    expect(shortenName(entrada), `entrada: ${JSON.stringify(entrada)}`).toBe(esperado);
+  }
+});
+
+test("nome que já tem dois nomes, ou um só, passa inteiro", () => {
+  // Cortar aqui não encurtaria nada e ainda desfiguraria o nome. O caso que
+  // obriga a regra a existir é "João da Silva": são TRÊS palavras e DOIS nomes,
+  // e quem conta palavras devolve "João Silva" sem precisar.
+  const intactos = [
+    "Cristiano Cunha",
+    "Wilson Neto",
+    "Eduarda Martins",
+    "Ana",
+    "João da Silva",
+    "Marcos dos Santos",
+  ];
+  for (const nome of intactos) {
+    expect(shortenName(nome), `entrada: ${JSON.stringify(nome)}`).toBe(nome);
+  }
+});
+
+test("a partícula colada no sobrenome viaja junto com ele", () => {
+  // "Maria Silva" apagaria o "da" de um sobrenome que é "da Silva". O corte
+  // existe para o nome caber no card, não para reescrever o nome de ninguém.
+  expect(shortenName("Maria Aparecida da Silva")).toBe("Maria da Silva");
+  expect(shortenName("Pedro Henrique dos Santos")).toBe("Pedro dos Santos");
+  expect(shortenName("Luiz Carlos de Oliveira")).toBe("Luiz de Oliveira");
+});
+
+test("espaço duplo, espaço nas pontas e nome vazio não quebram o card", () => {
+  // Nome digitado à mão num formulário chega assim. Antes de existir esta
+  // função, o `split(" ")` cru produzia partes vazias e a sigla saía errada.
+  expect(shortenName("  Maria   Aparecida  da   Silva Souza  ")).toBe("Maria Souza");
+  expect(shortenName("   Ana   ")).toBe("Ana");
+  expect(shortenName("")).toBe("");
+  expect(shortenName("     ")).toBe("");
+  // Só partícula: não dá para escolher primeiro e último nome, e devolver algo
+  // estranho é melhor que devolver vazio e sumir com a pessoa do muro.
+  expect(shortenName("de la")).toBe("de la");
+});
+
+test("a sigla do avatar acompanha o nome já encurtado", () => {
+  // A sigla e o nome do card saem do mesmo dado, e é isso que impede o par
+  // "Maria Souza" com avatar "MS" de virar "Maria Souza" com avatar "MA".
+  const casos: [string, string][] = [
+    ["Maria Aparecida da Silva Souza", "MS"],
+    ["Maria Aparecida da Silva", "MS"],
+    ["João da Silva", "JS"],
+    ["Cristiano Cunha", "CC"],
+    ["Ana", "A"],
+    ["de la", "?"],
+  ];
+  for (const [entrada, esperado] of casos) {
+    expect(initials(shortenName(entrada)), `entrada: ${JSON.stringify(entrada)}`).toBe(esperado);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// apoiaseHeaders
+// ---------------------------------------------------------------------------
+
+test("os headers da APOIA.se levam a chave e o segredo cada um no seu lugar", () => {
+  // Valores de mentira, e óbvios: teste de credencial não guarda credencial.
+  const headers = apoiaseHeaders("CHAVE_DE_TESTE_NAO_DEVE_VAZAR", "SEGREDO_DE_TESTE_NAO_DEVE_VAZAR");
+
+  // O formato é cópia literal da doc v0.1 da APOIA.se:
+  //   x-api-key: <chave>
+  //   authorization: Bearer <segredo>
+  // Trocar os dois de lado devolve 401, e um 401 só aparece no build da `main`.
+  expect(headers["x-api-key"]).toBe("CHAVE_DE_TESTE_NAO_DEVE_VAZAR");
+  expect(headers.Authorization).toBe("Bearer SEGREDO_DE_TESTE_NAO_DEVE_VAZAR");
+
+  // O segredo nunca vai no `x-api-key`, nem a chave no `Authorization`.
+  expect(headers["x-api-key"]).not.toContain("SEGREDO");
+  expect(headers.Authorization).not.toContain("CHAVE_DE_TESTE");
+});

--- a/tests/segredo-nao-vai-para-o-cliente.spec.ts
+++ b/tests/segredo-nao-vai-para-o-cliente.spec.ts
@@ -159,7 +159,12 @@ const REGRAS: Regra[] = [
   // que não haja caminho, e esta regra é a prova de que continua não havendo.
   {
     nome: "endereço de e-mail",
-    re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+    // O `(?!...)` recusa as extensões de arquivo, e não é preciosismo: um asset
+    // de tela retina (`logo@2x.png`) casa com a forma `algo@algo.algo` letra por
+    // letra. Hoje o build não tem nenhum, e é justamente por isso que a carve-out
+    // entra agora: o dia em que alguém commitar um `@2x.png` em `public/` não
+    // pode ser o dia em que a CI fica vermelha por um PR de conteúdo.
+    re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.(?!(?:png|jpe?g|gif|svg|webp|avif|ico|css|m?js|json|map|woff2?|ttf|txt|xml|html?)\b)[A-Za-z]{2,}\b/g,
     porque:
       "e-mail é dado pessoal e o `out/` é público. Se for e-mail de EXEMPLO num artigo, " +
       "declare a ocorrência em CONHECIDOS com a rota e o motivo, em vez de afrouxar a regra.",
@@ -167,8 +172,9 @@ const REGRAS: Regra[] = [
 ];
 
 /**
- * Dívida conhecida, com endereço e contagem, no mesmo formato do `CONHECIDOS`
- * do `sem-travessao.spec.ts`.
+ * Dívida conhecida, por par arquivo+regra, com a contagem exata. Mesma ideia do
+ * `CONHECIDOS` do `sem-travessao.spec.ts`, e pela mesma razão: o guarda entra
+ * medindo o estado real em vez de esperar um PR de limpeza que nunca vem.
  *
  * Existe para o dia em que um ARTIGO legitimamente escrever "Bearer abc123" num
  * bloco de código explicando HTTP. Nesse dia a resposta certa é declarar a
@@ -338,10 +344,15 @@ test("o valor real da credencial não aparece no build", () => {
   // reprovar o site funcionando. Ele entra na lista só quando NÃO é o pedaço
   // público, que é o caso do id do painel.
   const campanha = process.env.APOIASE_CAMPAIGN ?? process.env.APOIASE_CAMPAIGN_ID;
-  if (campanha && campanha.length >= 4 && !LINKS.apoiar.includes(campanha)) {
+  if (campanha && !LINKS.apoiar.includes(campanha)) {
     segredos.push(["APOIASE_CAMPAIGN", campanha]);
   }
 
+  // O piso de 8 caracteres vale para TODOS, inclusive a campanha, e é o que
+  // impede o teste de virar gerador de alarme falso: procurar uma string curta
+  // (um id de 4 dígitos, digamos) dentro de 1.242 arquivos acha o hash de um
+  // chunk mais cedo ou mais tarde, e a falha apontaria para um arquivo em que
+  // não há vazamento nenhum. Credencial curta fica para as regras por forma.
   const presentes = segredos.filter(([, v]) => v !== undefined && v.trim().length >= 8);
   test.skip(
     presentes.length === 0,

--- a/tests/segredo-nao-vai-para-o-cliente.spec.ts
+++ b/tests/segredo-nao-vai-para-o-cliente.spec.ts
@@ -1,0 +1,409 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { LINKS } from "../src/lib/links";
+
+/**
+ * As credenciais da APOIA.se ficam no build, e o build não pode ficar no site.
+ *
+ * POR QUE ESTE ARQUIVO EXISTE
+ *
+ * A página `/apoie/` monta o muro de apoiadores chamando a API da APOIA.se
+ * durante o `next build`, com credencial lida do ambiente
+ * (`src/app/apoie/apoiadores.ts`). Isso é seguro por CONSTRUÇÃO: o módulo só é
+ * importado por um Server Component, o `output: "export"` roda a chamada na
+ * máquina de build e o navegador recebe só os nomes já prontos no HTML.
+ *
+ * "Seguro por construção" é uma frase, não uma medida. Bastam três linhas para
+ * ela deixar de valer, e nenhuma delas quebra o build:
+ *
+ *   · um `"use client"` no topo do `apoiadores.ts`, ou um import dele a partir
+ *     de um componente de cliente: o módulo inteiro passa a ser um chunk, com o
+ *     `process.env` e o cabeçalho de autenticação dentro;
+ *   · renomear a variável para `NEXT_PUBLIC_APOIASE_SECRET` "para funcionar no
+ *     dev": o Next INLINE o valor em todo lugar que a referencia;
+ *   · passar a credencial como prop de um Server Component para um filho de
+ *     cliente: ela sai serializada no payload RSC, que neste projeto mora em
+ *     960 arquivos `.txt` dentro do `out/`.
+ *
+ * Nos três casos o site continua de pé, a página continua bonita e o segredo
+ * está publicado. Este arquivo é a medida que falta: ele lê o ARTEFATO inteiro,
+ * arquivo por arquivo, byte por byte, e reprova se qualquer forma de credencial
+ * aparecer.
+ *
+ * POR QUE SOBRE O `out/`, E POR QUE TODOS OS ARQUIVOS
+ *
+ * Porque é o `out/` que o Cloudflare Pages publica. Varrer a fonte responderia
+ * "alguém escreveu o segredo?", e a pergunta é outra: "o segredo chegou ao
+ * artefato?". São 1.242 arquivos, e o vazamento não escolhe extensão: além dos
+ * 116 HTML e dos 105 chunks de JS, o export estático emite 960 `.txt` com o
+ * payload RSC de cada rota, que é texto e é servido igual.
+ *
+ * COMO REPETIR A MEDIDA À MÃO, COM CREDENCIAL FALSA
+ *
+ *     APOIASE_KEY=CHAVE_FALSA_NAO_DEVE_VAZAR \
+ *     APOIASE_SECRET=SEGREDO_FALSO_NAO_DEVE_VAZAR \
+ *     APOIASE_CAMPAIGN=99999 npm run build
+ *     grep -rn "NAO_DEVE_VAZAR" out/ ; echo "esperado: nada"
+ *
+ * O teste `o valor real da credencial não aparece no build` abaixo faz
+ * exatamente isso quando as variáveis existem no ambiente de quem roda a suíte,
+ * e é assim que a varredura vale também para os valores de verdade.
+ */
+
+const OUT = path.join(process.cwd(), "out");
+
+// ---------------------------------------------------------------------------
+// as regras
+// ---------------------------------------------------------------------------
+
+type Regra = {
+  /** Nome curto, é o que aparece no relatório de falha. */
+  nome: string;
+  re: RegExp;
+  /** O que este padrão significa quando aparece, e o que fazer. */
+  porque: string;
+};
+
+/**
+ * Cada regra é uma FORMA de vazamento, não um valor.
+ *
+ * Regra por valor só pega o segredo de hoje, e só na máquina que o tem no
+ * ambiente. Regra por forma pega o segredo de amanhã, na CI, sem que ninguém
+ * precise contar à suíte qual é o segredo — o que é bom, porque contar o
+ * segredo à suíte seria o mesmo problema num arquivo diferente.
+ *
+ * O corpus entra ZERADO: as 16 regras dão 0 ocorrência nos 1.242 arquivos do
+ * build de hoje. É de propósito, e é o que torna este guarda sustentável:
+ * guarda que nasce vermelho é desligado na semana seguinte.
+ */
+const REGRAS: Regra[] = [
+  // -- nome de variável de ambiente ----------------------------------------
+  // O nome só chega ao bundle junto com o código que o LÊ. Achar `APOIASE_KEY`
+  // num chunk quer dizer que `apoiadores.ts` (ou um irmão dele) entrou no grafo
+  // de cliente, e aí o valor vem atrás, inlineado pelo Next.
+  {
+    nome: "nome de variável APOIASE_*",
+    re: /APOIASE_[A-Z0-9_]*/g,
+    porque:
+      "o módulo que lê a credencial da APOIA.se entrou no grafo de CLIENTE. " +
+      "`src/app/apoie/apoiadores.ts` só pode ser importado por Server Component.",
+  },
+  {
+    nome: "nome de variável CLOUDFLARE_*/CF_*",
+    re: /\b(?:CLOUDFLARE|CF)_[A-Z0-9_]{3,}/g,
+    porque: "credencial de deploy não tem nada que fazer no artefato publicado.",
+  },
+  {
+    nome: "variável NEXT_PUBLIC_ com cara de segredo",
+    re: /NEXT_PUBLIC_[A-Z0-9_]*(?:TOKEN|SECRET|KEY|PASSWORD|SENHA)[A-Z0-9_]*/g,
+    porque:
+      "`NEXT_PUBLIC_` é justamente o prefixo que o Next INLINE no bundle. " +
+      "Segredo com esse prefixo é segredo publicado, mesmo que só o servidor o use.",
+  },
+
+  // -- host da API privada --------------------------------------------------
+  // Canário do mesmo defeito, por outro caminho: o host da API do painel é uma
+  // string que só existe naquele módulo. Se ele aparecer, o módulo apareceu.
+  //
+  // O padrão exige "api" no rótulo do host para NÃO casar com `apoia.se/craftcodeclub`,
+  // que é o link público do botão "Quero apoiar" e aparece 11 vezes no build de
+  // hoje, legitimamente.
+  {
+    nome: "host de API da APOIA.se",
+    re: /[a-z0-9-]*api[a-z0-9.-]*\.apoia\.se/gi,
+    porque:
+      "a API da APOIA.se é chamada NO BUILD, pelo servidor. A URL dela num chunk " +
+      "quer dizer que a chamada foi parar no navegador, sem credencial e com CORS.",
+  },
+
+  // -- cabeçalho de autenticação -------------------------------------------
+  // A forma casada é a de CÓDIGO montando header (`Authorization:` seguido de
+  // aspas), e não a palavra solta: um artigo que explique HTTP pode escrever
+  // "Authorization" no texto, e isso não é vazamento.
+  {
+    nome: "montagem de cabeçalho Authorization",
+    re: /["'`]?[Aa]uthorization["'`]?\s*:\s*["'`]/g,
+    porque: "código que monta cabeçalho de autenticação está rodando no cliente.",
+  },
+  {
+    // `x-api-key` é o header da chave da APOIA.se (doc v0.1). É uma string que
+    // só existe em `apoiaseHeaders()`, o que a torna um canário melhor que o
+    // `Authorization`: nenhum artigo deste site tem motivo para escrevê-la.
+    nome: "cabeçalho x-api-key",
+    re: /x-api-key/gi,
+    porque: "o header da chave da APOIA.se está sendo montado no navegador.",
+  },
+  { nome: "credencial Bearer", re: /\bBearer\s+[A-Za-z0-9._~+/-]{8,}/g, porque: "token no artefato." },
+  { nome: "credencial Basic", re: /\bBasic\s+[A-Za-z0-9+/]{12,}={0,2}/g, porque: "par chave/segredo em base64 no artefato." },
+  { nome: "client_secret", re: /client_secret/gi, porque: "troca de OAuth acontecendo no cliente." },
+
+  // -- formas conhecidas de segredo ----------------------------------------
+  {
+    nome: "JWT",
+    re: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g,
+    porque: "um JSON Web Token inteiro, legível por qualquer visitante.",
+  },
+  { nome: "token do GitHub", re: /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9]{20,}|\bgithub_pat_[A-Za-z0-9_]{20,}/g, porque: "token do GitHub no artefato." },
+  { nome: "chave de API estilo OpenAI", re: /\bsk-[A-Za-z0-9_-]{20,}/g, porque: "chave de API no artefato." },
+  { nome: "chave da AWS", re: /\bAKIA[0-9A-Z]{16}\b/g, porque: "access key da AWS no artefato." },
+  { nome: "token do Slack", re: /\bxox[baprs]-[A-Za-z0-9-]{10,}/g, porque: "token do Slack no artefato." },
+  { nome: "chave privada PEM", re: /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/g, porque: "chave privada no artefato." },
+
+  // -- dado pessoal ---------------------------------------------------------
+  // Não é credencial, e entra na mesma varredura porque vaza pelo mesmo cano.
+  // A resposta da APOIA.se traz e-mail de apoiador (a rota documentada da v0.1 é
+  // literalmente `/backers/charges/<email>`), e a página publica nomes. Um
+  // `pickName()` que um dia caia no campo errado publicaria o e-mail de quem
+  // apoia, num HTML que o Google indexa. O tipo `Supporter` tem um campo só para
+  // que não haja caminho, e esta regra é a prova de que continua não havendo.
+  {
+    nome: "endereço de e-mail",
+    re: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b/g,
+    porque:
+      "e-mail é dado pessoal e o `out/` é público. Se for e-mail de EXEMPLO num artigo, " +
+      "declare a ocorrência em CONHECIDOS com a rota e o motivo, em vez de afrouxar a regra.",
+  },
+];
+
+/**
+ * Dívida conhecida, com endereço e contagem, no mesmo formato do `CONHECIDOS`
+ * do `sem-travessao.spec.ts`.
+ *
+ * Existe para o dia em que um ARTIGO legitimamente escrever "Bearer abc123" num
+ * bloco de código explicando HTTP. Nesse dia a resposta certa é declarar a
+ * ocorrência aqui, com a rota e o motivo, e não afrouxar a regra para todo o
+ * build.
+ *
+ * ⚠️ A contagem é EXATA, não é teto: uma ocorrência a mais no mesmo arquivo
+ * reprova.
+ */
+const CONHECIDOS: Record<string, number> = {
+  // Vazio, e este é o estado a manter.
+};
+
+// ---------------------------------------------------------------------------
+// a varredura
+// ---------------------------------------------------------------------------
+
+type Achado = { arquivo: string; regra: string; porque: string; trecho: string };
+
+/** Todo arquivo do `out/`, caminho relativo, incluindo os sem extensão. */
+function arquivosDoBuild(): string[] {
+  return readdirSync(OUT, { recursive: true, withFileTypes: true })
+    .filter((e) => e.isFile())
+    .map((e) => path.relative(OUT, path.join(e.parentPath, e.name)))
+    .sort();
+}
+
+/**
+ * Aplica as regras a um texto.
+ *
+ * Exportada de propósito: é a MESMA função que o teste de autoverificação usa
+ * para provar que a varredura acusa um segredo plantado. Teste que reimplementa
+ * o motor prova que a cópia funciona, e é o defeito que este repositório já
+ * pagou em outros guardas.
+ */
+function varrer(arquivo: string, texto: string): Achado[] {
+  const achados: Achado[] = [];
+  for (const regra of REGRAS) {
+    // `lastIndex` é estado do próprio RegExp com a flag `g`. Sem zerar, a
+    // segunda chamada continua de onde a primeira parou e a varredura pula
+    // arquivos em silêncio, que é a pior falha possível num guarda.
+    regra.re.lastIndex = 0;
+    for (const m of texto.matchAll(regra.re)) {
+      achados.push({
+        arquivo,
+        regra: regra.nome,
+        porque: regra.porque,
+        trecho: texto.slice(Math.max(0, m.index - 40), m.index + m[0].length + 40).replace(/\s+/g, " "),
+      });
+    }
+  }
+  return achados;
+}
+
+/**
+ * `latin1` e não `utf8`, de propósito: ele mapeia byte a byte, nunca estoura em
+ * arquivo binário e preserva o ASCII, que é o alfabeto de toda credencial que
+ * este arquivo procura. Ler tudo como `utf8` substituiria bytes inválidos por
+ * U+FFFD e poderia partir uma string procurada ao meio dentro de um PNG.
+ */
+function conteudo(rel: string): Buffer {
+  return readFileSync(path.join(OUT, rel));
+}
+
+/**
+ * Byte NUL nos primeiros 8 KB, que é a heurística que o git usa para decidir se
+ * um arquivo é binário. PNG tem NUL logo no cabeçalho.
+ *
+ * ISTO NÃO É OTIMIZAÇÃO, É CORREÇÃO, e o caso foi medido: rodando as regras por
+ * FORMA sobre os PNG dos cards de Open Graph, os bytes comprimidos de
+ * `out/topicos/bst/opengraph-image` casaram com o padrão de e-mail
+ * (`...M+¯@¼ÒÌb7...` tem a forma `algo@algo.algo` em latin1). Ruído de imagem
+ * comprimida acerta qualquer padrão frouxo se você der arquivos suficientes a
+ * ele, e um guarda que reprova por ruído é desligado na semana seguinte.
+ *
+ * O que NÃO muda: o binário continua sendo varrido pelo VALOR literal da
+ * credencial, no teste seguinte. Um segredo de 30 caracteres não aparece por
+ * acaso num PNG; um arroba, sim.
+ */
+function ehBinario(buf: Buffer): boolean {
+  return buf.subarray(0, 8192).includes(0);
+}
+
+function relatorio(achados: Achado[]): string {
+  return achados
+    .slice(0, 12)
+    .map((a) => `  [${a.regra}] ${a.arquivo}\n      ...${a.trecho}...\n      ${a.porque}`)
+    .join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// os testes
+// ---------------------------------------------------------------------------
+
+test("nenhuma credencial chega ao HTML, aos chunks ou ao payload RSC", () => {
+  const arquivos = arquivosDoBuild();
+
+  // Um guarda que varre um `out/` pela metade passa verde sem ter olhado nada.
+  // Estes três pisos são a prova de que a varredura viu o build inteiro: as
+  // contagens de hoje são 116 HTML, 105 JS e 960 `.txt` de payload RSC.
+  expect(arquivos.length, "build vazio ou parcial: rode `npm run build` antes").toBeGreaterThan(1000);
+  const porExtensao = (ext: string) => arquivos.filter((a) => a.endsWith(ext)).length;
+  expect(porExtensao(".html"), "nenhum HTML no build").toBeGreaterThan(100);
+  expect(porExtensao(".js"), "nenhum chunk de JS no build").toBeGreaterThan(50);
+  expect(porExtensao(".txt"), "nenhum payload RSC no build").toBeGreaterThan(500);
+
+  // As regras por forma valem sobre TEXTO. O binário fica de fora aqui e é
+  // coberto pelo valor literal no teste seguinte (ver `ehBinario`).
+  const binarios: string[] = [];
+  const achados: Achado[] = [];
+  for (const rel of arquivos) {
+    const buf = conteudo(rel);
+    if (ehBinario(buf)) {
+      binarios.push(rel);
+      continue;
+    }
+    achados.push(...varrer(rel, buf.toString("latin1")));
+  }
+
+  // O recorte tem que continuar sendo o que eu medi. Sem esta asserção, o dia em
+  // que um chunk de JS passasse a ter um NUL ele sairia da varredura CALADO, e o
+  // guarda seguiria verde tendo parado de olhar justamente onde o segredo mora.
+  // Os únicos binários do build são os cards de Open Graph, que são PNG.
+  const inesperados = binarios.filter((b) => !b.endsWith("opengraph-image"));
+  expect(
+    inesperados,
+    "arquivo binário fora dos cards de Open Graph: ele NÃO foi varrido pelas regras por forma"
+  ).toEqual([]);
+  expect(binarios.length, "nenhum card de Open Graph no build").toBeGreaterThan(40);
+
+  // A dívida declarada sai da conta pelo par arquivo+regra, e pela contagem exata.
+  const porChave = new Map<string, Achado[]>();
+  for (const a of achados) {
+    const chave = `${a.arquivo}::${a.regra}`;
+    porChave.set(chave, [...(porChave.get(chave) ?? []), a]);
+  }
+  const novos: Achado[] = [];
+  for (const [chave, lista] of porChave) {
+    const declarados = CONHECIDOS[chave] ?? 0;
+    if (lista.length !== declarados) novos.push(...lista);
+  }
+
+  expect(
+    novos.length,
+    `${novos.length} ocorrência(s) de credencial no artefato que o Cloudflare Pages publica:\n${relatorio(novos)}`
+  ).toBe(0);
+});
+
+test("o valor real da credencial não aparece no build", () => {
+  // Só roda de verdade em quem tem o `.env.local` preenchido (e no dia em que a
+  // suíte rodar com os secrets no ambiente). Sem as variáveis, as regras por
+  // FORMA acima seguem valendo — este teste é o cinto por cima do suspensório,
+  // porque valor é a única coisa que forma nenhuma pega: uma credencial que por
+  // acaso pareça um identificador comum passaria por todas as 16 regras.
+  const segredos: [string, string | undefined][] = [
+    ["APOIASE_KEY", process.env.APOIASE_KEY],
+    ["APOIASE_SECRET", process.env.APOIASE_SECRET],
+    // Nomes do formato anterior (um Bearer do painel e o id da campanha).
+    // Continuam aqui porque o `.env.local` de quem trabalhou nisto antes ainda
+    // pode tê-los, e um segredo aposentado vaza igual.
+    ["APOIASE_TOKEN", process.env.APOIASE_TOKEN],
+  ];
+
+  // O id/slug da campanha é caso à parte, e não por descuido: ele NÃO é segredo.
+  // Ele está na URL pública do botão "Quero apoiar" (`LINKS.apoiar`), que sai em
+  // 11 lugares do build de propósito. Cobrá-lo como os outros faria o guarda
+  // reprovar o site funcionando. Ele entra na lista só quando NÃO é o pedaço
+  // público, que é o caso do id do painel.
+  const campanha = process.env.APOIASE_CAMPAIGN ?? process.env.APOIASE_CAMPAIGN_ID;
+  if (campanha && campanha.length >= 4 && !LINKS.apoiar.includes(campanha)) {
+    segredos.push(["APOIASE_CAMPAIGN", campanha]);
+  }
+
+  const presentes = segredos.filter(([, v]) => v !== undefined && v.trim().length >= 8);
+  test.skip(
+    presentes.length === 0,
+    "nenhuma credencial da APOIA.se no ambiente: nada de valor para conferir (as regras por forma já rodaram)"
+  );
+
+  // Aqui entra TUDO, binário incluído: é a metade da varredura que os PNG dos
+  // cards de Open Graph não podem escapar, e o valor literal não sofre do falso
+  // positivo que tirou o binário do teste anterior.
+  const vazados: string[] = [];
+  for (const rel of arquivosDoBuild()) {
+    const texto = conteudo(rel).toString("latin1");
+    for (const [nome, valor] of presentes) {
+      if (texto.includes(valor!.trim())) vazados.push(`${nome} aparece em out/${rel}`);
+    }
+  }
+
+  // A mensagem NÃO imprime o valor: um relatório de vazamento que imprime o
+  // segredo no log da CI vaza o segredo no log da CI.
+  expect(vazados, `credencial em texto claro no artefato:\n  ${vazados.join("\n  ")}`).toEqual([]);
+});
+
+test("o build não leva junto nenhum arquivo de ambiente", () => {
+  // `public/` é copiado inteiro para o `out/`. Um `.env` salvo ali por engano
+  // vira uma URL pública, e nenhuma das regras por forma pegaria um arquivo
+  // cujo conteúdo é só `CHAVE=valor`.
+  const ambiente = arquivosDoBuild().filter((a) => path.basename(a).startsWith(".env"));
+  expect(ambiente, "arquivo de ambiente publicado junto com o site").toEqual([]);
+});
+
+test("a varredura acusa um segredo plantado", () => {
+  // Sem este teste, o de cima é indistinguível de uma função que devolve lista
+  // vazia. Ele exercita o MESMO `varrer()` dos outros, com um artefato de
+  // mentira que carrega uma forma de cada família.
+  // Nenhum valor aqui é real, e nenhum pode ser: um guarda que guarda o segredo
+  // dentro de si para se testar é o vazamento que ele diz impedir.
+  const plantado = [
+    `const k=process.env.APOIASE_KEY;fetch("https://api.apoia.se/backers?campaign=1",{headers:{"x-api-key":"CHAVE_DE_TESTE_NAO_DEVE_VAZAR",Authorization:"Bearer SEGREDO_DE_TESTE_NAO_DEVE_VAZAR"}})`,
+    `const jwt="eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk"`,
+    `const b="Basic Y3JhZnRjb2RlY2x1YjpzZWdyZWRv"`,
+    `-----BEGIN RSA PRIVATE KEY-----`,
+    `<span class="apoiador-nome">apoiador.de.mentira@exemplo.com</span>`,
+  ].join("\n");
+
+  const achados = varrer("out/_next/static/chunks/falso.js", plantado);
+  const acusadas = new Set(achados.map((a) => a.regra));
+
+  for (const esperada of [
+    "nome de variável APOIASE_*",
+    "host de API da APOIA.se",
+    "montagem de cabeçalho Authorization",
+    "cabeçalho x-api-key",
+    "credencial Bearer",
+    "credencial Basic",
+    "JWT",
+    "chave privada PEM",
+    "endereço de e-mail",
+  ]) {
+    expect([...acusadas], `a varredura deixou passar: ${esperada}`).toContain(esperada);
+  }
+
+  // E o contrário: o que o build legítimo tem não pode acusar. O link público da
+  // campanha é o caso real, e é o que separa este guarda de um `grep apoia.se`.
+  expect(varrer("out/apoie/index.html", `<a href="${LINKS.apoiar}">Quero apoiar</a>`)).toEqual([]);
+});

--- a/tests/segredo-nao-vai-para-o-cliente.spec.ts
+++ b/tests/segredo-nao-vai-para-o-cliente.spec.ts
@@ -192,7 +192,15 @@ const CONHECIDOS: Record<string, number> = {
 // a varredura
 // ---------------------------------------------------------------------------
 
-type Achado = { arquivo: string; regra: string; porque: string; trecho: string };
+type Achado = {
+  arquivo: string;
+  regra: string;
+  porque: string;
+  /** Onde no arquivo, em bytes. Endereço, nunca conteúdo. */
+  posicao: number;
+  /** Quantos caracteres o padrão casou. Tamanho, nunca conteúdo. */
+  tamanho: number;
+};
 
 /** Todo arquivo do `out/`, caminho relativo, incluindo os sem extensão. */
 function arquivosDoBuild(): string[] {
@@ -218,11 +226,22 @@ function varrer(arquivo: string, texto: string): Achado[] {
     // arquivos em silêncio, que é a pior falha possível num guarda.
     regra.re.lastIndex = 0;
     for (const m of texto.matchAll(regra.re)) {
+      // ⚠️ O TEXTO CASADO NÃO ENTRA NO ACHADO, e isto não é economia de bytes.
+      // A primeira versão guardava um `trecho` com 40 caracteres de contexto de
+      // cada lado do casamento, incluindo o casamento. Ou seja: no dia em que um
+      // JWT vazasse para um chunk, a mensagem de falha copiaria o JWT inteiro
+      // para o log do GitHub Actions, e o guarda contra vazamento seria o
+      // segundo vazamento. Um log de CI é lido por mais gente que o artefato.
+      //
+      // O que sai é ENDEREÇO: arquivo, regra, posição e tamanho. É o bastante
+      // para achar a ocorrência (`npm run build && PORT=3301 npm test`, ou um
+      // `dd`/`cut` na posição), e não publica nada.
       achados.push({
         arquivo,
         regra: regra.nome,
         porque: regra.porque,
-        trecho: texto.slice(Math.max(0, m.index - 40), m.index + m[0].length + 40).replace(/\s+/g, " "),
+        posicao: m.index,
+        tamanho: m[0].length,
       });
     }
   }
@@ -258,10 +277,16 @@ function ehBinario(buf: Buffer): boolean {
   return buf.subarray(0, 8192).includes(0);
 }
 
+/** Endereço e diagnóstico. Nunca o conteúdo casado (ver `varrer`). */
 function relatorio(achados: Achado[]): string {
   return achados
     .slice(0, 12)
-    .map((a) => `  [${a.regra}] ${a.arquivo}\n      ...${a.trecho}...\n      ${a.porque}`)
+    .map(
+      (a) =>
+        `  [${a.regra}] out/${a.arquivo}\n` +
+        `      byte ${a.posicao}, ${a.tamanho} caracteres (conteúdo omitido de propósito)\n` +
+        `      ${a.porque}`
+    )
     .join("\n");
 }
 
@@ -417,4 +442,40 @@ test("a varredura acusa um segredo plantado", () => {
   // E o contrário: o que o build legítimo tem não pode acusar. O link público da
   // campanha é o caso real, e é o que separa este guarda de um `grep apoia.se`.
   expect(varrer("out/apoie/index.html", `<a href="${LINKS.apoiar}">Quero apoiar</a>`)).toEqual([]);
+});
+
+test("o relatório de falha não republica o segredo que encontrou", () => {
+  // Achado na review do PR #96, e é o defeito mais irônico possível num guarda
+  // deste tipo: a primeira versão guardava 40 caracteres de contexto de cada
+  // lado do casamento, o casamento INCLUÍDO. No dia em que um JWT vazasse para
+  // um chunk, a mensagem de falha copiaria o JWT inteiro para o log do GitHub
+  // Actions, que é lido por mais gente que o artefato. O guarda contra o
+  // vazamento seria o segundo vazamento.
+  const segredos = [
+    "CHAVE_DE_TESTE_NAO_DEVE_VAZAR",
+    "SEGREDO_DE_TESTE_NAO_DEVE_VAZAR",
+    "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+    "Y3JhZnRjb2RlY2x1YjpzZWdyZWRv",
+    "apoiador.de.mentira@exemplo.com",
+  ];
+  const plantado = [
+    `fetch("https://api.apoia.se/backers",{headers:{"x-api-key":"${segredos[0]}",Authorization:"Bearer ${segredos[1]}"}})`,
+    `const jwt="${segredos[2]}"`,
+    `const b="Basic ${segredos[3]}"`,
+    `<span>${segredos[4]}</span>`,
+  ].join("\n");
+
+  const achados = varrer("out/_next/static/chunks/falso.js", plantado);
+  expect(achados.length, "o cenário não plantou nada").toBeGreaterThan(0);
+
+  const texto = relatorio(achados);
+  for (const segredo of segredos) {
+    expect(texto, `o relatório republicou o segredo casado: ${segredo.slice(0, 12)}...`).not.toContain(
+      segredo
+    );
+  }
+
+  // E continua servindo para achar a ocorrência: arquivo, regra e endereço.
+  expect(texto).toContain("out/_next/static/chunks/falso.js");
+  expect(texto).toContain("byte ");
 });

--- a/tests/segredo-nao-vai-para-o-cliente.spec.ts
+++ b/tests/segredo-nao-vai-para-o-cliente.spec.ts
@@ -277,6 +277,47 @@ function ehBinario(buf: Buffer): boolean {
   return buf.subarray(0, 8192).includes(0);
 }
 
+/**
+ * Confronta o que a varredura achou com a dívida declarada, e devolve as DUAS
+ * metades.
+ *
+ * ⚠️ A UNIÃO DAS CHAVES, e não só as encontradas. A primeira versão iterava
+ * apenas o que a varredura tinha achado, e com isso uma entrada de `CONHECIDOS`
+ * cuja ocorrência sumiu do build nunca era comparada: a chave não aparecia no
+ * mapa, o laço não passava por ela, e a exceção morta ficava lá anistiando
+ * aquele par arquivo+regra para sempre. É o mesmo cuidado que o
+ * `sem-travessao.spec.ts` toma ao percorrer TODAS as rotas em vez de só as que
+ * têm ocorrência.
+ *
+ * Função à parte, e não laço embutido no teste, para o cenário da exceção
+ * obsoleta poder ser exercitado sem depender do build.
+ */
+function compararComDivida(
+  achados: Achado[],
+  conhecidos: Record<string, number>
+): { novos: Achado[]; obsoletos: string[] } {
+  const porChave = new Map<string, Achado[]>();
+  for (const a of achados) {
+    const chave = `${a.arquivo}::${a.regra}`;
+    porChave.set(chave, [...(porChave.get(chave) ?? []), a]);
+  }
+
+  const novos: Achado[] = [];
+  const obsoletos: string[] = [];
+  for (const chave of new Set([...porChave.keys(), ...Object.keys(conhecidos)])) {
+    const encontrados = porChave.get(chave) ?? [];
+    const declarados = conhecidos[chave] ?? 0;
+    if (declarados === 0) {
+      novos.push(...encontrados);
+    } else if (encontrados.length !== declarados) {
+      obsoletos.push(
+        `${chave}: ${encontrados.length}x no build, ${declarados}x declarada em CONHECIDOS`
+      );
+    }
+  }
+  return { novos, obsoletos };
+}
+
 /** Endereço e diagnóstico. Nunca o conteúdo casado (ver `varrer`). */
 function relatorio(achados: Achado[]): string {
   return achados
@@ -330,22 +371,20 @@ test("nenhuma credencial chega ao HTML, aos chunks ou ao payload RSC", () => {
   ).toEqual([]);
   expect(binarios.length, "nenhum card de Open Graph no build").toBeGreaterThan(40);
 
-  // A dívida declarada sai da conta pelo par arquivo+regra, e pela contagem exata.
-  const porChave = new Map<string, Achado[]>();
-  for (const a of achados) {
-    const chave = `${a.arquivo}::${a.regra}`;
-    porChave.set(chave, [...(porChave.get(chave) ?? []), a]);
-  }
-  const novos: Achado[] = [];
-  for (const [chave, lista] of porChave) {
-    const declarados = CONHECIDOS[chave] ?? 0;
-    if (lista.length !== declarados) novos.push(...lista);
-  }
+  const { novos, obsoletos } = compararComDivida(achados, CONHECIDOS);
 
   expect(
     novos.length,
     `${novos.length} ocorrência(s) de credencial no artefato que o Cloudflare Pages publica:\n${relatorio(novos)}`
   ).toBe(0);
+
+  // A outra metade, e ela é o guarda do guarda: exceção que encolheu vira
+  // entrada obsoleta, e entrada obsoleta anistia aquele par arquivo+regra em
+  // silêncio para sempre.
+  expect(
+    obsoletos,
+    "a contagem de uma dívida declarada mudou. Se você consertou, apague a entrada de CONHECIDOS"
+  ).toEqual([]);
 });
 
 test("o valor real da credencial não aparece no build", () => {
@@ -442,6 +481,38 @@ test("a varredura acusa um segredo plantado", () => {
   // E o contrário: o que o build legítimo tem não pode acusar. O link público da
   // campanha é o caso real, e é o que separa este guarda de um `grep apoia.se`.
   expect(varrer("out/apoie/index.html", `<a href="${LINKS.apoiar}">Quero apoiar</a>`)).toEqual([]);
+});
+
+test("uma exceção declarada que já não casa nada é acusada de obsoleta", () => {
+  // Achado na review do PR #96. A primeira versão comparava só as chaves que a
+  // varredura ENCONTROU, então uma entrada de CONHECIDOS cuja ocorrência sumiu
+  // do build nunca era visitada. A exceção morta ficava lá, e no dia em que o
+  // mesmo padrão voltasse àquele arquivo ela o anistiaria em silêncio: o guarda
+  // seguiria verde exatamente sobre a recaída que ele existe para pegar.
+  const chave = "_next/static/chunks/velho.js::JWT";
+
+  // Nada no build, e a dívida ainda declarada: obsoleta.
+  const so = compararComDivida([], { [chave]: 2 });
+  expect(so.novos).toEqual([]);
+  expect(so.obsoletos, "exceção morta passou batida").toHaveLength(1);
+  expect(so.obsoletos[0]).toContain("0x no build");
+
+  // A dívida que continua batendo não incomoda ninguém.
+  const achado: Achado = {
+    arquivo: "_next/static/chunks/velho.js",
+    regra: "JWT",
+    porque: "x",
+    posicao: 10,
+    tamanho: 100,
+  };
+  const bate = compararComDivida([achado], { [chave]: 1 });
+  expect(bate.novos).toEqual([]);
+  expect(bate.obsoletos).toEqual([]);
+
+  // E o que ninguém declarou continua reprovando.
+  const semDivida = compararComDivida([achado], {});
+  expect(semDivida.novos).toHaveLength(1);
+  expect(semDivida.obsoletos).toEqual([]);
 });
 
 test("o relatório de falha não republica o segredo que encontrou", () => {


### PR DESCRIPTION
Closes #94

## Onde a integração está

A autenticação com a APOIA.se passa a funcionar: as credenciais chegam ao build e os cabeçalhos são montados como a documentação descreve. **O que não existe é a listagem.** A documentação pública (v0.1) tem uma rota só, que consulta uma pessoa por e-mail e devolve booleanos; ela não devolve nome nem lista. Confirmado em três fontes independentes.

A prova de que a credencial está certa é a diferença de códigos: sem credencial o host responde 403 em qualquer caminho, e o build deste PR, com as credenciais reais, recebeu **404**. Passou pelo portão; falta a rota.

Por isso a página continua mostrando a lista de plano B, como antes.

## O que o PR entrega

A integração já existia no código, mas nunca chegou a rodar: lia nomes de credencial que não estavam configurados e caía num retorno silencioso que servia a lista fixa. Como esse era o único caminho sem aviso, o log não distinguia "rodou" de "nunca rodou". Agora distingue, e foi assim que o 404 apareceu.

- **Credenciais certas, e aviso em todo caminho de saída.**
- **A lista fixa virou plano B**, em vez de ser somada à resposta da API. Isso devolve a ordem por recência e elimina o risco de a mesma pessoa aparecer duas vezes por diferença de grafia.
- **Nome comprido vira primeiro + último** no card, respeitando preposições e nome único.
- **Guarda de vazamento**: varre o `out/` inteiro, HTML e chunks, atrás de credencial e dado pessoal. Verificado de três jeitos, incluindo baixar o artefato real da CI (construído com os secrets de verdade) e varrer os 1.242 arquivos: zero ocorrências. Tem autoteste que planta um segredo para provar que a varredura acusa.

## O que falta para fechar a issue

1. **Perguntar ao suporte da APOIA.se se existe rota de listagem** para a chave de campanha.
2. Antes de ligar qualquer listagem, resolver o ponto de privacidade descrito nos comentários deste PR.
3. Depois, conferir a contagem no deploy da `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
