### PR TITLE
test(nav): rota interna casa exato, que `includes` não distinguia

### DIFF
--- a/tests/barra-do-topo-responsiva.spec.ts
+++ b/tests/barra-do-topo-responsiva.spec.ts
@@ -245,16 +245,30 @@ for (const rota of ROTAS) {
  * A conferência é por destino, e não por rótulo, porque o mesmo lugar tem nome
  * diferente nos dois lados: "Tópicos" na barra é "Todos os tópicos" no menu, e
  * "Apoiar" é "Apoiadores e Parceiros".
+ *
+ * ROTA INTERNA CASA EXATO, e não por `includes`. Uma rota é prefixo da outra
+ * neste site: `"/"` está contido em TODO href interno, e `"/roadmaps/"` está
+ * contido em `"/roadmaps/fundamentos/"`. Com `includes`, "Início" nunca
+ * apareceria como perdido nem que sumisse dos dois lugares, e "Roadmaps"
+ * sobreviveria escondido atrás do link dos Fundamentos — o teste ficaria verde
+ * medindo a coisa errada.
+ *
+ * Os dois links de fora casam por trecho de propósito: o alvo ali é o HOST, e o
+ * caminho depois dele (o `@CraftCodeClub`, o código do convite) muda sem que a
+ * promessa da barra mude.
  */
 const DESTINOS = [
-  { nome: "Início", href: "/" },
-  { nome: "Fundamentos", href: "/roadmaps/fundamentos/" },
-  { nome: "Roadmaps", href: "/roadmaps/" },
-  { nome: "Tópicos", href: "/topicos/" },
-  { nome: "YouTube", href: "youtube.com" },
-  { nome: "Discord", href: "discord" },
-  { nome: "Apoiar", href: "/apoie/" },
+  { nome: "Início", href: "/", externo: false },
+  { nome: "Fundamentos", href: "/roadmaps/fundamentos/", externo: false },
+  { nome: "Roadmaps", href: "/roadmaps/", externo: false },
+  { nome: "Tópicos", href: "/topicos/", externo: false },
+  { nome: "Apoiar", href: "/apoie/", externo: false },
+  { nome: "YouTube", href: "youtube.com/", externo: true },
+  { nome: "Discord", href: "discord.gg/", externo: true },
 ] as const;
+
+const chegaAo = (href: string, destino: (typeof DESTINOS)[number]) =>
+  destino.externo ? href.includes(destino.href) : href === destino.href;
 
 test("nada sai da barra sem ter para onde ir: o menu ⋯ recolhe o que sumiu", async ({ page }) => {
   // O degrau novo (940px) tira "Início" e "YouTube" da barra, e o antigo (760)
@@ -286,7 +300,7 @@ test("nada sai da barra sem ter para onde ir: o menu ⋯ recolhe o que sumiu", a
         .map((a) => a.getAttribute("href") ?? "")
     );
 
-    const perdidos = DESTINOS.filter((d) => !alcancaveis.some((h) => h.includes(d.href)));
+    const perdidos = DESTINOS.filter((d) => !alcancaveis.some((h) => chegaAo(h, d)));
     expect(
       perdidos.map((d) => d.nome),
       `${w}px: destino que sumiu da barra e não apareceu no menu ⋯`

--- a/tests/barra-do-topo-responsiva.spec.ts
+++ b/tests/barra-do-topo-responsiva.spec.ts
@@ -240,35 +240,50 @@ for (const rota of ROTAS) {
 }
 
 /**
- * Os destinos que a barra promete, e o `href` de cada um.
+ * Os destinos que a barra promete, e como cada um é reconhecido.
  *
  * A conferência é por destino, e não por rótulo, porque o mesmo lugar tem nome
  * diferente nos dois lados: "Tópicos" na barra é "Todos os tópicos" no menu, e
  * "Apoiar" é "Apoiadores e Parceiros".
  *
- * ROTA INTERNA CASA EXATO, e não por `includes`. Uma rota é prefixo da outra
- * neste site: `"/"` está contido em TODO href interno, e `"/roadmaps/"` está
- * contido em `"/roadmaps/fundamentos/"`. Com `includes`, "Início" nunca
- * apareceria como perdido nem que sumisse dos dois lugares, e "Roadmaps"
- * sobreviveria escondido atrás do link dos Fundamentos — o teste ficaria verde
- * medindo a coisa errada.
+ * NADA AQUI CASA POR `includes`, e o motivo é o mesmo dos dois lados da lista:
+ * trecho contido dentro de outro texto acha o que não devia.
  *
- * Os dois links de fora casam por trecho de propósito: o alvo ali é o HOST, e o
- * caminho depois dele (o `@CraftCodeClub`, o código do convite) muda sem que a
- * promessa da barra mude.
+ *   `rota`  casa por IGUALDADE. Uma rota é prefixo da outra neste site: `"/"`
+ *           está contido em TODO href interno, e `"/roadmaps/"` está contido em
+ *           `"/roadmaps/fundamentos/"`. Por `includes`, "Início" nunca
+ *           apareceria como perdido nem que sumisse dos dois lugares, e
+ *           "Roadmaps" sobreviveria escondido atrás do link dos Fundamentos.
+ *   `host`  casa pelo HOSTNAME, ele mesmo ou um subdomínio dele. O caminho
+ *           depois do host (o `@CraftCodeClub`, o código do convite) muda sem
+ *           que a promessa da barra mude, então ele fica de fora da conta — mas
+ *           `includes("youtube.com")` aceitaria `notyoutube.com`, e
+ *           `hostname === "youtube.com"` recusaria o `www.` que o link usa
+ *           hoje. Igualdade ou subdomínio é o que diz "este host, e não um que
+ *           termina parecido".
  */
-const DESTINOS = [
-  { nome: "Início", href: "/", externo: false },
-  { nome: "Fundamentos", href: "/roadmaps/fundamentos/", externo: false },
-  { nome: "Roadmaps", href: "/roadmaps/", externo: false },
-  { nome: "Tópicos", href: "/topicos/", externo: false },
-  { nome: "Apoiar", href: "/apoie/", externo: false },
-  { nome: "YouTube", href: "youtube.com/", externo: true },
-  { nome: "Discord", href: "discord.gg/", externo: true },
-] as const;
+type Destino = { nome: string } & ({ rota: string } | { host: string });
 
-const chegaAo = (href: string, destino: (typeof DESTINOS)[number]) =>
-  destino.externo ? href.includes(destino.href) : href === destino.href;
+const DESTINOS: Destino[] = [
+  { nome: "Início", rota: "/" },
+  { nome: "Fundamentos", rota: "/roadmaps/fundamentos/" },
+  { nome: "Roadmaps", rota: "/roadmaps/" },
+  { nome: "Tópicos", rota: "/topicos/" },
+  { nome: "Apoiar", rota: "/apoie/" },
+  { nome: "YouTube", host: "youtube.com" },
+  { nome: "Discord", host: "discord.gg" },
+];
+
+function chegaAo(href: string, destino: Destino): boolean {
+  if ("rota" in destino) return href === destino.rota;
+  let hostname: string;
+  try {
+    hostname = new URL(href).hostname;
+  } catch {
+    return false; // href relativo nunca chega a um destino de fora
+  }
+  return hostname === destino.host || hostname.endsWith(`.${destino.host}`);
+}
 
 test("nada sai da barra sem ter para onde ir: o menu ⋯ recolhe o que sumiu", async ({ page }) => {
   // O degrau novo (940px) tira "Início" e "YouTube" da barra, e o antigo (760)


### PR DESCRIPTION
Continuação do #97 (issue #86). A review do Copilot chegou depois do merge e achou um furo real
no guarda que o #97 acabou de introduzir; este PR é só esse conserto.

## O furo

`tests/barra-do-topo-responsiva.spec.ts` tem um teste que garante que **nada sai da barra sem ter
para onde ir**: em cada largura, a união dos links da barra com os do menu `⋯` tem de conter os
sete destinos. Ele comparava cada destino com `href.includes(...)`, e neste site **uma rota é
prefixo da outra**:

- `"/"` está contido em TODO href interno, então **"Início" nunca apareceria como perdido**, nem
  que sumisse da barra E do menu ao mesmo tempo. Era exatamente a regressão que o teste existe
  para pegar;
- `"/roadmaps/"` está contido em `"/roadmaps/fundamentos/"`, então "Roadmaps" sobreviveria
  escondido atrás do link dos Fundamentos.

## Medido

Com os links para a home removidos do DOM em 390px (a regressão simulada):

```
hrefs restantes: ["https://discord.gg/…","/apoie/","/roadmaps/fundamentos/","/roadmaps/",
                  "/topicos/","https://www.youtube.com/@CraftCodeClub","/sobre/",…]

EXATO    -> perdidos: [ 'Início' ]
INCLUDES -> perdidos: []
```

## O conserto

Rota interna casa por **igualdade**. Os dois links de fora seguem casando por trecho (agora
`youtube.com/` e `discord.gg/`), e isso é decisão, não descuido: ali o alvo é o **host**, e o
caminho depois dele (o `@CraftCodeClub`, o código do convite) muda sem que a promessa da barra
mude.

O porquê ficou escrito no arquivo, junto da lista: um `includes` aqui volta sozinho na próxima
vez que alguém acrescentar um destino.

## Validação

```
npx tsc --noEmit                   0 erro
npm run build                      ok
PORT=3303 npm test                 767 passed, 3 skipped
npm run lint                       0 errors (6 warnings pré-existentes)
python3 scripts/guarda-ancoras.py  36 arquivos, nenhuma âncora
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review

Segunda passada do Copilot apontou que eu tinha consertado só metade: as rotas internas passaram
a casar por igualdade, mas os dois links de fora continuaram por `includes`, que aceita
`notyoutube.com` (e um `https://evil.com/?u=youtube.com/`). Procede, e o comentário do arquivo já
prometia o que o código não fazia. Corrigido em `7614281`: `new URL(href).hostname`, comparado
por igualdade **ou subdomínio** — os dois porque `hostname === "youtube.com"` sozinho recusaria o
`www.` que o link usa hoje, e prender o `www.` travaria o formato do link em vez do destino dele.

```
true   https://www.youtube.com/@CraftCodeClub      false  https://notyoutube.com/@CraftCodeClub
true   https://youtube.com/x                       false  https://evil.com/?u=youtube.com/
true   https://discord.gg/b5NnndAbFc               false  https://notdiscord.gg/x
```

A terceira passada do Copilot voltou sem comentário novo.
