### PR TITLE
fix(apoie): resposta vazia não cai no plano B, que anulava o fail-closed

### DIFF
--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -88,6 +88,11 @@ export const PARTNERS: Partner[] = [
  * "Wilson Gomes Neto" lá são duas chaves diferentes, e a mesma pessoa apareceria
  * em dois cards. Agora a API, quando responde, é a fonte; esta lista entra
  * quando ela não responde, e nunca junto.
+ *
+ * "NÃO RESPONDE" é literal: sem credencial, HTTP não-ok, rede, timeout ou
+ * formato ilegível. Uma resposta que chegou e devolveu zero nomes NÃO é este
+ * caso, é uma resposta válida cujo conteúdo é "ninguém autorizou aparecer", e
+ * ela vale. Confundir as duas coisas anula o filtro de privacidade.
  */
 const FALLBACK_SUPPORTERS: Supporter[] = [
   { name: "Cristiano Cunha" },
@@ -341,8 +346,11 @@ export function isActive(b: Raw): boolean {
  * dela.
  *
  * Consequência esperada e desejada: uma resposta que não traga `supportPrivate`
- * esvazia o muro e o faz cair no plano B, com aviso no log. Muro vazio conserta
- * em cinco minutos; nome publicado indevidamente, não.
+ * esvazia o muro, com aviso no log. Ela NÃO cai no plano B, e essa distinção é a
+ * outra metade da proteção: cair na lista fixa quando o filtro escondeu todo
+ * mundo publicaria três nomes escritos à mão, entre eles, no pior caso, a pessoa
+ * que acabou de marcar o apoio como privado. Muro vazio conserta em cinco
+ * minutos; nome publicado indevidamente, não.
  */
 export function isPublic(b: Raw): boolean {
   const declarado = [b.supportPrivate, b.support_private, b.isPrivate, b.private].find(
@@ -476,16 +484,31 @@ export async function fetchSupporters(): Promise<Supporter[]> {
     const muro = normalizeSupporters(toSupporters(raw));
 
     if (muro.length === 0) {
-      // Os três motivos possíveis, separados, porque o conserto de cada um é
-      // diferente. O do meio é o que mais assusta e é o comportamento correto:
-      // sem `supportPrivate: false` declarado, ninguém é publicado.
+      // RESPOSTA VAZIA NÃO É FALHA, e por isso ela NÃO cai no plano B.
+      //
+      // Este `return` já devolveu a lista fixa aqui, e era a contradição do
+      // arquivo: o filtro logo acima é fail-closed justamente para não publicar
+      // quem pediu para não aparecer, e então, quando ele escondia todo mundo, o
+      // plano B publicava três nomes escritos à mão. No pior caso ele publicaria
+      // exatamente a pessoa que acabou de marcar o apoio como privado, porque
+      // ela está nos dois lugares.
+      //
+      // A regra que resolve: uma resposta que a API entregou é a verdade, mesmo
+      // quando a verdade é "ninguém autorizou". O plano B existe para quando não
+      // houve resposta (sem credencial, HTTP não-ok, rede, timeout, formato), e
+      // só para isso. Muro vazio é um estado legítimo, e a página já sabe
+      // desenhá-lo: `page.tsx` mostra o convite "seja o primeiro".
+      //
+      // Os três números saem no log porque o conserto de cada motivo é
+      // diferente, e o do meio é o que mais assusta sendo o comportamento certo.
       const publicos = raw.filter(isPublic).length;
       const ativos = raw.filter(isPublic).filter(isActive).length;
       console.warn(
         `[apoia.se] ${raw.length} apoios recebidos e nenhum nome no muro: ${publicos} autorizaram ` +
-          `aparecer (supportPrivate: false), ${ativos} desses estão ativos. Muro no plano B.`
+          `aparecer (supportPrivate: false), ${ativos} desses estão ativos. O muro fica vazio, e é ` +
+          `o certo: a resposta da API vale, inclusive quando ela é "ninguém".`
       );
-      return normalizeSupporters(FALLBACK_SUPPORTERS);
+      return muro;
     }
 
     console.log(`[apoia.se] ${raw.length} apoios recebidos, ${muro.length} nomes no muro.`);

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
   apoiaseHeaders,
+  fetchSupporters,
   collectAllPages,
   initials,
   isActive,
@@ -319,4 +320,83 @@ test("os headers da APOIA.se levam a chave e o segredo cada um no seu lugar", ()
   // O segredo nunca vai no `x-api-key`, nem a chave no `Authorization`.
   expect(headers["x-api-key"]).not.toContain("SEGREDO");
   expect(headers.Authorization).not.toContain("CHAVE_DE_TESTE");
+});
+
+// ---------------------------------------------------------------------------
+// Resposta vazia NÃO cai no plano B
+//
+// O filtro de privacidade é fail-closed, e sozinho ele não basta: enquanto o
+// muro vazio caía na lista fixa, esconder todo mundo fazia o site publicar três
+// nomes escritos à mão. No pior caso, exatamente a pessoa que acabou de marcar o
+// apoio como privado, porque ela está nos dois lugares.
+//
+// A regra tem duas metades, e as duas precisam de guarda: uma resposta que
+// CHEGOU vale, inclusive quando o conteúdo dela é "ninguém"; e o plano B vale
+// quando NÃO houve resposta.
+// ---------------------------------------------------------------------------
+
+/** Roda `fetchSupporters` com credencial falsa e um `fetch` de mentira. */
+async function comApiFalsa(responder: () => Response | Promise<Response>) {
+  const antes = {
+    fetch: globalThis.fetch,
+    key: process.env.APOIASE_KEY,
+    secret: process.env.APOIASE_SECRET,
+    campaign: process.env.APOIASE_CAMPAIGN,
+  };
+  process.env.APOIASE_KEY = "CHAVE_DE_TESTE_NAO_DEVE_VAZAR";
+  process.env.APOIASE_SECRET = "SEGREDO_DE_TESTE_NAO_DEVE_VAZAR";
+  process.env.APOIASE_CAMPAIGN = "000000000000000000000000";
+  globalThis.fetch = (async () => responder()) as typeof fetch;
+  try {
+    return await fetchSupporters();
+  } finally {
+    globalThis.fetch = antes.fetch;
+    for (const [k, v] of [
+      ["APOIASE_KEY", antes.key],
+      ["APOIASE_SECRET", antes.secret],
+      ["APOIASE_CAMPAIGN", antes.campaign],
+    ] as const) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+}
+
+const json = (body: unknown) =>
+  new Response(JSON.stringify(body), { status: 200, headers: { "content-type": "application/json" } });
+
+test("resposta em que todo mundo é privado deixa o muro vazio, e não publica a lista fixa", async () => {
+  const muro = await comApiFalsa(() =>
+    json({
+      total: 2,
+      totalPages: 1,
+      backers: [
+        apoiador({ name: "Privada Uma", supportPrivate: true }),
+        apoiador({ name: "Privada Duas", supportPrivate: true }),
+      ],
+    })
+  );
+  // Vazio, e vazio é o certo: a página desenha o convite "seja o primeiro".
+  expect(muro, "o plano B publicou nomes numa resposta em que ninguém autorizou").toEqual([]);
+});
+
+test("resposta sem o campo de privacidade também deixa o muro vazio", async () => {
+  // O fail-closed do `isPublic` esconde quem não declarou. Se isso caísse no
+  // plano B, uma mudança de formato na API republicaria a lista fixa sozinha.
+  const semCampo = apoiador({ name: "Sem Declaracao" });
+  delete (semCampo as Record<string, unknown>).supportPrivate;
+  const muro = await comApiFalsa(() => json({ total: 1, totalPages: 1, backers: [semCampo] }));
+  expect(muro).toEqual([]);
+});
+
+test("a resposta que CHEGOU manda, e a que não chegou cai no plano B", async () => {
+  const comGente = await comApiFalsa(() =>
+    json({ total: 1, totalPages: 1, backers: [apoiador({ name: "Publica Silva" })] })
+  );
+  expect(comGente.map((s) => s.name)).toEqual(["Publica Silva"]);
+
+  // A outra metade: sem resposta, o plano B entra. Sem esta asserção o teste
+  // acima passaria com um `return []` incondicional.
+  const semResposta = await comApiFalsa(() => new Response("", { status: 500 }));
+  expect(semResposta.length, "HTTP 500 devia cair no plano B").toBeGreaterThan(0);
 });


### PR DESCRIPTION
Fecha a lacuna apontada pela quinta review do Copilot no #96, que chegou depois do merge. Verifiquei a alegação antes de agir: ela procede.

## O defeito

O filtro de privacidade é fail-closed, e sozinho não bastava. Quando ele escondia todo mundo, o muro ficava vazio e o código **caía na lista fixa** — publicando três nomes escritos à mão. No pior caso, exatamente a pessoa que acabou de marcar o apoio como privado, porque ela está nos dois lugares. A proteção se anulava no único cenário em que precisava valer.

## A regra

- Uma resposta que **chegou** é a verdade, inclusive quando a verdade é "ninguém autorizou". Muro vazio é estado legítimo, e `page.tsx` já desenha o convite "seja o primeiro".
- O plano B vale quando **não houve resposta**: sem credencial, HTTP não-ok, rede, timeout, formato ilegível.

Três comentários que descreviam o comportamento antigo foram corrigidos junto.

## Teste

As duas metades: resposta 200 com todos privados devolve vazio, 200 sem o campo de privacidade também, e HTTP 500 cai no plano B. A última asserção existe para o teste não passar com um `return []` incondicional.

793 testes verdes, lint sem erro. Nenhuma mudança de comportamento hoje: a rota ainda responde 404, então o caminho que roda é o de erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)