### PR TITLE
fix(apoie): cinco apoiadores no plano B, e nome em caixa alta não grita

### DIFF
--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -116,6 +116,68 @@ function realNameIndexes(parts: string[]): number[] {
 }
 
 /**
+ * O nome está TODO em maiúsculas?
+ *
+ * A pergunta é feita com as duas caixas, e não com uma regex de letra maiúscula,
+ * porque só assim ela responde "não" para o que não tem caixa nenhuma: "123" e
+ * "김" são iguais em maiúscula e em minúscula, e nenhum dos dois está gritando.
+ */
+function isShouting(name: string): boolean {
+  return name === name.toUpperCase() && name !== name.toLowerCase();
+}
+
+/**
+ * Uma palavra com a primeira letra maiúscula e o resto minúsculo.
+ *
+ * Capitaliza cada PEDAÇO alfanumérico, e não só o início da palavra, porque o
+ * separador de dentro do nome não é só o espaço: "SANT'ANA" vira "Sant'Ana",
+ * "D'ÁVILA" vira "D'Ávila" e "ANA-MARIA" vira "Ana-Maria". Cortar só no espaço
+ * devolveria "Sant'ana".
+ *
+ * O `[...]` antes de pegar a primeira letra é o mesmo cuidado de `initials`: não
+ * partir caractere fora do BMP no meio.
+ */
+function capitalizeWord(word: string): string {
+  return word.replace(/[\p{L}\p{N}]+/gu, (pedaco) => {
+    const letras = [...pedaco.toLowerCase()];
+    if (letras.length === 0) return pedaco;
+    return letras[0].toUpperCase() + letras.slice(1).join("");
+  });
+}
+
+/**
+ * Tira o grito do nome: "ELIEL SOUSA" vira "Eliel Sousa".
+ *
+ * ⚠️ SÓ MEXE EM NOME QUE ESTÁ INTEIRO EM MAIÚSCULAS, e essa condição é a função
+ * toda. Capitalizar palavra por palavra sem perguntar isso primeiro destrói os
+ * nomes que têm maiúscula legítima no meio: "McDonald" viraria "Mcdonald",
+ * "DiCaprio" viraria "Dicaprio", "d'Ávila" viraria "D'ávila". Um nome misto já
+ * está escrito do jeito que a pessoa escreve o próprio nome, e a regra aqui é
+ * não tocar nele.
+ *
+ * As partículas voltam em minúscula ("DE", "DA", "DOS" → "de", "da", "dos"),
+ * inclusive quando abrem o nome, que é a grafia portuguesa e é a mesma leitura
+ * que `shortenName` e `initials` já fazem da lista `NAME_PARTICLES`.
+ *
+ * O espaçamento sai como entrou: quem normaliza espaço é `normalizeSupporters`,
+ * e uma função que faz as duas coisas é uma função que ninguém consegue testar.
+ *
+ * POR QUE ISTO É UMA FUNÇÃO, e não um nome já capitalizado na lista de plano B.
+ * A lista fixa a gente digita, então nela bastaria escrever certo. Mas o muro
+ * também vem da API da APOIA.se, e lá o nome é digitado pela pessoa que apoia,
+ * num formulário sem validação de caixa: no dia em que a listagem for ligada,
+ * um "FULANO DA SILVA" cadastrado com Caps Lock chega direto ao HTML público.
+ * Escrever certo na lista conserta três nomes uma vez; a função conserta todos,
+ * inclusive os que ainda não existem.
+ */
+export function normalizeNameCase(name: string): string {
+  if (!isShouting(name)) return name;
+  return name.replace(/\S+/g, (palavra) =>
+    NAME_PARTICLES.has(palavra.toLowerCase()) ? palavra.toLowerCase() : capitalizeWord(palavra)
+  );
+}
+
+/**
  * O nome como ele aparece no card: primeiro e último, e só.
  *
  * "Maria Aparecida da Silva Souza" vira "Maria Souza". O muro tem cards
@@ -189,12 +251,23 @@ export function initials(name: string): string {
  *
  * A chave normaliza espaço e caixa porque "  maria   souza " e "Maria Souza"
  * são a mesma inscrição digitada duas vezes, e isso é repetição de verdade.
+ *
+ * É AQUI que a caixa do nome é arrumada (`normalizeNameCase`), e o lugar foi
+ * escolhido: esta é a única função por onde os DOIS caminhos do muro passam, o
+ * da API (`normalizeSupporters(toSupporters(raw))`) e o do plano B
+ * (`normalizeSupporters(FALLBACK_SUPPORTERS)`). Arrumar na página trataria só o
+ * que a página desenha, e a contagem do painel de gratidão sairia da lista
+ * ainda gritando; arrumar em cada chamada é a mesma regra escrita cinco vezes.
+ * A identidade que a API deu continua inteira: muda a caixa de quem estava com
+ * Caps Lock, e mais nada.
  */
 export function normalizeSupporters(list: Supporter[]): Supporter[] {
   const seen = new Set<string>();
   const out: Supporter[] = [];
   for (const s of list) {
-    const name = s.name.trim().replace(/\s+/g, " ");
+    const name = normalizeNameCase(s.name.trim().replace(/\s+/g, " "));
+    // A chave é minúscula, então arrumar a caixa acima não muda quem é repetido:
+    // "ELIEL SOUSA" e "Eliel Sousa" já eram o mesmo card antes desta linha.
     const key = name.toLowerCase();
     if (!key || seen.has(key)) continue;
     seen.add(key);

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -66,9 +66,10 @@
 // arquivo lia `APOIASE_TOKEN` e `APOIASE_CAMPAIGN_ID`, e NENHUM DOS DOIS existia
 // como secret do repositório (`gh secret list` trazia só os quatro do
 // Cloudflare). O build caía no primeiro `return` e renderizava a lista escrita à
-// mão, que tinha exatamente três nomes. E caía CALADO: aquele `return` era o
-// único caminho de saída sem um aviso, então nada no log do build denunciava que
-// a integração nunca tinha rodado. Agora ele avisa como todos os outros.
+// mão, que na época tinha exatamente três nomes. E caía CALADO: aquele `return`
+// era o único caminho de saída sem um aviso, então nada no log do build
+// denunciava que a integração nunca tinha rodado. Agora ele avisa como todos os
+// outros.
 
 export type Supporter = { name: string };
 export type Partner = { name: string; url?: string };
@@ -83,7 +84,7 @@ export const PARTNERS: Partner[] = [
  * PLANO B, e não "lista manual que se soma à API": a diferença é o defeito que
  * esta versão conserta. Antes estes nomes eram sempre colados na FRENTE do que a
  * API devolvesse, e isso cobrava dois preços. A ordem por recência ia embora
- * (três nomes fixos na frente de todo mundo), e o "sem repetir nome" dependia da
+ * (os nomes fixos na frente de todo mundo), e o "sem repetir nome" dependia da
  * grafia bater caractere a caractere com a do painel: "Wilson Neto" aqui contra
  * "Wilson Gomes Neto" lá são duas chaves diferentes, e a mesma pessoa apareceria
  * em dois cards. Agora a API, quando responde, é a fonte; esta lista entra
@@ -93,8 +94,19 @@ export const PARTNERS: Partner[] = [
  * formato ilegível. Uma resposta que chegou e devolveu zero nomes NÃO é este
  * caso, é uma resposta válida cujo conteúdo é "ninguém autorizou aparecer", e
  * ela vale. Confundir as duas coisas anula o filtro de privacidade.
+ *
+ * A ORDEM É DADO, não decoração: do apoio mais recente para o mais antigo, a
+ * mesma que `toSupporters` produz com `firstSupportDate`. Quem atualizar a lista
+ * põe o nome novo NO TOPO, senão os dois caminhos do muro passam a ordenar de
+ * jeitos diferentes e ninguém percebe, porque ordem errada não quebra nada.
+ *
+ * A caixa dos nomes daqui não precisa estar perfeita: a lista sai por
+ * `normalizeSupporters`, que arruma Caps Lock (ver `normalizeNameCase`). Ainda
+ * assim, o que se digita à mão se digita direito, e é o que está abaixo.
  */
 const FALLBACK_SUPPORTERS: Supporter[] = [
+  { name: "Eliel Sousa" },
+  { name: "Gustavo Huguenin" },
   { name: "Cristiano Cunha" },
   { name: "Wilson Neto" },
   { name: "Eduarda Martins" },
@@ -421,7 +433,7 @@ export function isActive(b: Raw): boolean {
  * Consequência esperada e desejada: uma resposta que não traga `supportPrivate`
  * esvazia o muro, com aviso no log. Ela NÃO cai no plano B, e essa distinção é a
  * outra metade da proteção: cair na lista fixa quando o filtro escondeu todo
- * mundo publicaria três nomes escritos à mão, entre eles, no pior caso, a pessoa
+ * mundo publicaria os nomes escritos à mão, entre eles, no pior caso, a pessoa
  * que acabou de marcar o apoio como privado. Muro vazio conserta em cinco
  * minutos; nome publicado indevidamente, não.
  */

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -179,8 +179,8 @@ function capitalizeWord(word: string): string {
  * também vem da API da APOIA.se, e lá o nome é digitado pela pessoa que apoia,
  * num formulário sem validação de caixa: no dia em que a listagem for ligada,
  * um "FULANO DA SILVA" cadastrado com Caps Lock chega direto ao HTML público.
- * Escrever certo na lista conserta três nomes uma vez; a função conserta todos,
- * inclusive os que ainda não existem.
+ * Escrever certo na lista conserta os nomes de hoje, uma vez; a função conserta
+ * todos, inclusive os que ainda não existem.
  */
 export function normalizeNameCase(name: string): string {
   if (!isShouting(name)) return name;
@@ -574,7 +574,7 @@ export async function fetchSupporters(): Promise<Supporter[]> {
       // Este `return` já devolveu a lista fixa aqui, e era a contradição do
       // arquivo: o filtro logo acima é fail-closed justamente para não publicar
       // quem pediu para não aparecer, e então, quando ele escondia todo mundo, o
-      // plano B publicava três nomes escritos à mão. No pior caso ele publicaria
+      // plano B publicava os nomes escritos à mão. No pior caso ele publicaria
       // exatamente a pessoa que acabou de marcar o apoio como privado, porque
       // ela está nos dois lugares.
       //

--- a/src/app/apoie/apoiadores.ts
+++ b/src/app/apoie/apoiadores.ts
@@ -146,11 +146,21 @@ function isShouting(name: string): boolean {
  * "D'ÁVILA" vira "D'Ávila" e "ANA-MARIA" vira "Ana-Maria". Cortar só no espaço
  * devolveria "Sant'ana".
  *
+ * ⚠️ O `\p{M}` da classe é o acento SOLTO, e ele não é decoração da regex. "Á"
+ * chega de duas formas: NFC, um code point só (U+00C1), e NFD, "A" seguido do
+ * acento combinante (U+0041 U+0301). Sem `\p{M}` na classe, o acento da forma
+ * decomposta vira SEPARADOR: "ÁVILA" em NFD casa como "A" e "VILA", dois
+ * pedaços, e sai "ÁVila", com uma maiúscula no meio do nome. Medido. E as duas
+ * formas chegam de verdade, porque o nome vem de formulário e de API, não de um
+ * literal deste arquivo.
+ *
  * O `[...]` antes de pegar a primeira letra é o mesmo cuidado de `initials`: não
- * partir caractere fora do BMP no meio.
+ * partir caractere fora do BMP no meio. Ele também é o que faz o acento
+ * combinante seguir colado na letra que acentua, em vez de virar a "segunda
+ * letra" da palavra.
  */
 function capitalizeWord(word: string): string {
-  return word.replace(/[\p{L}\p{N}]+/gu, (pedaco) => {
+  return word.replace(/[\p{L}\p{N}\p{M}]+/gu, (pedaco) => {
     const letras = [...pedaco.toLowerCase()];
     if (letras.length === 0) return pedaco;
     return letras[0].toUpperCase() + letras.slice(1).join("");

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -166,6 +166,31 @@ test("o separador de dentro do nome não é só o espaço", () => {
   expect(normalizeNameCase("FULANO D'ÁVILA")).toBe("Fulano D'Ávila");
 });
 
+test("acento solto não parte o nome em dois, e não é uma forma só que chega", () => {
+  // O defeito que este teste prende (achado na review do Copilot no PR #150):
+  // "Á" chega de duas formas, e só uma delas é um code point. Em NFD ele é "A"
+  // mais o acento combinante, e um acento combinante NÃO é `\p{L}` nem `\p{N}`.
+  // Sem `\p{M}` na classe da regex ele virava SEPARADOR: "ÁVILA" decomposto
+  // casava como "A" e "VILA", dois pedaços, e saía "ÁVila".
+  //
+  // Isso não é teoria: o nome vem de formulário e de API, e nem um nem outro
+  // prometem forma normalizada.
+  const composto = "FULANO ÁVILA";
+  const decomposto = composto.normalize("NFD");
+  // Garante que este teste está mesmo exercitando as duas formas, e não duas
+  // cópias da mesma. Sem isto ele passaria mesmo com o defeito de volta.
+  expect(decomposto).not.toBe(composto);
+
+  for (const entrada of [composto, decomposto]) {
+    // A comparação é em NFC porque o que importa é o nome que o leitor vê: a
+    // saída preserva a forma que entrou, e as duas desenham "Fulano Ávila".
+    expect(
+      normalizeNameCase(entrada).normalize("NFC"),
+      `forma ${entrada === composto ? "NFC" : "NFD"}`
+    ).toBe("Fulano Ávila");
+  }
+});
+
 test("arrumar a caixa não mexe no espaçamento nem some com ninguém", () => {
   // Quem normaliza espaço é `normalizeSupporters`. Se as duas coisas
   // acontecessem na mesma função, um teste não conseguiria dizer qual quebrou.

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -6,6 +6,7 @@ import {
   initials,
   isActive,
   isPublic,
+  normalizeNameCase,
   normalizeSupporters,
   readPage,
   shortenName,
@@ -102,6 +103,107 @@ test("a sigla do avatar acompanha o nome já encurtado", () => {
   for (const [entrada, esperado] of casos) {
     expect(initials(shortenName(entrada)), `entrada: ${JSON.stringify(entrada)}`).toBe(esperado);
   }
+});
+
+// ---------------------------------------------------------------------------
+// normalizeNameCase: o muro não grita o nome de ninguém
+//
+// A lista de plano B é digitada à mão e a da API é digitada pela pessoa que
+// apoia, num formulário sem validação de caixa. Nas duas pontas aparece nome com
+// Caps Lock, e o card renderiza o que recebe: "FULANA SOUSA" gritava no meio de
+// uma fileira de nomes em caixa normal.
+//
+// O defeito que os testes desta seção evitam NÃO é "esqueci de capitalizar", é o
+// conserto ingênuo dele: capitalizar toda palavra de todo nome. Isso arruma um
+// nome e estraga os outros, porque maiúscula no meio de nome é comum e é
+// deliberada. Por isso a função só age quando o nome está INTEIRO em maiúsculas.
+//
+// Nenhum nome desta seção é de pessoa real.
+// ---------------------------------------------------------------------------
+
+test("nome inteiro em maiúsculas chega ao card em caixa normal", () => {
+  const casos: [string, string][] = [
+    ["FULANA SOUSA", "Fulana Sousa"],
+    ["BELTRANO HUGUENIN", "Beltrano Huguenin"],
+    // Partícula volta em minúscula, que é a grafia portuguesa e é a mesma
+    // leitura que `shortenName` e `initials` fazem da lista de partículas.
+    ["SICRANA DA COSTA", "Sicrana da Costa"],
+    ["FULANO DOS SANTOS NETO", "Fulano dos Santos Neto"],
+    ["BELTRANA DE OLIVEIRA E SOUZA", "Beltrana de Oliveira e Souza"],
+    // Acento em caixa alta também desce.
+    ["JOSÉ ANTÔNIO GONÇALVES", "José Antônio Gonçalves"],
+  ];
+  for (const [entrada, esperado] of casos) {
+    expect(normalizeNameCase(entrada), `entrada: ${JSON.stringify(entrada)}`).toBe(esperado);
+  }
+});
+
+test("nome que já tem caixa mista sai intacto, inclusive a maiúscula do meio", () => {
+  // ESTE é o teste que prende o conserto ingênuo. Capitalizar palavra por
+  // palavra sem perguntar se o nome está gritando devolveria "Mcallister",
+  // "Dicarli" e "D'ávila", que são três nomes destruídos para arrumar zero.
+  const intactos = [
+    "Fulana McAllister",
+    "Beltrano DiCarli",
+    "Sicrana d'Ávila",
+    "Fulano van der Berg",
+    "Cristiano Cunha",
+    "Ana",
+    "  Beltrana   da  Costa  ",
+    "",
+    "   ",
+  ];
+  for (const nome of intactos) {
+    expect(normalizeNameCase(nome), `entrada: ${JSON.stringify(nome)}`).toBe(nome);
+  }
+});
+
+test("o separador de dentro do nome não é só o espaço", () => {
+  // Cortar só no espaço devolveria "Sant'ana" e "Ana-maria": o pedaço depois do
+  // apóstrofo e do hífen continuaria minúsculo.
+  expect(normalizeNameCase("SICRANA SANT'ANA")).toBe("Sicrana Sant'Ana");
+  expect(normalizeNameCase("ANA-MARIA FERREIRA")).toBe("Ana-Maria Ferreira");
+  expect(normalizeNameCase("FULANO D'ÁVILA")).toBe("Fulano D'Ávila");
+});
+
+test("arrumar a caixa não mexe no espaçamento nem some com ninguém", () => {
+  // Quem normaliza espaço é `normalizeSupporters`. Se as duas coisas
+  // acontecessem na mesma função, um teste não conseguiria dizer qual quebrou.
+  expect(normalizeNameCase("  FULANA   SOUSA  ")).toBe("  Fulana   Sousa  ");
+  // Sem caixa nenhuma para arrumar, devolve igual: nada aqui pode apagar nome.
+  expect(normalizeNameCase("")).toBe("");
+  expect(normalizeNameCase("1234")).toBe("1234");
+});
+
+test("o nome encurtado e a sigla saem do nome já em caixa normal", () => {
+  // O card mostra `shortenName` e o avatar mostra `initials`, e os dois leem a
+  // lista depois da normalização. Sem ela o card diria "FULANA SOUSA" no meio de
+  // uma fileira em caixa normal.
+  const muro = normalizeSupporters([{ name: "FULANA APARECIDA DA SILVA SOUSA" }]);
+  expect(muro).toEqual([{ name: "Fulana Aparecida da Silva Sousa" }]);
+  expect(shortenName(muro[0].name)).toBe("Fulana Sousa");
+  expect(initials(shortenName(muro[0].name))).toBe("FS");
+});
+
+test("a mesma pessoa com e sem Caps Lock continua sendo um card só", () => {
+  // A chave da deduplicação é minúscula, então arrumar a caixa não pode criar
+  // nem desfazer repetição. Quem chega primeiro define a grafia guardada.
+  const muro = normalizeSupporters([
+    { name: "FULANA SOUSA" },
+    { name: "Fulana Sousa" },
+    { name: "Beltrano Huguenin" },
+  ]);
+  expect(muro).toEqual([{ name: "Fulana Sousa" }, { name: "Beltrano Huguenin" }]);
+});
+
+test("nome gritado que vem da API também desce, e nada além do nome passa", () => {
+  // Os dois caminhos do muro atravessam `normalizeSupporters`, e é por isso que
+  // a normalização mora lá: o dia em que a listagem da APOIA.se for ligada, o
+  // Caps Lock digitado no formulário dela já chega arrumado.
+  const muro = normalizeSupporters(
+    toSupporters([apoiador({ name: "BELTRANA DE OLIVEIRA", email: "b@exemplo.invalid" })])
+  );
+  expect(muro).toEqual([{ name: "Beltrana de Oliveira" }]);
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/nome-no-muro-de-apoiadores.spec.ts
+++ b/tests/nome-no-muro-de-apoiadores.spec.ts
@@ -502,3 +502,31 @@ test("a resposta que CHEGOU manda, e a que não chegou cai no plano B", async ()
   const semResposta = await comApiFalsa(() => new Response("", { status: 500 }));
   expect(semResposta.length, "HTTP 500 devia cair no plano B").toBeGreaterThan(0);
 });
+
+test("todo nome do plano B rende uma sigla de avatar de verdade", async () => {
+  // Este teste prende a FORMA da lista fixa, e não os nomes dela, e as duas
+  // regras que levam a isso estão escritas neste repositório: nenhum dado de
+  // pessoa real entra em teste (o cabeçalho da seção do contrato, acima), e
+  // `navegacao.spec.ts` não prende nome no muro de propósito, porque isso
+  // reprovaria no dia em que a API começasse a responder, que é o dia em que
+  // tudo está finalmente certo.
+  //
+  // UMA asserção, e é a única que sobrou de propósito. A primeira versão deste
+  // teste também exigia nome não vazio, nome de card não vazio e caixa já
+  // normal, e as três NÃO CONSEGUEM FALHAR: a lista chega aqui depois do
+  // `normalizeSupporters`, que já descarta nome vazio e já arruma Caps Lock.
+  // Medi isso sujando a lista de propósito e vendo quais asserções reagiam.
+  // Asserção que não pode reprovar não protege nada, só faz o teste parecer
+  // maior do que é.
+  //
+  // A que sobra tem dente: um nome só de partículas ("de la") atravessa o
+  // `normalizeSupporters` inteiro, vira um card no muro e chega ao avatar como
+  // "?". É o único jeito de a lista digitada à mão desenhar errado sem que nada
+  // reclame.
+  const muro = await comApiFalsa(() => new Response("", { status: 500 }));
+  expect(muro.length, "sem API, o plano B não pode chegar vazio").toBeGreaterThan(0);
+
+  for (const { name } of muro) {
+    expect(initials(shortenName(name)), `"${name}" não vira sigla de avatar`).not.toBe("?");
+  }
+});


### PR DESCRIPTION
Closes #99

A lista fixa do muro de `/apoie/` passa de três para cinco nomes, e o nome que veio em caixa alta deixa de gritar no card.

## O que tem aqui

**1. `fix(apoie): nome em caixa alta não grita no muro de apoiadores`**

`ELIEL SOUSA` veio do painel em Caps Lock, e o card renderiza o que recebe: um nome gritando no meio de uma fileira em caixa normal.

*Onde normalizar.* Escrever `Eliel Sousa` direto na lista conserta os nomes de hoje e nada mais. O muro tem **dois** caminhos, e no outro ninguém revisa a digitação: o nome da API da APOIA.se é digitado pela própria pessoa que apoia, num formulário sem validação de caixa. No dia em que a rota de listagem for ligada, um `FULANO DA SILVA` cadastrado com Caps Lock chega direto ao HTML público. Então a normalização é uma função, `normalizeNameCase`.

*Onde ela mora.* Em `normalizeSupporters`, a única função por onde os dois caminhos passam (`normalizeSupporters(toSupporters(raw))` e `normalizeSupporters(FALLBACK_SUPPORTERS)`). Na página trataria só o que a página desenha, e a contagem do painel de gratidão sai da mesma lista, ainda gritando.

*A regra que a torna segura.* Ela **só age em nome que está inteiro em maiúsculas**. O conserto ingênuo (capitalizar toda palavra de todo nome) arruma um nome e destrói os outros, porque maiúscula no meio de nome é comum e deliberada: `McAllister` viraria `Mcallister`, `DiCarli` viraria `Dicarli`, `d'Ávila` viraria `D'ávila`. Nome misto já está escrito do jeito que a pessoa escreve o próprio nome.

Os detalhes que a issue pediu atenção:

| Entrada | Saída | Por quê |
| --- | --- | --- |
| `SICRANA DA COSTA` | `Sicrana da Costa` | partícula volta em minúscula, mesma lista `NAME_PARTICLES` que `shortenName` e `initials` já leem |
| `Fulana McAllister` | `Fulana McAllister` | caixa mista, não se toca |
| `SICRANA SANT'ANA` | `Sicrana Sant'Ana` | o separador de dentro do nome não é só o espaço (apóstrofo e hífen também) |
| `JOSÉ ANTÔNIO` | `José Antônio` | acento desce junto, nas duas formas Unicode (ver o commit 4) |
| `  FULANA   SOUSA  ` | `  Fulana   Sousa  ` | espaçamento sai como entrou; quem cuida de espaço é o `normalizeSupporters`, uma linha acima |

A deduplicação não muda: a chave já era minúscula, então `ELIEL SOUSA` e `Eliel Sousa` sempre foram o mesmo card.

**2. `chore(apoie): atualiza a lista de plano B do muro de apoiadores`**

Os cinco nomes da issue.

*A ordem.* O comentário promete "do apoio mais recente para o mais antigo", que é a mesma ordem que `toSupporters` produz a partir de `firstSupportDate`. A issue lista os dois nomes novos primeiro e mantém os três antigos na ordem em que já estavam, ou seja, ela já vem por recência: entrou literal, novos no topo. A promessa virou instrução no comentário, porque ordem errada não quebra nada, só mente.

*As contagens na prosa.* O arquivo dizia "três nomes" em quatro frases. Duas viraram "os nomes" aqui e mais uma no commit 3; a do histórico do #96 ganhou um "na época", que a mantém verdadeira sem depender do tamanho de hoje.

**3. `fix(apoie): tira a contagem da prosa e prende a sigla do plano B`** (review do Copilot)

Ele achou uma quarta ocorrência de "três nomes" que eu tinha reintroduzido na docstring nova, e pediu um teste para a lista. O detalhe do que foi feito, e do que foi recusado e por quê, está nas threads.

**4. `fix(apoie): acento solto não parte o nome em dois na normalização`** (review do Copilot)

Comentário suprimido, e era defeito de verdade. `"Á"` chega em NFC (um code point) ou em NFD (`A` mais acento combinante), e acento combinante é `\p{M}`, que não estava na classe da regex: virava separador. Medido, com o mesmo nome nas duas formas:

```
NFC  "FULANO ÁVILA"  ->  antes: "Fulano Ávila"   depois: "Fulano Ávila"
NFD  "FULANO ÁVILA"  ->  antes: "Fulano ÁVila"   depois: "Fulano Ávila"
```

Ou seja, o conserto de caixa alta produzia exatamente o defeito que ele existe para evitar. `\p{M}` entrou na classe.

## Testes

Onze testes novos em `tests/nome-no-muro-de-apoiadores.spec.ts`, no estilo do arquivo (nome em português, comentário com o defeito que cada um evita). Nenhum nome de pessoa real: são os `Fulana`/`Beltrano`/`Sicrana` do resto do arquivo.

Vale registrar uma coisa que só apareceu porque fui sujar a lista de propósito para ver o teste reprovar: a primeira versão do teste da lista de plano B tinha quatro asserções e **três não conseguiam falhar**, porque a lista chega ao teste depois do `normalizeSupporters`, que já descarta nome vazio e já arruma Caps Lock. Ficou só a que tem dente.

## O que a lista É, depois do #100

Ela não são "os apoiadores do site". É o que o muro mostra quando a API **não responde** (sem credencial, HTTP não-ok, rede, timeout, formato ilegível). Resposta que chega manda, inclusive quando o conteúdo dela é "ninguém": nesse caso o muro fica vazio e a página desenha o convite "seja o primeiro". Nada aqui reabre essa porta.

## Verificação

| Passo | Resultado |
| --- | --- |
| `npx tsc --noEmit` | limpo |
| `npm run build` | 55+ páginas, ok |
| `PORT=3304 npm test` | 802 passed, 4 skipped |
| `npm run lint` | 0 errors (6 warnings de `set-state-in-effect`, pré-existentes) |
| `python3 scripts/guarda-ancoras.py` | 36 arquivos, nenhuma âncora |

No `out/apoie/index.html` e no preview publicado: `Eliel Sousa`, `Gustavo Huguenin`, `Cristiano Cunha`, `Wilson Neto`, `Eduarda Martins`, com as siglas `ES`, `GH`, `CC`, `WN`, `EM` e o painel de gratidão dizendo `5`. Conferido a 390px (dois por linha, cinco cards mais o convite fecham três fileiras, sem overflow) e a 1280px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YKqwFeNooGoTsbY8joV6F6
