### PR TITLE
fix(nav): a barra do topo encolhe em degraus antes de se quebrar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,7 +149,17 @@ PORT=3101 npm test   # porta alternativa: obrigatório quando há mais de uma su
   `discord.gg/<código>` cru em arquivo de documentação.
 - Barra: **esquerda** = Início, Fundamentos, Roadmaps, Tópicos; **direita** = YouTube, Discord,
   Apoiar + menu `⋯`. O menu `⋯` tem: Sobre o projeto, Craft & Code Club, GitHub do projeto,
-  Apoiadores e Parceiros (e, só no mobile, os quatro da esquerda + YouTube).
+  Apoiadores e Parceiros — e, conforme a largura aperta, os itens que saíram da barra.
+- **A barra encolhe em degraus, e a ordem é comprimir antes de esconder** (a mesma filosofia da
+  casca dos visualizadores). São quatro, todos no `globals.css`: **1000px** comprime o respiro
+  (é onde nasce a gaveta e ela rouba 42px); **940px** manda Início e YouTube para o `⋯`
+  (`nav-hide-md` na barra, `only-mobile only-md` no menu); **760px** manda Fundamentos, Roadmaps
+  e Tópicos (`nav-hide-sm` / `only-mobile`); **400px** comprime o que sobrou.
+  Duas regras que não se negociam: **nada some da barra sem aparecer no `⋯`**, e **as peças da
+  barra são rígidas** (sem `min-width: 0`, sem quebra de linha). A rigidez é de propósito: peça
+  que encolhe em silêncio se sobrepõe sem estourar a página, e nenhuma medição de overflow pega
+  isso — foi assim que a marca passou a quebrar em três linhas em 920px. Quem mede os quatro
+  degraus é `tests/barra-do-topo-responsiva.spec.ts`, varrendo 1400 → 320px.
 - **Um tópico tem DUAS URLs, e elas não competem.** `/topicos/<slug>/` é a **canônica**: quem chega
   pelo índice geral, sem percurso, e vê na barra os roadmaps que citam o tópico.
   `/roadmaps/<r>/<slug>/` é a mesma página dentro de um percurso: menu do roadmap, anterior/próximo,

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -103,21 +103,35 @@ html { scroll-behavior: smooth; }
   background: rgba(11, 17, 28, 0.86); backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--ccc-line);
 }
-.header-left { display: flex; align-items: center; gap: 8px; min-width: 0; }
+/* A barra do topo é RÍGIDA de propósito: nada aqui encolhe nem quebra linha.
+   O `min-width: 0` que morava neste bloco (no `.header-left` e no `.brand`)
+   deixava a marca ser espremida abaixo do próprio conteúdo, e o resultado
+   medido em 920px era este: "Roadmap DSA / por Craft & Code Club" quebrando em
+   TRÊS linhas e transbordando os 60px do cabeçalho, com o texto passando por
+   cima de "Início"; em 800px as caixas de "Tópicos" e "YouTube" se sobrepunham
+   3px, e em 320px o quadrado do logo saía da própria caixa e cobria 13px do
+   botão do Discord.
+   Encolher em silêncio é a pior falha possível aqui, porque ela não estoura
+   nada e nenhuma medição de overflow de página a pega. Com as peças rígidas,
+   faltar espaço vira estouro horizontal — alto, visível e medido por
+   `tests/barra-do-topo-responsiva.spec.ts`. Quem garante que isso nunca
+   acontece são os degraus da seção "responsive": comprimir, depois recolher
+   para o menu ⋯. */
+.header-left { display: flex; align-items: center; gap: 8px; }
 .nav-left { margin-left: 10px; }
-.brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
+.brand { display: flex; align-items: center; gap: 12px; flex: none; }
 .brand-mark {
   display: grid; place-items: center; width: 34px; height: 34px; border-radius: 9px;
   background: linear-gradient(150deg, var(--ccc-purple), var(--ccc-accent));
   font-weight: 700; font-size: 11.5px; color: #fff; letter-spacing: -0.03em; flex: none;
 }
-.brand-name { display: block; font-size: 14.5px; font-weight: 600; letter-spacing: -0.01em; line-height: 1.15; }
-.brand-sub { font-size: 11px; color: var(--ccc-muted); line-height: 1.15; }
-.topnav { display: flex; align-items: center; gap: 4px; }
+.brand-name { display: block; font-size: 14.5px; font-weight: 600; letter-spacing: -0.01em; line-height: 1.15; white-space: nowrap; }
+.brand-sub { display: block; font-size: 11px; color: var(--ccc-muted); line-height: 1.15; white-space: nowrap; }
+.topnav { display: flex; align-items: center; gap: 4px; flex: none; }
 .topnav a, .topnav .navbtn {
   padding: 8px 12px; border: none; border-radius: 8px; background: transparent;
   font-family: inherit; font-size: 13.5px; font-weight: 500; color: var(--ccc-muted);
-  cursor: pointer;
+  cursor: pointer; white-space: nowrap;
 }
 .topnav a:hover, .topnav .navbtn:hover { color: #fff; background: rgba(255, 255, 255, 0.05); }
 .topnav a.on, .topnav .navbtn.on { color: #fff; background: rgba(255, 255, 255, 0.07); }
@@ -150,11 +164,20 @@ html { scroll-behavior: smooth; }
 .menu-item:hover { background: rgba(255, 255, 255, 0.06); color: #fff; }
 .menu-item .mi-ico { width: 16px; display: inline-flex; align-items: center; justify-content: center; color: var(--ccc-muted); }
 .menu-item .ext-arrow { margin-left: auto; }
+/* Os dois níveis do que a barra devolve ao menu ⋯, e por que são dois.
+   `only-mobile` é o item que só aparece aqui no celular (≤760px), quando os
+   quatro links da esquerda somem. `only-md` é o degrau novo, que sobe o limiar
+   do MESMO item para 940px: Início e YouTube saem da barra antes dos outros.
+   O modificador vem somado (`only-mobile only-md`), e não no lugar de, por
+   duas razões: a especificidade de duas classes vence a de uma sozinha sem
+   depender da ordem do arquivo, e `.menu-item:not(.only-mobile)` continua
+   significando "item que está SEMPRE no menu" para quem mede a ordem dele. */
 .only-mobile { display: none; }
 .nav-more { position: relative; }
 .nav-icon {
   display: grid; place-items: center; width: 34px; height: 34px; border-radius: 8px;
   border: none; background: transparent; color: var(--ccc-muted); cursor: pointer;
+  flex: none;
 }
 .nav-icon:hover { color: #fff; background: rgba(255, 255, 255, 0.05); }
 .header-menu-toggle { display: none; }
@@ -2214,6 +2237,24 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
     height: calc(100dvh - var(--ccc-header-h));
   }
   .header-menu-toggle { display: grid; }
+  /* ---- barra do topo, degrau 1: COMPRIMIR ----------------------------------
+     Este é o ponto em que a barra começa a sofrer, e não por acaso: é aqui que
+     nasce o botão da gaveta, que rouba 34px mais o respiro. Medido no
+     `/topicos/dijkstra/`: sem gaveta a barra precisa de 949px; com ela, 991.
+     Então de 1000px para baixo a conta já está no limite, e é aí que a marca
+     começava a ser espremida.
+     A primeira resposta é apertar o RESPIRO, nunca o conteúdo: padding da
+     barra, distância entre os dois blocos, e o espaço em volta do rótulo de
+     cada link. Os 97px que isto devolve (991 → 894) são o que segura a barra
+     inteira, com os sete links legíveis, até o degrau 2. Nada some aqui. */
+  .header { padding: 0 14px; gap: 14px; }
+  .header-left { gap: 6px; }
+  .brand { gap: 9px; }
+  .nav-left { margin-left: 2px; }
+  .topnav { gap: 2px; }
+  .topnav a, .topnav .navbtn { padding: 8px 9px; }
+  .nav-discord { margin-left: 4px; }
+  .nav-coffee { margin-left: 2px; }
   .hero { padding: 48px 24px 40px; }
   .hero h1 { font-size: 40px; }
   .stats { grid-template-columns: 1fr 1fr; }
@@ -2234,8 +2275,24 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
   .viz-fit[data-codigo="off"] .viz-split { grid-template-columns: minmax(0, 1fr); }
   .site-foot { padding: 24px 20px; }
 }
+/* ---- barra do topo, degrau 2: RECOLHER O QUE TEM CÓPIA ---------------------
+   Comprimida, a barra cabe até 894px. Abaixo disso não há respiro sobrando
+   para apertar, e a escolha passa a ser QUAL item sai. O limiar é 940 e não
+   894: 46px de margem é o que absorve o mesmo texto medido com outra fonte de
+   reserva, quando o webfont demora ou falha.
+   Saem os dois que o leitor não perde: "Início", porque o próprio logo já leva
+   para a home, e "YouTube", que é o mais leve dos três da direita (os outros
+   dois têm borda de marca) e já era o primeiro a sair no celular. Os dois
+   reaparecem no menu ⋯ pelo `only-md`, então nada fica sem porta. Sobram cinco
+   links, todos com o rótulo inteiro, até os 760px. */
+@media (max-width: 940px) {
+  .nav-hide-md { display: none !important; }
+  .only-mobile.only-md { display: flex; }
+}
 @media (max-width: 760px) {
-  /* Início, Roadmap e YouTube saem da barra e vão para o menu ⋯.
+  /* ---- barra do topo, degrau 3: A ESQUERDA INTEIRA VAI PARA O ⋯ ----------
+     Fundamentos, Roadmaps e Tópicos seguem Início e YouTube para o menu. Fica
+     o essencial: gaveta, marca, Discord, Apoiar e o ⋯.
      !important vence o display:flex do .nav-yt (mesma especificidade). */
   .nav-hide-sm { display: none !important; }
   .only-mobile { display: flex; }
@@ -2299,6 +2356,30 @@ button.ps-cell:hover { border-color: rgba(255, 255, 255, 0.3); color: #fff; }
   /* A linha do índice vira bloco: nome e descrição em cima, etiquetas embaixo.
      Lado a lado em 390px a coluna de etiquetas espremia o nome em três linhas. */
   .topic-done { flex-direction: column; align-items: flex-start; }
+}
+/* ---- barra do topo, degrau 4: O CELULAR ESTREITO --------------------------
+   Da esquerda já não sobra nada para recolher: gaveta, logo, Discord, Apoiar e
+   o ⋯ são o piso da barra, e os dois botões de marca são justamente os que não
+   têm cópia no menu ⋯. Medido em 320px (o menor aparelho que ainda aparece nas
+   estatísticas): esse piso pedia 338px e estourava a página em 18.
+   Então volta a primeira ferramenta, comprimir, agora no respiro que sobrou —
+   inclusive o vão entre o logo e um nome que já saiu em 560px e continuava com
+   lugar guardado. São 46px de volta (338 → 292), nenhum rótulo encolhe. */
+@media (max-width: 400px) {
+  .header { padding: 0 8px; gap: 8px; }
+  .header-left { gap: 4px; }
+  .brand { gap: 0; }
+  .nav-right { gap: 4px; }
+  .nav-discord, .nav-coffee { gap: 5px; }
+  /* a margem separava o Discord do YouTube, que aqui já não existe */
+  .nav-discord { margin-left: 0; }
+  .topnav a, .topnav .navbtn { padding: 8px; }
+  /* A ÚNICA coisa que some nesta faixa, e depois de a compressão acabar: o ↗.
+     Ele é decoração `aria-hidden` (leitor de tela nunca o leu), sobrou um
+     externo só na barra e os 12px dele são a diferença entre caber e estourar
+     em 320px. No menu ⋯ ele continua, que é onde a lista mistura link interno
+     com externo e a seta faz falta de verdade. */
+  .topnav > a.ext .ext-arrow { display: none; }
 }
 /* Consulta por ALTURA, que é a dimensão que estoura no notebook: a largura
    está sobrando e a vertical não. Aperta o que é respiro, nunca conteúdo, e só

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -160,7 +160,10 @@ export function Shell({ children }: { children: React.ReactNode }) {
           {/* Cada landmark com nome próprio: são três `nav` na página, e sem
               rótulo o leitor de tela anuncia "navegação" três vezes. */}
           <nav className="topnav nav-left" aria-label="Principal">
-            <Link href="/" className={`nav-hide-sm${navOn("/") ? " on" : ""}`}>Início</Link>
+            {/* `nav-hide-md`, e não `nav-hide-sm`: "Início" é o primeiro a sair
+                da barra (940px) porque é o único item cujo destino já tem outro
+                caminho visível ao lado dele — o logo. */}
+            <Link href="/" className={`nav-hide-md${navOn("/") ? " on" : ""}`}>Início</Link>
             <Link href={URL_DOS_FUNDAMENTOS} className={`nav-hide-sm${nosFundamentos ? " on" : ""}`}>Fundamentos</Link>
             <Link href="/roadmaps" className={`nav-hide-sm${naAreaDeRoadmaps ? " on" : ""}`}>Roadmaps</Link>
             <Link href="/topicos" className={`nav-hide-sm${naAreaDeTopicos ? " on" : ""}`}>Tópicos</Link>
@@ -168,7 +171,10 @@ export function Shell({ children }: { children: React.ReactNode }) {
         </div>
 
         <nav className="topnav nav-right" aria-label="Comunidade e apoio">
-          <a href={LINKS.youtube} className="nav-yt nav-hide-sm ext" target="_blank" rel="noopener noreferrer">
+          {/* Sai junto com o "Início", em 940px: é o mais leve dos três da
+              direita (Discord e Apoiar têm borda de marca) e já era o primeiro
+              a sair no celular. */}
+          <a href={LINKS.youtube} className="nav-yt nav-hide-md ext" target="_blank" rel="noopener noreferrer">
             <span className="dot" />YouTube<span className="ext-arrow" aria-hidden="true">↗</span>
           </a>
           <a href={LINKS.discord} className="nav-discord ext" target="_blank" rel="noopener noreferrer">
@@ -187,8 +193,11 @@ export function Shell({ children }: { children: React.ReactNode }) {
               <>
                 <div style={{ position: "fixed", inset: 0, zIndex: 50 }} onClick={() => setMenu(false)} />
                 <div className="nav-menu">
-                  {/* somem da barra no mobile → voltam aqui */}
-                  <Link className="menu-item only-mobile" href="/" onClick={() => setMenu(false)}>
+                  {/* Somem da barra → voltam aqui, e cada um no degrau em que
+                      saiu: `only-md` abre em 940px (Início e YouTube),
+                      `only-mobile` sozinho em 760px (o resto da esquerda).
+                      Nada sai da barra sem ter para onde ir. */}
+                  <Link className="menu-item only-mobile only-md" href="/" onClick={() => setMenu(false)}>
                     <span className="mi-ico">⌂</span> Início
                   </Link>
                   <Link className="menu-item only-mobile" href={URL_DOS_FUNDAMENTOS} onClick={() => setMenu(false)}>
@@ -200,7 +209,7 @@ export function Shell({ children }: { children: React.ReactNode }) {
                   <Link className="menu-item only-mobile" href="/topicos" onClick={() => setMenu(false)}>
                     <span className="mi-ico">≡</span> Todos os tópicos
                   </Link>
-                  <a className="menu-item only-mobile ext" href={LINKS.youtube} target="_blank" rel="noopener noreferrer" onClick={() => setMenu(false)}>
+                  <a className="menu-item only-mobile only-md ext" href={LINKS.youtube} target="_blank" rel="noopener noreferrer" onClick={() => setMenu(false)}>
                     <span className="mi-ico" style={{ color: "#ff0000" }}>▶</span> YouTube<span className="ext-arrow" aria-hidden="true">↗</span>
                   </a>
                   {/* sempre no menu, e a `/sobre` primeiro: é a resposta à

--- a/tests/barra-do-topo-responsiva.spec.ts
+++ b/tests/barra-do-topo-responsiva.spec.ts
@@ -1,0 +1,301 @@
+import { test, expect, type Page } from "@playwright/test";
+
+// A barra do topo, medida largura por largura.
+//
+// POR QUE EXISTE
+// A barra cresceu (marca com nome e subtítulo, quatro links à esquerda,
+// YouTube, Discord, Apoiar e o ⋯ à direita) e tinha UM corte só, em 760px. Do
+// lado de cima desse corte ela se descaracterizava, e nenhuma medição da suíte
+// pegava, porque nada disso estoura a página. O que foi medido em
+// `/topicos/dijkstra/`, antes:
+//
+//   920px  "Roadmap DSA / por Craft & Code Club" quebrava em TRÊS linhas e
+//          transbordava os 60px do cabeçalho, passando por cima de "Início";
+//   800px  as caixas de "Tópicos" e "YouTube" se sobrepunham 3px (23px em 780);
+//   340px  o quadrado do logo saía da própria caixa, e em 320px cobria 13px do
+//          botão do Discord.
+//
+// Nos três casos `document.body.scrollWidth === window.innerWidth`. Encolher em
+// silêncio é o defeito: as peças tinham `min-width: 0` e cediam antes de
+// qualquer limiar disparar.
+//
+// O QUE ELE MEDE, E POR QUE ESSAS CINCO COISAS
+// Uma varredura de 1400 até 320px, e em cada largura as cinco formas conhecidas
+// de a barra quebrar:
+//
+//   1. a PÁGINA estoura na horizontal. Com as peças rígidas (é assim que o
+//      `globals.css` as deixou), faltar espaço vira estouro — que é o que se
+//      quer: alto e medível, em vez de sobreposição silenciosa;
+//   2. uma PEÇA sai da caixa do cabeçalho. Pega o transbordo vertical, que é a
+//      cara do defeito de 920px e que nenhuma medição de largura vê;
+//   3. duas peças se SOBREPÕEM. Só conta quando os dois eixos se cruzam: nome e
+//      subtítulo da marca ficam um sobre o outro de propósito;
+//   4. um rótulo é CORTADO (`scrollWidth > clientWidth` no elemento);
+//   5. um rótulo fica pequeno demais para ler. A barra nunca deve resolver
+//      espaço encolhendo fonte, e sem esta linha um `font-size: 11px` passaria
+//      as quatro medições acima.
+//
+// O 320 do piso é o menor aparelho que ainda aparece; o 1400 do teto é acima do
+// ponto em que a barra volta a ter espaço de sobra.
+
+const ALTURA = 800;
+const PISO = 320;
+const TETO = 1400;
+
+/** O menor rótulo de NAVEGAÇÃO legível. Não é gosto: é o valor que os links da
+ *  barra usam hoje (13.5px) menos um respiro. Abaixo disso a régua é "está
+ *  escrito lá", não "dá para ler", e a issue pedia legibilidade antes de tudo.
+ *
+ *  Vale só para os links e botões. A marca fica de fora de propósito: o "DSA"
+ *  dentro do quadrado sai a 11.5px e o "por Craft & Code Club" a 11px, e os
+ *  dois são tipografia de assinatura, não rótulo que alguém precisa ler para
+ *  navegar. Um piso único reprovaria a marca desde 1400px, que é largura em que
+ *  não falta espaço nenhum. */
+const PISO_FONTE = 12;
+
+/** A folga mínima entre o bloco da esquerda e o da direita. É o `gap` do
+ *  `.header` no degrau mais apertado (8px, abaixo de 400px): abaixo disso os
+ *  dois blocos estão se encostando, mesmo sem sobrepor. */
+const FOLGA_MINIMA = 8;
+
+/** As duas cascas de cabeçalho que existem: com gaveta (o botão ☰ à esquerda
+ *  rouba 34px) e sem. A vitrine `/roadmaps/` é `sem-lateral` por decisão do
+ *  `Shell`, então ela é a segunda casca, não uma segunda página igual. */
+const ROTAS = [
+  { url: "/topicos/dijkstra/", casca: "com gaveta" },
+  { url: "/roadmaps/", casca: "sem gaveta" },
+] as const;
+
+/**
+ * As larguras varridas: de 20 em 20, mais os VIZINHOS EXATOS de cada degrau.
+ *
+ * O passo de 20 sozinho pula 761 e 941, que são justamente as larguras mais
+ * apertadas da barra: um degrau alivia a largura logo abaixo dele e deixa a
+ * pior largura um pixel acima. Um teste que só olha múltiplos de 20 mede a
+ * faixa confortável de cada faixa.
+ */
+function larguras(): number[] {
+  const vistas = new Set<number>();
+  for (let w = TETO; w >= PISO; w -= 20) vistas.add(w);
+  for (const degrau of [1000, 940, 760, 560, 400]) {
+    vistas.add(degrau + 1);
+    vistas.add(degrau);
+    vistas.add(degrau - 1);
+  }
+  return [...vistas].filter((w) => w >= PISO && w <= TETO).sort((a, b) => b - a);
+}
+
+type Peca = {
+  nome: string;
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+  corte: number;
+  fonte: number;
+  /** Link ou botão da barra, ou seja: rótulo que existe para ser lido e
+   *  clicado. A marca não é. Só estes respondem ao `PISO_FONTE`. */
+  navegavel: boolean;
+};
+type Medida = {
+  estouroDaPagina: number;
+  folga: number;
+  cabecalho: { left: number; right: number; top: number; bottom: number };
+  pecas: Peca[];
+};
+
+/**
+ * As peças da barra, medidas nas FOLHAS e não nos contêineres.
+ *
+ * A marca entra como três peças (quadrado, nome, subtítulo) porque o defeito de
+ * 920px era o conteúdo dela vazando da própria caixa: medir o `.brand` mediria
+ * exatamente a caixa que mentia.
+ */
+async function medir(page: Page): Promise<Medida> {
+  return page.evaluate(() => {
+    const cabecalho = document.querySelector(".header")!.getBoundingClientRect();
+    const visivel = (el: Element) => {
+      const b = el.getBoundingClientRect();
+      return b.width > 0 && b.height > 0;
+    };
+    const NAVEGAVEIS = ".header-menu-toggle, .header .topnav > a, .nav-more > button";
+    const alvos: Element[] = [
+      ...document.querySelectorAll(`${NAVEGAVEIS}, .brand-mark, .brand-name, .brand-sub`),
+    ].filter(visivel);
+
+    const pecas = alvos.map((el) => {
+      const b = el.getBoundingClientRect();
+      const cs = getComputedStyle(el);
+      return {
+        nome:
+          (el.textContent || "").trim().replace(/\s+/g, " ").slice(0, 24) ||
+          el.getAttribute("aria-label") ||
+          el.className,
+        left: b.left,
+        right: b.right,
+        top: b.top,
+        bottom: b.bottom,
+        corte: el.scrollWidth - el.clientWidth,
+        fonte: parseFloat(cs.fontSize),
+        navegavel: el.matches(NAVEGAVEIS),
+      };
+    });
+
+    const esquerda = document.querySelector(".header-left")!.getBoundingClientRect();
+    const direita = document.querySelector(".nav-right")!.getBoundingClientRect();
+
+    return {
+      estouroDaPagina: document.body.scrollWidth - window.innerWidth,
+      folga: direita.left - esquerda.right,
+      cabecalho: {
+        left: cabecalho.left,
+        right: cabecalho.right,
+        top: cabecalho.top,
+        bottom: cabecalho.bottom,
+      },
+      pecas,
+    };
+  });
+}
+
+/** Meio pixel de tolerância: as caixas vêm de `getBoundingClientRect`, que é
+ *  fracionário, e um arredondamento não é um defeito de layout. */
+const FOLGA_DE_ARREDONDAMENTO = 0.5;
+
+function sobreposicoes(pecas: Peca[]): string[] {
+  const achadas: string[] = [];
+  for (let i = 0; i < pecas.length; i++) {
+    for (let j = i + 1; j < pecas.length; j++) {
+      const a = pecas[i];
+      const b = pecas[j];
+      const x = Math.min(a.right, b.right) - Math.max(a.left, b.left);
+      const y = Math.min(a.bottom, b.bottom) - Math.max(a.top, b.top);
+      // Os dois eixos, e não só o horizontal: o nome e o subtítulo da marca
+      // dividem a mesma coluna de propósito, um embaixo do outro.
+      if (x > FOLGA_DE_ARREDONDAMENTO && y > FOLGA_DE_ARREDONDAMENTO) {
+        achadas.push(`"${a.nome}" × "${b.nome}" (${x.toFixed(0)}px)`);
+      }
+    }
+  }
+  return achadas;
+}
+
+function forasDaCaixa(m: Medida): string[] {
+  const t = FOLGA_DE_ARREDONDAMENTO;
+  return m.pecas
+    .filter(
+      (p) =>
+        p.left < m.cabecalho.left - t ||
+        p.right > m.cabecalho.right + t ||
+        p.top < m.cabecalho.top - t ||
+        p.bottom > m.cabecalho.bottom + t
+    )
+    .map(
+      (p) =>
+        `"${p.nome}" em ${p.left.toFixed(0)}..${p.right.toFixed(0)} x ` +
+        `${p.top.toFixed(0)}..${p.bottom.toFixed(0)}`
+    );
+}
+
+for (const rota of ROTAS) {
+  test(`a barra do topo aguenta de ${TETO} a ${PISO}px (${rota.casca})`, async ({ page }) => {
+    await page.setViewportSize({ width: TETO, height: ALTURA });
+    await page.goto(rota.url);
+    // As larguras são larguras de TEXTO: medir antes de a fonte trocar mede a
+    // de reserva, e a barra inteira muda de tamanho embaixo da medição.
+    await page.evaluate(() => document.fonts.ready.then(() => undefined));
+
+    const estouraram: string[] = [];
+    const vazaram: string[] = [];
+    const sobrepostas: string[] = [];
+    const cortadas: string[] = [];
+    const miudas: string[] = [];
+    const grudadas: string[] = [];
+
+    for (const w of larguras()) {
+      await page.setViewportSize({ width: w, height: ALTURA });
+      const m = await medir(page);
+
+      if (m.estouroDaPagina > 0) estouraram.push(`${w}px: +${m.estouroDaPagina}px`);
+      for (const fora of forasDaCaixa(m)) vazaram.push(`${w}px: ${fora}`);
+      for (const par of sobreposicoes(m.pecas)) sobrepostas.push(`${w}px: ${par}`);
+      for (const p of m.pecas.filter((p) => p.corte > 1)) {
+        cortadas.push(`${w}px: "${p.nome}" cortado em ${p.corte}px`);
+      }
+      for (const p of m.pecas.filter((p) => p.navegavel && p.fonte < PISO_FONTE)) {
+        miudas.push(`${w}px: "${p.nome}" a ${p.fonte}px`);
+      }
+      if (m.folga < FOLGA_MINIMA - FOLGA_DE_ARREDONDAMENTO) {
+        grudadas.push(`${w}px: ${m.folga.toFixed(0)}px entre os dois blocos`);
+      }
+    }
+
+    expect(estouraram, "a barra empurrou a página para fora da janela").toEqual([]);
+    expect(vazaram, "peça da barra fora da caixa do cabeçalho (transbordo)").toEqual([]);
+    expect(sobrepostas, "duas peças da barra ocupando o mesmo lugar").toEqual([]);
+    expect(cortadas, "rótulo da barra cortado dentro da própria caixa").toEqual([]);
+    expect(miudas, `rótulo da barra abaixo de ${PISO_FONTE}px`).toEqual([]);
+    expect(grudadas, `os dois blocos da barra a menos de ${FOLGA_MINIMA}px um do outro`).toEqual([]);
+  });
+}
+
+/**
+ * Os destinos que a barra promete, e o `href` de cada um.
+ *
+ * A conferência é por destino, e não por rótulo, porque o mesmo lugar tem nome
+ * diferente nos dois lados: "Tópicos" na barra é "Todos os tópicos" no menu, e
+ * "Apoiar" é "Apoiadores e Parceiros".
+ */
+const DESTINOS = [
+  { nome: "Início", href: "/" },
+  { nome: "Fundamentos", href: "/roadmaps/fundamentos/" },
+  { nome: "Roadmaps", href: "/roadmaps/" },
+  { nome: "Tópicos", href: "/topicos/" },
+  { nome: "YouTube", href: "youtube.com" },
+  { nome: "Discord", href: "discord" },
+  { nome: "Apoiar", href: "/apoie/" },
+] as const;
+
+test("nada sai da barra sem ter para onde ir: o menu ⋯ recolhe o que sumiu", async ({ page }) => {
+  // O degrau novo (940px) tira "Início" e "YouTube" da barra, e o antigo (760)
+  // tira os outros três da esquerda. Recolher item para lugar nenhum seria
+  // trocar uma barra feia por uma navegação quebrada, então a régua é a mesma
+  // em toda largura: barra ∪ menu tem de conter os sete destinos.
+  await page.goto("/topicos/dijkstra/");
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+
+  const botao = page.getByRole("button", { name: "Mais opções" });
+  // O menu aberto põe um véu `position: fixed` sobre a página inteira, que é o
+  // que o fecha ao clicar fora — e que também intercepta um segundo clique no
+  // próprio botão. Fechar é clicar no véu, que é o gesto que o usuário faz.
+  const veu = page.locator(".nav-more > div:not(.nav-menu)");
+
+  for (const w of [1200, 1000, 941, 900, 800, 761, 700, 500, 390, 320]) {
+    await page.setViewportSize({ width: w, height: ALTURA });
+
+    await expect(botao, `${w}px: o ⋯ nasce fechado`).toHaveAttribute("aria-expanded", "false");
+    await botao.click();
+    await expect(botao, `${w}px: o ⋯ abriu sem dizer que abriu`).toHaveAttribute(
+      "aria-expanded",
+      "true"
+    );
+
+    const alcancaveis = await page.evaluate(() =>
+      [...document.querySelectorAll(".header a, .nav-menu a")]
+        .filter((a) => a.getBoundingClientRect().width > 0)
+        .map((a) => a.getAttribute("href") ?? "")
+    );
+
+    const perdidos = DESTINOS.filter((d) => !alcancaveis.some((h) => h.includes(d.href)));
+    expect(
+      perdidos.map((d) => d.nome),
+      `${w}px: destino que sumiu da barra e não apareceu no menu ⋯`
+    ).toEqual([]);
+
+    await veu.click({ position: { x: 5, y: 5 } });
+    await expect(botao, `${w}px: o ⋯ fechou sem dizer que fechou`).toHaveAttribute(
+      "aria-expanded",
+      "false"
+    );
+  }
+});


### PR DESCRIPTION
A barra do topo cresceu com as features novas e continuava com **um corte só**, em 760px. Acima
dele ela não cabia, e o jeito como ela não cabia era o pior possível: as peças tinham
`min-width: 0`, então cediam em silêncio. `document.body.scrollWidth === window.innerWidth` em
todas as larguras quebradas — nenhuma medição de overflow da suíte via nada, porque não havia
overflow.

Closes #86

## O que foi medido

Instrumento: Playwright + Chromium, `/topicos/dijkstra/`, varredura de larguras, `document.fonts.ready`
antes de medir. "Itens na barra" conta os links visíveis (`.header .topnav > a`); "folga" é a
distância entre o bloco da esquerda e o da direita; "transbordo" é peça fora da caixa do
cabeçalho (que vai de y=0 a y=60).

### ANTES

| largura | itens na barra | estouro da página | folga entre os blocos | transbordo | sobreposição | corte |
| ---: | ---: | ---: | ---: | --- | --- | --- |
| 1400px | 7 | 0 | 475px | - | - | - |
| 1200px | 7 | 0 | 275px | - | - | - |
| 1000px | 7 | 0 | 33px | - | - | - |
| 960px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | - | - |
| 941px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | - | - |
| 920px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | - | **DSARoadmap DSApor... -18px** |
| 880px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | **Roadmap DSA×Início 40px; por Craft & Code Clu×Início 31px** | **-58px** |
| 840px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | **DSA×Início 3px; Roadmap DSA×Início 44px; Roadmap DSA×Fundamentos 17px; por Craft & Code Clu×Início 44px; por Craft & Code Clu×Fundamentos 8px** | **-98px** |
| 800px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | **DSA×Início 16px; Roadmap DSA×Início 31px; Roadmap DSA×Fundamentos 31px; por Craft & Code Clu×Início 31px; por Craft & Code Clu×Fundamentos 22px; Tópicos×YouTube↗ 3px** | - |
| 780px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | **... Tópicos×YouTube↗ 23px** | - |
| 761px | 7 | 0 | 24px | **Roadmap DSA (y -7..26); por Craft & Code Clu (y 31..65)** | **... Tópicos×YouTube↗ 42px** | - |
| 700px | 2 | 0 | 237px | - | - | - |
| 560px | 2 | 0 | 195px | - | - | - |
| 420px | 2 | 0 | 55px | - | - | - |
| 390px | 2 | 0 | 25px | - | - | - |
| 360px | 2 | 0 | 10px | - | - | - |
| 340px | 2 | 0 | 10px | - | - | **logo com caixa de 15px para um quadrado de 34px** |
| 320px | 2 | 0 | 10px | - | **DSA×Discord↗ 13px** | **caixa de 0px** |

O cabeçalho tem 60px de altura. A marca ocupava de **-7 a 65**: ela transbordava por cima e por
baixo, em TODA largura de 761 a 960.

### DEPOIS

| largura | itens na barra | estouro da página | folga entre os blocos | transbordo | sobreposição | corte |
| ---: | ---: | ---: | ---: | --- | --- | --- |
| 1400px | 7 | 0 | 475px | - | - | - |
| 1200px | 7 | 0 | 275px | - | - | - |
| 1000px | 7 | 0 | 120px | - | - | - |
| 960px | 7 | 0 | 80px | - | - | - |
| 941px | 7 | 0 | 61px | - | - | - |
| 920px | 5 | 0 | 203px | - | - | - |
| 880px | 5 | 0 | 163px | - | - | - |
| 840px | 5 | 0 | 123px | - | - | - |
| 800px | 5 | 0 | 83px | - | - | - |
| 780px | 5 | 0 | 63px | - | - | - |
| 761px | 5 | 0 | 44px | - | - | - |
| 700px | 2 | 0 | 262px | - | - | - |
| 560px | 2 | 0 | 220px | - | - | - |
| 420px | 2 | 0 | 80px | - | - | - |
| 390px | 2 | 0 | 106px | - | - | - |
| 360px | 2 | 0 | 76px | - | - | - |
| 340px | 2 | 0 | 56px | - | - | - |
| 320px | 2 | 0 | 36px | - | - | - |

Zero transbordo, zero sobreposição, zero corte, em todas as 56 larguras varridas de 1400 a 320.
A barra só começa a estourar de verdade abaixo de **301px**.

## O degrau que faltava

A filosofia é a mesma da casca dos visualizadores: **comprimir antes de esconder**. Antes havia
um corte só; agora são quatro degraus.

| degrau | largura | o que acontece | quanto devolve |
| --- | ---: | --- | ---: |
| 1. comprimir | ≤1000px | padding da barra, vão entre os blocos e espaço em volta de cada rótulo. **Nada sai** | 991 → 894px |
| 2. recolher (**novo**) | ≤940px | **Início** e **YouTube** vão para o menu `⋯` | 894 → 727px |
| 3. recolher (já existia) | ≤760px | Fundamentos, Roadmaps e Tópicos vão para o menu | 727 → 338px |
| 4. comprimir | ≤400px | o respiro que sobrou, incluindo o vão de um nome que já saiu em 560px | 338 → 292px |

**Por que Início e YouTube** são os dois que saem primeiro: "Início" é o único item cujo destino
já tem outro caminho visível ao lado dele (o próprio logo), e "YouTube" é o mais leve dos três da
direita (Discord e Apoiar têm borda de marca) e já era o primeiro a sair no celular. O limiar é
940 e não 894 porque 46px de margem é o que absorve o mesmo texto medido com a fonte de reserva,
quando o webfont demora ou falha — conferido com `fonts.gstatic.com` bloqueado: a folga varia
1 a 4px.

**Nada some sem ter para onde ir.** Os dois reaparecem no menu `⋯` pelo `only-md`, somado ao
`only-mobile` em vez de substituí-lo: a especificidade de duas classes dispensa depender da ordem
do arquivo, e `.menu-item:not(.only-mobile)` (que `seo-datas-e-autoria.spec.ts` usa) continua
querendo dizer "item que está sempre no menu". O `aria-expanded` do `⋯` continua correto, e item
escondido com `display: none` sai da árvore de acessibilidade junto com a tela, que é o certo:
a cópia dele está no menu.

## A rigidez, que é a mudança de fundo

As peças da barra perderam o `min-width: 0` e ganharam `white-space: nowrap` e `flex: none`.
Não é preciosismo, é **trocar o modo de falhar**. Frouxa, faltar espaço vira sobreposição
silenciosa que passa verde em toda medição de overflow. Rígida, faltar espaço vira estouro
horizontal: alto, visível e medível. Os quatro degraus garantem que isso não aconteça, e o teste
garante os degraus.

## O teste

`tests/barra-do-topo-responsiva.spec.ts` varre 1400 → 320px de 20 em 20, mais os vizinhos exatos
dos cinco limiares (1001/1000/999, 941/940/939, ...), nas **duas** cascas de cabeçalho (com
gaveta, em `/topicos/dijkstra/`, e sem, em `/roadmaps/`). Os múltiplos de 20 sozinhos mediriam a
faixa confortável de cada degrau: um degrau alivia a largura logo abaixo dele e deixa a pior um
pixel acima, que é 761 e 941.

Em cada largura, as cinco formas de a barra quebrar: página estourando, peça fora da caixa do
cabeçalho (o transbordo vertical, que largura nenhuma vê), duas peças cruzando os dois eixos,
rótulo cortado, e rótulo pequeno demais para ler (o contrário do mesmo defeito: resolver espaço
encolhendo fonte passaria nas quatro de cima). Mais um terceiro teste: barra ∪ menu `⋯` contém
os sete destinos em toda largura, conferido por `href` porque o mesmo lugar tem nome diferente
nos dois lados.

**Conferido que reprova:** rodado contra o CSS anterior, ele acusa exatamente as larguras da
tabela ANTES (`"920px: \"Roadmap DSA\" em 66..151 x -7..26"`).

## Validação

```
npx tsc --noEmit                   0 erro
npm run build                      ok
PORT=3303 npm test                 767 passed, 3 skipped
npm run lint                       0 errors (6 warnings pré-existentes)
python3 scripts/guarda-ancoras.py  36 arquivos, nenhuma âncora
```

Conferência visual com `agent-browser` em 1000, 960, 920, 800 (com o `⋯` aberto), 790 e 320px.

O `CLAUDE.md` ganhou os quatro degraus na seção "Navegação e links", porque a descrição do menu
`⋯` ("só no mobile") deixou de ser verdade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review

**Copilot** achou um furo real no teste, corrigido em `eb98b89`: o guarda de "nada sai da barra
sem ter para onde ir" comparava cada destino com `href.includes(...)`, e neste site uma rota é
prefixo da outra. `"/"` está contido em TODO href interno, então "Início" nunca apareceria como
perdido nem que sumisse dos dois lugares; `"/roadmaps/"` sobrevivia escondido atrás de
`/roadmaps/fundamentos/`. Medido com os links para a home removidos do DOM em 390px: por
`includes` a lista de perdidos vem vazia, por igualdade vem `["Início"]`. Rota interna passou a
casar exato; os dois links de fora seguem casando por trecho, porque ali o alvo é o host.
