### PR TITLE
test(apoie): o piso da varredura conta por categoria, não arquivos

### DIFF
--- a/tests/segredo-nao-vai-para-o-cliente.spec.ts
+++ b/tests/segredo-nao-vai-para-o-cliente.spec.ts
@@ -339,13 +339,25 @@ test("nenhuma credencial chega ao HTML, aos chunks ou ao payload RSC", () => {
   const arquivos = arquivosDoBuild();
 
   // Um guarda que varre um `out/` pela metade passa verde sem ter olhado nada.
-  // Estes três pisos são a prova de que a varredura viu o build inteiro: as
-  // contagens de hoje são 116 HTML, 105 JS e 960 `.txt` de payload RSC.
-  expect(arquivos.length, "build vazio ou parcial: rode `npm run build` antes").toBeGreaterThan(1000);
+  // Os pisos abaixo são a prova de que a varredura viu o build inteiro.
+  //
+  // POR CATEGORIA, E NUNCA PELO TOTAL. O total já esteve aqui, como
+  // `> 1000`, e reprovou o primeiro bump de Next que apareceu: o 16.3 deixou
+  // de emitir metade dos `.txt` de pré-carregamento (960 viraram 457), o
+  // `out/` caiu de 1242 para 738 arquivos, e o guarda gritou "build vazio ou
+  // parcial" sobre um build que tinha as 115 páginas e as 55 imagens no lugar.
+  //
+  // O erro não foi o número, foi a régua: quantos arquivos o Next emite é
+  // detalhe de implementação dele, e muda sem avisar em qualquer versão menor.
+  // O que este guarda precisa afirmar é que as SUPERFÍCIES por onde um segredo
+  // vaza estão todas no `out/` para serem varridas — o HTML que o leitor
+  // recebe, o JavaScript que ele baixa, e o payload RSC da navegação. Cada uma
+  // com o seu piso, todos bem abaixo do medido, e nenhum encostando num
+  // detalhe do framework.
   const porExtensao = (ext: string) => arquivos.filter((a) => a.endsWith(ext)).length;
-  expect(porExtensao(".html"), "nenhum HTML no build").toBeGreaterThan(100);
+  expect(porExtensao(".html"), "nenhum HTML no build: rode `npm run build` antes").toBeGreaterThan(100);
   expect(porExtensao(".js"), "nenhum chunk de JS no build").toBeGreaterThan(50);
-  expect(porExtensao(".txt"), "nenhum payload RSC no build").toBeGreaterThan(500);
+  expect(porExtensao(".txt"), "nenhum payload RSC no build").toBeGreaterThan(100);
 
   // As regras por forma valem sobre TEXTO. O binário fica de fora aqui e é
   // coberto pelo valor literal no teste seguinte (ver `ehBinario`).


### PR DESCRIPTION
Destrava os PRs do Dependabot (#152, #153, #154), que estavam reprovando por um guarda nosso e não por defeito deles.

## O que acontecia

O guarda que prova que a varredura de segredo viu o `out/` inteiro exigia **mais de 1000 arquivos**. O Next 16.3 deixou de emitir metade dos `.txt` de pré-carregamento (960 viraram 457), o `out/` caiu de **1242 para 738**, e o guarda acusou "build vazio ou parcial" sobre um build com as **115 páginas e as 55 imagens OG no lugar**.

## A correção

O erro não foi o número, foi a régua: quantos arquivos o Next emite é detalhe de implementação dele. O piso agora é **por categoria** — HTML, JS e payload RSC, que são as superfícies por onde um segredo pode vazar e portanto as que precisam estar lá para serem varridas.

## Provado nos três cenários

| cenário | resultado |
| --- | --- |
| Next 16.2.12, 1242 arquivos | passa |
| Next 16.3.1, 738 arquivos | passa |
| build pela metade (100 HTML apagados) | **reprova**, com "nenhum HTML no build" |

O terceiro é o que garante que a correção não virou concessão.

793 testes verdes, lint sem erro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)